### PR TITLE
bugfix for make-ing stanc on windows from expression tests or benchmarks

### DIFF
--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -244,7 +244,7 @@ def get_signatures():
         stanc3 = ".\\test\\expressions\\stanc.exe"
     else:
         stanc3 = "./test/expressions/stanc"
-    p = subprocess.Popen((make, stanc3))
+    p = subprocess.Popen((make, stanc3.replace("\\", "/")))
     if p.wait() != 0:
         sys.stderr.write("Error in making stanc3!")
         sys.exit(-1)


### PR DESCRIPTION
## Summary

Fixes a bug in expression tests and benchmark generation, where downloading `stanc.exe` did not work on Windows.

## Tests
None.

## Side Effects
None.

## Release notes

Fixed a bug in expression tests and benchmark generation, where downloading `stanc.exe` did not work on Windows.

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
