### PR TITLE
Turn off autodiff expression tests for quantiles

### DIFF
--- a/stan/math/prim/fun/quantile.hpp
+++ b/stan/math/prim/fun/quantile.hpp
@@ -30,15 +30,16 @@ namespace math {
 template <typename T, require_vector_t<T>* = nullptr,
           require_vector_vt<std::is_arithmetic, T>* = nullptr>
 inline double quantile(const T& samples_vec, const double p) {
-  check_not_nan("quantile", "samples_vec", samples_vec);
   check_not_nan("quantile", "p", p);
   check_bounded("quantile", "p", p, 0, 1);
+
   const size_t n_sample = samples_vec.size();
   if (n_sample == 0) {
     return {};
   }
 
   Eigen::VectorXd x = as_array_or_scalar(samples_vec);
+  check_not_nan("quantile", "samples_vec", x);
 
   if (n_sample == 1)
     return x.coeff(0);
@@ -76,11 +77,9 @@ inline double quantile(const T& samples_vec, const double p) {
  */
 template <typename T, typename Tp, require_all_vector_t<T, Tp>* = nullptr,
           require_vector_vt<std::is_arithmetic, T>* = nullptr,
-          require_vector_vt<std::is_arithmetic, Tp>* = nullptr>
+          require_std_vector_vt<std::is_arithmetic, Tp>* = nullptr>
 inline std::vector<double> quantile(const T& samples_vec, const Tp& ps) {
-  check_not_nan("quantile", "samples_vec", samples_vec);
   check_not_nan("quantile", "ps", ps);
-
   check_bounded("quantile", "ps", ps, 0, 1);
 
   const size_t n_sample = samples_vec.size();
@@ -90,6 +89,8 @@ inline std::vector<double> quantile(const T& samples_vec, const Tp& ps) {
   }
 
   Eigen::VectorXd x = as_array_or_scalar(samples_vec);
+  check_not_nan("quantile", "samples_vec", x);
+
   const auto& p = as_array_or_scalar(ps);
   std::vector<double> ret(n_ps, 0.0);
 

--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -154,7 +154,7 @@ non_differentiable_args = {
 }
 
 # lists of functions that do not support fwd or rev autodiff
-no_rev_overload = ["hmm_hidden_state_prob"]
+no_rev_overload = ["hmm_hidden_state_prob", "quantile"]
 no_fwd_overload = [
     "algebra_solver",
     "algebra_solver_newton",
@@ -165,7 +165,8 @@ no_fwd_overload = [
     "ode_bdf",
     "ode_bdf_tol",
     "ode_rk45",
-    "ode_rk45_tol"
+    "ode_rk45_tol",
+    "quantile"
 ]
 
 internal_signatures = [

--- a/test/unit/math/prim/fun/quantile_test.cpp
+++ b/test/unit/math/prim/fun/quantile_test.cpp
@@ -163,27 +163,3 @@ TEST(MathFunctions, quantileEigenVectorXdStdVecDouble) {
 TEST(MathFunctions, quantileEigenRowVectorXdStdVecDouble) {
   test_quantile_double<Eigen::RowVectorXd, std::vector<double>>();
 }
-
-TEST(MathFunctions, quantileStdVecDoubleVectorXd) {
-  test_quantile_double<std::vector<double>, Eigen::VectorXd>();
-}
-
-TEST(MathFunctions, quantileEigenVectorXdVectorXd) {
-  test_quantile_double<Eigen::VectorXd, Eigen::VectorXd>();
-}
-
-TEST(MathFunctions, quantileEigenRowVectorXdVectorXd) {
-  test_quantile_double<Eigen::RowVectorXd, Eigen::VectorXd>();
-}
-
-TEST(MathFunctions, quantileStdVecDoubleRowVectorXd) {
-  test_quantile_double<std::vector<double>, Eigen::RowVectorXd>();
-}
-
-TEST(MathFunctions, quantileEigenVectorXdRowVectorXd) {
-  test_quantile_double<Eigen::VectorXd, Eigen::RowVectorXd>();
-}
-
-TEST(MathFunctions, quantileEigenRowVectorXdRowVectorXd) {
-  test_quantile_double<Eigen::RowVectorXd, Eigen::RowVectorXd>();
-}


### PR DESCRIPTION
## Summary

I turned off the autodiff expression tests, move the NaN checks to avoid a double eval, and I also tightened up the requirement on the second argument to be a `std::vector` since that is what we expose in stanc3 (which meant deleting a few tests).

## Checklist

- [x] Math issue #2481

- [x] Copyright holder: Ben Bales

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
