### PR TITLE
Have conditional_var_value_t return correct matrix type if scalar is var

### DIFF
--- a/stan/math/rev/meta/conditional_var_value.hpp
+++ b/stan/math/rev/meta/conditional_var_value.hpp
@@ -13,7 +13,7 @@ namespace stan {
  *  scalar of a double.
  * @tparam T_scalar Determines the scalar (var/double) of the type.
  * @tparam T_container Determines the container (matrix/vector/matrix_cl ...) of
- * the type. This must be a prim type.
+ * the type.
  */
 template <typename T_scalar, typename T_container, typename = void>
 struct conditional_var_value {

--- a/stan/math/rev/meta/conditional_var_value.hpp
+++ b/stan/math/rev/meta/conditional_var_value.hpp
@@ -8,7 +8,9 @@
 namespace stan {
 
 /**
- * Constructs a prim type or var_value from a scalar and a container.
+ * Conditionally construct a var_value container based on a scalar type. For
+ * var types as the scalar, the `var_value<Matrix>`'s inner type will have a
+ *  scalar of a double.  
  * @tparam T_scalar Determines the scalar (var/double) of the type.
  * @tparam T_container Determines the container (matrix/vector/matrix_cl ...) of
  * the type. This must be a prim type.

--- a/stan/math/rev/meta/conditional_var_value.hpp
+++ b/stan/math/rev/meta/conditional_var_value.hpp
@@ -10,7 +10,7 @@ namespace stan {
 /**
  * Conditionally construct a var_value container based on a scalar type. For
  * var types as the scalar, the `var_value<Matrix>`'s inner type will have a
- *  scalar of a double.  
+ *  scalar of a double.
  * @tparam T_scalar Determines the scalar (var/double) of the type.
  * @tparam T_container Determines the container (matrix/vector/matrix_cl ...) of
  * the type. This must be a prim type.

--- a/stan/math/rev/meta/conditional_var_value.hpp
+++ b/stan/math/rev/meta/conditional_var_value.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/core/var.hpp>
 #include <stan/math/rev/meta/plain_type.hpp>
+#include <stan/math/prim/meta/promote_scalar_type.hpp>
 
 namespace stan {
 
@@ -15,8 +16,8 @@ namespace stan {
 template <typename T_scalar, typename T_container, typename = void>
 struct conditional_var_value {
   using type = std::conditional_t<is_var<scalar_type_t<T_scalar>>::value,
-                                  math::var_value<plain_type_t<T_container>>,
-                                  plain_type_t<T_container>>;
+    math::var_value<math::promote_scalar_t<double, plain_type_t<T_container>>>,
+    plain_type_t<T_container>>;
 };
 template <typename T_scalar, typename T_container>
 struct conditional_var_value<T_scalar, T_container,

--- a/test/unit/math/rev/meta/conditional_var_value_test.cpp
+++ b/test/unit/math/rev/meta/conditional_var_value_test.cpp
@@ -44,6 +44,8 @@ TEST(MathMetaRev, conditional_var_value_matrix) {
                    conditional_var_value_t<double, Eigen::MatrixXd>);
   EXPECT_SAME_TYPE(var_value<Eigen::MatrixXd>,
                    conditional_var_value_t<var, Eigen::MatrixXd>);
+  EXPECT_SAME_TYPE(var_value<Eigen::MatrixXd>,
+                conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>);
 }
 
 TEST(MathMetaRev, conditional_var_value_expression) {


### PR DESCRIPTION

## Summary

This just makes `conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>` returns back a `var_value<Eigen::Matrix<double, -1, -1>>`

## Tests

Test added for checking above behavior

```
./runTests.py ./test/unit/math/rev/meta/conditional_var_value_test.cpp
```

## Side Effects

Nope

## Release notes

Fixes case for `conditional_var_value_t`

## Checklist

- [x] Math issue #1805 

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
