### PR TITLE
OpenCL symmetric eigensolver 2/3: double double

### DIFF
--- a/stan/math/opencl/copy.hpp
+++ b/stan/math/opencl/copy.hpp
@@ -56,7 +56,7 @@ inline matrix_cl<scalar_type_t<T>> to_matrix_cl(T&& src) {
  * @return Eigen matrix with a copy of the data in the source matrix
  */
 template <typename T_ret, typename T,
-          require_eigen_vt<std::is_arithmetic, T_ret>* = nullptr,
+          require_eigen_t<T_ret>* = nullptr,
           require_matrix_cl_t<T>* = nullptr,
           require_st_same<T_ret, T>* = nullptr>
 inline auto from_matrix_cl(const T& src) {

--- a/stan/math/opencl/double_d.hpp
+++ b/stan/math/opencl/double_d.hpp
@@ -274,7 +274,6 @@ const char* double_d_src = STRINGIFY(
         } inline bool ge_d_dd(double a, double_d b) {
           return !lt_d_dd(a, b);
         } inline bool ge_dd_d(double_d a, double b) { return !lt_dd_d(a, b); }
-
         // \cond
     );
 // \endcond

--- a/stan/math/opencl/double_d.hpp
+++ b/stan/math/opencl/double_d.hpp
@@ -275,7 +275,7 @@ const char* double_d_src = STRINGIFY(
           return !lt_d_dd(a, b);
         } inline bool ge_dd_d(double_d a, double b) { return !lt_dd_d(a, b); }
         // \cond
-    );
+    ); //NOLINT(whitespace/parens)
 // \endcond
 
 inline double_d operator+(double_d a, double b) { return add_dd_d(a, b); }

--- a/stan/math/opencl/double_d.hpp
+++ b/stan/math/opencl/double_d.hpp
@@ -1,0 +1,322 @@
+#ifndef STAN_MATH_OPENCL_DOUBLE_D_HPP
+#define STAN_MATH_OPENCL_DOUBLE_D_HPP
+
+#include <stan/math/opencl/stringify.hpp>
+
+#include <string>
+#include <cmath>
+#include <cfloat>
+#include <limits>
+
+/**
+ * Alternative stringify, that also exposes the code for use in C++ host code.
+ */
+#define STRINGIFY2(A) \
+#A;                 \
+  A
+namespace stan {
+namespace math {
+namespace internal {
+
+/**
+ * Double double - a 128 bit floating point number defined as an exact sum of 2
+ * doubles. `low` should be less than 1 ulp of `high`.
+ */
+typedef struct double_d {
+  double high;
+  double low;
+
+  double_d() {}
+  double_d(double a) {
+    high = a;
+    low = 0;
+  }
+  double_d(double h, double l) {
+    high = h;
+    low = l;
+  }
+} double_d;
+
+using std::copysign;
+using std::fabs;
+using std::isfinite;
+using std::isinf;
+using std::isnan;
+using std::ldexp;
+
+// \cond
+const char* double_d_src = STRINGIFY(
+    // \endcond
+    typedef struct {
+      double high;
+      double low;
+    } double_d;
+    // \cond
+    )
+    STRINGIFY2(
+        // \endcond
+
+        //    inline double_d mul_d_d(double a, double b) {
+        //      double_d res;
+        //      volatile double temp = a * b;
+        //      res.high = temp;
+        //      res.low = fma(a, b, -temp);
+        //      return res;
+        //    }
+
+        inline double_d mul_d_d(double a, double b) {
+          double_d res;
+          const double C = (2 << 26) + 1;
+          double p = a * C;
+          if (!isfinite(p)) {
+            res.high = p;
+            res.low = 0;
+            return res;
+          }
+          double hx = a - p + p;
+          double tx = a - hx;
+          p = b * C;
+          if (!isfinite(p)) {
+            res.high = p;
+            res.low = 0;
+            return res;
+          }
+          double hy = b - p + p;
+          double ty = b - hy;
+          p = hx * hy;
+          double q = hx * ty + tx * hy;
+          res.high = p + q;
+          if (isfinite(res.high)) {
+            res.low = p - res.high + q + tx * ty;
+          } else {
+            res.low = 0;
+          }
+          return res;
+        }
+
+        inline double_d neg(double_d a) {
+          double_d res;
+          res.high = -a.high;
+          res.low = -a.low;
+          return res;
+        }
+
+        inline double_d add_dd_dd(double_d a, double_d b) {
+          double_d res;
+          double high = a.high + b.high;
+          if (isfinite(high)) {
+            double low;
+            if (fabs(a.high) > fabs(b.high)) {
+              low = a.high - high + b.high;
+            } else {
+              low = b.high - high + a.high;
+            }
+            low += a.low + b.low;
+            res.high = high + low;
+            res.low = high - res.high + low;
+          } else {
+            res.high = high;
+            res.low = 0;
+          }
+          return res;
+        }
+
+        inline double_d add_dd_d(double_d a, double b) {
+          double_d res;
+          double high = a.high + b;
+          if (isfinite(high)) {
+            double low;
+            if (fabs(a.high) > fabs(b)) {
+              low = a.high - high + b;
+            } else {
+              low = b - high + a.high;
+            }
+            low += a.low;
+            res.high = high + low;
+            res.low = high - res.high + low;
+          } else {
+            res.high = high;
+            res.low = 0;
+          }
+          return res;
+        }
+
+        inline double_d sub_dd_dd(double_d a, double_d b) {
+          return add_dd_dd(a, neg(b));
+        }
+
+        inline double_d sub_dd_d(double_d a, double b) {
+          return add_dd_d(a, -b);
+        }
+
+        inline double_d sub_d_dd(double a, double_d b) {
+          return add_dd_d(neg(b), a);
+        }
+
+        inline double_d mul_dd_dd(double_d a, double_d b) {
+          double_d high = mul_d_d(a.high, b.high);
+          double_d res;
+          if (isfinite(high.high)) {
+            high.low += a.high * b.low + a.low * b.high;
+            res.high = high.high + high.low;
+            res.low = high.high - res.high + high.low;
+          } else {
+            high.low = 0;
+            return high;
+          }
+          return res;
+        }
+
+        inline double_d mul_dd_d(double_d a, double b) {
+          double_d high = mul_d_d(a.high, b);
+          double_d res;
+          if (isfinite(high.high)) {
+            high.low += a.low * b;
+            res.high = high.high + high.low;
+            res.low = high.high - res.high + high.low;
+            return res;
+          } else {
+            high.low = 0;
+            return high;
+          }
+        }
+
+        inline double_d div_dd_dd(double_d a, double_d b) {
+          double high = a.high / b.high;
+          double_d res;
+          if (isfinite(high)) {
+            double_d u = mul_d_d(high, b.high);
+            if (isfinite(u.high)) {
+              double low
+                  = (a.high - u.high - u.low + a.low - high * b.low) / b.high;
+              res.high = high + low;
+              res.low = high - res.high + low;
+              return res;
+            }
+          }
+          res.high = high;
+          res.low = 0;
+          return res;
+        }
+
+        inline double_d div_dd_d(double_d a, double b) {
+          double high = a.high / b;
+          double_d res;
+          if (isfinite(high)) {
+            double_d u = mul_d_d(high, b);
+            double low = (a.high - u.high - u.low + a.low) / b;
+            res.high = high + low;
+            res.low = high - res.high + low;
+          } else {
+            res.high = high;
+            res.low = 0;
+          }
+          return res;
+        }
+
+        inline double_d div_d_dd(double a, double_d b) {
+          double high = a / b.high;
+          double_d res;
+          if (isfinite(high)) {
+            double_d u = mul_d_d(high, b.high);
+            double low = (a - u.high - u.low - high * b.low) / b.high;
+            res.high = high + low;
+            res.low = high - res.high + low;
+          } else {
+            res.high = high;
+            res.low = 0;
+          }
+          return res;
+        }
+
+        inline double copysign_d_dd(double a, double_d b) {
+          return copysign(a, b.high);
+        }
+
+        inline double_d abs_dd(double_d a) { return a.high > 0 ? a : neg(a); }
+
+        inline bool isnan_dd(double_d a) { return isnan(a.high); }
+
+        inline bool isinf_dd(double_d a) { return isinf(a.high); }
+
+        inline bool lt_dd_dd(double_d a, double_d b) {
+          return a.high < b.high || (a.high == b.high && a.low < b.low);
+        }
+
+        inline bool lt_d_dd(double a, double_d b) {
+          return lt_dd_dd((double_d){a, 0}, b);
+        }
+
+        inline bool lt_dd_d(double_d a, double b) {
+          return lt_dd_dd(a, (double_d){b, 0});
+        }
+
+        inline bool gt_dd_dd(double_d a, double_d b) {
+          return a.high > b.high || (a.high == b.high && a.low > b.low);
+        }
+
+        inline bool gt_d_dd(double a, double_d b) {
+          return gt_dd_dd((double_d){a, 0}, b);
+        }
+
+        inline bool gt_dd_d(double_d a, double b) {
+          return gt_dd_dd(a, (double_d){b, 0});
+        }
+
+        inline bool le_dd_dd(double_d a, double_d b) {
+          return !gt_dd_dd(a, b);
+        } inline bool le_d_dd(double a, double_d b) {
+          return !gt_d_dd(a, b);
+        } inline bool le_dd_d(double_d a, double b) { return !gt_dd_d(a, b); }
+
+        inline bool ge_dd_dd(double_d a, double_d b) {
+          return !lt_dd_dd(a, b);
+        } inline bool ge_d_dd(double a, double_d b) {
+          return !lt_d_dd(a, b);
+        } inline bool ge_dd_d(double_d a, double b) { return !lt_dd_d(a, b); }
+
+        // \cond
+    );
+// \endcond
+
+inline double_d operator+(double_d a, double b) { return add_dd_d(a, b); }
+inline double_d operator+(double a, double_d b) { return add_dd_d(b, a); }
+inline double_d operator+(double_d a, double_d b) { return add_dd_dd(a, b); }
+
+inline double_d operator-(double a, double_d b) { return sub_d_dd(a, b); }
+inline double_d operator-(double_d a, double b) { return sub_dd_d(a, b); }
+inline double_d operator-(double_d a, double_d b) { return sub_dd_dd(a, b); }
+
+inline double_d operator*(double_d a, double b) { return mul_dd_d(a, b); }
+inline double_d operator*(double a, double_d b) { return mul_dd_d(b, a); }
+inline double_d operator*(double_d a, double_d b) { return mul_dd_dd(a, b); }
+
+inline double_d operator/(double_d a, double b) { return div_dd_d(a, b); }
+inline double_d operator/(double a, double_d b) { return div_d_dd(a, b); }
+inline double_d operator/(double_d a, double_d b) { return div_dd_dd(a, b); }
+
+inline double_d operator-(double_d a) { return neg(a); }
+
+inline bool operator<(double_d a, double_d b) { return lt_dd_dd(a, b); }
+inline bool operator<(double a, double_d b) { return lt_d_dd(a, b); }
+inline bool operator<(double_d a, double b) { return lt_dd_d(a, b); }
+inline bool operator>(double_d a, double_d b) { return gt_dd_dd(a, b); }
+inline bool operator>(double a, double_d b) { return gt_d_dd(a, b); }
+inline bool operator>(double_d a, double b) { return gt_dd_d(a, b); }
+inline bool operator<=(double_d a, double_d b) { return le_dd_dd(a, b); }
+inline bool operator<=(double a, double_d b) { return le_d_dd(a, b); }
+inline bool operator<=(double_d a, double b) { return le_dd_d(a, b); }
+inline bool operator>=(double_d a, double_d b) { return ge_dd_dd(a, b); }
+inline bool operator>=(double a, double_d b) { return ge_d_dd(a, b); }
+inline bool operator>=(double_d a, double b) { return ge_dd_d(a, b); }
+
+inline double_d fabs(double_d a) { return abs_dd(a); }
+inline bool isnan(double_d a) { return isnan_dd(a); }
+inline bool isinf(double_d a) { return isinf_dd(a); }
+inline double copysign(double a, double_d b) { return copysign_d_dd(a, b); }
+
+}  // namespace internal
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/opencl/kernel_generator/matrix_cl_conversion.hpp
+++ b/stan/math/opencl/kernel_generator/matrix_cl_conversion.hpp
@@ -14,7 +14,7 @@ namespace math {
 template <typename T>
 template <typename Expr,
           require_all_kernel_expressions_and_none_scalar_t<Expr>*>
-matrix_cl<T, require_arithmetic_t<T>>::matrix_cl(const Expr& expresion)
+matrix_cl<T>::matrix_cl(const Expr& expresion)
     : rows_(0), cols_(0) {
   results(*this) = expressions(expresion);
 }
@@ -22,7 +22,7 @@ matrix_cl<T, require_arithmetic_t<T>>::matrix_cl(const Expr& expresion)
 template <typename T>
 template <typename Expr,
           require_all_kernel_expressions_and_none_scalar_t<Expr>*>
-matrix_cl<T>& matrix_cl<T, require_arithmetic_t<T>>::operator=(
+matrix_cl<T>& matrix_cl<T>::operator=(
     const Expr& expresion) {
   results(*this) = expressions(expresion);
   return *this;

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -31,7 +31,7 @@ namespace math {
  *  @{
  */
 
-template <typename, typename = void>
+template <typename>
 class matrix_cl;
 
 /**
@@ -39,7 +39,7 @@ class matrix_cl;
  * @tparam T an arithmetic type for the type stored in the OpenCL buffer.
  */
 template <typename T>
-class matrix_cl<T, require_arithmetic_t<T>> : public matrix_cl_base {
+class matrix_cl : public matrix_cl_base {
  private:
   cl::Buffer buffer_cl_;  // Holds the allocated memory on the device
   int rows_{0};           // Number of rows.
@@ -624,13 +624,6 @@ class matrix_cl<T, require_arithmetic_t<T>> : public matrix_cl_base {
     delete static_cast<U*>(container);
   }
 };
-
-template <typename T>
-using matrix_cl_prim = matrix_cl<T, require_arithmetic_t<T>>;
-
-template <typename T>
-using matrix_cl_fp = matrix_cl<T, require_floating_point_t<T>>;
-
 /** @}*/
 
 }  // namespace math

--- a/stan/math/opencl/zeros_strict_tri.hpp
+++ b/stan/math/opencl/zeros_strict_tri.hpp
@@ -29,7 +29,7 @@ namespace math {
  */
 template <typename T>
 template <matrix_cl_view matrix_view>
-inline void matrix_cl<T, require_arithmetic_t<T>>::zeros_strict_tri() try {
+inline void matrix_cl<T>::zeros_strict_tri() try {
   if (matrix_view == matrix_cl_view::Entire) {
     invalid_argument(
         "zeros_strict_tri", "matrix_view",

--- a/test/unit/math/opencl/double_d_test.cpp
+++ b/test/unit/math/opencl/double_d_test.cpp
@@ -1,0 +1,179 @@
+
+#include <stan/math/opencl/double_d.hpp>
+//#include <test/unit/math/expect_near_rel.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <Eigen/Core>
+
+#define EXPECT_NORMALIZED(a) \
+  EXPECT_LT(std::abs(a.low), \
+            std::abs(a.high) * std::numeric_limits<double>::epsilon());
+
+TEST(double_d, add_dd_dd_test) {
+  using stan::math::internal::add_dd_dd;
+  using stan::math::internal::double_d;
+  double eps = std::numeric_limits<double>::epsilon();
+  double h_eps = eps * 0.5;
+  double_d a{1.0, h_eps};
+  double_d c{h_eps, 0.0};
+  double_d d{-1.0, -h_eps + eps * h_eps};
+
+  // simple
+  double_d res = add_dd_dd(a, a);
+  EXPECT_NORMALIZED(res);
+  EXPECT_TRUE(res.high == 2.0);
+  EXPECT_TRUE(res.low == eps);
+
+  // carry
+  res = add_dd_dd(a, c);
+  EXPECT_NORMALIZED(res);
+  EXPECT_TRUE(res.high == 1.0 + eps);
+  EXPECT_TRUE(res.low == 0.0);
+
+  // cancelation
+  res = add_dd_dd(a, d);
+  EXPECT_NORMALIZED(res);
+  EXPECT_TRUE(res.high == eps * h_eps);
+  EXPECT_TRUE(res.low == 0.0);
+}
+
+TEST(double_d, mul_dd_dd_test) {
+  using stan::math::internal::double_d;
+  using stan::math::internal::mul_dd_dd;
+  double eps = std::numeric_limits<double>::epsilon();
+  double h_eps = eps * 0.5;
+  double_d a{1.0, h_eps * 0.001};
+  double_d b{h_eps, h_eps * h_eps * h_eps * h_eps};
+  double_d c{1.0, h_eps};
+  double_d d{1.0, -h_eps};
+
+  // simple
+  double_d res = mul_dd_dd(a, b);
+  EXPECT_NORMALIZED(res);
+  EXPECT_TRUE(res.high == h_eps);
+  EXPECT_TRUE(res.low == h_eps * h_eps * 0.001);
+
+  // carry
+  res = mul_dd_dd(c, c);
+  EXPECT_NORMALIZED(res);
+  EXPECT_TRUE(res.high == 1.0 + eps);
+  EXPECT_TRUE(res.low == 0.0);
+
+  // cancelation
+  res = mul_dd_dd(c, d);
+  EXPECT_NORMALIZED(res);
+  EXPECT_TRUE(res.high == 1.0);
+  EXPECT_TRUE(res.low == 0.0);
+}
+
+TEST(double_d, div_dd_dd_test) {
+  using stan::math::internal::div_dd_dd;
+  using stan::math::internal::double_d;
+  double eps = std::numeric_limits<double>::epsilon();
+  double h_eps = eps * 0.5;
+  double_d a{1.0, h_eps};
+  double_d b{1.0, h_eps * (1 - eps)};
+  double_d c{0.0, 0.0};
+  double_d d{1.0, -h_eps};
+
+  // simple
+  double_d res = div_dd_dd(a, a);
+  EXPECT_NORMALIZED(res);
+  EXPECT_TRUE(res.high == 1.0);
+  EXPECT_TRUE(res.low == 0.0);
+
+  res = div_dd_dd(a, b);
+  EXPECT_NORMALIZED(res);
+  EXPECT_TRUE(res.high == 1.0);
+  EXPECT_TRUE(res.low == h_eps * eps);
+
+  // div by zero
+  res = div_dd_dd(a, c);
+  EXPECT_TRUE(res.high == std::numeric_limits<double>::infinity());
+  EXPECT_TRUE(res.low == 0);
+}
+
+// this is the best test we have, but it relies on the nonstandard gcc extension
+// quadmath, so it is not run by default
+#ifdef GCC_QUADMATH_TEST
+#include <quadmath.h>
+
+#define EXPECT_DD_F128_EQ(dd, f128) \
+  tmp = (dd);                       \
+  EXPECT_NEAR((__float128)tmp.high + tmp.low, (f128), 1e-30 * 1e30)
+
+TEST(double_d, all) {
+  using stan::math::internal::double_d;
+  for (int i = 0; i < 10000000; i++) {
+    double_d tmp;
+    double high = Eigen::MatrixXd::Random(0, 0).coeff(0, 0) * 1e30;
+    double low = Eigen::MatrixXd::Random(0, 0).coeff(0, 0) * 1e-20 * 1e30;
+    double_d dd = high;
+    dd.low = low;
+    __float128 f128 = high;
+    f128 += low;
+    EXPECT_DD_F128_EQ(dd, f128);
+
+    double high2 = Eigen::MatrixXd::Random(0, 0).coeff(0, 0);
+    double low2 = Eigen::MatrixXd::Random(0, 0).coeff(0, 0) * 1e-20;
+    double_d dd2 = high2;
+    dd2.low = low2;
+    __float128 f1282 = high2;
+    f1282 += low2;
+    EXPECT_DD_F128_EQ(dd2, f1282);
+
+    EXPECT_DD_F128_EQ(dd + dd2, f128 + f1282);
+    EXPECT_DD_F128_EQ(dd - dd2, f128 - f1282);
+    EXPECT_DD_F128_EQ(dd * dd2, f128 * f1282);
+    EXPECT_DD_F128_EQ(dd / dd2, f128 / f1282);
+
+    __float128 f1283 = high;
+    __float128 f1284 = high2;
+    EXPECT_DD_F128_EQ(stan::math::internal::mul_d_d(high, high2),
+                      f1283 * f1284);
+  }
+}
+#endif
+
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/prim.hpp>
+static const std::string double_d_test_kernel_code
+    = STRINGIFY(__kernel void double_d_test_kernel(__global double_d *C,
+                                                   const __global double_d *A,
+                                                   const __global double *B) {
+        const int i = get_global_id(0);
+        C[i] = mul_dd_d(A[i], B[i]);
+      });
+
+const stan::math::opencl_kernels::kernel_cl<
+    stan::math::opencl_kernels::out_buffer,
+    stan::math::opencl_kernels::in_buffer,
+    stan::math::opencl_kernels::in_buffer>
+    double_d_test_kernel("double_d_test_kernel",
+                         {stan::math::internal::double_d_src,
+                          double_d_test_kernel_code});
+
+TEST(double_d, opencl) {
+  using stan::math::internal::double_d;
+  using VectorXdd = Eigen::Matrix<double_d, -1, 1>;
+  int n = 10;
+  VectorXdd a(n);
+  Eigen::VectorXd b = Eigen::VectorXd::Random(n);
+  for (int i = 0; i < n; i++) {
+    a[i].high = Eigen::VectorXd::Random(1)[0];
+    a[i].low = Eigen::VectorXd::Random(1)[0] * 1e-17;
+  }
+  stan::math::matrix_cl<double_d> a_cl(a);
+  stan::math::matrix_cl<double> b_cl(b);
+  stan::math::matrix_cl<double_d> c_cl(n, 1);
+  double_d_test_kernel(cl::NDRange(n), c_cl, a_cl, b_cl);
+  VectorXdd c = stan::math::from_matrix_cl(c_cl);
+  for (int i = 0; i < n; i++) {
+    double_d correct = a[i] * b[i];
+    EXPECT_EQ(c[i].high, correct.high);
+    EXPECT_NEAR(c[i].low, correct.low, 1e-30);
+  }
+}
+
+#endif

--- a/test/unit/math/opencl/double_d_test.cpp
+++ b/test/unit/math/opencl/double_d_test.cpp
@@ -1,6 +1,4 @@
-
 #include <stan/math/opencl/double_d.hpp>
-//#include <test/unit/math/expect_near_rel.hpp>
 #include <gtest/gtest.h>
 #include <limits>
 #include <Eigen/Core>
@@ -21,20 +19,20 @@ TEST(double_d, add_dd_dd_test) {
   // simple
   double_d res = add_dd_dd(a, a);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high == 2.0);
-  EXPECT_TRUE(res.low == eps);
+  EXPECT_TRUE(res.high, 2.0);
+  EXPECT_TRUE(res.low, eps);
 
   // carry
   res = add_dd_dd(a, c);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high == 1.0 + eps);
-  EXPECT_TRUE(res.low == 0.0);
+  EXPECT_TRUE(res.high, 1.0 + eps);
+  EXPECT_TRUE(res.low, 0.0);
 
   // cancelation
   res = add_dd_dd(a, d);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high == eps * h_eps);
-  EXPECT_TRUE(res.low == 0.0);
+  EXPECT_TRUE(res.high, eps * h_eps);
+  EXPECT_TRUE(res.low, 0.0);
 }
 
 TEST(double_d, mul_dd_dd_test) {
@@ -50,20 +48,20 @@ TEST(double_d, mul_dd_dd_test) {
   // simple
   double_d res = mul_dd_dd(a, b);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high == h_eps);
-  EXPECT_TRUE(res.low == h_eps * h_eps * 0.001);
+  EXPECT_TRUE(res.high, h_eps);
+  EXPECT_TRUE(res.low, h_eps * h_eps * 0.001);
 
   // carry
   res = mul_dd_dd(c, c);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high == 1.0 + eps);
-  EXPECT_TRUE(res.low == 0.0);
+  EXPECT_TRUE(res.high, 1.0 + eps);
+  EXPECT_TRUE(res.low, 0.0);
 
   // cancelation
   res = mul_dd_dd(c, d);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high == 1.0);
-  EXPECT_TRUE(res.low == 0.0);
+  EXPECT_TRUE(res.high, 1.0);
+  EXPECT_TRUE(res.low, 0.0);
 }
 
 TEST(double_d, div_dd_dd_test) {
@@ -79,18 +77,18 @@ TEST(double_d, div_dd_dd_test) {
   // simple
   double_d res = div_dd_dd(a, a);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high == 1.0);
-  EXPECT_TRUE(res.low == 0.0);
+  EXPECT_TRUE(res.high, 1.0);
+  EXPECT_TRUE(res.low, 0.0);
 
   res = div_dd_dd(a, b);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high == 1.0);
-  EXPECT_TRUE(res.low == h_eps * eps);
+  EXPECT_TRUE(res.high, 1.0);
+  EXPECT_TRUE(res.low, h_eps * eps);
 
   // div by zero
   res = div_dd_dd(a, c);
-  EXPECT_TRUE(res.high == std::numeric_limits<double>::infinity());
-  EXPECT_TRUE(res.low == 0);
+  EXPECT_TRUE(res.high, std::numeric_limits<double>::infinity());
+  EXPECT_TRUE(res.low, 0);
 }
 
 // this is the best test we have, but it relies on the nonstandard gcc extension

--- a/test/unit/math/opencl/double_d_test.cpp
+++ b/test/unit/math/opencl/double_d_test.cpp
@@ -19,20 +19,20 @@ TEST(double_d, add_dd_dd_test) {
   // simple
   double_d res = add_dd_dd(a, a);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high, 2.0);
-  EXPECT_TRUE(res.low, eps);
+  EXPECT_EQ(res.high, 2.0);
+  EXPECT_EQ(res.low, eps);
 
   // carry
   res = add_dd_dd(a, c);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high, 1.0 + eps);
-  EXPECT_TRUE(res.low, 0.0);
+  EXPECT_EQ(res.high, 1.0 + eps);
+  EXPECT_EQ(res.low, 0.0);
 
   // cancelation
   res = add_dd_dd(a, d);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high, eps * h_eps);
-  EXPECT_TRUE(res.low, 0.0);
+  EXPECT_EQ(res.high, eps * h_eps);
+  EXPECT_EQ(res.low, 0.0);
 }
 
 TEST(double_d, mul_dd_dd_test) {
@@ -48,20 +48,20 @@ TEST(double_d, mul_dd_dd_test) {
   // simple
   double_d res = mul_dd_dd(a, b);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high, h_eps);
-  EXPECT_TRUE(res.low, h_eps * h_eps * 0.001);
+  EXPECT_EQ(res.high, h_eps);
+  EXPECT_EQ(res.low, h_eps * h_eps * 0.001);
 
   // carry
   res = mul_dd_dd(c, c);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high, 1.0 + eps);
-  EXPECT_TRUE(res.low, 0.0);
+  EXPECT_EQ(res.high, 1.0 + eps);
+  EXPECT_EQ(res.low, 0.0);
 
   // cancelation
   res = mul_dd_dd(c, d);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high, 1.0);
-  EXPECT_TRUE(res.low, 0.0);
+  EXPECT_EQ(res.high, 1.0);
+  EXPECT_EQ(res.low, 0.0);
 }
 
 TEST(double_d, div_dd_dd_test) {
@@ -77,18 +77,18 @@ TEST(double_d, div_dd_dd_test) {
   // simple
   double_d res = div_dd_dd(a, a);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high, 1.0);
-  EXPECT_TRUE(res.low, 0.0);
+  EXPECT_EQ(res.high, 1.0);
+  EXPECT_EQ(res.low, 0.0);
 
   res = div_dd_dd(a, b);
   EXPECT_NORMALIZED(res);
-  EXPECT_TRUE(res.high, 1.0);
-  EXPECT_TRUE(res.low, h_eps * eps);
+  EXPECT_EQ(res.high, 1.0);
+  EXPECT_EQ(res.low, h_eps * eps);
 
   // div by zero
   res = div_dd_dd(a, c);
-  EXPECT_TRUE(res.high, std::numeric_limits<double>::infinity());
-  EXPECT_TRUE(res.low, 0);
+  EXPECT_EQ(res.high, std::numeric_limits<double>::infinity());
+  EXPECT_EQ(res.low, 0);
 }
 
 // this is the best test we have, but it relies on the nonstandard gcc extension


### PR DESCRIPTION
## Summary

Adds implementation for double double - a 128 bit scalar, with similar accuracy to IEEE quadruple precision, but faster to calculate with. It is defined as a struct of 2 doubles, with its value being the exact sum of the two doubles. Those two doubles are high and low, with low having absolute value less than 1 ULP of high. This adds the following operations on double double: +, -, *, /, comparisons, abs, copysign, abs, isinf, isnan (these are needed in MRRR).

## Tests
Added tests for double double operations. Basic tests can be run anywhere, but the best test requires the GCC extension `quadmath` (IEEE quadruple precision numbers - the tests compares results between quad precision and double double). There is also a test that checks double doubles work in OpenCL kernels.

## Side Effects

The operations on double double are defined in a way that makes them available to both host C++ code and OpenCL kernels. For C++ this require some using statements in the namespace where these are defined - currently `stan::math::internal` (the only alternative I can think of would require duplicating all the implementations).

Since we will need double doubles in OpenCL kernels we need to remove the `require_arithmetic` on `matrix_cl` scalars.

## Checklist

- [ ] Math issue #2498

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
