### PR TITLE
Bugfix OpenCL QR decomposition test

### DIFF
--- a/test/unit/math/opencl/qr_decomposition_test.cpp
+++ b/test/unit/math/opencl/qr_decomposition_test.cpp
@@ -15,7 +15,7 @@ TEST(MathMatrixGPU, qr_decomposition_cl_small) {
 
   matrix_cl<double> m_cl(m);
 
-  matrix_cl<double> q_cl, r_cl(m);
+  matrix_cl<double> q_cl, r_cl;
 
   stan::math::qr_decomposition_cl(m_cl, q_cl, r_cl);
 
@@ -56,7 +56,7 @@ TEST(MathMatrixGPU, qr_decomposition_cl_big) {
 
     matrix_cl<double> m_cl(m);
 
-    matrix_cl<double> q_cl, r_cl(m);
+    matrix_cl<double> q_cl, r_cl;
 
     stan::math::qr_decomposition_cl(m_cl, q_cl, r_cl);
 


### PR DESCRIPTION
## Summary

Fixes a bug in OpenCL QR decomposition tests introduced in #2479. 

We managed to merge a buggy test due to an issue in Jenkins - it did not run OpenCL CPU tests on the PR. That still needs to be investigated.

## Tests
This whole PR.

## Side Effects

None.

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
