### PR TITLE
Cleanup unused local typedefs

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -100,7 +100,7 @@ else
 endif
 
 %.hpp-test : %.hpp test/dummy.cpp
-	$(COMPILE.cpp) $(CXXFLAGS) -O0 -include $^ -o $(DEV_NULL)
+	$(COMPILE.cpp) $(CXXFLAGS) -O0 -include $^ -o $(DEV_NULL) -Wunused-local-typedefs
 
 test/dummy.cpp:
 	@mkdir -p test

--- a/stan/math/fwd/fun/mdivide_left.hpp
+++ b/stan/math/fwd/fun/mdivide_left.hpp
@@ -60,7 +60,6 @@ template <typename T1, typename T2,
 inline Eigen::Matrix<value_type_t<T2>, T1::RowsAtCompileTime,
                      T2::ColsAtCompileTime>
 mdivide_left(const T1& A, const T2& b) {
-  using T = typename value_type_t<T2>::Scalar;
   constexpr int S1 = T1::RowsAtCompileTime;
   constexpr int C2 = T2::ColsAtCompileTime;
 

--- a/stan/math/fwd/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/fwd/fun/mdivide_left_tri_low.hpp
@@ -55,7 +55,6 @@ template <typename T1, typename T2, require_eigen_t<T1>* = nullptr,
 inline Eigen::Matrix<value_type_t<T2>, T1::RowsAtCompileTime,
                      T2::ColsAtCompileTime>
 mdivide_left_tri_low(const T1& A, const T2& b) {
-  using T = typename value_type_t<T2>::Scalar;
   constexpr int S1 = T1::RowsAtCompileTime;
   constexpr int C2 = T2::ColsAtCompileTime;
 

--- a/stan/math/prim/fun/generalized_inverse.hpp
+++ b/stan/math/prim/fun/generalized_inverse.hpp
@@ -31,8 +31,6 @@ template <typename EigMat, require_eigen_t<EigMat>* = nullptr,
 inline Eigen::Matrix<value_type_t<EigMat>, EigMat::ColsAtCompileTime,
                      EigMat::RowsAtCompileTime>
 generalized_inverse(const EigMat& G) {
-  using value_t = value_type_t<EigMat>;
-
   if (G.size() == 0)
     return {};
 

--- a/stan/math/prim/fun/tail.hpp
+++ b/stan/math/prim/fun/tail.hpp
@@ -39,7 +39,6 @@ inline auto tail(const T& v, size_t n) {
  */
 template <typename T>
 std::vector<T> tail(const std::vector<T>& sv, size_t n) {
-  using idx_t = index_type_t<std::vector<T>>;
   if (n != 0) {
     check_std_vector_index("tail", "n", sv, n);
   }

--- a/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
@@ -56,10 +56,6 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   using std::exp;
   constexpr int T_x_rows = T_x::RowsAtCompileTime;
   using T_partials_return = partials_return_t<T_y, T_x, T_alpha, T_beta>;
-  using T_y_val =
-      typename std::conditional_t<is_vector<T_y>::value,
-                                  Eigen::Matrix<partials_return_t<T_y>, -1, 1>,
-                                  partials_return_t<T_y>>;
   using T_ytheta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_partials_return,
                                   Array<T_partials_return, Dynamic, 1>>;

--- a/stan/math/prim/prob/beta_lpdf.hpp
+++ b/stan/math/prim/prob/beta_lpdf.hpp
@@ -47,7 +47,6 @@ template <bool propto, typename T_y, typename T_scale_succ,
 return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
     const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
-  using T_partials_matrix = Eigen::Matrix<T_partials_return, Eigen::Dynamic, 1>;
   using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
   using T_alpha_ref
       = ref_type_if_t<!is_constant<T_scale_succ>::value, T_scale_succ>;

--- a/stan/math/prim/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lpdf.hpp
@@ -52,8 +52,6 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
                                                        const T_loc& mu,
                                                        const T_prec& kappa) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_prec>;
-  using T_partials_return_kappa = return_type_t<T_prec>;
-  using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using std::log;
   using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
   using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;

--- a/stan/math/prim/prob/cauchy_lpdf.hpp
+++ b/stan/math/prim/prob/cauchy_lpdf.hpp
@@ -43,7 +43,6 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> cauchy_lpdf(const T_y& y, const T_loc& mu,
                                                const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using std::log;
   using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
   using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;

--- a/stan/math/prim/prob/dirichlet_lpdf.hpp
+++ b/stan/math/prim/prob/dirichlet_lpdf.hpp
@@ -59,7 +59,6 @@ template <bool propto, typename T_prob, typename T_prior_size,
 return_type_t<T_prob, T_prior_size> dirichlet_lpdf(const T_prob& theta,
                                                    const T_prior_size& alpha) {
   using T_partials_return = partials_return_t<T_prob, T_prior_size>;
-  using T_partials_vec = typename Eigen::Matrix<T_partials_return, -1, 1>;
   using T_partials_array = typename Eigen::Array<T_partials_return, -1, -1>;
   using T_theta_ref = ref_type_t<T_prob>;
   using T_alpha_ref = ref_type_t<T_prior_size>;

--- a/stan/math/prim/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lpdf.hpp
@@ -42,7 +42,6 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
   using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
   using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;

--- a/stan/math/prim/prob/frechet_cdf.hpp
+++ b/stan/math/prim/prob/frechet_cdf.hpp
@@ -29,7 +29,6 @@ return_type_t<T_y, T_shape, T_scale> frechet_cdf(const T_y& y,
                                                  const T_shape& alpha,
                                                  const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-  using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using T_y_ref = ref_type_t<T_y>;
   using T_alpha_ref = ref_type_t<T_shape>;
   using T_sigma_ref = ref_type_t<T_scale>;

--- a/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
@@ -53,9 +53,6 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
   using T_partials_return = partials_return_t<T_y, T_loc, T_covar>;
   using matrix_partials_t
       = Eigen::Matrix<T_partials_return, Eigen::Dynamic, Eigen::Dynamic>;
-  using vector_partials_t = Eigen::Matrix<T_partials_return, Eigen::Dynamic, 1>;
-  using row_vector_partials_t
-      = Eigen::Matrix<T_partials_return, 1, Eigen::Dynamic>;
   using T_y_ref = ref_type_t<T_y>;
   using T_mu_ref = ref_type_t<T_loc>;
   using T_L_ref = ref_type_t<T_covar>;

--- a/stan/math/prim/prob/ordered_logistic_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_lpmf.hpp
@@ -76,7 +76,6 @@ return_type_t<T_loc, T_cut> ordered_logistic_lpmf(const T_y& y,
                                                   const T_loc& lambda,
                                                   const T_cut& c) {
   using T_partials_return = partials_return_t<T_loc, T_cut>;
-  using T_partials_array = Eigen::Array<T_partials_return, -1, 1>;
   using T_cuts_val = partials_return_t<T_cut>;
   using T_y_ref = ref_type_t<T_y>;
   using T_lambda_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;

--- a/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
@@ -59,10 +59,6 @@ return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(const T_y& y,
   using std::exp;
   constexpr int T_x_rows = T_x::RowsAtCompileTime;
   using T_partials_return = partials_return_t<T_y, T_x, T_alpha, T_beta>;
-  using T_alpha_val = typename std::conditional_t<
-      is_vector<T_alpha>::value,
-      Eigen::Array<partials_return_t<T_alpha>, -1, 1>,
-      partials_return_t<T_alpha>>;
   using T_theta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_partials_return,
                                   Array<T_partials_return, Dynamic, 1>>;

--- a/stan/math/prim/prob/skew_double_exponential_lpdf.hpp
+++ b/stan/math/prim/prob/skew_double_exponential_lpdf.hpp
@@ -44,7 +44,6 @@ return_type_t<T_y, T_loc, T_scale, T_skewness> skew_double_exponential_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_skewness& tau) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_skewness>;
-  using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
   using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
   using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;

--- a/stan/math/rev/fun/cholesky_decompose.hpp
+++ b/stan/math/rev/fun/cholesky_decompose.hpp
@@ -80,7 +80,6 @@ inline auto unblocked_cholesky_lambda(T1& L_A, T2& L, T3& A) {
 template <typename T1, typename T2, typename T3>
 inline auto cholesky_lambda(T1& L_A, T2& L, T3& A) {
   return [L_A, L, A]() mutable {
-    using Block_ = Eigen::Block<Eigen::MatrixXd>;
     using Eigen::Lower;
     using Eigen::StrictlyUpper;
     using Eigen::Upper;

--- a/stan/math/rev/fun/cholesky_factor_constrain.hpp
+++ b/stan/math/rev/fun/cholesky_factor_constrain.hpp
@@ -29,7 +29,6 @@ namespace math {
 template <typename T, require_var_vector_t<T>* = nullptr>
 var_value<Eigen::MatrixXd> cholesky_factor_constrain(const T& x, int M, int N) {
   using std::exp;
-  using T_scalar = value_type_t<T>;
   check_greater_or_equal("cholesky_factor_constrain",
                          "num rows (must be greater or equal to num cols)", M,
                          N);

--- a/stan/math/rev/fun/generalized_inverse.hpp
+++ b/stan/math/rev/fun/generalized_inverse.hpp
@@ -61,7 +61,6 @@ inline auto generalized_inverse_lambda(T1& G_arena, T2& inv_G) {
  */
 template <typename VarMat, require_rev_matrix_t<VarMat>* = nullptr>
 inline auto generalized_inverse(const VarMat& G) {
-  using value_t = value_type_t<VarMat>;
   using ret_type = promote_var_matrix_t<VarMat, VarMat>;
 
   if (G.size() == 0)

--- a/stan/math/rev/fun/lub_constrain.hpp
+++ b/stan/math/rev/fun/lub_constrain.hpp
@@ -482,7 +482,6 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
   auto lb_val = value_of(arena_lb).array();
   auto ub_val = value_of(arena_ub).array();
   check_less("lub_constrain", "lb", lb_val, ub_val);
-  using plain_x_array = plain_type_t<decltype(arena_x_val.array())>;
   auto inv_logit_x = to_arena(inv_logit(arena_x_val.array()));
   auto is_lb_inf = to_arena((lb_val == NEGATIVE_INFTY));
   auto is_ub_inf = to_arena((ub_val == INFTY));
@@ -562,7 +561,6 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
   auto lb_val = value_of(arena_lb).array();
   auto ub_val = value_of(arena_ub).array();
   check_less("lub_constrain", "lb", lb_val, ub_val);
-  using plain_x_array = plain_type_t<decltype(arena_x_val.array())>;
   auto inv_logit_x = to_arena(inv_logit(arena_x_val.array()));
   auto is_lb_inf = to_arena((lb_val == NEGATIVE_INFTY));
   auto is_ub_inf = to_arena((ub_val == INFTY));


### PR DESCRIPTION
## Summary
This PR removes any type definitions that aren't used, as they cause compiler warnings. It also adds the flag `-Wunused-local-typedefs` to the header tests, to avoid it occurring with new code.

## Tests

Adds `-Wunused-local-typedefs` to header tests

## Side Effects

Cleaner codebase 

## Release notes

Cleanup unused local typedefs

## Checklist

- [x] Math issue #2504 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
