### PR TITLE
Force threads=1 when STAN_THREADS is not defined

### DIFF
--- a/stan/math/prim/core/init_threadpool_tbb.hpp
+++ b/stan/math/prim/core/init_threadpool_tbb.hpp
@@ -45,6 +45,7 @@ namespace internal {
  */
 inline int get_num_threads() {
   int num_threads = 1;
+#ifdef STAN_THREADS
   const char* env_stan_num_threads = std::getenv("STAN_NUM_THREADS");
   if (env_stan_num_threads != nullptr) {
     try {
@@ -67,6 +68,7 @@ inline int get_num_threads() {
                        "' but it must be a positive number or -1");
     }
   }
+#endif
   return num_threads;
 }
 
@@ -96,7 +98,8 @@ inline int get_num_threads() {
  * and the value of STAN_NUM_THREADS environment variable is invalid.
  */
 inline tbb::task_arena& init_threadpool_tbb(int n_threads = 0) {
-  int tbb_max_threads;
+  int tbb_max_threads = 1;
+#ifdef STAN_THREADS
   if (n_threads == 0) {
     tbb_max_threads = internal::get_num_threads();
   } else if (n_threads > 0) {
@@ -108,6 +111,7 @@ inline tbb::task_arena& init_threadpool_tbb(int n_threads = 0) {
                      "The number of threads is '",
                      "' but it must be positive or -1");
   }
+#endif
   static tbb::global_control tbb_gc(
       tbb::global_control::max_allowed_parallelism, tbb_max_threads);
   static tbb::task_arena tbb_arena(tbb_max_threads, 1);
@@ -139,7 +143,8 @@ inline tbb::task_arena& init_threadpool_tbb(int n_threads = 0) {
  * and the value of STAN_NUM_THREADS environment variable is invalid.
  */
 inline tbb::task_scheduler_init& init_threadpool_tbb(int n_threads = 0) {
-  int tbb_max_threads;
+  int tbb_max_threads = 1;
+#ifdef STAN_THREADS
   if (n_threads == 0) {
     tbb_max_threads = internal::get_num_threads();
   } else if (n_threads > 0) {
@@ -151,6 +156,7 @@ inline tbb::task_scheduler_init& init_threadpool_tbb(int n_threads = 0) {
                      "The number of threads is '",
                      "' but it must be positive or -1");
   }
+#endif
   static tbb::task_scheduler_init tbb_scheduler(tbb_max_threads, 0);
   return tbb_scheduler;
 }

--- a/test/unit/math/prim/core/get_num_threads_test.cpp
+++ b/test/unit/math/prim/core/get_num_threads_test.cpp
@@ -3,6 +3,7 @@
 #include <test/unit/math/prim/functor/utils_threads.hpp>
 #include <gtest/gtest.h>
 
+#ifdef STAN_THREADS
 TEST(get_num_threads, correct_values) {
   set_n_threads("10");
   EXPECT_EQ(stan::math::internal::get_num_threads(), 10);
@@ -32,3 +33,15 @@ TEST(get_num_threads, incorrect_values) {
   EXPECT_THROW_MSG(stan::math::internal::get_num_threads(),
                    std::invalid_argument, "must be positive or -1");
 }
+#else
+TEST(get_num_threads, correct_values) {
+  set_n_threads("10");
+  EXPECT_EQ(stan::math::internal::get_num_threads(), 1);
+
+  set_n_threads("4");
+  EXPECT_EQ(stan::math::internal::get_num_threads(), 1);
+
+  set_n_threads("-1");
+  EXPECT_EQ(stan::math::internal::get_num_threads(), 1);
+}
+#endif

--- a/test/unit/math/prim/core/get_num_threads_test.cpp
+++ b/test/unit/math/prim/core/get_num_threads_test.cpp
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 
 #ifdef STAN_THREADS
-TEST(get_num_threads, correct_values) {
+TEST(get_num_threads, correct_values_stan_threads) {
   set_n_threads("10");
   EXPECT_EQ(stan::math::internal::get_num_threads(), 10);
 
@@ -34,7 +34,7 @@ TEST(get_num_threads, incorrect_values) {
                    std::invalid_argument, "must be positive or -1");
 }
 #else
-TEST(get_num_threads, correct_values) {
+TEST(get_num_threads, correct_values_no_stan_threads) {
   set_n_threads("10");
   EXPECT_EQ(stan::math::internal::get_num_threads(), 1);
 

--- a/test/unit/math/prim/core/init_threadpool_tbb_late_test.cpp
+++ b/test/unit/math/prim/core/init_threadpool_tbb_late_test.cpp
@@ -1,13 +1,13 @@
 #include <stan/math/prim/core.hpp>
 
-#include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 #include <test/unit/math/prim/functor/utils_threads.hpp>
+#include <tbb/task_arena.h>
+#include <gtest/gtest.h>
 
 #ifdef TBB_INTERFACE_NEW
 
 #include <tbb/global_control.h>
-#include <tbb/task_arena.h>
 
 TEST(intel_tbb_new_late_init, check_status) {
   const int num_threads = tbb::global_control::max_allowed_parallelism;
@@ -32,7 +32,6 @@ TEST(intel_tbb_new_late_init, check_status) {
 #else
 
 #include <tbb/task_scheduler_init.h>
-#include <tbb/task_arena.h>
 
 TEST(intel_tbb_late_init, check_status) {
   const int num_threads = tbb::task_scheduler_init::default_num_threads();

--- a/test/unit/math/prim/core/init_threadpool_tbb_late_test.cpp
+++ b/test/unit/math/prim/core/init_threadpool_tbb_late_test.cpp
@@ -20,7 +20,11 @@ TEST(intel_tbb_new_late_init, check_status) {
 
       // STAN_NUM_THREADS is not being honored if we have first
       // initialized the TBB scheduler outside of init_threadpool_tbb
+#ifdef STAN_THREADS
       EXPECT_EQ(num_threads, tbb::this_task_arena::max_concurrency());
+#else
+      EXPECT_EQ(num_threads, 1);
+#endif
     });
   }
 }
@@ -41,7 +45,11 @@ TEST(intel_tbb_late_init, check_status) {
 
     // STAN_NUM_THREADS is not being honored if we have first
     // initialized the TBB scheduler outside of init_threadpool_tbb
+#ifdef STAN_THREADS
     EXPECT_EQ(num_threads, tbb::this_task_arena::max_concurrency());
+#else
+    EXPECT_EQ(num_threads, 1);
+#endif
   }
 }
 

--- a/test/unit/math/prim/core/init_threadpool_tbb_test.cpp
+++ b/test/unit/math/prim/core/init_threadpool_tbb_test.cpp
@@ -9,7 +9,11 @@ TEST(intel_tbb_new_init, check_status) {
   auto& tbb_init = stan::math::init_threadpool_tbb();
   EXPECT_TRUE(tbb_init.is_active());
 
+#ifdef STAN_THREADS
   EXPECT_EQ(std::thread::hardware_concurrency(), tbb_init.max_concurrency());
+#else
+  EXPECT_EQ(1, tbb_init.max_concurrency());
+#endif
 
   auto& tbb_reinit = stan::math::init_threadpool_tbb();
   EXPECT_TRUE(tbb_init.is_active());

--- a/test/unit/math/prim/core/set_num_threads_test.cpp
+++ b/test/unit/math/prim/core/set_num_threads_test.cpp
@@ -6,5 +6,9 @@ TEST(intel_tbb_new_init, set_threads) {
   auto& tbb_init = stan::math::init_threadpool_tbb(num_threads - 1);
   EXPECT_TRUE(tbb_init.is_active());
 
-  EXPECT_EQ(num_threads - 1, tbb_init.max_concurrency());
+  #ifdef STAN_THREADS
+    EXPECT_EQ(num_threads - 1, tbb_init.max_concurrency());
+  #else
+    EXPECT_EQ(1, tbb_init.max_concurrency());
+  #endif
 }


### PR DESCRIPTION

## Summary

This is a fix for the parallel nuts sampler https://github.com/stan-dev/stan/pull/3033#discussion_r651425049. When `STAN_THREADS` is not defined then the number of threads for the tbb should be 1. This just adds a ifdef STAN_THREADS on in the tbb initialization stuff so that if STAN_THREADS is not defined then the number of threads is set to 1.

## Tests

@wds15 should there be new tests for this?

## Side Effects

When STAN_THREADS is not defined TBB is only given 1 thread

## Release notes

Fix tbb initialization so that if STAN_THREADS is not defined then the number of threads is set to 1.

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
