### PR TITLE
adds to_vector() support for var<Matrix>

### DIFF
--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -170,6 +170,7 @@
 #include <stan/math/rev/fun/to_var.hpp>
 #include <stan/math/rev/fun/to_arena.hpp>
 #include <stan/math/rev/fun/to_var_value.hpp>
+#include <stan/math/rev/fun/to_vector.hpp>
 #include <stan/math/rev/fun/trace.hpp>
 #include <stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp>
 #include <stan/math/rev/fun/trace_gen_quad_form.hpp>

--- a/stan/math/rev/fun/to_vector.hpp
+++ b/stan/math/rev/fun/to_vector.hpp
@@ -19,8 +19,9 @@ namespace math {
 template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
 inline auto to_vector(const var_value<EigMat>& x) {
   using view_type = Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1>>;
-  return vari_view<view_type>(view_type(x.vi_->val_.data(), x.rows() * x.cols()),
-   view_type(x.vi_->adj_.data(), x.rows() * x.cols()));
+  return vari_view<view_type>(
+      view_type(x.vi_->val_.data(), x.rows() * x.cols()),
+      view_type(x.vi_->adj_.data(), x.rows() * x.cols()));
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/to_vector.hpp
+++ b/stan/math/rev/fun/to_vector.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Cast a `var_value<Matrix>` to a `var_value<ColumnVector>`.
+ * Reshape a `var_value<Matrix>` to a `var_value<ColumnVector>`.
  * @tparam EigMat Inner type of the `var_value` that must inherit from
  *  `Eigen::EigenBase`.
  * @param x A var whose inner matrix type is to be cast to an Column matrix.

--- a/stan/math/rev/fun/to_vector.hpp
+++ b/stan/math/rev/fun/to_vector.hpp
@@ -12,7 +12,7 @@ namespace math {
  * Reshape a `var_value<Matrix>` to a `var_value<ColumnVector>`.
  * @tparam EigMat Inner type of the `var_value` that must inherit from
  *  `Eigen::EigenBase`.
- * @param x A var whose inner matrix type is to be cast to an Column matrix.
+ * @param x A var whose inner matrix type is to be reshaped to an Column matrix.
  * @return A view of the original `x` with inner value and adjoint matrices
  *  mapped to a column vector.
  */

--- a/stan/math/rev/fun/to_vector.hpp
+++ b/stan/math/rev/fun/to_vector.hpp
@@ -1,0 +1,28 @@
+#ifndef STAN_MATH_REV_FUN_TO_VECTOR_HPP
+#define STAN_MATH_REV_FUN_TO_VECTOR_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/rev/core.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Cast a `var_value<Matrix>` to a `var_value<ColumnVector>`.
+ * @tparam EigMat Inner type of the `var_value` that must inherit from
+ *  `Eigen::EigenBase`.
+ * @param x A var whose inner matrix type is to be cast to an Column matrix.
+ * @return A view of the original `x` with inner value and adjoint matrices
+ *  mapped to a column vector.
+ */
+template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
+inline auto to_vector(const var_value<EigMat>& x) {
+  using view_type = Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1>>;
+  return vari_view<view_type>(view_type(x.vi_->val_.data(), x.rows() * x.cols()),
+   view_type(x.vi_->adj_.data(), x.rows() * x.cols()));
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/test/unit/math/rev/fun/to_vector_test.cpp
+++ b/test/unit/math/rev/fun/to_vector_test.cpp
@@ -9,7 +9,9 @@ TEST(MathFunRev, to_vector_var_value) {
   stan::math::var_value<Eigen::MatrixXd> a(a_val);
   auto&& tmp = stan::math::to_vector(a);
   EXPECT_TRUE((stan::is_col_vector<decltype(tmp.val())>::value));
-  EXPECT_MATRIX_EQ(tmp.val(), Eigen::Map<Eigen::VectorXd>(a_val.data(), a.rows() * a.cols()));
+  EXPECT_MATRIX_EQ(tmp.val(), Eigen::Map<Eigen::VectorXd>(a_val.data(),
+                                                          a.rows() * a.cols()));
   tmp.adj().array() += 1.0;
-  EXPECT_MATRIX_EQ(tmp.adj(), Eigen::Map<Eigen::VectorXd>(a.vi_->adj_.data(), a.rows() * a.cols()));
+  EXPECT_MATRIX_EQ(tmp.adj(), Eigen::Map<Eigen::VectorXd>(a.vi_->adj_.data(),
+                                                          a.rows() * a.cols()));
 }

--- a/test/unit/math/rev/fun/to_vector_test.cpp
+++ b/test/unit/math/rev/fun/to_vector_test.cpp
@@ -7,7 +7,9 @@ TEST(MathFunRev, to_vector_var_value) {
   constexpr Eigen::Index n = 100;
   Eigen::MatrixXd a_val = Eigen::MatrixXd::Random(n, n);
   stan::math::var_value<Eigen::MatrixXd> a(a_val);
-  const auto& tmp = stan::math::to_vector(a);
+  auto&& tmp = stan::math::to_vector(a);
   EXPECT_TRUE((stan::is_col_vector<decltype(tmp.val())>::value));
   EXPECT_MATRIX_EQ(tmp.val(), Eigen::Map<Eigen::VectorXd>(a_val.data(), a.rows() * a.cols()));
+  tmp.adj().array() += 1.0;
+  EXPECT_MATRIX_EQ(tmp.adj(), Eigen::Map<Eigen::VectorXd>(a.vi_->adj_.data(), a.rows() * a.cols()));
 }

--- a/test/unit/math/rev/fun/to_vector_test.cpp
+++ b/test/unit/math/rev/fun/to_vector_test.cpp
@@ -1,0 +1,13 @@
+#include <stan/math/rev.hpp>
+#include <test/unit/util.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(MathFunRev, to_vector_var_value) {
+  constexpr Eigen::Index n = 100;
+  Eigen::MatrixXd a_val = Eigen::MatrixXd::Random(n, n);
+  stan::math::var_value<Eigen::MatrixXd> a(a_val);
+  const auto& tmp = stan::math::to_vector(a);
+  EXPECT_TRUE((stan::is_col_vector<decltype(tmp.val())>::value));
+  EXPECT_MATRIX_EQ(tmp.val(), Eigen::Map<Eigen::VectorXd>(a_val.data(), a.rows() * a.cols()));
+}


### PR DESCRIPTION

## Summary

Adds a `to_vector()` method for `var_value<Eigen::Matrix>`.

## Tests

I just added a test in `rev` that checks the values are the same and updating the adjoints in the tmp made by `to_vector()` changes the adjoint in the original `var_value<Matrix>`

```
./runTests.py -j4 ./test/unit/math/rev/fun/to_vector_test.cpp
```

## Side Effects

Nope!

## Release notes

Adds a `to_vector()` method for `var_value<Eigen::Matrix>`.

## Checklist

- [x] Math issue #1805 

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
