### PR TITLE
Fix OpenCL Jenkins CPU tests and minor issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -245,6 +245,11 @@ pipeline {
                                 sh "echo STAN_OPENCL=true>> make/local"
                                 sh "echo OPENCL_PLATFORM_ID=${env.OPENCL_PLATFORM_ID_CPU}>> make/local"
                                 sh "echo OPENCL_DEVICE_ID=${env.OPENCL_DEVICE_ID_CPU}>> make/local"
+                                // skips tests that require specific support in OpenCL
+                                sh 'echo "ifdef NO_CPU_OPENCL_INT64_BASE_ATOMIC" >> make/local'
+                                sh 'echo "CXXFLAGS += -DSTAN_TEST_SKIP_REQUIRING_OPENCL_INT64_BASE_ATOMIC" >> make/local'
+                                sh "echo endif"
+
                                 runTests("test/unit/math/opencl", false)
                                 runTests("test/unit/multiple_translation_units_test.cpp")
                             } else {

--- a/lib/tbb_2020.3/build/macos.inc
+++ b/lib/tbb_2020.3/build/macos.inc
@@ -36,10 +36,14 @@ ifndef arch
      export arch:=ppc32
    endif
  else
-   ifeq ($(shell /usr/sbin/sysctl -n hw.optional.x86_64 2>/dev/null),1)
-     export arch:=intel64
+   ifeq ($(shell /usr/sbin/sysctl -n hw.machine),arm64)
+    export arch:=arm64
    else
-     export arch:=ia32
+    ifeq ($(shell /usr/sbin/sysctl -n hw.optional.x86_64 2>/dev/null),1)
+      export arch:=intel64
+    else
+      export arch:=ia32
+    endif
    endif
  endif
 endif

--- a/test/unit/math/opencl/indexing_rev_test.cpp
+++ b/test/unit/math/opencl/indexing_rev_test.cpp
@@ -1,4 +1,5 @@
 #ifdef STAN_OPENCL
+#ifndef STAN_TEST_SKIP_REQUIRING_OPENCL_INT64_BASE_ATOMIC
 #include <stan/math/opencl/indexing_rev.hpp>
 #include <stan/math/opencl/copy.hpp>
 #include <test/unit/util.hpp>
@@ -6,7 +7,6 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 
-#ifndef STAN_TEST_SKIP_REQUIRING_OPENCL_INT64_BASE_ATOMIC
 TEST(indexing_rev, indexing_rev_small) {
   Eigen::MatrixXd res(3, 3);
   res << 1, 2, 3, 4, 5, 6, 7, 8, 9;

--- a/test/unit/math/opencl/indexing_rev_test.cpp
+++ b/test/unit/math/opencl/indexing_rev_test.cpp
@@ -47,5 +47,5 @@ TEST(indexing_rev, indexing_rev_large) {
     EXPECT_NEAR_REL(stan::math::from_matrix_cl(adj_cl), correct);
   }
 }
-#endif // STAN_TEST_SKIP_REQUIRING_OPENCL_INT64_BASE_ATOMIC
+#endif  // STAN_TEST_SKIP_REQUIRING_OPENCL_INT64_BASE_ATOMIC
 #endif

--- a/test/unit/math/opencl/indexing_rev_test.cpp
+++ b/test/unit/math/opencl/indexing_rev_test.cpp
@@ -5,7 +5,8 @@
 #include <test/unit/math/expect_near_rel.hpp>
 #include <gtest/gtest.h>
 #include <algorithm>
-
+ 
+#ifndef STAN_TEST_SKIP_REQUIRING_OPENCL_INT64_BASE_ATOMIC
 TEST(indexing_rev, indexing_rev_small) {
   Eigen::MatrixXd res(3, 3);
   res << 1, 2, 3, 4, 5, 6, 7, 8, 9;
@@ -46,5 +47,5 @@ TEST(indexing_rev, indexing_rev_large) {
     EXPECT_NEAR_REL(stan::math::from_matrix_cl(adj_cl), correct);
   }
 }
-
+#endif // STAN_TEST_SKIP_REQUIRING_OPENCL_INT64_BASE_ATOMIC
 #endif

--- a/test/unit/math/opencl/indexing_rev_test.cpp
+++ b/test/unit/math/opencl/indexing_rev_test.cpp
@@ -5,7 +5,7 @@
 #include <test/unit/math/expect_near_rel.hpp>
 #include <gtest/gtest.h>
 #include <algorithm>
- 
+
 #ifndef STAN_TEST_SKIP_REQUIRING_OPENCL_INT64_BASE_ATOMIC
 TEST(indexing_rev, indexing_rev_small) {
   Eigen::MatrixXd res(3, 3);

--- a/test/unit/math/rev/core/profiling_test.cpp
+++ b/test/unit/math/rev/core/profiling_test.cpp
@@ -8,13 +8,15 @@ TEST(Profiling, double_basic) {
   double a = 3.0, b = 2.0, c;
   {
     profile<double> p1("p1", profiles);
-    c = a + b;
+    c = log(exp(a)) * log(exp(b));
   }
   {
     profile<int> p1("p1", profiles);
-    c = a + b;
+    c = log(exp(a)) * log(exp(b));
   }
+
   stan::math::profile_key key = {"p1", std::this_thread::get_id()};
+  EXPECT_NEAR(c, 6.0, 1E-8);
   EXPECT_EQ(profiles[key].get_chain_stack_used(), 0);
   EXPECT_EQ(profiles[key].get_nochain_stack_used(), 0);
   EXPECT_FLOAT_EQ(profiles[key].get_rev_time(), 0.0);


### PR DESCRIPTION
## Summary

A few minor fixes: 
 - fixes the current issue with OpenCL tests on develop by not running some tests on the GG Linux machine. I would prefer not running them entirely on that machine, but given the lack of test machine with OpenCL CPU support, this is not a realistic option right now. The same tests are run on OpenCL GPU tests so skipping them here is a bit less problematic.
- fixes issue where some blocks had too short fwd passes (at least on Windows machines this caused occasional failures)
- reapplies https://github.com/stan-dev/math/pull/2208 that was lost after https://github.com/stan-dev/math/pull/2447
