### PR TITLE
fix benchmarking script not working with special arguments

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -419,14 +419,15 @@ def benchmark(
                 value = 0.4
                 if function_name in special_arg_values:
                     if isinstance(special_arg_values[function_name][n], str):
-                        make_arg_function = special_arg_values[function_name][n]
+                        make_arg_function = make_special_arg_values[special_arg_values[function_name][n]]
                     elif isinstance(
                             special_arg_values[function_name][n], numbers.Number
                     ):
                         value = special_arg_values[function_name][n]
                 if not is_argument_autodiff or (
-                      not is_argument_scalar and (opencl == "base" or varmat == "base")
-				):
+                      not is_argument_scalar and (
+                          opencl == "base" or varmat == "base" or make_arg_function != "make_arg"
+                )):
                     arg_type_prim = cpp_arg_template.replace("SCALAR", "double");
                     setup += (
                         "  {} {} = stan::test::{}<{}>({}, state.range(0));\n".format(
@@ -454,6 +455,11 @@ def benchmark(
                                 arg_type_prim, var_name + "_varmat", var_name
                             )
                             var_name += "_varmat"
+                        elif is_argument_autodiff: #rev
+                            var_conversions += "    {} {} = {};\n".format(
+                                arg_type, var_name + "_var", var_name
+                            )
+                            var_name += "_var"
                 else:
                     var_conversions += (
                         "    {} {} = stan::test::{}<{}>({}, state.range(0));\n".format(

--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -56,6 +56,11 @@ simplex = "simplex"
 pos_definite = "positive_definite_matrix"
 scalar_return_type = "scalar_return_type"
 
+make_special_arg_values = {
+    simplex : "make_simplex",
+    pos_definite : "make_pos_definite_matrix"
+}
+
 # list of function arguments that need special scalar values.
 # None means to use the default argument value.
 special_arg_values = {


### PR DESCRIPTION
## Summary

Bugfix benchmarking script not working with special arguments (simplex, SPD matrices) since the expression test refactor. Also fixes a bug that included some additional operations when running rev benchamrks on special arguments.

## Tests
None.

## Side Effects
None.

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
