### PR TITLE
Let check functions take in var<Matrix>

### DIFF
--- a/stan/math/fwd/fun.hpp
+++ b/stan/math/fwd/fun.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/fwd/fun/Eigen_NumTraits.hpp>
 
 #include <stan/math/fwd/fun/abs.hpp>
+#include <stan/math/fwd/fun/accumulator.hpp>
 #include <stan/math/fwd/fun/acos.hpp>
 #include <stan/math/fwd/fun/acosh.hpp>
 #include <stan/math/fwd/fun/asin.hpp>

--- a/stan/math/fwd/fun/accumulator.hpp
+++ b/stan/math/fwd/fun/accumulator.hpp
@@ -1,9 +1,10 @@
-#ifndef STAN_MATH_PRIM_FUN_ACCUMULATOR_HPP
-#define STAN_MATH_PRIM_FUN_ACCUMULATOR_HPP
+#ifndef STAN_MATH_FWD_FUN_ACCUMULATOR_HPP
+#define STAN_MATH_FWD_FUN_ACCUMULATOR_HPP
 
-#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/fun/sum.hpp>
+#include <stan/math/prim/fun/accumulator.hpp>
+#include <stan/math/fwd/meta.hpp>
+#include <stan/math/fwd/fun/sum.hpp>
 #include <vector>
 #include <type_traits>
 
@@ -21,15 +22,11 @@ namespace math {
  * @tparam T Type of scalar added
  */
 template <typename T>
-class accumulator {
+class accumulator<fvar<T>> {
  private:
-  T buf_{0.0};
+  fvar<T> buf_{0.0};
 
  public:
-  /**
-   * Construct an accumulator.
-   */
-  accumulator() : buf_(0.0) {}
 
   /**
    * Add the specified arithmetic type value to the buffer after
@@ -41,8 +38,8 @@ class accumulator {
    * @tparam S Type of argument
    * @param x Value to add
    */
-  template <typename S, typename = require_arithmetic_t<S>>
-  void add(S x) {
+  template <typename S, typename = require_stan_scalar_t<S>>
+  inline void add(S x) {
     buf_ += x;
   }
 
@@ -54,7 +51,7 @@ class accumulator {
    * @param m Matrix of values to add
    */
   template <typename S, require_matrix_t<S>* = nullptr>
-  void add(const S& m) {
+  inline void add(const S& m) {
     buf_ += stan::math::sum(m);
   }
 
@@ -68,14 +65,14 @@ class accumulator {
    * @param xs Vector of entries to add
    */
   template <typename S, require_container_t<S>* = nullptr>
-  void add(const std::vector<S>& xs) {
+  inline void add(const std::vector<S>& xs) {
     for (size_t i = 0; i < xs.size(); ++i) {
       this->add(xs[i]);
     }
   }
 
   template <typename S, require_not_container_t<S>* = nullptr>
-  void add(const std::vector<S>& xs) {
+  inline void add(const std::vector<S>& xs) {
     buf_ += stan::math::sum(xs);
   }
 
@@ -84,7 +81,7 @@ class accumulator {
    *
    * @return Sum of accumulated values.
    */
-  T sum() const {
+  inline fvar<T> sum() const noexcept {
     return buf_;
   }
 };

--- a/stan/math/fwd/fun/accumulator.hpp
+++ b/stan/math/fwd/fun/accumulator.hpp
@@ -27,7 +27,6 @@ class accumulator<fvar<T>> {
   fvar<T> buf_{0.0};
 
  public:
-
   /**
    * Add the specified arithmetic type value to the buffer after
    * static casting it to the class type <code>T</code>.
@@ -81,9 +80,7 @@ class accumulator<fvar<T>> {
    *
    * @return Sum of accumulated values.
    */
-  inline fvar<T> sum() const noexcept {
-    return buf_;
-  }
+  inline fvar<T> sum() const noexcept { return buf_; }
 };
 
 }  // namespace math

--- a/stan/math/fwd/fun/sum.hpp
+++ b/stan/math/fwd/fun/sum.hpp
@@ -1,10 +1,11 @@
 #ifndef STAN_MATH_FWD_FUN_SUM_HPP
 #define STAN_MATH_FWD_FUN_SUM_HPP
 
-#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/sum.hpp>
 #include <stan/math/fwd/core.hpp>
+#include <stan/math/fwd/meta.hpp>
 #include <vector>
 
 namespace stan {
@@ -45,7 +46,7 @@ inline value_type_t<T> sum(const T& m) {
   if (m.size() == 0) {
     return 0.0;
   }
-  const Eigen::Ref<const plain_type_t<T>>& m_ref = m;
+  const auto& m_ref = to_ref(m);
   return {sum(m_ref.val()), sum(m_ref.d())};
 }
 

--- a/stan/math/prim/err/check_cholesky_factor.hpp
+++ b/stan/math/prim/err/check_cholesky_factor.hpp
@@ -18,7 +18,7 @@ namespace math {
  * elements are all positive.  Note that Cholesky factors need not
  * be square, but require at least as many rows M as columns N
  * (i.e., M &gt;= N).
- * @tparam EigMat Type of the Cholesky factor (must be derived from \c
+ * @tparam Mat Type of the Cholesky factor (must be derived from \c
  * Eigen::MatrixBase)
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
@@ -27,9 +27,9 @@ namespace math {
  *   factor, if number of rows is less than the number of columns,
  *   if there are 0 columns, or if any element in matrix is NaN
  */
-template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
+template <typename Mat, require_matrix_t<Mat>* = nullptr>
 inline void check_cholesky_factor(const char* function, const char* name,
-                                  const EigMat& y) {
+                                  const Mat& y) {
   check_less_or_equal(function, "columns and rows of Cholesky factor", y.cols(),
                       y.rows());
   check_positive(function, "columns of Cholesky factor", y.cols());

--- a/stan/math/prim/err/check_cholesky_factor.hpp
+++ b/stan/math/prim/err/check_cholesky_factor.hpp
@@ -3,6 +3,8 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
 #include <stan/math/prim/err/check_positive.hpp>
 #include <stan/math/prim/err/check_less_or_equal.hpp>
 #include <stan/math/prim/err/check_lower_triangular.hpp>
@@ -31,7 +33,7 @@ inline void check_cholesky_factor(const char* function, const char* name,
   check_less_or_equal(function, "columns and rows of Cholesky factor", y.cols(),
                       y.rows());
   check_positive(function, "columns of Cholesky factor", y.cols());
-  const Eigen::Ref<const plain_type_t<EigMat>>& y_ref = y;
+  const auto& y_ref = to_ref(value_of(y));
   check_lower_triangular(function, name, y_ref);
   check_positive(function, name, y_ref.diagonal());
 }

--- a/stan/math/prim/err/check_cholesky_factor_corr.hpp
+++ b/stan/math/prim/err/check_cholesky_factor_corr.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
 #include <stan/math/prim/err/check_positive.hpp>
 #include <stan/math/prim/err/check_lower_triangular.hpp>
 #include <stan/math/prim/err/check_square.hpp>
@@ -32,7 +33,7 @@ namespace math {
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 void check_cholesky_factor_corr(const char* function, const char* name,
                                 const EigMat& y) {
-  const auto& y_ref = to_ref(y);
+  const auto& y_ref = to_ref(value_of(y));
   check_square(function, name, y_ref);
   check_lower_triangular(function, name, y_ref);
   check_positive(function, name, y_ref.diagonal());

--- a/stan/math/prim/err/check_cholesky_factor_corr.hpp
+++ b/stan/math/prim/err/check_cholesky_factor_corr.hpp
@@ -21,7 +21,7 @@ namespace math {
  * be square, but require at least as many rows M as columns N
  * (i.e., M &gt;= N).
  * Tolerance is specified by <code>math::CONSTRAINT_TOLERANCE</code>.
- * @tparam EigMat Type inheriting from `MatrixBase` with dynamic rows and
+ * @tparam Mat Type inheriting from `MatrixBase` with dynamic rows and
  * columns.
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
@@ -30,9 +30,9 @@ namespace math {
  *   factor, if number of rows is less than the number of columns,
  *   if there are 0 columns, or if any element in matrix is NaN
  */
-template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
+template <typename Mat, require_matrix_t<Mat>* = nullptr>
 void check_cholesky_factor_corr(const char* function, const char* name,
-                                const EigMat& y) {
+                                const Mat& y) {
   const auto& y_ref = to_ref(value_of(y));
   check_square(function, name, y_ref);
   check_lower_triangular(function, name, y_ref);

--- a/stan/math/prim/err/check_corr_matrix.hpp
+++ b/stan/math/prim/err/check_corr_matrix.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/prim/err/check_pos_definite.hpp>
 #include <stan/math/prim/err/check_square.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
 #include <sstream>
 #include <string>
 #include <cmath>
@@ -21,7 +22,7 @@ namespace math {
  * (inclusive).
  * This function throws exceptions if the variable is not a valid
  * correlation matrix.
- * @tparam EigMat Type inheriting from `MatrixBase` with dynamic rows and
+ * @tparam Mat Type inheriting from `MatrixBase` with dynamic rows and
  * columns.
  * @param function Name of the function this was called from
  * @param name Name of the variable
@@ -31,10 +32,10 @@ namespace math {
  *   diagonals not near 1, not positive definite, or any of the
  *   elements nan
  */
-template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
+template <typename Mat, require_matrix_t<Mat>* = nullptr>
 inline void check_corr_matrix(const char* function, const char* name,
-                              const EigMat& y) {
-  const auto& y_ref = to_ref(y);
+                              const Mat& y) {
+  const auto& y_ref = to_ref(value_of(y));
   check_square(function, name, y_ref);
   using std::fabs;
   if (y_ref.size() == 0) {
@@ -43,6 +44,7 @@ inline void check_corr_matrix(const char* function, const char* name,
 
   for (Eigen::Index k = 0; k < y.rows(); ++k) {
     if (!(fabs(y_ref(k, k) - 1.0) <= CONSTRAINT_TOLERANCE)) {
+      [&]() STAN_COLD_PATH {
       std::ostringstream msg;
       msg << "is not a valid correlation matrix. " << name << "("
           << stan::error_index::value + k << "," << stan::error_index::value + k
@@ -50,6 +52,7 @@ inline void check_corr_matrix(const char* function, const char* name,
       std::string msg_str(msg.str());
       throw_domain_error(function, name, y_ref(k, k), msg_str.c_str(),
                          ", but should be near 1.0");
+      }();
     }
   }
   check_pos_definite(function, "y", y_ref);

--- a/stan/math/prim/err/check_cov_matrix.hpp
+++ b/stan/math/prim/err/check_cov_matrix.hpp
@@ -11,7 +11,7 @@ namespace math {
  * Check if the specified matrix is a valid covariance matrix.
  * A valid covariance matrix is a square, symmetric matrix that is
  * positive definite.
- * @tparam EigMat Type inheriting from `MatrixBase` with dynamic rows and
+ * @tparam Mat Type inheriting from `MatrixBase` with dynamic rows and
  * columns.
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
@@ -22,9 +22,9 @@ namespace math {
  *   if the matrix is not positive definite,
  *   or if any element of the matrix is nan
  */
-template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
+template <typename Mat, require_matrix_t<Mat>* = nullptr>
 inline void check_cov_matrix(const char* function, const char* name,
-                             const EigMat& y) {
+                             const Mat& y) {
   check_pos_definite(function, name, y);
 }
 

--- a/stan/math/prim/err/check_finite.hpp
+++ b/stan/math/prim/err/check_finite.hpp
@@ -6,8 +6,8 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/get.hpp>
 #include <stan/math/prim/fun/size.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
-#include <stan/math/prim/fun/value_of_rec.hpp>
 #include <cmath>
 
 namespace stan {
@@ -27,7 +27,7 @@ namespace math {
 template <typename T_y>
 inline void check_finite(const char* function, const char* name, const T_y& y) {
   elementwise_check([](double x) { return std::isfinite(x); }, function, name,
-                    y, "finite");
+                    to_ref(value_of(y)), "finite");
 }
 
 }  // namespace math

--- a/stan/math/prim/err/check_greater.hpp
+++ b/stan/math/prim/err/check_greater.hpp
@@ -8,52 +8,11 @@
 #include <stan/math/prim/fun/scalar_seq_view.hpp>
 #include <stan/math/prim/fun/size.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
 #include <string>
 
 namespace stan {
 namespace math {
-
-namespace internal {
-template <typename T_y, typename T_low, bool is_vec>
-struct greater {
-  static void check(const char* function, const char* name, const T_y& y,
-                    const T_low& low) {
-    scalar_seq_view<T_low> low_vec(low);
-    for (size_t n = 0; n < stan::math::size(low); n++) {
-      if (!(y > low_vec[n])) {
-        [&]() STAN_COLD_PATH {
-          std::stringstream msg;
-          msg << ", but must be greater than ";
-          msg << low_vec[n];
-          std::string msg_str(msg.str());
-          throw_domain_error(function, name, y, "is ", msg_str.c_str());
-        }();
-      }
-    }
-  }
-};
-
-template <typename T_y, typename T_low>
-struct greater<T_y, T_low, true> {
-  static void check(const char* function, const char* name, const T_y& y,
-                    const T_low& low) {
-    scalar_seq_view<T_low> low_vec(low);
-    const auto& y_ref = to_ref(y);
-    for (size_t n = 0; n < stan::math::size(y_ref); n++) {
-      if (!(stan::get(y_ref, n) > low_vec[n])) {
-        [&]() STAN_COLD_PATH {
-          std::stringstream msg;
-          msg << ", but must be greater than ";
-          msg << low_vec[n];
-          std::string msg_str(msg.str());
-          throw_domain_error_vec(function, name, y_ref, n, "is ",
-                                 msg_str.c_str());
-        }();
-      }
-    }
-  }
-};
-}  // namespace internal
 
 /**
  * Check if <code>y</code> is strictly greater than <code>low</code>.
@@ -68,12 +27,58 @@ struct greater<T_y, T_low, true> {
  * @throw <code>domain_error</code> if y is not greater than low or
  *   if any element of y or low is NaN.
  */
-template <typename T_y, typename T_low>
+template <typename T_y, typename T_low, require_vector_t<T_y>* = nullptr>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low) {
-  internal::greater<T_y, T_low, is_vector_like<T_y>::value>::check(
-      function, name, y, low);
+  const auto& low_ref = to_ref(value_of(low));
+  scalar_seq_view<decltype(low_ref)> low_vec(low_ref);
+  const auto& y_ref = to_ref(value_of(y));
+  for (size_t n = 0; n < stan::math::size(y_ref); n++) {
+    if (!(stan::get(y_ref, n) > low_vec[n])) {
+      [&]() STAN_COLD_PATH {
+        std::stringstream msg;
+        msg << ", but must be greater than ";
+        msg << low_vec[n];
+        std::string msg_str(msg.str());
+        throw_domain_error_vec(function, name, y_ref, n, "is ",
+                               msg_str.c_str());
+      }();
+    }
+  }
 }
+
+/**
+ * Check if <code>y</code> is strictly greater than <code>low</code>.
+ * This function is vectorized and will check each element of
+ * <code>y</code> against each element of <code>low</code>.
+ * @tparam T_y Type of y
+ * @tparam T_low Type of lower bound
+ * @param function Function name (for error messages)
+ * @param name Variable name (for error messages)
+ * @param y Variable to check
+ * @param low Lower bound
+ * @throw <code>domain_error</code> if y is not greater than low or
+ *   if any element of y or low is NaN.
+ */
+template <typename T_y, typename T_low, require_not_vector_t<T_y>* = nullptr>
+inline void check_greater(const char* function, const char* name, const T_y& y,
+                          const T_low& low) {
+  const auto& low_ref = to_ref(value_of(low));
+  scalar_seq_view<decltype(low_ref)> low_vec(low_ref);
+  for (size_t n = 0; n < stan::math::size(low); n++) {
+    if (!(y > low_vec[n])) {
+      [&]() STAN_COLD_PATH {
+        std::stringstream msg;
+        msg << ", but must be greater than ";
+        msg << low_vec[n];
+        std::string msg_str(msg.str());
+        throw_domain_error(function, name, y, "is ", msg_str.c_str());
+      }();
+    }
+  }
+
+}
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/err/check_greater.hpp
+++ b/stan/math/prim/err/check_greater.hpp
@@ -27,7 +27,7 @@ namespace math {
  * @throw <code>domain_error</code> if y is not greater than low or
  *   if any element of y or low is NaN.
  */
-template <typename T_y, typename T_low, require_vector_t<T_y>* = nullptr>
+template <typename T_y, typename T_low, require_container_t<T_y>* = nullptr>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low) {
   const auto& low_ref = to_ref(value_of(low));
@@ -60,7 +60,7 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  * @throw <code>domain_error</code> if y is not greater than low or
  *   if any element of y or low is NaN.
  */
-template <typename T_y, typename T_low, require_not_vector_t<T_y>* = nullptr>
+template <typename T_y, typename T_low, require_not_container_t<T_y>* = nullptr>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low) {
   const auto& low_ref = to_ref(value_of(low));
@@ -76,7 +76,12 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
       }();
     }
   }
+}
 
+template <typename T_y, typename T_low, require_any_var_matrix_t<T_y, T_low>* = nullptr>
+inline void check_greater(const char* function, const char* name,
+                                const T_y& y, const T_low& low) {
+    check_greater(function, name, value_of(y), value_of(low));
 }
 
 }  // namespace math

--- a/stan/math/prim/err/check_greater.hpp
+++ b/stan/math/prim/err/check_greater.hpp
@@ -78,10 +78,11 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
   }
 }
 
-template <typename T_y, typename T_low, require_any_var_matrix_t<T_y, T_low>* = nullptr>
-inline void check_greater(const char* function, const char* name,
-                                const T_y& y, const T_low& low) {
-    check_greater(function, name, value_of(y), value_of(low));
+template <typename T_y, typename T_low,
+          require_any_var_matrix_t<T_y, T_low>* = nullptr>
+inline void check_greater(const char* function, const char* name, const T_y& y,
+                          const T_low& low) {
+  check_greater(function, name, value_of(y), value_of(low));
 }
 
 }  // namespace math

--- a/stan/math/prim/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/err/check_greater_or_equal.hpp
@@ -29,22 +29,21 @@ namespace math {
 template <typename T_y, typename T_low, require_container_t<T_y>* = nullptr>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low) {
-     const auto& low_ref = to_ref(value_of(low));
-     scalar_seq_view<decltype(low_ref)> low_vec(low_ref);
-     const auto& y_ref = to_ref(value_of(y));
-     for (size_t n = 0; n < stan::math::size(y_ref); n++) {
-       if (!(stan::get(y_ref, n) >= low_vec[n])) {
-         [&]() STAN_COLD_PATH {
-           std::stringstream msg;
-           msg << ", but must be greater than or equal to ";
-           msg << low_vec[n];
-           std::string msg_str(msg.str());
-           throw_domain_error_vec(function, name, y_ref, n, "is ",
-                                  msg_str.c_str());
-         }();
-       }
-     }
-
+  const auto& low_ref = to_ref(value_of(low));
+  scalar_seq_view<decltype(low_ref)> low_vec(low_ref);
+  const auto& y_ref = to_ref(value_of(y));
+  for (size_t n = 0; n < stan::math::size(y_ref); n++) {
+    if (!(stan::get(y_ref, n) >= low_vec[n])) {
+      [&]() STAN_COLD_PATH {
+        std::stringstream msg;
+        msg << ", but must be greater than or equal to ";
+        msg << low_vec[n];
+        std::string msg_str(msg.str());
+        throw_domain_error_vec(function, name, y_ref, n, "is ",
+                               msg_str.c_str());
+      }();
+    }
+  }
 }
 
 /**
@@ -66,22 +65,23 @@ inline void check_greater_or_equal(const char* function, const char* name,
   const auto& low_ref = to_ref(value_of(low));
   scalar_seq_view<decltype(low_ref)> low_vec(low_ref);
   for (size_t n = 0; n < stan::math::size(low); n++) {
-   if (!(y >= low_vec[n])) {
-     [&]() STAN_COLD_PATH {
-       std::stringstream msg;
-       msg << ", but must be greater than or equal to ";
-       msg << low_vec[n];
-       std::string msg_str(msg.str());
-       throw_domain_error(function, name, y, "is ", msg_str.c_str());
-     }();
-   }
+    if (!(y >= low_vec[n])) {
+      [&]() STAN_COLD_PATH {
+        std::stringstream msg;
+        msg << ", but must be greater than or equal to ";
+        msg << low_vec[n];
+        std::string msg_str(msg.str());
+        throw_domain_error(function, name, y, "is ", msg_str.c_str());
+      }();
+    }
   }
 }
 
-template <typename T_y, typename T_low, require_any_var_matrix_t<T_y, T_low>* = nullptr>
+template <typename T_y, typename T_low,
+          require_any_var_matrix_t<T_y, T_low>* = nullptr>
 inline void check_greater_or_equal(const char* function, const char* name,
-                                const T_y& y, const T_low& low) {
-    check_greater_or_equal(function, name, value_of(y), value_of(low));
+                                   const T_y& y, const T_low& low) {
+  check_greater_or_equal(function, name, value_of(y), value_of(low));
 }
 
 }  // namespace math

--- a/stan/math/prim/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/err/check_greater_or_equal.hpp
@@ -26,7 +26,7 @@ namespace math {
  * @throw <code>domain_error</code> if y is not greater or equal to low or
  *   if any element of y or low is NaN.
  */
-template <typename T_y, typename T_low, require_vector_t<T_y>* = nullptr>
+template <typename T_y, typename T_low, require_container_t<T_y>* = nullptr>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low) {
      const auto& low_ref = to_ref(value_of(low));
@@ -60,7 +60,7 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * @throw <code>domain_error</code> if y is not greater or equal to low or
  *   if any element of y or low is NaN.
  */
-template <typename T_y, typename T_low, require_not_vector_t<T_y>* = nullptr>
+template <typename T_y, typename T_low, require_not_container_t<T_y>* = nullptr>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low) {
   const auto& low_ref = to_ref(value_of(low));
@@ -76,7 +76,12 @@ inline void check_greater_or_equal(const char* function, const char* name,
      }();
    }
   }
+}
 
+template <typename T_y, typename T_low, require_any_var_matrix_t<T_y, T_low>* = nullptr>
+inline void check_greater_or_equal(const char* function, const char* name,
+                                const T_y& y, const T_low& low) {
+    check_greater_or_equal(function, name, value_of(y), value_of(low));
 }
 
 }  // namespace math

--- a/stan/math/prim/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/err/check_greater_or_equal.hpp
@@ -27,7 +27,7 @@ namespace math {
  *   if any element of y or low is NaN.
  */
 template <typename T_y, typename T_low, require_container_t<T_y>* = nullptr,
-  require_not_var_matrix_t<T_low>* = nullptr>
+          require_not_var_matrix_t<T_low>* = nullptr>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low) {
   const auto& low_ref = to_ref(value_of(low));

--- a/stan/math/prim/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/err/check_greater_or_equal.hpp
@@ -13,47 +13,39 @@
 namespace stan {
 namespace math {
 
-namespace internal {
-template <typename T_y, typename T_low, bool is_vec>
-struct greater_or_equal {
-  static void check(const char* function, const char* name, const T_y& y,
-                    const T_low& low) {
-    scalar_seq_view<T_low> low_vec(low);
-    for (size_t n = 0; n < stan::math::size(low); n++) {
-      if (!(y >= low_vec[n])) {
-        [&]() STAN_COLD_PATH {
-          std::stringstream msg;
-          msg << ", but must be greater than or equal to ";
-          msg << low_vec[n];
-          std::string msg_str(msg.str());
-          throw_domain_error(function, name, y, "is ", msg_str.c_str());
-        }();
-      }
-    }
-  }
-};
+/**
+ * Check if <code>y</code> is greater or equal than <code>low</code>.
+ * This function is vectorized and will check each element of
+ * <code>y</code> against each element of <code>low</code>.
+ * @tparam T_y Type of y
+ * @tparam T_low Type of lower bound
+ * @param function Function name (for error messages)
+ * @param name Variable name (for error messages)
+ * @param y Variable to check
+ * @param low Lower bound
+ * @throw <code>domain_error</code> if y is not greater or equal to low or
+ *   if any element of y or low is NaN.
+ */
+template <typename T_y, typename T_low, require_vector_t<T_y>* = nullptr>
+inline void check_greater_or_equal(const char* function, const char* name,
+                                   const T_y& y, const T_low& low) {
+     const auto& low_ref = to_ref(value_of(low));
+     scalar_seq_view<decltype(low_ref)> low_vec(low_ref);
+     const auto& y_ref = to_ref(value_of(y));
+     for (size_t n = 0; n < stan::math::size(y_ref); n++) {
+       if (!(stan::get(y_ref, n) >= low_vec[n])) {
+         [&]() STAN_COLD_PATH {
+           std::stringstream msg;
+           msg << ", but must be greater than or equal to ";
+           msg << low_vec[n];
+           std::string msg_str(msg.str());
+           throw_domain_error_vec(function, name, y_ref, n, "is ",
+                                  msg_str.c_str());
+         }();
+       }
+     }
 
-template <typename T_y, typename T_low>
-struct greater_or_equal<T_y, T_low, true> {
-  static void check(const char* function, const char* name, const T_y& y,
-                    const T_low& low) {
-    scalar_seq_view<T_low> low_vec(low);
-    const auto& y_ref = to_ref(y);
-    for (size_t n = 0; n < stan::math::size(y_ref); n++) {
-      if (!(stan::get(y_ref, n) >= low_vec[n])) {
-        [&]() STAN_COLD_PATH {
-          std::stringstream msg;
-          msg << ", but must be greater than or equal to ";
-          msg << low_vec[n];
-          std::string msg_str(msg.str());
-          throw_domain_error_vec(function, name, y_ref, n, "is ",
-                                 msg_str.c_str());
-        }();
-      }
-    }
-  }
-};
-}  // namespace internal
+}
 
 /**
  * Check if <code>y</code> is greater or equal than <code>low</code>.
@@ -68,12 +60,25 @@ struct greater_or_equal<T_y, T_low, true> {
  * @throw <code>domain_error</code> if y is not greater or equal to low or
  *   if any element of y or low is NaN.
  */
-template <typename T_y, typename T_low>
+template <typename T_y, typename T_low, require_not_vector_t<T_y>* = nullptr>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low) {
-  internal::greater_or_equal<T_y, T_low, is_vector_like<T_y>::value>::check(
-      function, name, y, low);
+  const auto& low_ref = to_ref(value_of(low));
+  scalar_seq_view<decltype(low_ref)> low_vec(low_ref);
+  for (size_t n = 0; n < stan::math::size(low); n++) {
+   if (!(y >= low_vec[n])) {
+     [&]() STAN_COLD_PATH {
+       std::stringstream msg;
+       msg << ", but must be greater than or equal to ";
+       msg << low_vec[n];
+       std::string msg_str(msg.str());
+       throw_domain_error(function, name, y, "is ", msg_str.c_str());
+     }();
+   }
+  }
+
 }
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/err/check_greater_or_equal.hpp
@@ -26,7 +26,8 @@ namespace math {
  * @throw <code>domain_error</code> if y is not greater or equal to low or
  *   if any element of y or low is NaN.
  */
-template <typename T_y, typename T_low, require_container_t<T_y>* = nullptr>
+template <typename T_y, typename T_low, require_container_t<T_y>* = nullptr,
+  require_not_var_matrix_t<T_low>* = nullptr>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low) {
   const auto& low_ref = to_ref(value_of(low));
@@ -59,7 +60,7 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * @throw <code>domain_error</code> if y is not greater or equal to low or
  *   if any element of y or low is NaN.
  */
-template <typename T_y, typename T_low, require_not_container_t<T_y>* = nullptr>
+template <typename T_y, typename T_low, require_stan_scalar_t<T_y>* = nullptr>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low) {
   const auto& low_ref = to_ref(value_of(low));

--- a/stan/math/prim/err/check_less.hpp
+++ b/stan/math/prim/err/check_less.hpp
@@ -146,6 +146,25 @@ inline void check_less(const char* function, const char* name, const T_y& y,
   }
 }
 
+/**
+ * Check if <code>y</code> is strictly less than <code>high</code>.
+ * This function is vectorized and will check each element of
+ * <code>y</code> against each element of <code>high</code>.
+ * @tparam T_y Either a scalar, container, or var_value<T> holding a container.
+ * @tparam T_high  Either a scalar, container, or var_value<T> holding a container.
+ * @param function Function name (for error messages)
+ * @param name Variable name (for error messages)
+ * @param y Variable to check
+ * @param high Upper bound
+ * @throw <code>domain_error</code> if y is not less than low
+ *   or if any element of y or high is NaN.
+ */
+template <typename T_y, typename T_high, require_any_var_matrix_t<T_y, T_high>* = nullptr>
+inline void check_less(const char* function, const char* name, const T_y& y,
+                       const T_high& high) {
+  check_less(function, name, value_of(y), value_of(high));
+}
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/err/check_less_or_equal.hpp
+++ b/stan/math/prim/err/check_less_or_equal.hpp
@@ -59,7 +59,8 @@ inline void check_less_or_equal(const char* function, const char* name,
  * @throw <code>std::domain_error</code> if y is not less than or equal
  *   to low or if any element of y or high is NaN
  */
-template <typename T_y, typename T_high, require_not_container_t<T_y>* = nullptr>
+template <typename T_y, typename T_high,
+          require_not_container_t<T_y>* = nullptr>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
   const auto& high_ref = to_ref(value_of(high));
@@ -77,10 +78,11 @@ inline void check_less_or_equal(const char* function, const char* name,
   }
 }
 
-template <typename T_y, typename T_high, require_any_var_matrix_t<T_y>* = nullptr>
+template <typename T_y, typename T_high,
+          require_any_var_matrix_t<T_y>* = nullptr>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
-    check_less_or_equal(function, name, value_of(y), value_of(high));
+  check_less_or_equal(function, name, value_of(y), value_of(high));
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/err/check_less_or_equal.hpp
+++ b/stan/math/prim/err/check_less_or_equal.hpp
@@ -27,7 +27,7 @@ namespace math {
  *   to low or if any element of y or high is NaN
  */
 template <typename T_y, typename T_high, require_container_t<T_y>* = nullptr,
- require_not_var_matrix_t<T_high>* = nullptr>
+          require_not_var_matrix_t<T_high>* = nullptr>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
   const auto& high_ref = to_ref(value_of(high));
@@ -60,9 +60,8 @@ inline void check_less_or_equal(const char* function, const char* name,
  * @throw <code>std::domain_error</code> if y is not less than or equal
  *   to low or if any element of y or high is NaN
  */
-template <typename T_y, typename T_high,
-  require_stan_scalar_t<T_y>* = nullptr,
-  require_not_var_matrix_t<T_high>* = nullptr>
+template <typename T_y, typename T_high, require_stan_scalar_t<T_y>* = nullptr,
+          require_not_var_matrix_t<T_high>* = nullptr>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
   const auto& high_ref = to_ref(value_of(high));

--- a/stan/math/prim/err/check_less_or_equal.hpp
+++ b/stan/math/prim/err/check_less_or_equal.hpp
@@ -26,7 +26,7 @@ namespace math {
  * @throw <code>std::domain_error</code> if y is not less than or equal
  *   to low or if any element of y or high is NaN
  */
-template <typename T_y, typename T_high, require_vector_t<T_y>* = nullptr>
+template <typename T_y, typename T_high, require_container_t<T_y>* = nullptr>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
     const auto& high_ref = to_ref(value_of(high));
@@ -59,7 +59,7 @@ inline void check_less_or_equal(const char* function, const char* name,
  * @throw <code>std::domain_error</code> if y is not less than or equal
  *   to low or if any element of y or high is NaN
  */
-template <typename T_y, typename T_high, require_not_vector_t<T_y>* = nullptr>
+template <typename T_y, typename T_high, require_not_container_t<T_y>* = nullptr>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
     const auto& high_ref = to_ref(value_of(high));
@@ -77,6 +77,11 @@ inline void check_less_or_equal(const char* function, const char* name,
     }
 }
 
+template <typename T_y, typename T_high, require_any_var_matrix_t<T_y>* = nullptr>
+inline void check_less_or_equal(const char* function, const char* name,
+                                const T_y& y, const T_high& high) {
+    check_less_or_equal(function, name, value_of(y), value_of(high));
+}
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/err/check_less_or_equal.hpp
+++ b/stan/math/prim/err/check_less_or_equal.hpp
@@ -13,32 +13,25 @@
 namespace stan {
 namespace math {
 
-namespace internal {
-template <typename T_y, typename T_high, bool is_vec>
-struct less_or_equal {
-  static void check(const char* function, const char* name, const T_y& y,
-                    const T_high& high) {
-    scalar_seq_view<T_high> high_vec(high);
-    for (size_t n = 0; n < stan::math::size(high); n++) {
-      if (!(y <= high_vec[n])) {
-        [&]() STAN_COLD_PATH {
-          std::stringstream msg;
-          msg << ", but must be less than or equal to ";
-          msg << high_vec[n];
-          std::string msg_str(msg.str());
-          throw_domain_error(function, name, y, "is ", msg_str.c_str());
-        }();
-      }
-    }
-  }
-};
-
-template <typename T_y, typename T_high>
-struct less_or_equal<T_y, T_high, true> {
-  static void check(const char* function, const char* name, const T_y& y,
-                    const T_high& high) {
-    scalar_seq_view<T_high> high_vec(high);
-    const auto& y_ref = to_ref(y);
+/**
+ * Check if <code>y</code> is less or equal to <code>high</code>.
+ * This function is vectorized and will check each element of
+ * <code>y</code> against each element of <code>high</code>.
+ * @tparam T_y Type of y
+ * @tparam T_high Type of upper bound
+ * @param function Function name (for error messages)
+ * @param name Variable name (for error messages)
+ * @param y Variable to check
+ * @param high Upper bound
+ * @throw <code>std::domain_error</code> if y is not less than or equal
+ *   to low or if any element of y or high is NaN
+ */
+template <typename T_y, typename T_high, require_vector_t<T_y>* = nullptr>
+inline void check_less_or_equal(const char* function, const char* name,
+                                const T_y& y, const T_high& high) {
+    const auto& high_ref = to_ref(value_of(high));
+    scalar_seq_view<decltype(high_ref)> high_vec(high_ref);
+    const auto& y_ref = to_ref(value_of(y));
     for (size_t n = 0; n < stan::math::size(y_ref); n++) {
       if (!(stan::get(y_ref, n) <= high_vec[n])) {
         [&]() STAN_COLD_PATH {
@@ -51,9 +44,7 @@ struct less_or_equal<T_y, T_high, true> {
         }();
       }
     }
-  }
-};
-}  // namespace internal
+}
 
 /**
  * Check if <code>y</code> is less or equal to <code>high</code>.
@@ -68,12 +59,24 @@ struct less_or_equal<T_y, T_high, true> {
  * @throw <code>std::domain_error</code> if y is not less than or equal
  *   to low or if any element of y or high is NaN
  */
-template <typename T_y, typename T_high>
+template <typename T_y, typename T_high, require_not_vector_t<T_y>* = nullptr>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
-  internal::less_or_equal<T_y, T_high, is_vector_like<T_y>::value>::check(
-      function, name, y, high);
+    const auto& high_ref = to_ref(value_of(high));
+    scalar_seq_view<decltype(high_ref)> high_vec(high_ref);
+    for (size_t n = 0; n < stan::math::size(high); n++) {
+      if (!(y <= high_vec[n])) {
+        [&]() STAN_COLD_PATH {
+          std::stringstream msg;
+          msg << ", but must be less than or equal to ";
+          msg << high_vec[n];
+          std::string msg_str(msg.str());
+          throw_domain_error(function, name, y, "is ", msg_str.c_str());
+        }();
+      }
+    }
 }
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/err/check_less_or_equal.hpp
+++ b/stan/math/prim/err/check_less_or_equal.hpp
@@ -26,7 +26,8 @@ namespace math {
  * @throw <code>std::domain_error</code> if y is not less than or equal
  *   to low or if any element of y or high is NaN
  */
-template <typename T_y, typename T_high, require_container_t<T_y>* = nullptr>
+template <typename T_y, typename T_high, require_container_t<T_y>* = nullptr,
+ require_not_var_matrix_t<T_high>* = nullptr>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
   const auto& high_ref = to_ref(value_of(high));
@@ -60,7 +61,8 @@ inline void check_less_or_equal(const char* function, const char* name,
  *   to low or if any element of y or high is NaN
  */
 template <typename T_y, typename T_high,
-          require_not_container_t<T_y>* = nullptr>
+  require_stan_scalar_t<T_y>* = nullptr,
+  require_not_var_matrix_t<T_high>* = nullptr>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
   const auto& high_ref = to_ref(value_of(high));
@@ -79,7 +81,7 @@ inline void check_less_or_equal(const char* function, const char* name,
 }
 
 template <typename T_y, typename T_high,
-          require_any_var_matrix_t<T_y>* = nullptr>
+          require_any_var_matrix_t<T_y, T_high>* = nullptr>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
   check_less_or_equal(function, name, value_of(y), value_of(high));

--- a/stan/math/prim/err/check_lower_triangular.hpp
+++ b/stan/math/prim/err/check_lower_triangular.hpp
@@ -3,6 +3,8 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
 #include <stan/math/prim/err/throw_domain_error.hpp>
 #include <sstream>
 #include <string>
@@ -23,10 +25,10 @@ namespace math {
  *   lower triangular or if any element in the upper triangular
  *   portion is NaN
  */
-template <typename T_y, require_eigen_t<T_y>* = nullptr>
+template <typename T_y, require_matrix_t<T_y>* = nullptr>
 inline void check_lower_triangular(const char* function, const char* name,
                                    const T_y& y) {
-  const auto& y_ref = to_ref(y);
+  const auto& y_ref = to_ref(value_of(y));
   for (int n = 1; n < y.cols(); ++n) {
     for (int m = 0; m < n && m < y.rows(); ++m) {
       if (y_ref(m, n) != 0) {

--- a/stan/math/prim/err/check_ordered.hpp
+++ b/stan/math/prim/err/check_ordered.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err/throw_domain_error.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -22,9 +23,9 @@ namespace math {
  *   not ordered, if there are duplicated
  *   values, or if any element is <code>NaN</code>.
  */
-template <typename T_y, require_eigen_vector_t<T_y>* = nullptr>
+template <typename T_y, require_vector_t<T_y>* = nullptr>
 void check_ordered(const char* function, const char* name, const T_y& y) {
-  const auto& y_ref = to_ref(y);
+  const auto& y_ref = to_ref(value_of(y));
   for (Eigen::Index n = 1; n < y_ref.size(); n++) {
     if (!(y_ref[n] > y_ref[n - 1])) {
       [&]() STAN_COLD_PATH {

--- a/stan/math/prim/err/check_pos_semidefinite.hpp
+++ b/stan/math/prim/err/check_pos_semidefinite.hpp
@@ -8,6 +8,7 @@
 #include <stan/math/prim/err/check_symmetric.hpp>
 #include <stan/math/prim/err/throw_domain_error.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
 #include <stan/math/prim/fun/value_of_rec.hpp>
 #include <sstream>
 
@@ -16,7 +17,7 @@ namespace math {
 
 /**
  * Check if the specified matrix is positive definite
- * @tparam EigMat A type derived from `EigenBase` with dynamic rows and columns
+ * @tparam Mat A type derived from `EigenBase` with dynamic rows and columns
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Matrix to test
@@ -26,10 +27,10 @@ namespace math {
  *   or if it is not positive semi-definite,
  *   or if any element of the matrix is <code>NaN</code>.
  */
-template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
+template <typename Mat, require_matrix_t<Mat>* = nullptr>
 inline void check_pos_semidefinite(const char* function, const char* name,
-                                   const EigMat& y) {
-  const auto& y_ref = to_ref(y);
+                                   const Mat& y) {
+  const auto& y_ref = to_ref(value_of(y));
   check_symmetric(function, name, y_ref);
   check_positive(function, name, "rows", y_ref.rows());
   check_not_nan(function, name, y_ref);

--- a/stan/math/prim/err/check_positive_ordered.hpp
+++ b/stan/math/prim/err/check_positive_ordered.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/prim/err/throw_domain_error.hpp>
 #include <stan/math/prim/err/check_ordered.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
 #include <sstream>
 #include <string>
 
@@ -15,7 +16,7 @@ namespace math {
 /**
  * Check if the specified vector contains non-negative values and is sorted into
  * strictly increasing order.
- * @tparam EigVec A type derived from `EigenBase` with 1 compile time row or
+ * @tparam Vec A type derived from `EigenBase` with 1 compile time row or
  * column
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
@@ -24,14 +25,14 @@ namespace math {
  *   values, if the values are not ordered, if there are duplicated
  *   values, or if any element is <code>NaN</code>.
  */
-template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
+template <typename Vec, require_vector_t<Vec>* = nullptr>
 void check_positive_ordered(const char* function, const char* name,
-                            const EigVec& y) {
+                            const Vec& y) {
   if (y.size() == 0) {
     return;
   }
 
-  const auto& y_ref = to_ref(y);
+  const auto& y_ref = to_ref(value_of(y));
   if (y_ref[0] < 0) {
     [&]() STAN_COLD_PATH {
       std::ostringstream msg;

--- a/stan/math/prim/err/check_simplex.hpp
+++ b/stan/math/prim/err/check_simplex.hpp
@@ -1,10 +1,12 @@
 #ifndef STAN_MATH_PRIM_ERR_CHECK_SIMPLEX_HPP
 #define STAN_MATH_PRIM_ERR_CHECK_SIMPLEX_HPP
 
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
 #include <stan/math/prim/err/check_nonzero_size.hpp>
 #include <stan/math/prim/err/constraint_tolerance.hpp>
-#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/err/throw_domain_error.hpp>
 #include <sstream>
 #include <string>
@@ -35,11 +37,11 @@ namespace math {
  * @throw <code>std::domain_error</code> if the vector is not a
  *   simplex or if any element is <code>NaN</code>.
  */
-template <typename T, require_eigen_t<T>* = nullptr>
+template <typename T, require_matrix_t<T>* = nullptr>
 void check_simplex(const char* function, const char* name, const T& theta) {
   using std::fabs;
   check_nonzero_size(function, name, theta);
-  ref_type_t<T> theta_ref = theta;
+  const auto& theta_ref = to_ref(value_of(theta));
   if (!(fabs(1.0 - theta_ref.sum()) <= CONSTRAINT_TOLERANCE)) {
     [&]() STAN_COLD_PATH {
       std::stringstream msg;

--- a/stan/math/prim/err/check_symmetric.hpp
+++ b/stan/math/prim/err/check_symmetric.hpp
@@ -20,7 +20,7 @@ namespace math {
  * Check if the specified matrix is symmetric.
  * The error message is either 0 or 1 indexed, specified by
  * <code>stan::error_index::value</code>.
- * @tparam EigMat Type of matrix
+ * @tparam Mat Type of matrix
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Matrix to test
@@ -28,9 +28,9 @@ namespace math {
  * @throw <code>std::domain_error</code> if any element not on the
  *   main diagonal is <code>NaN</code>
  */
-template <typename EigMat, require_matrix_t<EigMat>* = nullptr>
+template <typename Mat, require_matrix_t<Mat>* = nullptr>
 inline void check_symmetric(const char* function, const char* name,
-                            const EigMat& y) {
+                            const Mat& y) {
   check_square(function, name, y);
   using std::fabs;
 
@@ -38,11 +38,10 @@ inline void check_symmetric(const char* function, const char* name,
   if (k <= 1) {
     return;
   }
-  const auto& y_ref = to_ref(y);
+  const auto& y_ref = to_ref(value_of(y));
   for (Eigen::Index m = 0; m < k; ++m) {
     for (Eigen::Index n = m + 1; n < k; ++n) {
-      if (!(fabs(value_of(y_ref(m, n)) - value_of(y_ref(n, m)))
-            <= CONSTRAINT_TOLERANCE)) {
+      if (!(fabs(y_ref(m, n) - y_ref(n, m)) <= CONSTRAINT_TOLERANCE)) {
         [&]() STAN_COLD_PATH {
           std::ostringstream msg1;
           msg1 << "is not symmetric. " << name << "["

--- a/stan/math/prim/err/check_unit_vector.hpp
+++ b/stan/math/prim/err/check_unit_vector.hpp
@@ -31,12 +31,12 @@ namespace math {
  * @throw <code>std::domain_error</code> if the vector is not a unit
  *   vector or if any element is <code>NaN</code>
  */
-template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
+template <typename Vec, require_vector_t<Vec>* = nullptr>
 void check_unit_vector(const char* function, const char* name,
-                       const EigVec& theta) {
+                       const Vec& theta) {
   check_nonzero_size(function, name, theta);
   using std::fabs;
-  value_type_t<EigVec> ssq = theta.squaredNorm();
+  scalar_type_t<Vec> ssq = value_of(theta).squaredNorm();
   if (!(fabs(1.0 - ssq) <= CONSTRAINT_TOLERANCE)) {
     [&]() STAN_COLD_PATH {
       std::stringstream msg;

--- a/stan/math/prim/err/check_vector.hpp
+++ b/stan/math/prim/err/check_vector.hpp
@@ -30,8 +30,8 @@ template <typename Mat,
           require_any_t<is_matrix<Mat>,
                         is_prim_or_rev_kernel_expression<Mat>>* = nullptr>
 inline void check_vector(const char* function, const char* name, const Mat& x) {
+  STAN_NO_RANGE_CHECKS_RETURN;
   if (!(x.rows() == 1 || x.cols() == 1)) {
-    STAN_NO_RANGE_CHECKS_RETURN;
     [&]() STAN_COLD_PATH {
       std::ostringstream msg;
       msg << ") has " << x.rows() << " rows and " << x.cols()

--- a/stan/math/prim/fun/accumulator.hpp
+++ b/stan/math/prim/fun/accumulator.hpp
@@ -84,9 +84,7 @@ class accumulator {
    *
    * @return Sum of accumulated values.
    */
-  T sum() const {
-    return buf_;
-  }
+  T sum() const { return buf_; }
 };
 
 }  // namespace math

--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -12,6 +12,7 @@
 #include <stan/math/rev/fun/Phi.hpp>
 #include <stan/math/rev/fun/Phi_approx.hpp>
 #include <stan/math/rev/fun/abs.hpp>
+#include <stan/math/rev/fun/accumulator.hpp>
 #include <stan/math/rev/fun/acos.hpp>
 #include <stan/math/rev/fun/acosh.hpp>
 #include <stan/math/rev/fun/as_bool.hpp>

--- a/stan/math/rev/fun/accumulator.hpp
+++ b/stan/math/rev/fun/accumulator.hpp
@@ -27,7 +27,6 @@ class accumulator<var> {
   var buf_{0.0};
 
  public:
-
   /**
    * Add the specified arithmetic type value to the buffer after
    * static casting it to the class type <code>T</code>.
@@ -64,7 +63,8 @@ class accumulator<var> {
    * @tparam S A standard vector holding non-container elements
    * @param xs Vector of entries to add
    */
-  template <typename S, require_all_not_t<is_container<S>, is_var_matrix<S>>* = nullptr>
+  template <typename S,
+            require_all_not_t<is_container<S>, is_var_matrix<S>>* = nullptr>
   inline void add(const std::vector<S>& xs) {
     buf_ += stan::math::sum(xs);
   }
@@ -78,7 +78,8 @@ class accumulator<var> {
    * @tparam S A standard vector holding container elements
    * @param xs Vector of entries to add
    */
-  template <typename S, require_any_t<is_container<S>, is_var_matrix<S>>* = nullptr>
+  template <typename S,
+            require_any_t<is_container<S>, is_var_matrix<S>>* = nullptr>
   inline void add(const std::vector<S>& xs) {
     for (size_t i = 0; i < xs.size(); ++i) {
       this->add(xs[i]);
@@ -90,9 +91,7 @@ class accumulator<var> {
    *
    * @return Sum of accumulated values.
    */
-  inline var sum() const noexcept {
-    return buf_;
-  }
+  inline var sum() const noexcept { return buf_; }
 };
 
 }  // namespace math

--- a/stan/math/rev/fun/accumulator.hpp
+++ b/stan/math/rev/fun/accumulator.hpp
@@ -1,9 +1,10 @@
-#ifndef STAN_MATH_PRIM_FUN_ACCUMULATOR_HPP
-#define STAN_MATH_PRIM_FUN_ACCUMULATOR_HPP
+#ifndef STAN_MATH_REV_FUN_ACCUMULATOR_HPP
+#define STAN_MATH_REV_FUN_ACCUMULATOR_HPP
 
-#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/fun/sum.hpp>
+#include <stan/math/prim/fun/accumulator.hpp>
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/rev/fun/sum.hpp>
 #include <vector>
 #include <type_traits>
 
@@ -20,16 +21,12 @@ namespace math {
  *
  * @tparam T Type of scalar added
  */
-template <typename T>
-class accumulator {
+template <>
+class accumulator<var> {
  private:
-  T buf_{0.0};
+  var buf_{0.0};
 
  public:
-  /**
-   * Construct an accumulator.
-   */
-  accumulator() : buf_(0.0) {}
 
   /**
    * Add the specified arithmetic type value to the buffer after
@@ -41,8 +38,8 @@ class accumulator {
    * @tparam S Type of argument
    * @param x Value to add
    */
-  template <typename S, typename = require_arithmetic_t<S>>
-  void add(S x) {
+  template <typename S, require_stan_scalar_t<S>* = nullptr>
+  inline void add(S x) {
     buf_ += x;
   }
 
@@ -54,7 +51,7 @@ class accumulator {
    * @param m Matrix of values to add
    */
   template <typename S, require_matrix_t<S>* = nullptr>
-  void add(const S& m) {
+  inline void add(const S& m) {
     buf_ += stan::math::sum(m);
   }
 
@@ -64,19 +61,28 @@ class accumulator {
    * autodiff variables to be added; if the vector entries
    * are collections, their elements are recursively added.
    *
-   * @tparam S Type of value to recursively add.
+   * @tparam S A standard vector holding non-container elements
    * @param xs Vector of entries to add
    */
-  template <typename S, require_container_t<S>* = nullptr>
-  void add(const std::vector<S>& xs) {
+  template <typename S, require_all_not_t<is_container<S>, is_var_matrix<S>>* = nullptr>
+  inline void add(const std::vector<S>& xs) {
+    buf_ += stan::math::sum(xs);
+  }
+
+  /**
+   * Recursively add each entry in the specified standard vector
+   * to the buffer.  This will allow vectors of primitives,
+   * autodiff variables to be added; if the vector entries
+   * are collections, their elements are recursively added.
+   *
+   * @tparam S A standard vector holding container elements
+   * @param xs Vector of entries to add
+   */
+  template <typename S, require_any_t<is_container<S>, is_var_matrix<S>>* = nullptr>
+  inline void add(const std::vector<S>& xs) {
     for (size_t i = 0; i < xs.size(); ++i) {
       this->add(xs[i]);
     }
-  }
-
-  template <typename S, require_not_container_t<S>* = nullptr>
-  void add(const std::vector<S>& xs) {
-    buf_ += stan::math::sum(xs);
   }
 
   /**
@@ -84,7 +90,7 @@ class accumulator {
    *
    * @return Sum of accumulated values.
    */
-  T sum() const {
+  inline var sum() const noexcept {
     return buf_;
   }
 };

--- a/stan/math/rev/fun/sum.hpp
+++ b/stan/math/rev/fun/sum.hpp
@@ -76,9 +76,8 @@ inline var sum(const std::vector<var>& m) {
  */
 template <typename T, require_eigen_t<T>* = nullptr>
 inline var sum(const var_value<T>& x) {
-  return make_callback_var(sum(x.val()), [x](auto& vi) mutable {
-    x.adj().array() += vi.adj();
-  });
+  return make_callback_var(
+      sum(x.val()), [x](auto& vi) mutable { x.adj().array() += vi.adj(); });
 }
 
 template <typename T, require_eigen_vt<is_var, T>* = nullptr>

--- a/stan/math/rev/fun/sum.hpp
+++ b/stan/math/rev/fun/sum.hpp
@@ -2,11 +2,11 @@
 #define STAN_MATH_REV_FUN_SUM_HPP
 
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/sum.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core/arena_matrix.hpp>
 #include <stan/math/rev/core/reverse_pass_callback.hpp>
-#include <stan/math/rev/fun/sum.hpp>
 #include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/rev/core/typedefs.hpp>
 #include <vector>
@@ -74,7 +74,14 @@ inline var sum(const std::vector<var>& m) {
  * @param x Specified var_value containing a matrix or vector.
  * @return Sum of coefficients of matrix.
  */
-template <typename T, require_rev_matrix_t<T>* = nullptr>
+template <typename T, require_eigen_t<T>* = nullptr>
+inline var sum(const var_value<T>& x) {
+  return make_callback_var(sum(x.val()), [x](auto& vi) mutable {
+    x.adj().array() += vi.adj();
+  });
+}
+
+template <typename T, require_eigen_vt<is_var, T>* = nullptr>
 inline var sum(const T& x) {
   arena_t<T> x_arena = x;
   return make_callback_var(sum(x_arena.val()), [x_arena](auto& vi) mutable {

--- a/test/unit/math/mix/fun/accumulator_test.cpp
+++ b/test/unit/math/mix/fun/accumulator_test.cpp
@@ -13,7 +13,7 @@ TEST(AgradMixMatrixAccumulate, fvar_var) {
   using stan::math::fvar;
   using stan::math::var;
 
-  accumulator<fvar<var> > a;
+  accumulator<fvar<var>> a;
   test_sum(a, 0);
 
   a.add(1.0);
@@ -32,12 +32,12 @@ TEST(AgradMixMatrixAccumulate, collection_fvar_var) {
   using stan::math::vector_fv;
   using std::vector;
 
-  accumulator<fvar<var> > a;
+  accumulator<fvar<var>> a;
 
   int pos = 0;
   test_sum(a, 0);
 
-  vector<fvar<var> > v(10);
+  vector<fvar<var>> v(10);
   for (size_t i = 0; i < 10; ++i)
     v[i] = pos++;
   a.add(v);
@@ -50,9 +50,9 @@ TEST(AgradMixMatrixAccumulate, collection_fvar_var) {
   a.add(x);
   test_sum(a, pos - 1);
 
-  vector<vector<fvar<var> > > ww(10);
+  vector<vector<fvar<var>>> ww(10);
   for (size_t i = 0; i < 10; ++i) {
-    vector<fvar<var> > w(5);
+    vector<fvar<var>> w(5);
     for (size_t n = 0; n < 5; ++n)
       w[n] = pos++;
     ww[i] = w;
@@ -89,7 +89,7 @@ TEST(AgradMixMatrixAccumulate, fvar_fvar_var) {
   using stan::math::fvar;
   using stan::math::var;
 
-  accumulator<fvar<fvar<var> > > a;
+  accumulator<fvar<fvar<var>>> a;
   test_sum(a, 0);
 
   a.add(1.0);
@@ -108,12 +108,12 @@ TEST(AgradMixMatrixAccumulate, collection_fvar_fvar_var) {
   using stan::math::vector_ffv;
   using std::vector;
 
-  accumulator<fvar<fvar<var> > > a;
+  accumulator<fvar<fvar<var>>> a;
 
   int pos = 0;
   test_sum(a, 0);
 
-  vector<fvar<fvar<var> > > v(10);
+  vector<fvar<fvar<var>>> v(10);
   for (size_t i = 0; i < 10; ++i)
     v[i] = pos++;
   a.add(v);
@@ -126,9 +126,9 @@ TEST(AgradMixMatrixAccumulate, collection_fvar_fvar_var) {
   a.add(x);
   test_sum(a, pos - 1);
 
-  vector<vector<fvar<fvar<var> > > > ww(10);
+  vector<vector<fvar<fvar<var>>>> ww(10);
   for (size_t i = 0; i < 10; ++i) {
-    vector<fvar<fvar<var> > > w(5);
+    vector<fvar<fvar<var>>> w(5);
     for (size_t n = 0; n < 5; ++n)
       w[n] = pos++;
     ww[i] = w;
@@ -160,7 +160,6 @@ TEST(AgradMixMatrixAccumulate, collection_fvar_fvar_var) {
   test_sum(a, pos - 1);
 }
 
-
 TEST(AgradMixMatrixAccumulate, var_matrix) {
   auto f = [](const auto& x) {
     using x_t = decltype(x);
@@ -177,5 +176,4 @@ TEST(AgradMixMatrixAccumulate, var_matrix) {
   x_vec.push_back(x);
   stan::test::expect_ad(f, x_vec);
   stan::test::expect_ad_matvar(f, x_vec);
-
 }

--- a/test/unit/math/mix/fun/accumulator_test.cpp
+++ b/test/unit/math/mix/fun/accumulator_test.cpp
@@ -1,4 +1,4 @@
-#include <stan/math/mix.hpp>
+#include <test/unit/math/test_ad.hpp>
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -158,4 +158,24 @@ TEST(AgradMixMatrixAccumulate, collection_fvar_fvar_var) {
   }
   a.add(vvx);
   test_sum(a, pos - 1);
+}
+
+
+TEST(AgradMixMatrixAccumulate, var_matrix) {
+  auto f = [](const auto& x) {
+    using x_t = decltype(x);
+    stan::math::accumulator<stan::scalar_type_t<x_t>> acc;
+    acc.add(x);
+    return acc.sum();
+  };
+  Eigen::MatrixXd x = Eigen::MatrixXd::Random(2, 2);
+  stan::test::expect_ad(f, x);
+  stan::test::expect_ad_matvar(f, x);
+  std::vector<Eigen::MatrixXd> x_vec;
+  x_vec.push_back(x);
+  x_vec.push_back(x);
+  x_vec.push_back(x);
+  stan::test::expect_ad(f, x_vec);
+  stan::test::expect_ad_matvar(f, x_vec);
+
 }

--- a/test/unit/math/rev/err/check_cholesky_factor_corr_test.cpp
+++ b/test/unit/math/rev/err/check_cholesky_factor_corr_test.cpp
@@ -1,0 +1,80 @@
+#include <stan/math/rev.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandlingMatrix, checkCorrCholeskyVarMatrix) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+
+  using stan::math::check_cholesky_factor_corr;
+  using std::sqrt;
+  using var_mat = stan::math::var_value<Eigen::MatrixXd>;
+  y.resize(1, 1);
+  y << 1;
+  EXPECT_NO_THROW(
+      check_cholesky_factor_corr("checkCorrCholeskyMatrix", "y", var_mat(y)));
+
+  y.resize(3, 3);
+  y << 1, 0, 0, sqrt(0.5), sqrt(0.5), 0, sqrt(0.25), sqrt(0.25), sqrt(0.5);
+  EXPECT_NO_THROW(
+      check_cholesky_factor_corr("checkCorrCholeskyMatrix", "y", var_mat(y)));
+
+  // not positive
+  y.resize(1, 1);
+  y << -1;
+  EXPECT_THROW(check_cholesky_factor_corr("checkCorrCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+
+  // not lower triangular
+  y.resize(3, 3);
+  y << 1, 2, 3, 0, 5, 6, 0, 0, 9;
+  EXPECT_THROW(check_cholesky_factor_corr("checkCorrCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+
+  // not positive
+  y.resize(3, 3);
+  y << 1, 0, 0, 2, -1, 0, 1, 2, 3;
+  EXPECT_THROW(check_cholesky_factor_corr("checkCorrCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+
+  // not rectangular
+  y.resize(2, 3);
+  y << 1, 2, 3, 4, 5, 6;
+  EXPECT_THROW(check_cholesky_factor_corr("checkCorrCholeskyMatrix", "y", var_mat(y)),
+               std::invalid_argument);
+  y.resize(3, 2);
+  y << 1, 0, 2, 3, 4, 5;
+  EXPECT_THROW(check_cholesky_factor_corr("checkCorrCholeskyMatrix", "y", var_mat(y)),
+               std::invalid_argument);
+
+  // not unit vectors
+  y.resize(3, 3);
+  y << 1, 0, 0, 1, 1, 0, 1, 1, 1;
+  EXPECT_THROW(check_cholesky_factor_corr("checkCorrCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+}
+
+TEST(ErrorHandlingMatrix, checkCorrCholeskyVarMatrix_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  using stan::math::check_cholesky_factor_corr;
+  using std::sqrt;
+  using var_mat = stan::math::var_value<Eigen::MatrixXd>;
+
+  y.resize(1, 1);
+  y << nan;
+  EXPECT_THROW(check_cholesky_factor_corr("checkCorrCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+
+  y.resize(3, 3);
+  y << 1, 0, 0, sqrt(0.5), sqrt(0.5), 0, sqrt(0.25), sqrt(0.25), sqrt(0.5);
+  EXPECT_NO_THROW(
+      check_cholesky_factor_corr("checkCorrCholeskyMatrix", "y", var_mat(y)));
+
+  for (int i = 0; i < y.size(); i++) {
+    y(i) = nan;
+    EXPECT_THROW(check_cholesky_factor_corr("checkCorrCholeskyMatrix", "y", var_mat(y)),
+                 std::domain_error);
+    y << 1, 0, 0, sqrt(0.5), sqrt(0.5), 0, sqrt(0.25), sqrt(0.25), sqrt(0.5);
+  }
+}

--- a/test/unit/math/rev/err/check_cholesky_factor_test.cpp
+++ b/test/unit/math/rev/err/check_cholesky_factor_test.cpp
@@ -1,0 +1,97 @@
+#include <stan/math/rev.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandlingMatrix, checkCovCholeskyVarMatrix) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+
+  using stan::math::check_cholesky_factor;
+  using var_mat = stan::math::var_value<Eigen::MatrixXd>;
+
+  y.resize(1, 1);
+  y << 1;
+  EXPECT_NO_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)));
+
+  y.resize(3, 3);
+  y << 1, 0, 0, 1, 1, 0, 1, 1, 1;
+  EXPECT_NO_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)));
+
+  // not positive
+  y.resize(1, 1);
+  y << -1;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+
+  // not lower triangular
+  y.resize(3, 3);
+  y << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+
+  // not positive
+  y.resize(3, 3);
+  y << 1, 0, 0, 2, -1, 0, 1, 2, 3;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+
+  // not rectangular
+  y.resize(2, 3);
+  y << 1, 2, 3, 4, 5, 6;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+  y.resize(3, 2);
+  y << 1, 0, 2, 3, 4, 5;
+  EXPECT_NO_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)));
+  y(0, 1) = 1.5;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+}
+
+TEST(ErrorHandlingMatrix, checkCovCholeskyVarMatrix_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  using stan::math::check_cholesky_factor;
+  using var_mat = stan::math::var_value<Eigen::MatrixXd>;
+
+  y.resize(1, 1);
+  y << nan;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+
+  y.resize(3, 3);
+  y << nan, 0, 0, nan, nan, 0, nan, nan, nan;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+
+  // not positive
+  y.resize(1, 1);
+  y << nan;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+
+  // not lower triangular
+  y.resize(3, 3);
+  y << 1, nan, 3, 4, 5, nan, 7, 8, 9;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+
+  // not positive
+  y.resize(3, 3);
+  y << 1, 0, 0, 2, nan, 0, 1, 2, 3;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+
+  // not rectangular
+  y.resize(2, 3);
+  y << 1, 2, nan, nan, 5, 6;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+  y.resize(3, 2);
+  y << 1, 0, 2, nan, 4, 5;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+  y(0, 1) = nan;
+  EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", "y", var_mat(y)),
+               std::domain_error);
+}

--- a/test/unit/math/rev/err/check_corr_matrix_test.cpp
+++ b/test/unit/math/rev/err/check_corr_matrix_test.cpp
@@ -1,0 +1,57 @@
+#include <stan/math/rev.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+
+TEST(ErrorHandlingMatrix, CheckCorrVarMatrix) {
+  using stan::math::check_corr_matrix;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  using var_mat = stan::math::var_value<Eigen::MatrixXd>;
+  y.resize(2, 2);
+
+  y << 1, 0, 0, 1;
+  EXPECT_NO_THROW(check_corr_matrix("test", "y", var_mat(y)));
+
+  y << 10, 0, 0, 10;
+  EXPECT_THROW(check_corr_matrix("test", "y", var_mat(y)), std::domain_error);
+}
+
+TEST(ErrorHandlingMatrix, CheckCorrVarMatrix_one_indexed_message) {
+  using stan::math::check_corr_matrix;
+  std::string message;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  using var_mat = stan::math::var_value<Eigen::MatrixXd>;
+  y.resize(2, 2);
+
+  y << 10, 0, 0, 1;
+  try {
+    check_corr_matrix("test", "y", var_mat(y));
+    FAIL() << "should have thrown";
+  } catch (std::domain_error& e) {
+    message = e.what();
+  } catch (...) {
+    FAIL() << "threw the wrong error";
+  }
+
+  EXPECT_NE(std::string::npos, message.find("(1,1)")) << message;
+
+  EXPECT_EQ(std::string::npos, message.find("(0, 0)")) << message;
+}
+
+TEST(ErrorHandlingMatrix, CheckCorrVarMatrix_nan) {
+  using stan::math::check_corr_matrix;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  using var_mat = stan::math::var_value<Eigen::MatrixXd>;
+  y.resize(2, 2);
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  for (int i = 0; i < y.size(); i++) {
+    y << 1, 0, 0, 1;
+    y(i) = nan;
+    EXPECT_THROW(check_corr_matrix("test", "y", var_mat(y)), std::domain_error);
+
+    y << 10, 0, 0, 10;
+    y(i) = nan;
+    EXPECT_THROW(check_corr_matrix("test", "y", var_mat(y)), std::domain_error);
+  }
+}

--- a/test/unit/math/rev/err/check_cov_matrix_test.cpp
+++ b/test/unit/math/rev/err/check_cov_matrix_test.cpp
@@ -1,0 +1,35 @@
+#include <stan/math/rev.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandlingMatrix, checkCovVarMatrix) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  using var_mat = stan::math::var_value<Eigen::MatrixXd>;
+
+  y.resize(3, 3);
+  y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
+  EXPECT_NO_THROW(stan::math::check_cov_matrix("checkCovMatrix", "y", var_mat(y)));
+
+  y << 1, 2, 3, 2, 1, 2, 3, 2, 1;
+  EXPECT_THROW(stan::math::check_cov_matrix("checkCovMatrix", "y", var_mat(y)),
+               std::domain_error);
+}
+
+TEST(ErrorHandlingMatrix, checkCovVarMatrix_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  using var_mat = stan::math::var_value<Eigen::MatrixXd>;
+
+  y.resize(3, 3);
+  y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
+  EXPECT_NO_THROW(stan::math::check_cov_matrix("checkCovMatrix", "y", var_mat(y)));
+
+  for (int i = 0; i < y.size(); i++) {
+    y.resize(3, 3);
+    y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
+    y(i) = nan;
+    EXPECT_THROW(stan::math::check_cov_matrix("checkCovMatrix", "y", var_mat(y)),
+                 std::domain_error);
+    y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
+  }
+}

--- a/test/unit/math/rev/err/check_finite_test.cpp
+++ b/test/unit/math/rev/err/check_finite_test.cpp
@@ -90,3 +90,37 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckUnivariate) {
 
   stan::math::recover_memory();
 }
+
+
+TEST(ErrorHandlingMat, CheckFinite_VarMatrix) {
+  using stan::math::check_finite;
+  const char* function = "check_finite";
+  Eigen::Matrix<double, Eigen::Dynamic, 1> x;
+  using var_mat = stan::math::var_value<Eigen::MatrixXd>;
+
+  x.resize(3);
+  x << -1, 0, 1;
+  ASSERT_NO_THROW(check_finite(function, "x", var_mat(x)))
+      << "check_finite should be true with finite x";
+
+  ASSERT_NO_THROW(check_finite(function, "x", var_mat(x).array()))
+      << "check_finite should be true with finite x";
+
+  ASSERT_NO_THROW(check_finite(function, "x", var_mat(x).transpose()))
+      << "check_finite should be true with finite x";
+
+  x.resize(3);
+  x << -1, 0, std::numeric_limits<double>::infinity();
+  EXPECT_THROW(check_finite(function, "x", var_mat(x)), std::domain_error)
+      << "check_finite should throw exception on Inf";
+
+  x.resize(3);
+  x << -1, 0, -std::numeric_limits<double>::infinity();
+  EXPECT_THROW(check_finite(function, "x", var_mat(x)), std::domain_error)
+      << "check_finite should throw exception on -Inf";
+
+  x.resize(3);
+  x << -1, 0, std::numeric_limits<double>::quiet_NaN();
+  EXPECT_THROW(check_finite(function, "x", var_mat(x)), std::domain_error)
+      << "check_finite should throw exception on NaN";
+}

--- a/test/unit/math/rev/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/err/check_less_or_equal_test.cpp
@@ -116,6 +116,89 @@ TEST(AgradRevErrorHandlingMatrix, CheckLessOrEqual_Matrix) {
   stan::math::recover_memory();
 }
 
+
+TEST(AgradRevErrorHandlingMatrix, CheckLessOrEqual_VarMatrix) {
+  using stan::math::check_less_or_equal;
+  using stan::math::var;
+  using stan::math::to_var_value;
+  const char* function = "check_less_or_equal";
+  var x;
+  var high;
+  Eigen::Matrix<var, Eigen::Dynamic, 1> x_vec;
+  Eigen::Matrix<var, Eigen::Dynamic, 1> high_vec;
+  x_vec.resize(3);
+  high_vec.resize(3);
+
+  // x_vec, high
+  x_vec << -5, 0, 5;
+  high = 10;
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", to_var_value(x_vec), high));
+
+  x_vec << -5, 0, 5;
+  high = std::numeric_limits<double>::infinity();
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", to_var_value(x_vec), high));
+
+  x_vec << -5, 0, 5;
+  high = 5;
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", to_var_value(x_vec), high));
+
+  x_vec << -5, 0, std::numeric_limits<double>::infinity();
+  high = 5;
+  EXPECT_THROW(check_less_or_equal(function, "x", to_var_value(x_vec), high),
+               std::domain_error);
+
+  x_vec << -5, 0, std::numeric_limits<double>::infinity();
+  high = std::numeric_limits<double>::infinity();
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", to_var_value(x_vec), high));
+
+  // x_vec, to_var_value(high_vec)
+  x_vec << -5, 0, 5;
+  high_vec << 0, 5, 10;
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", to_var_value(x_vec), to_var_value(high_vec)));
+
+  x_vec << -5, 0, 5;
+  high_vec << std::numeric_limits<double>::infinity(), 10, 10;
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", to_var_value(x_vec), to_var_value(high_vec)));
+
+  x_vec << -5, 0, 5;
+  high_vec << 10, 10, 5;
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", to_var_value(x_vec), to_var_value(high_vec)));
+
+  x_vec << -5, 0, std::numeric_limits<double>::infinity();
+  high_vec << 10, 10, 10;
+  EXPECT_THROW(check_less_or_equal(function, "x", to_var_value(x_vec), to_var_value(high_vec)),
+               std::domain_error);
+
+  x_vec << -5, 0, std::numeric_limits<double>::infinity();
+  high_vec << 10, 10, std::numeric_limits<double>::infinity();
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", to_var_value(x_vec), to_var_value(high_vec)));
+
+  // x, to_var_value(high_vec)
+  x = -100;
+  high_vec << 0, 5, 10;
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, to_var_value(high_vec)));
+
+  x = 10;
+  high_vec << 100, 200, std::numeric_limits<double>::infinity();
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, to_var_value(high_vec)));
+
+  x = 5;
+  high_vec << 100, 200, 5;
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, to_var_value(high_vec)));
+
+  x = std::numeric_limits<double>::infinity();
+  high_vec << 10, 20, 30;
+  EXPECT_THROW(check_less_or_equal(function, "x", x, to_var_value(high_vec)),
+               std::domain_error);
+
+  x = std::numeric_limits<double>::infinity();
+  high_vec << std::numeric_limits<double>::infinity(),
+      std::numeric_limits<double>::infinity(),
+      std::numeric_limits<double>::infinity();
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, to_var_value(high_vec)));
+  stan::math::recover_memory();
+}
+
 TEST(AgradRevErrorHandlingScalar, CheckLessOrEqual) {
   using stan::math::check_less_or_equal;
   using stan::math::var;

--- a/test/unit/math/rev/err/check_less_test.cpp
+++ b/test/unit/math/rev/err/check_less_test.cpp
@@ -114,6 +114,85 @@ TEST(AgradRevErrorHandlingMatrix, CheckLess_Matrix) {
   stan::math::recover_memory();
 }
 
+TEST(AgradRevErrorHandlingMatrix, CheckLess_VarMatrix) {
+  using stan::math::check_less;
+  using stan::math::var;
+  using stan::math::to_var_value;
+  const char* function = "check_less";
+  var x;
+  var high;
+  Eigen::Matrix<var, Eigen::Dynamic, 1> x_vec;
+  Eigen::Matrix<var, Eigen::Dynamic, 1> high_vec;
+  x_vec.resize(3);
+  high_vec.resize(3);
+
+  // x_vec, high
+  x_vec << -5, 0, 5;
+  high = 10;
+  EXPECT_NO_THROW(check_less(function, "x", to_var_value(x_vec), high));
+
+  x_vec << -5, 0, 5;
+  high = std::numeric_limits<double>::infinity();
+  EXPECT_NO_THROW(check_less(function, "x", to_var_value(x_vec), high));
+
+  x_vec << -5, 0, 5;
+  high = 5;
+  EXPECT_THROW(check_less(function, "x", to_var_value(x_vec), high), std::domain_error);
+
+  x_vec << -5, 0, std::numeric_limits<double>::infinity();
+  high = 5;
+  EXPECT_THROW(check_less(function, "x", to_var_value(x_vec), high), std::domain_error);
+
+  x_vec << -5, 0, std::numeric_limits<double>::infinity();
+  high = std::numeric_limits<double>::infinity();
+  EXPECT_THROW(check_less(function, "x", to_var_value(x_vec), high), std::domain_error);
+
+  // x_vec, high_vec
+  x_vec << -5, 0, 5;
+  high_vec << 0, 5, 10;
+  EXPECT_NO_THROW(check_less(function, "x", to_var_value(x_vec), to_var_value(high_vec)));
+
+  x_vec << -5, 0, 5;
+  high_vec << std::numeric_limits<double>::infinity(), 10, 10;
+  EXPECT_NO_THROW(check_less(function, "x", to_var_value(x_vec), to_var_value(high_vec)));
+
+  x_vec << -5, 0, 5;
+  high_vec << 10, 10, 5;
+  EXPECT_THROW(check_less(function, "x", to_var_value(x_vec), to_var_value(high_vec)), std::domain_error);
+
+  x_vec << -5, 0, std::numeric_limits<double>::infinity();
+  high_vec << 10, 10, 10;
+  EXPECT_THROW(check_less(function, "x", to_var_value(x_vec), to_var_value(high_vec)), std::domain_error);
+
+  x_vec << -5, 0, std::numeric_limits<double>::infinity();
+  high_vec << 10, 10, std::numeric_limits<double>::infinity();
+  EXPECT_THROW(check_less(function, "x", to_var_value(x_vec), to_var_value(high_vec)), std::domain_error);
+
+  // x, to_var_value(high_vec)
+  x = -100;
+  high_vec << 0, 5, 10;
+  EXPECT_NO_THROW(check_less(function, "x", x, to_var_value(high_vec)));
+
+  x = 10;
+  high_vec << 100, 200, std::numeric_limits<double>::infinity();
+  EXPECT_NO_THROW(check_less(function, "x", x, to_var_value(high_vec)));
+
+  x = 5;
+  high_vec << 100, 200, 5;
+  EXPECT_THROW(check_less(function, "x", x, to_var_value(high_vec)), std::domain_error);
+
+  x = std::numeric_limits<double>::infinity();
+  high_vec << 10, 20, 30;
+  EXPECT_THROW(check_less(function, "x", x, to_var_value(high_vec)), std::domain_error);
+
+  x = std::numeric_limits<double>::infinity();
+  high_vec << std::numeric_limits<double>::infinity(),
+      std::numeric_limits<double>::infinity(),
+      std::numeric_limits<double>::infinity();
+  EXPECT_THROW(check_less(function, "x", x, to_var_value(high_vec)), std::domain_error);
+  stan::math::recover_memory();
+}
+
 TEST(AgradRevErrorHandlingScalar, CheckLess) {
   using stan::math::check_less;
   using stan::math::var;

--- a/test/unit/math/rev/err/check_pos_definite_test.cpp
+++ b/test/unit/math/rev/err/check_pos_definite_test.cpp
@@ -33,3 +33,32 @@ TEST(AgradRevErrorHandlingMatrix, checkPosDefiniteMatrix_nan) {
   EXPECT_THROW(check_pos_definite("checkPosDefiniteMatrix", "y", y),
                std::domain_error);
 }
+
+TEST(AgradRevErrorHandlingMatrix, checkPosDefiniteMatrix_nan_varmat) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::var_value;
+
+  Matrix<double, Dynamic, Dynamic> y_val(3, 3);
+  y_val << 2, -1, 0, -1, 2, -1, 0, -1, 2;
+  var_value<Matrix<double, Dynamic, Dynamic>> y(y_val);
+  using stan::math::check_pos_definite;
+
+  EXPECT_NO_THROW(check_pos_definite("checkPosDefiniteMatrix", "y", y));
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  for (int i = 0; i < y.rows(); i++)
+    for (int j = 0; j < y.cols(); j++) {
+      y.vi_->val_(i, j) = nan;
+      if (i >= j)
+        EXPECT_THROW(check_pos_definite("checkPosDefiniteMatrix", "y", y),
+                     std::domain_error);
+     y.vi_->val_ = y_val;
+    }
+
+  Matrix<double, Dynamic, Dynamic> y_val_zero(3, 3);
+  y_val_zero << 0, 0, 0, 0, 0, 0, 0, 0, 0;
+  var_value<Matrix<double, Dynamic, Dynamic>> y_zero(y_val_zero);
+  EXPECT_THROW(check_pos_definite("checkPosDefiniteMatrix", "y_zero", y_zero),
+               std::domain_error);
+}

--- a/test/unit/math/rev/err/check_positive_test.cpp
+++ b/test/unit/math/rev/err/check_positive_test.cpp
@@ -39,6 +39,26 @@ TEST(AgradRevErrorHandlingMatrix, CheckPositive) {
   stan::math::recover_memory();
 }
 
+TEST(AgradRevErrorHandlingMatrix, CheckPositiveVarMat) {
+  using stan::math::check_positive;
+  using stan::math::var_value;
+
+  const char* function = "check_positive";
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> x_mat_val(3);
+  x_mat_val << 1, 2, 3;
+  var_value<Eigen::Matrix<double, Eigen::Dynamic, 1>> x_mat(x_mat_val);
+  for (int i = 0; i < x_mat.size(); i++) {
+    EXPECT_NO_THROW(check_positive(function, "x", x_mat));
+  }
+
+  x_mat.vi->val_(0) = 0;
+
+  EXPECT_THROW(check_positive(function, "x", x_mat), std::domain_error);
+
+  stan::math::recover_memory();
+}
+
 TEST(AgradRevErrorHandlingScalar, CheckPositive) {
   using stan::math::check_positive;
   using stan::math::var;


### PR DESCRIPTION
## Summary

This let's the error checking functions that can take in matrices also take in `var_value<Matrix>` types. The main change here was just to change the require from `require_eigen_t<>` to `require_matrix_t<>` and to use `value_of()` on the input. I also fixed up `check_less_or_equal` etc. to use SFINAE instead of the struct templating schemes.

## Tests

Several tests were added for var matrix types, though after a bit it started to look like the tests were becoming redundant with the tests that already exist. I added tests for functions which have changes besides calling `value_of()`

## Side Effects

Nope!

## Release notes

Let check functions accept new matrix type.

## Checklist

- [x] Math issue #1805 

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
