### PR TITLE
fix for log apply scalar unary

### DIFF
--- a/stan/math/rev/fun/log.hpp
+++ b/stan/math/rev/fun/log.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core.hpp>
+#include <stan/math/rev/functor/apply_scalar_unary.hpp>
 #include <stan/math/rev/fun/abs.hpp>
 #include <stan/math/rev/fun/arg.hpp>
 #include <stan/math/rev/fun/atan2.hpp>


### PR DESCRIPTION

## Summary

Fix for failure on develop. We were not including the var specialization of `apply_scalar_unary` before `log()` in `rev`

## Tests

No new tests

## Side Effects

Nope!

## Release notes

Bug fix for vectorized log include order

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
