### PR TITLE
optimization

### DIFF
--- a/stan/math/opencl/kernel_generator/multi_result_kernel.hpp
+++ b/stan/math/opencl/kernel_generator/multi_result_kernel.hpp
@@ -267,7 +267,7 @@ class expressions_cl {
    */
   explicit expressions_cl(T_expressions&&... expressions)
       : expressions_(
-          T_expressions(std::forward<T_expressions>(expressions))...) {}
+            T_expressions(std::forward<T_expressions>(expressions))...) {}
 
  private:
   std::tuple<T_expressions...> expressions_;
@@ -327,8 +327,8 @@ class results_cl {
   void operator=(expressions_cl<T_expressions...>&& exprs) {
     index_apply<sizeof...(T_expressions)>([this, &exprs](auto... Is) mutable {
       assignment_impl(std::tuple_cat(make_assignment_pair(
-          std::get<Is>(results_), std::forward<T_expressions>(
-                                      std::get<Is>(exprs.expressions_)))...));
+          std::get<Is>(results_),
+          std::forward<T_expressions>(std::get<Is>(exprs.expressions_)))...));
     });
   }
 

--- a/test/unit/math/opencl/kernel_generator/multi_result_kernel_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/multi_result_kernel_test.cpp
@@ -131,4 +131,21 @@ TEST(KernelGenerator, multi_result_kernel_reuse_kernel) {
   EXPECT_MATRIX_NEAR(res_diff, correct_diff, 1e-9);
 }
 
+TEST(KernelGenerator, multi_result_kernel_matrix_cl_move) {
+  MatrixXd m1(3, 3);
+  m1 << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  MatrixXd m2(3, 3);
+  m2 << 10, 100, 1000, 0, -10, -12, 2, 4, 8;
+
+  matrix_cl<double> m1_cl(m1);
+  matrix_cl<double> m2_cl(m2);
+
+  cl_mem m2_buf = m2_cl.buffer()();
+
+  stan::math::results(m1_cl) = stan::math::expressions(m2_cl);
+  EXPECT_NE(m1_cl.buffer()(), m2_buf);
+  stan::math::results(m1_cl) = stan::math::expressions(std::move(m2_cl));
+  EXPECT_EQ(m1_cl.buffer()(), m2_buf);
+}
+
 #endif


### PR DESCRIPTION
## Summary

Optimize kernel generator so it can use `matrix_cl`'s move assignment where possible instead of copying the data.

## Tests

Added a test to check that the new optimization is used.

## Side Effects
None.

## Release notes
OpenCL: Optimized kernel generator so it can use `matrix_cl`'s move assignment where possible instead of copying the data.

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
