### PR TITLE
fix to_vector for new matrix type

### DIFF
--- a/stan/math/rev/fun/to_vector.hpp
+++ b/stan/math/rev/fun/to_vector.hpp
@@ -19,7 +19,7 @@ namespace math {
 template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
 inline auto to_vector(const var_value<EigMat>& x) {
   using view_type = Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1>>;
-  return var_value<vari_view<view_type>>(new vari_view<view_type>(
+  return var_value<view_type>(new vari_view<view_type>(
       view_type(x.vi_->val_.data(), x.rows() * x.cols()),
       view_type(x.vi_->adj_.data(), x.rows() * x.cols())));
 }

--- a/stan/math/rev/fun/to_vector.hpp
+++ b/stan/math/rev/fun/to_vector.hpp
@@ -19,9 +19,9 @@ namespace math {
 template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
 inline auto to_vector(const var_value<EigMat>& x) {
   using view_type = Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1>>;
-  return vari_view<view_type>(
+  return var_value<vari_view<view_type>>(new vari_view<view_type>(
       view_type(x.vi_->val_.data(), x.rows() * x.cols()),
-      view_type(x.vi_->adj_.data(), x.rows() * x.cols()));
+      view_type(x.vi_->adj_.data(), x.rows() * x.cols())));
 }
 
 }  // namespace math

--- a/test/unit/math/rev/fun/to_vector_test.cpp
+++ b/test/unit/math/rev/fun/to_vector_test.cpp
@@ -8,6 +8,7 @@ TEST(MathFunRev, to_vector_var_value) {
   Eigen::MatrixXd a_val = Eigen::MatrixXd::Random(n, n);
   stan::math::var_value<Eigen::MatrixXd> a(a_val);
   auto&& tmp = stan::math::to_vector(a);
+  EXPECT_TRUE((stan::is_var<decltype(tmp)>::value));
   EXPECT_TRUE((stan::is_col_vector<decltype(tmp.val())>::value));
   EXPECT_MATRIX_EQ(tmp.val(), Eigen::Map<Eigen::VectorXd>(a_val.data(),
                                                           a.rows() * a.cols()));


### PR DESCRIPTION

## Summary

Fixes a bug in to_vector for `var<Matrix>` which needs to return a `var_value<Matrix>` instead of a `vari_value<Matrix>`

## Tests

Test added to `to_vector()` that checks the return type is a var.

## Side Effects

Nope

## Release notes

Fix bug in `to_vector()` with new matrix type.

## Checklist

- [x] Math issue #1805 

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
