### PR TITLE
Create Jacobian template parameter overload for constrain functions

### DIFF
--- a/stan/math/prim/fun/cholesky_corr_constrain.hpp
+++ b/stan/math/prim/fun/cholesky_corr_constrain.hpp
@@ -13,7 +13,7 @@ namespace stan {
 namespace math {
 
 template <typename EigVec, require_eigen_col_vector_t<EigVec>* = nullptr>
-Eigen::Matrix<value_type_t<EigVec>, Eigen::Dynamic, Eigen::Dynamic>
+inline Eigen::Matrix<value_type_t<EigVec>, Eigen::Dynamic, Eigen::Dynamic>
 cholesky_corr_constrain(const EigVec& y, int K) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -44,8 +44,8 @@ cholesky_corr_constrain(const EigVec& y, int K) {
 
 // FIXME to match above after debugged
 template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
-Eigen::Matrix<value_type_t<EigVec>, Eigen::Dynamic, Eigen::Dynamic>
-cholesky_corr_constrain(const EigVec& y, int K, value_type_t<EigVec>& lp) {
+inline Eigen::Matrix<value_type_t<EigVec>, Eigen::Dynamic, Eigen::Dynamic>
+cholesky_corr_constrain(const EigVec& y, int K, scalar_type_t<EigVec>& lp) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using std::sqrt;
@@ -74,6 +74,25 @@ cholesky_corr_constrain(const EigVec& y, int K, value_type_t<EigVec>& lp) {
   return x;
 }
 
+/**
+ * Return The cholesky of a `KxK` correlation matrix.
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T A type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column.
+ * @param y Linearly Serialized vector of size `(K * (K - 1))/2` holding the
+ *  column major order elements of the lower triangurlar.
+ * @param K The size of the matrix to return.
+ * @param lp Log probability that is incremented with the log Jacobian
+ */
+template <bool Jacobian, typename T>
+inline auto cholesky_corr_constrain(const T& y, int K, scalar_type_t<T>& lp) {
+  if (Jacobian) {
+    return cholesky_corr_constrain(y, K, lp);
+  } else {
+    return cholesky_corr_constrain(y, K);
+  }
+}
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/fun/cholesky_factor_constrain.hpp
+++ b/stan/math/prim/fun/cholesky_factor_constrain.hpp
@@ -26,7 +26,7 @@ namespace math {
  * @return Cholesky factor
  */
 template <typename T, require_eigen_col_vector_t<T>* = nullptr>
-Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
+inline Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
 cholesky_factor_constrain(const T& x, int M, int N) {
   using std::exp;
   using T_scalar = value_type_t<T>;
@@ -71,8 +71,8 @@ cholesky_factor_constrain(const T& x, int M, int N) {
  * @return Cholesky factor
  */
 template <typename T, require_eigen_vector_t<T>* = nullptr>
-Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
-cholesky_factor_constrain(const T& x, int M, int N, value_type_t<T>& lp) {
+inline Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
+cholesky_factor_constrain(const T& x, int M, int N, scalar_type_t<T>& lp) {
   check_size_match("cholesky_factor_constrain", "x.size()", x.size(),
                    "((N * (N + 1)) / 2 + (M - N) * N)",
                    ((N * (N + 1)) / 2 + (M - N) * N));
@@ -83,6 +83,32 @@ cholesky_factor_constrain(const T& x, int M, int N, value_type_t<T>& lp) {
     lp += x_ref.coeff(pos++);
   }
   return cholesky_factor_constrain(x_ref, M, N);
+}
+
+/**
+ * Return the Cholesky factor of the specified size read from the
+ * specified vector and increment the specified log probability
+ * reference with the log Jacobian adjustment of the transform.  A total
+ * of (N choose 2) + N + N * (M - N) free parameters are required to read
+ * an M by N Cholesky factor.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T A type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column.
+ * @param x Vector of unconstrained values
+ * @param M number of rows
+ * @param N number of columns
+ * @param lp Log probability that is incremented with the log Jacobian
+ * @return Cholesky factor
+ */
+template <bool Jacobian, typename T>
+inline auto cholesky_factor_constrain(const T& x, int M, int N, scalar_type_t<T>& lp) {
+  if (Jacobian) {
+    return cholesky_factor_constrain(x, M, N, lp);
+  } else {
+    return cholesky_factor_constrain(x, M, N);
+  }
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/corr_constrain.hpp
+++ b/stan/math/prim/fun/corr_constrain.hpp
@@ -24,7 +24,7 @@ namespace math {
  * @return tanh transform
  */
 template <typename T>
-inline auto corr_constrain(const T& x) {
+inline plain_type_t<T> corr_constrain(const T& x) {
   return tanh(x);
 }
 
@@ -48,6 +48,33 @@ inline auto corr_constrain(const T_x& x, T_lp& lp) {
   lp += sum(log1m(square(tanh_x)));
   return tanh_x;
 }
+
+/**
+ * Return the result of transforming the specified scalar or container of values
+ * to have a valid correlation value between -1 and 1 (inclusive).
+ *
+ * <p>The transform used is as specified for
+ * <code>corr_constrain(T)</code>.  The log absolute Jacobian
+ * determinant is
+ *
+ * <p>\f$\log | \frac{d}{dx} \tanh x  | = \log (1 - \tanh^2 x)\f$.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T_x Type of scalar or container
+ * @tparam T_lp A scalar
+ * @param[in] x value or container
+ * @param[in,out] lp log density accumulator
+ */
+template <bool Jacobian, typename T_x, typename T_lp>
+inline auto corr_constrain(const T_x& x, T_lp& lp) {
+  if (Jacobian) {
+    return corr_constrain(x, lp);
+  } else {
+    return corr_constrain(x);
+  }
+}
+
+
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/corr_matrix_constrain.hpp
+++ b/stan/math/prim/fun/corr_matrix_constrain.hpp
@@ -37,7 +37,7 @@ namespace math {
  * matrix.
  */
 template <typename T, require_eigen_col_vector_t<T>* = nullptr>
-Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
+inline Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
 corr_matrix_constrain(const T& x, Eigen::Index k) {
   Eigen::Index k_choose_2 = (k * (k - 1)) / 2;
   check_size_match("cov_matrix_constrain", "x.size()", x.size(), "k_choose_2",
@@ -66,12 +66,43 @@ corr_matrix_constrain(const T& x, Eigen::Index k) {
  * @param lp Log probability reference to increment.
  */
 template <typename T, require_eigen_col_vector_t<T>* = nullptr>
-Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
-corr_matrix_constrain(const T& x, Eigen::Index k, value_type_t<T>& lp) {
+inline Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
+corr_matrix_constrain(const T& x, Eigen::Index k, scalar_type_t<T>& lp) {
   Eigen::Index k_choose_2 = (k * (k - 1)) / 2;
   check_size_match("cov_matrix_constrain", "x.size()", x.size(), "k_choose_2",
                    k_choose_2);
   return read_corr_matrix(corr_constrain(x, lp), k, lp);
+}
+
+/**
+ * Return the correlation matrix of the specified dimensionality
+ * derived from the specified vector of unconstrained values.  The
+ * input vector must be of length \f${k \choose 2} =
+ * \frac{k(k-1)}{2}\f$.  The values in the input vector represent
+ * unconstrained (partial) correlations among the dimensions.
+ *
+ * <p>The transform is as specified for
+ * <code>corr_matrix_constrain(Matrix, size_t)</code>; the
+ * paper it cites also defines the Jacobians for correlation inputs,
+ * which are composed with the correlation constrained Jacobians
+ * defined in <code>corr_constrain(T, double)</code> for
+ * this function.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T A type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column.
+ * @param x Vector of unconstrained partial correlations.
+ * @param k Dimensionality of returned correlation matrix.
+ * @param lp Log probability reference to increment.
+ */
+template <bool Jacobian, typename T>
+inline auto corr_matrix_constrain(const T& x, Eigen::Index k, scalar_type_t<T>& lp) {
+  if (Jacobian) {
+    return corr_matrix_constrain(x, k, lp);
+  } else {
+    return corr_matrix_constrain(x, k);
+  }
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cov_matrix_constrain.hpp
+++ b/stan/math/prim/fun/cov_matrix_constrain.hpp
@@ -28,7 +28,7 @@ namespace math {
  * @throws std::invalid_argument if (x.size() != K + (K choose 2)).
  */
 template <typename T, require_eigen_col_vector_t<T>* = nullptr>
-Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
+inline Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
 cov_matrix_constrain(const T& x, Eigen::Index K) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -63,8 +63,8 @@ cov_matrix_constrain(const T& x, Eigen::Index K) {
  * @throws std::domain_error if (x.size() != K + (K choose 2)).
  */
 template <typename T, require_eigen_col_vector_t<T>* = nullptr>
-Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
-cov_matrix_constrain(const T& x, Eigen::Index K, value_type_t<T>& lp) {
+inline Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
+cov_matrix_constrain(const T& x, Eigen::Index K, scalar_type_t<T>& lp) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using std::exp;
@@ -87,6 +87,33 @@ cov_matrix_constrain(const T& x, Eigen::Index K, value_type_t<T>& lp) {
   }
   return multiply_lower_tri_self_transpose(L);
 }
+
+/**
+ * Return the symmetric, positive-definite matrix of dimensions K
+ * by K resulting from transforming the specified finite vector of
+ * size K plus (K choose 2).
+ *
+ * <p>See <code>cov_matrix_free()</code> for the inverse transform.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T A type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column.
+ * @param x The vector to convert to a covariance matrix.
+ * @param K The dimensions of the resulting covariance matrix.
+ * @param lp Reference
+ * @throws std::domain_error if (x.size() != K + (K choose 2)).
+ */
+template <bool Jacobian, typename T>
+inline auto
+cov_matrix_constrain(const T& x, Eigen::Index K, scalar_type_t<T>& lp) {
+  if (Jacobian) {
+    return cov_matrix_constrain(x, K, lp);
+  } else {
+    return cov_matrix_constrain(x, K);
+  }
+}
+
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/cov_matrix_constrain_lkj.hpp
+++ b/stan/math/prim/fun/cov_matrix_constrain_lkj.hpp
@@ -31,7 +31,7 @@ namespace math {
  * correlations and deviations.
  */
 template <typename T, require_eigen_vector_t<T>* = nullptr>
-Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
+inline Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
 cov_matrix_constrain_lkj(const T& x, size_t k) {
   size_t k_choose_2 = (k * (k - 1)) / 2;
   const auto& x_ref = to_ref(x);
@@ -65,13 +65,50 @@ cov_matrix_constrain_lkj(const T& x, size_t k) {
  * correlations and deviations.
  */
 template <typename T, require_eigen_vector_t<T>* = nullptr>
-Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
-cov_matrix_constrain_lkj(const T& x, size_t k, value_type_t<T>& lp) {
+inline Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
+cov_matrix_constrain_lkj(const T& x, size_t k, scalar_type_t<T>& lp) {
   size_t k_choose_2 = (k * (k - 1)) / 2;
   const auto& x_ref = x;
   return read_cov_matrix(corr_constrain(x_ref.head(k_choose_2)),
                          positive_constrain(x_ref.tail(k)), lp);
 }
+
+/**
+ * Return the covariance matrix of the specified dimensionality
+ * derived from constraining the specified vector of unconstrained
+ * values and increment the specified log probability reference
+ * with the log absolute Jacobian determinant.
+ *
+ * <p>The transform is defined as for
+ * <code>cov_matrix_constrain(Matrix, size_t)</code>.
+ *
+ * <p>The log absolute Jacobian determinant is derived by
+ * composing the log absolute Jacobian determinant for the
+ * underlying correlation matrix as defined in
+ * <code>cov_matrix_constrain(Matrix, size_t, T&)</code> with
+ * the Jacobian of the transform of the correlation matrix
+ * into a covariance matrix by scaling by standard deviations.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T A type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time rows or columns equal to 1.
+ * @param x Input vector of unconstrained partial correlations and
+ * standard deviations.
+ * @param k Dimensionality of returned covariance matrix.
+ * @param lp Log probability reference to increment.
+ * @return Covariance matrix derived from the unconstrained partial
+ * correlations and deviations.
+ */
+template <bool Jacobian, typename T>
+inline auto
+cov_matrix_constrain_lkj(const T& x, size_t k, scalar_type_t<T>& lp) {
+  if (Jacobian) {
+    return cov_matrix_constrain_lkj(x, k, lp);
+  } else {
+    return cov_matrix_constrain_lkj(x, k);
+  }
+}
+
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/identity_constrain.hpp
+++ b/stan/math/prim/fun/identity_constrain.hpp
@@ -11,12 +11,13 @@ namespace math {
  * transform to the input. This promotes the input to the least upper
  * bound of the input types.
  *
+ * @tparam Jacobian Unused, only here for standardized API
  * @tparam T type of value to promote
  * @tparam Types Other types.
  * @param[in] x object
  * @return transformed input
  */
-template <typename T, typename... Types,
+template <bool Jacobian = false, typename T, typename... Types,
           require_all_not_var_matrix_t<T, Types...>* = nullptr>
 inline auto identity_constrain(T&& x, Types&&... /* args */) {
   return promote_scalar_t<return_type_t<T, Types...>, T>(x);

--- a/stan/math/prim/fun/lb_constrain.hpp
+++ b/stan/math/prim/fun/lb_constrain.hpp
@@ -221,6 +221,28 @@ inline auto lb_constrain(const std::vector<T>& x, const std::vector<L>& lb,
   return ret;
 }
 
+/**
+ * Specialization of `lb_constrain` to apply a container of lower bounds
+ * elementwise to each input element.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T A type inheriting from `Eigen::EigenBase`, a `var_value` with inner type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @tparam L A type inheriting from `Eigen::EigenBase`, a `var_value` with inner type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @param[in] x unconstrained input
+ * @param[in] lb lower bound on output
+ * @param[in,out] lp reference to log probability to increment
+ * @return lower-bound constrained value corresponding to inputs
+ */
+template <bool Jacobian, typename T, typename L>
+inline auto lb_constrain(const T& x, const L& lb, return_type_t<T, L>& lp) {
+  if (Jacobian) {
+    return lb_constrain(x, lb, lp);
+  } else {
+    return lb_constrain(x, lb);
+  }
+}
+
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/lub_constrain.hpp
+++ b/stan/math/prim/fun/lub_constrain.hpp
@@ -366,6 +366,36 @@ inline auto lub_constrain(const std::vector<T>& x, const std::vector<L>& lb,
   return ret;
 }
 
+/**
+ * Return the lower and upper-bounded scalar derived by
+ * transforming the specified free scalar given the specified
+ * lower and upper bounds.
+ *
+ * <p>The transform is the transformed and scaled inverse logit,
+ *
+ * <p>\f$f(x) = L + (U - L) \mbox{logit}^{-1}(x)\f$
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T A type inheriting from `Eigen::EigenBase`, a `var_value` with inner type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @tparam L A type inheriting from `Eigen::EigenBase`, a `var_value` with inner type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @tparam U A type inheriting from `Eigen::EigenBase`, a `var_value` with inner type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @param[in] x Free scalar to transform.
+ * @param[in] lb Lower bound.
+ * @param[in] ub Upper bound.
+ * @return Lower- and upper-bounded scalar derived from transforming
+ *   the free scalar.
+ * @throw std::domain_error if ub <= lb
+ */
+template <bool Jacobian, typename T, typename L, typename U>
+inline auto lub_constrain(const T& x, const L& lb, const U& ub,
+                          return_type_t<T, L, U>& lp) {
+  if (Jacobian) {
+    return lub_constrain(x, lb, ub, lp);
+  } else {
+    return lub_constrain(x, lb, ub);
+  }
+}
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/offset_multiplier_constrain.hpp
+++ b/stan/math/prim/fun/offset_multiplier_constrain.hpp
@@ -272,6 +272,43 @@ inline auto offset_multiplier_constrain(const std::vector<T>& x,
   return ret;
 }
 
+/**
+ * Return the linearly transformed value for the specified unconstrained input
+ * and specified offset and multiplier.
+ *
+ * <p>The transform applied is
+ *
+ * <p>\f$f(x) = mu + sigma * x\f$
+ *
+ * <p>where mu is the offset and sigma is the multiplier.
+ *
+ * <p>If the offset is zero and the multiplier is one this
+ * reduces to <code>identity_constrain(x)</code>.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T A type inheriting from `Eigen::EigenBase`, a `var_value` with inner type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @tparam M A type inheriting from `Eigen::EigenBase`, a `var_value` with inner type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @tparam S A type inheriting from `Eigen::EigenBase`, a `var_value` with inner type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @param[in] x Unconstrained scalar input
+ * @param[in] mu offset of constrained output
+ * @param[in] sigma multiplier of constrained output
+ * @return linear transformed value corresponding to inputs
+ * @throw std::domain_error if sigma <= 0
+ * @throw std::domain_error if mu is not finite
+ */
+template <bool Jacobian, typename T, typename M, typename S>
+inline auto offset_multiplier_constrain(const T& x,
+                                        const M& mu,
+                                        const S& sigma,
+                                        return_type_t<T, M, S>& lp) {
+  if (Jacobian) {
+    return offset_multiplier_constrain(x, mu, sigma, lp);
+  } else {
+    return offset_multiplier_constrain(x, mu, sigma);
+  }
+}
+
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/ordered_constrain.hpp
+++ b/stan/math/prim/fun/ordered_constrain.hpp
@@ -22,7 +22,7 @@ namespace math {
  */
 template <typename EigVec, require_eigen_col_vector_t<EigVec>* = nullptr,
           require_not_st_var<EigVec>* = nullptr>
-plain_type_t<EigVec> ordered_constrain(const EigVec& x) {
+inline plain_type_t<EigVec> ordered_constrain(const EigVec& x) {
   using std::exp;
   Eigen::Index k = x.size();
   plain_type_t<EigVec> y(k);
@@ -50,12 +50,36 @@ plain_type_t<EigVec> ordered_constrain(const EigVec& x) {
  * @return Positive, increasing ordered vector.
  */
 template <typename EigVec, require_eigen_col_vector_t<EigVec>* = nullptr>
-auto ordered_constrain(const EigVec& x, value_type_t<EigVec>& lp) {
+inline auto ordered_constrain(const EigVec& x, value_type_t<EigVec>& lp) {
   const auto& x_ref = to_ref(x);
   if (likely(x.size() > 1)) {
     lp += x_ref.tail(x.size() - 1).sum();
   }
   return ordered_constrain(x_ref);
+}
+
+/**
+ * Return a positive valued, increasing ordered vector derived
+ * from the specified free vector and increment the specified log
+ * probability reference with the log absolute Jacobian determinant
+ * of the transform.  The returned constrained vector
+ * will have the same dimensionality as the specified free vector.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T A type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column.
+ * @param x Free vector of scalars.
+ * @param lp Log probability reference.
+ * @return Positive, increasing ordered vector.
+ */
+template <bool Jacobian, typename T>
+inline auto ordered_constrain(const T& x, scalar_type_t<T>& lp) {
+  if (Jacobian) {
+    return ordered_constrain(x, lp);
+  } else {
+    return ordered_constrain(x);
+  }
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/positive_constrain.hpp
+++ b/stan/math/prim/fun/positive_constrain.hpp
@@ -46,6 +46,32 @@ inline auto positive_constrain(const T& x, S& lp) {
   return exp(x);
 }
 
+/**
+ * Return the positive value for the specified unconstrained input,
+ * incrementing the scalar reference with the log absolute
+ * Jacobian determinant.
+ *
+ * <p>See <code>positive_constrain(T)</code> for details
+ * of the transform.  The log absolute Jacobian determinant is
+ *
+ * <p>\f$\log | \frac{d}{dx} \mbox{exp}(x) |
+ *    = \log | \mbox{exp}(x) | =  x\f$.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T A type inheriting from `Eigen::EigenBase`, a `var_value` with inner type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @param x unconstrained value or container
+ * @param lp log density reference.
+ * @return positive constrained version of unconstrained value(s)
+ */
+template <bool Jacobian, typename T>
+inline auto positive_constrain(const T& x, scalar_type_t<T>& lp) {
+  if (Jacobian) {
+    return positive_constrain(x, lp);
+  } else {
+    return positive_constrain(x);
+  }
+}
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/positive_ordered_constrain.hpp
+++ b/stan/math/prim/fun/positive_ordered_constrain.hpp
@@ -21,7 +21,7 @@ namespace math {
  */
 template <typename EigVec, require_eigen_col_vector_t<EigVec>* = nullptr,
           require_not_st_var<EigVec>* = nullptr>
-auto positive_ordered_constrain(const EigVec& x) {
+inline auto positive_ordered_constrain(const EigVec& x) {
   using std::exp;
   Eigen::Index k = x.size();
   plain_type_t<EigVec> y(k);
@@ -54,6 +54,29 @@ inline auto positive_ordered_constrain(const Vec& x, scalar_type_t<Vec>& lp) {
   lp += sum(x_ref);
   return positive_ordered_constrain(x_ref);
 }
+
+/**
+ * Return a positive valued, increasing positive ordered vector derived
+ * from the specified free vector and increment the specified log
+ * probability reference with the log absolute Jacobian determinant
+ * of the transform.  The returned constrained vector
+ * will have the same dimensionality as the specified free vector.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam Vec A type inheriting from `Eigen::EigenBase`, a `var_value` with inner type inheriting from `Eigen::EigenBase`.
+ * @param x Free vector of scalars.
+ * @param lp Log probability reference.
+ * @return Positive, increasing ordered vector.
+ */
+template <bool Jacobian, typename Vec>
+inline auto positive_ordered_constrain(const Vec& x, scalar_type_t<Vec>& lp) {
+  if (Jacobian) {
+    return positive_ordered_constrain(x, lp);
+  } else {
+    return positive_ordered_constrain(x);
+  }
+}
+
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/prob_constrain.hpp
+++ b/stan/math/prim/fun/prob_constrain.hpp
@@ -55,6 +55,35 @@ inline T prob_constrain(const T& x, T& lp) {
   return inv_logit_x;
 }
 
+/**
+ * Return a probability value constrained to fall between 0 and 1
+ * (inclusive) for the specified free scalar and increment the
+ * specified log probability reference with the log absolute Jacobian
+ * determinant of the transform.
+ *
+ * <p>The transform is as defined for <code>prob_constrain(T)</code>.
+ * The log absolute Jacobian determinant is
+ *
+ * <p>The log absolute Jacobian determinant is
+ *
+ * <p>\f$\log | \frac{d}{dx} \mbox{logit}^{-1}(x) |\f$
+ * <p>\f$\log ((\mbox{logit}^{-1}(x)) (1 - \mbox{logit}^{-1}(x))\f$
+ * <p>\f$\log (\mbox{logit}^{-1}(x)) + \log (1 - \mbox{logit}^{-1}(x))\f$.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T type of scalar
+ * @param[in] x unconstrained value
+ * @param[in, out] lp log density
+ * @return result constrained to fall in (0, 1)
+ */
+template <bool Jacobian, typename T>
+inline auto prob_constrain(const T& x, T& lp) {
+  if (Jacobian) {
+    return prob_constrain(x, lp);
+  } else {
+    return prob_constrain(x);
+  }
+}
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/simplex_constrain.hpp
+++ b/stan/math/prim/fun/simplex_constrain.hpp
@@ -20,13 +20,13 @@ namespace math {
  *
  * The transform is based on a centered stick-breaking process.
  *
- * @tparam ColVec type of the vector
+ * @tparam Vec type of the vector
  * @param y Free vector input of dimensionality K - 1.
  * @return Simplex of dimensionality K.
  */
 template <typename Vec, require_eigen_col_vector_t<Vec>* = nullptr,
           require_not_st_var<Vec>* = nullptr>
-auto simplex_constrain(const Vec& y) {
+inline auto simplex_constrain(const Vec& y) {
   // cut & paste simplex_constrain(Eigen::Matrix, T) w/o Jacobian
   using std::log;
   using T = value_type_t<Vec>;
@@ -51,14 +51,14 @@ auto simplex_constrain(const Vec& y) {
  * The simplex transform is defined through a centered
  * stick-breaking process.
  *
- * @tparam ColVec type of the vector
+ * @tparam Vec type of the vector
  * @param y Free vector input of dimensionality K - 1.
  * @param lp Log probability reference to increment.
  * @return Simplex of dimensionality K.
  */
 template <typename Vec, require_eigen_col_vector_t<Vec>* = nullptr,
           require_not_st_var<Vec>* = nullptr>
-auto simplex_constrain(const Vec& y, value_type_t<Vec>& lp) {
+inline auto simplex_constrain(const Vec& y, value_type_t<Vec>& lp) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using std::log;
@@ -79,6 +79,31 @@ auto simplex_constrain(const Vec& y, value_type_t<Vec>& lp) {
   }
   x.coeffRef(Km1) = stick_len;  // no Jacobian contrib for last dim
   return x;
+}
+
+/**
+ * Return the simplex corresponding to the specified free vector
+ * and increment the specified log probability reference with
+ * the log absolute Jacobian determinant of the transform.
+ *
+ * The simplex transform is defined through a centered
+ * stick-breaking process.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam Vec A type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column.
+ * @param y Free vector input of dimensionality K - 1.
+ * @param lp Log probability reference to increment.
+ * @return Simplex of dimensionality K.
+ */
+template <bool Jacobian, typename Vec>
+auto simplex_constrain(const Vec& y, scalar_type_t<Vec>& lp) {
+  if (Jacobian) {
+    return simplex_constrain(y, lp);
+  } else {
+    return simplex_constrain(y);
+  }
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/ub_constrain.hpp
+++ b/stan/math/prim/fun/ub_constrain.hpp
@@ -231,6 +231,27 @@ inline auto ub_constrain(const std::vector<T>& x, const std::vector<U>& ub,
   return ret;
 }
 
+/**
+ * Specialization of `ub_constrain` to apply a container of upper bounds
+ * elementwise to each input element.
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T A type inheriting from `Eigen::EigenBase`, a `var_value` with inner type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @tparam U A type inheriting from `Eigen::EigenBase`, a `var_value` with inner type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @param[in] x unconstrained input
+ * @param[in] ub upper bound on output
+ * @param[in,out] lp reference to log probability to increment
+ * @return lower-bound constrained value corresponding to inputs
+ */
+template <bool Jacobian, typename T, typename U>
+inline auto ub_constrain(const T& x, const U& ub, return_type_t<T, U>& lp) {
+  if (Jacobian) {
+    return ub_constrain(x, ub, lp);
+  } else {
+    return ub_constrain(x, ub);
+  }
+}
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/unit_vector_constrain.hpp
+++ b/stan/math/prim/fun/unit_vector_constrain.hpp
@@ -17,30 +17,27 @@ namespace math {
  * href="https://en.wikipedia.org/wiki/N-sphere#Generating_random_points">the
  * Wikipedia page on generating random points on an N-sphere</a>.
  *
- * @tparam EigMat type inheriting from `EigenBase` that does not have an fvar
+ * @tparam T type inheriting from `EigenBase` that does not have an fvar
  *  scalar type.
  * @param y vector of K unrestricted variables
  * @return Unit length vector of dimension K
  */
 template <typename T, require_eigen_col_vector_t<T>* = nullptr,
           require_not_vt_autodiff<T>* = nullptr>
-inline auto unit_vector_constrain(const T& y) {
+inline plain_type_t<T> unit_vector_constrain(const T& y) {
   using std::sqrt;
   check_nonzero_size("unit_vector_constrain", "y", y);
-  return make_holder(
-      [](const auto& y_ref) {
-        value_type_t<T> SN = dot_self(y_ref);
-        check_positive_finite("unit_vector_constrain", "norm", SN);
-        return y_ref / sqrt(SN);
-      },
-      to_ref(y));
+  auto&& y_ref = to_ref(y);
+  value_type_t<T> SN = dot_self(y_ref);
+  check_positive_finite("unit_vector_constrain", "norm", SN);
+  return y_ref.array() / sqrt(SN);
 }
 
 /**
  * Return the unit length vector corresponding to the free vector y.
  * See https://en.wikipedia.org/wiki/N-sphere#Generating_random_points
  *
- * @tparam EigMat type inheriting from `EigenBase` that does not have an fvar
+ * @tparam T1 type inheriting from `EigenBase` that does not have an fvar
  *  scalar type.
  *
  * @param y vector of K unrestricted variables
@@ -52,14 +49,32 @@ template <typename T1, typename T2, require_eigen_col_vector_t<T1>* = nullptr,
 inline plain_type_t<T1> unit_vector_constrain(const T1& y, T2& lp) {
   using std::sqrt;
   check_nonzero_size("unit_vector_constrain", "y", y);
-  return make_holder(
-      [](const auto& y_ref, auto& lp) {
-        value_type_t<T1> SN = dot_self(y_ref);
-        check_positive_finite("unit_vector_constrain", "norm", SN);
-        lp -= 0.5 * SN;
-        return y_ref / sqrt(SN);
-      },
-      to_ref(y), lp);
+  auto&& y_ref = to_ref(y);
+  value_type_t<T1> SN = dot_self(y_ref);
+  check_positive_finite("unit_vector_constrain", "norm", SN);
+  lp -= 0.5 * SN;
+  return y_ref.array() / sqrt(SN);
+}
+
+/**
+ * Return the unit length vector corresponding to the free vector y.
+ * See https://en.wikipedia.org/wiki/N-sphere#Generating_random_points
+ *
+ * @tparam Jacobian If true, incremented `lp` with the log Jacobian
+ * @tparam T A type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column.
+ * @param y vector of K unrestricted variables
+ * @return Unit length vector of dimension K
+ * @param lp Log probability reference to increment.
+ */
+template <bool Jacobian, typename T>
+inline auto unit_vector_constrain(const T& y, scalar_type_t<T>& lp) {
+  if (Jacobian) {
+    return unit_vector_constrain(y, lp);
+  } else {
+    return unit_vector_constrain(y);
+  }
 }
 
 }  // namespace math

--- a/test/unit/math/mix/fun/cholesky_corr_constrain_test.cpp
+++ b/test/unit/math/mix/fun/cholesky_corr_constrain_test.cpp
@@ -14,21 +14,20 @@ int inv_size(const T& x) {
 }
 
 template <typename T>
-typename Eigen::Matrix<typename stan::scalar_type<T>::type, -1, -1> g1(
-    const T& x) {
-  return stan::math::cholesky_corr_constrain(x, inv_size(x));
+auto g1( const T& x) {
+  stan::scalar_type_t<T> lp = 0;
+  return stan::math::cholesky_corr_constrain<false>(x, inv_size(x), lp);
 }
 template <typename T>
-typename Eigen::Matrix<typename stan::scalar_type<T>::type, -1, -1> g2(
-    const T& x) {
-  typename stan::scalar_type<T>::type lp = 0;
-  auto a = stan::math::cholesky_corr_constrain(x, inv_size(x), lp);
+auto g2(const T& x) {
+  stan::scalar_type_t<T> lp = 0;
+  auto a = stan::math::cholesky_corr_constrain<true>(x, inv_size(x), lp);
   return a;
 }
 template <typename T>
-typename stan::scalar_type<T>::type g3(const T& x) {
-  typename stan::scalar_type<T>::type lp = 0;
-  stan::math::cholesky_corr_constrain(x, inv_size(x), lp);
+auto g3(const T& x) {
+  stan::scalar_type_t<T> lp = 0;
+  stan::math::cholesky_corr_constrain<true>(x, inv_size(x), lp);
   return lp;
 }
 

--- a/test/unit/math/mix/fun/cholesky_factor_constrain_test.cpp
+++ b/test/unit/math/mix/fun/cholesky_factor_constrain_test.cpp
@@ -3,7 +3,8 @@
 TEST(mathMixMatFun, cholesky_factor_constrain) {
   auto f = [](int M, int N) {
     return [M, N](const auto& x1) {
-      return stan::math::cholesky_factor_constrain(x1, M, N);
+      stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
+      return stan::math::cholesky_factor_constrain<false>(x1, M, N, lp);
     };
   };
 
@@ -22,14 +23,14 @@ TEST(mathMixMatFun, cholesky_factor_constrain_lp) {
   auto f1 = [](int M, int N) {
     return [M, N](const auto& x1) {
       stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
-      return stan::math::cholesky_factor_constrain(x1, M, N, lp);
+      return stan::math::cholesky_factor_constrain<true>(x1, M, N, lp);
     };
   };
 
   auto f2 = [](int M, int N) {
     return [M, N](const auto& x1) {
       stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
-      stan::math::cholesky_factor_constrain(x1, M, N, lp);
+      stan::math::cholesky_factor_constrain<true>(x1, M, N, lp);
       return lp;
     };
   };

--- a/test/unit/math/mix/fun/corr_constrain_test.cpp
+++ b/test/unit/math/mix/fun/corr_constrain_test.cpp
@@ -1,7 +1,10 @@
 #include <test/unit/math/test_ad.hpp>
 
 TEST(mathMixMatFun, corr_constrain) {
-  auto f = [](const auto& x1) { return stan::math::corr_constrain(x1); };
+  auto f = [](const auto& x1) {
+   stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
+   return stan::math::corr_constrain<false>(x1, lp);
+  };
 
   std::vector<double> x0 = {-1.0, 2.0, 3.0};
   Eigen::VectorXd x1(3);
@@ -29,12 +32,12 @@ TEST(mathMixMatFun, corr_constrain) {
 TEST(mathMixMatFun, corr_constrain_lp) {
   auto f1 = [](const auto& x1) {
     stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
-    return stan::math::corr_constrain(x1, lp);
+    return stan::math::corr_constrain<true>(x1, lp);
   };
 
   auto f2 = [](const auto& x1) {
     stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
-    stan::math::corr_constrain(x1, lp);
+    stan::math::corr_constrain<true>(x1, lp);
     return lp;
   };
 

--- a/test/unit/math/mix/fun/corr_matrix_constrain_test.cpp
+++ b/test/unit/math/mix/fun/corr_matrix_constrain_test.cpp
@@ -14,21 +14,20 @@ int inv_size(const T& x) {
 }
 
 template <typename T>
-typename Eigen::Matrix<typename stan::scalar_type<T>::type, -1, -1> g1(
-    const T& x) {
-  return stan::math::corr_matrix_constrain(x, inv_size(x));
+auto g1(const T& x) {
+  stan::scalar_type_t<T> lp = 0;
+  return stan::math::corr_matrix_constrain<false>(x, inv_size(x), lp);
 }
 template <typename T>
-typename Eigen::Matrix<typename stan::scalar_type<T>::type, -1, -1> g2(
-    const T& x) {
-  typename stan::scalar_type<T>::type lp = 0;
-  auto a = stan::math::corr_matrix_constrain(x, inv_size(x), lp);
+auto g2(const T& x) {
+  stan::scalar_type_t<T> lp = 0;
+  auto a = stan::math::corr_matrix_constrain<true>(x, inv_size(x), lp);
   return a;
 }
 template <typename T>
-typename stan::scalar_type<T>::type g3(const T& x) {
-  typename stan::scalar_type<T>::type lp = 0;
-  stan::math::corr_matrix_constrain(x, inv_size(x), lp);
+auto g3(const T& x) {
+  stan::scalar_type_t<T> lp = 0;
+  stan::math::corr_matrix_constrain<true>(x, inv_size(x), lp);
   return lp;
 }
 
@@ -69,7 +68,8 @@ TEST(MathMixMatFun, corr_matrixTransform) {
 TEST(mathMixMatFun, corr_matrix_constrain) {
   auto f = [](int K) {
     return [K](const auto& x1) {
-      return stan::math::corr_matrix_constrain(x1, K);
+      stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
+      return stan::math::corr_matrix_constrain<false>(x1, K, lp);
     };
   };
 
@@ -87,14 +87,14 @@ TEST(mathMixMatFun, corr_matrix_constrain_lp) {
   auto f1 = [](int K) {
     return [K](const auto& x1) {
       stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
-      return stan::math::corr_matrix_constrain(x1, K, lp);
+      return stan::math::corr_matrix_constrain<true>(x1, K, lp);
     };
   };
 
   auto f2 = [](int K) {
     return [K](const auto& x1) {
       stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
-      stan::math::corr_matrix_constrain(x1, K, lp);
+      stan::math::corr_matrix_constrain<true>(x1, K, lp);
       return lp;
     };
   };

--- a/test/unit/math/mix/fun/cov_matrix_constrain_lkj_test.cpp
+++ b/test/unit/math/mix/fun/cov_matrix_constrain_lkj_test.cpp
@@ -3,7 +3,8 @@
 TEST(mathMixMatFun, cov_matrix_constrain_lkj) {
   auto f = [](int K) {
     return [K](const auto& x1) {
-      return stan::math::cov_matrix_constrain_lkj(x1, K);
+      stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
+      return stan::math::cov_matrix_constrain_lkj<false>(x1, K, lp);
     };
   };
 
@@ -21,14 +22,14 @@ TEST(mathMixMatFun, cov_matrix_constrain_lkj_lp) {
   auto f1 = [](int K) {
     return [K](const auto& x1) {
       stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
-      return stan::math::cov_matrix_constrain_lkj(x1, K, lp);
+      return stan::math::cov_matrix_constrain_lkj<true>(x1, K, lp);
     };
   };
 
   auto f2 = [](int K) {
     return [K](const auto& x1) {
       stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
-      stan::math::cov_matrix_constrain_lkj(x1, K, lp);
+      stan::math::cov_matrix_constrain_lkj<true>(x1, K, lp);
       return lp;
     };
   };

--- a/test/unit/math/mix/fun/cov_matrix_constrain_test.cpp
+++ b/test/unit/math/mix/fun/cov_matrix_constrain_test.cpp
@@ -14,21 +14,21 @@ int inv_size(const T& x) {
 }
 
 template <typename T>
-typename Eigen::Matrix<typename stan::scalar_type<T>::type, -1, -1> g1(
-    const T& x) {
-  return stan::math::cov_matrix_constrain(x, inv_size(x));
+auto g1(const T& x) {
+  stan::scalar_type_t<T> lp = 0.0;
+  return stan::math::cov_matrix_constrain<false>(x, inv_size(x), lp);
 }
 template <typename T>
-typename Eigen::Matrix<typename stan::scalar_type<T>::type, -1, -1> g2(
+auto g2(
     const T& x) {
   typename stan::scalar_type<T>::type lp = 0;
-  auto a = stan::math::cov_matrix_constrain(x, inv_size(x), lp);
+  auto a = stan::math::cov_matrix_constrain<true>(x, inv_size(x), lp);
   return a;
 }
 template <typename T>
-typename stan::scalar_type<T>::type g3(const T& x) {
+auto g3(const T& x) {
   typename stan::scalar_type<T>::type lp = 0;
-  stan::math::cov_matrix_constrain(x, inv_size(x), lp);
+  stan::math::cov_matrix_constrain<true>(x, inv_size(x), lp);
   return lp;
 }
 
@@ -78,7 +78,10 @@ TEST(MathMixMatFun, cov_matrixTransform) {
 TEST(mathMixMatFun, cov_matrix_constrain) {
   auto f = [](int K) {
     return
-        [K](const auto& x1) { return stan::math::cov_matrix_constrain(x1, K); };
+        [K](const auto& x1) {
+          stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
+          return stan::math::cov_matrix_constrain<false>(x1, K, lp);
+         };
   };
 
   Eigen::VectorXd x1(10);
@@ -95,14 +98,14 @@ TEST(mathMixMatFun, cov_matrix_constrain_lp) {
   auto f1 = [](int K) {
     return [K](const auto& x1) {
       stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
-      return stan::math::cov_matrix_constrain(x1, K, lp);
+      return stan::math::cov_matrix_constrain<true>(x1, K, lp);
     };
   };
 
   auto f2 = [](int K) {
     return [K](const auto& x1) {
       stan::scalar_type_t<std::decay_t<decltype(x1)>> lp = 0.0;
-      stan::math::cov_matrix_constrain(x1, K, lp);
+      stan::math::cov_matrix_constrain<true>(x1, K, lp);
       return lp;
     };
   };

--- a/test/unit/math/mix/fun/lb_constrain_matvar_test.cpp
+++ b/test/unit/math/mix/fun/lb_constrain_matvar_test.cpp
@@ -5,20 +5,21 @@ namespace lb_constrain_test {
 template <typename T1, typename T2>
 void expect_matvar(const T1& x, const T2& lb) {
   auto f1 = [](const auto& x, const auto& lb) {
-    return stan::math::lb_constrain(x, lb);
+    stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
+    return stan::math::lb_constrain<false>(x, lb, lp);
   };
   auto f2 = [](const auto& x, const auto& lb) {
     stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
-    return stan::math::lb_constrain(x, lb, lp);
+    return stan::math::lb_constrain<true>(x, lb, lp);
   };
   auto f3 = [](const auto& x, const auto& lb) {
     stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
-    stan::math::lb_constrain(x, lb, lp);
+    stan::math::lb_constrain<true>(x, lb, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& lb) {
     stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
-    auto xx = stan::math::lb_constrain(x, lb, lp);
+    auto xx = stan::math::lb_constrain<true>(x, lb, lp);
     return stan::math::add(lp, stan::math::sum(xx));
   };
 
@@ -31,20 +32,21 @@ void expect_matvar(const T1& x, const T2& lb) {
 template <typename T1, typename T2>
 void expect_vec_matvar(const T1& x, const T2& lb) {
   auto f1 = [](const auto& x, const auto& lb) {
-    return stan::math::lb_constrain(x, lb);
+    stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
+    return stan::math::lb_constrain<false>(x, lb, lp);
   };
   auto f2 = [](const auto& x, const auto& lb) {
     stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
-    return stan::math::lb_constrain(x, lb, lp);
+    return stan::math::lb_constrain<true>(x, lb, lp);
   };
   auto f3 = [](const auto& x, const auto& lb) {
     stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
-    stan::math::lb_constrain(x, lb, lp);
+    stan::math::lb_constrain<true>(x, lb, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& lb) {
     stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
-    auto xx = stan::math::eval(stan::math::lb_constrain(x, lb, lp));
+    auto xx = stan::math::eval(stan::math::lb_constrain<true>(x, lb, lp));
     stan::return_type_t<decltype(x), decltype(lb)> xx_acc = 0;
     for (size_t i = 0; i < xx.size(); ++i) {
       xx_acc += stan::math::sum(xx[i]);

--- a/test/unit/math/mix/fun/lb_constrain_test.cpp
+++ b/test/unit/math/mix/fun/lb_constrain_test.cpp
@@ -5,20 +5,21 @@ namespace lb_constrain_test {
 template <typename T1, typename T2>
 void expect(const T1& x, const T2& lb) {
   auto f1 = [](const auto& x, const auto& lb) {
-    return stan::math::lb_constrain(x, lb);
+    stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
+    return stan::math::lb_constrain<false>(x, lb, lp);
   };
   auto f2 = [](const auto& x, const auto& lb) {
     stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
-    return stan::math::lb_constrain(x, lb, lp);
+    return stan::math::lb_constrain<true>(x, lb, lp);
   };
   auto f3 = [](const auto& x, const auto& lb) {
     stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
-    stan::math::lb_constrain(x, lb, lp);
+    stan::math::lb_constrain<true>(x, lb, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& lb) {
     stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
-    auto xx = stan::math::lb_constrain(x, lb, lp);
+    auto xx = stan::math::lb_constrain<true>(x, lb, lp);
     return stan::math::add(lp, stan::math::sum(xx));
   };
 
@@ -31,20 +32,21 @@ void expect(const T1& x, const T2& lb) {
 template <typename T1, typename T2>
 void expect_vec(const T1& x, const T2& lb) {
   auto f1 = [](const auto& x, const auto& lb) {
-    return stan::math::lb_constrain(x, lb);
+    stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
+    return stan::math::lb_constrain<false>(x, lb, lp);
   };
   auto f2 = [](const auto& x, const auto& lb) {
     stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
-    return stan::math::lb_constrain(x, lb, lp);
+    return stan::math::lb_constrain<true>(x, lb, lp);
   };
   auto f3 = [](const auto& x, const auto& lb) {
     stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
-    stan::math::lb_constrain(x, lb, lp);
+    stan::math::lb_constrain<true>(x, lb, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& lb) {
     stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
-    auto xx = stan::math::eval(stan::math::lb_constrain(x, lb, lp));
+    auto xx = stan::math::eval(stan::math::lb_constrain<true>(x, lb, lp));
     stan::return_type_t<decltype(x), decltype(lb)> xx_acc = 0;
     for (size_t i = 0; i < xx.size(); ++i) {
       xx_acc += stan::math::sum(xx[i]);

--- a/test/unit/math/mix/fun/lub_constrain_helpers.hpp
+++ b/test/unit/math/mix/fun/lub_constrain_helpers.hpp
@@ -5,20 +5,21 @@ namespace lub_constrain_tests {
 template <typename T1, typename T2, typename T3>
 void expect(const T1& x, const T2& lb, const T3& ub) {
   auto f1 = [](const auto& x, const auto& lb, const auto& ub) {
-    return stan::math::lub_constrain(x, lb, ub);
+    stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
+    return stan::math::lub_constrain<false>(x, lb, ub, lp);
   };
   auto f2 = [](const auto& x, const auto& lb, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
-    return stan::math::lub_constrain(x, lb, ub, lp);
+    return stan::math::lub_constrain<true>(x, lb, ub, lp);
   };
   auto f3 = [](const auto& x, const auto& lb, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
-    stan::math::lub_constrain(x, lb, ub, lp);
+    stan::math::lub_constrain<true>(x, lb, ub, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& lb, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
-    auto xx = stan::math::lub_constrain(x, lb, ub, lp);
+    auto xx = stan::math::lub_constrain<true>(x, lb, ub, lp);
     return stan::math::add(lp, stan::math::sum(xx));
   };
 
@@ -30,20 +31,21 @@ void expect(const T1& x, const T2& lb, const T3& ub) {
 template <typename T1, typename T2, typename T3>
 void expect_vec(const T1& x, const T2& lb, const T3& ub) {
   auto f1 = [](const auto& x, const auto& lb, const auto& ub) {
-    return stan::math::lub_constrain(x, lb, ub);
+    stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
+    return stan::math::lub_constrain<false>(x, lb, ub, lp);
   };
   auto f2 = [](const auto& x, const auto& lb, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
-    return stan::math::lub_constrain(x, lb, ub, lp);
+    return stan::math::lub_constrain<true>(x, lb, ub, lp);
   };
   auto f3 = [](const auto& x, const auto& lb, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
-    stan::math::lub_constrain(x, lb, ub, lp);
+    stan::math::lub_constrain<true>(x, lb, ub, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& lb, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
-    auto xx = stan::math::lub_constrain(x, lb, ub, lp);
+    auto xx = stan::math::lub_constrain<true>(x, lb, ub, lp);
     stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> xx_acc = 0;
     for (size_t i = 0; i < xx.size(); ++i) {
       xx_acc += stan::math::sum(xx[i]);

--- a/test/unit/math/mix/fun/lub_constrain_matvar_test.cpp
+++ b/test/unit/math/mix/fun/lub_constrain_matvar_test.cpp
@@ -4,20 +4,21 @@ namespace lub_constrain_tests {
 template <typename T1, typename T2, typename T3>
 void expect_matvar(const T1& x, const T2& lb, const T3& ub) {
   auto f1 = [](const auto& x, const auto& lb, const auto& ub) {
-    return stan::math::lub_constrain(x, lb, ub);
+    stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
+    return stan::math::lub_constrain<false>(x, lb, ub, lp);
   };
   auto f2 = [](const auto& x, const auto& lb, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
-    return stan::math::lub_constrain(x, lb, ub, lp);
+    return stan::math::lub_constrain<true>(x, lb, ub, lp);
   };
   auto f3 = [](const auto& x, const auto& lb, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
-    stan::math::lub_constrain(x, lb, ub, lp);
+    stan::math::lub_constrain<true>(x, lb, ub, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& lb, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
-    auto xx = stan::math::lub_constrain(x, lb, ub, lp);
+    auto xx = stan::math::lub_constrain<true>(x, lb, ub, lp);
     return stan::math::add(lp, stan::math::sum(xx));
   };
 

--- a/test/unit/math/mix/fun/offset_multiplier_constrain_7_test.cpp
+++ b/test/unit/math/mix/fun/offset_multiplier_constrain_7_test.cpp
@@ -2,7 +2,8 @@
 
 TEST(mathMixMatFun, offset_multiplier_consistent_sizes) {
   auto f = [](const auto& x1, const auto& x2, const auto& x3) {
-    return stan::math::offset_multiplier_constrain(x1, x2, x3);
+    stan::return_type_t<decltype(x1), decltype(x2), decltype(x3)> lp = 0;
+    return stan::math::offset_multiplier_constrain<false>(x1, x2, x3, lp);
   };
 
   double xd = 1.0;

--- a/test/unit/math/mix/fun/offset_multiplier_constrain_helpers.hpp
+++ b/test/unit/math/mix/fun/offset_multiplier_constrain_helpers.hpp
@@ -5,22 +5,23 @@ namespace offset_multiplier_constrain_tests {
 template <typename T1, typename T2, typename T3>
 void expect(const T1& x, const T2& mu, const T3& sigma) {
   auto f1 = [](const auto& x, const auto& mu, const auto& sigma) {
-    return stan::math::offset_multiplier_constrain(x, mu, sigma);
+    stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)> lp = 0;
+    return stan::math::offset_multiplier_constrain<false>(x, mu, sigma, lp);
   };
   auto f2 = [](const auto& x, const auto& mu, const auto& sigma) {
     stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)> lp = 0;
-    return stan::math::offset_multiplier_constrain(x, mu, sigma, lp);
+    return stan::math::offset_multiplier_constrain<true>(x, mu, sigma, lp);
   };
   auto f3 = [](const auto& x, const auto& mu, const auto& sigma) {
     stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)> lp = 0;
-    stan::math::offset_multiplier_constrain(x, mu, sigma, lp);
+    stan::math::offset_multiplier_constrain<true>(x, mu, sigma, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& mu, const auto& sigma) {
     using lub_t
         = stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)>;
     lub_t lp = 0;
-    auto xx = stan::math::offset_multiplier_constrain(x, mu, sigma, lp);
+    auto xx = stan::math::offset_multiplier_constrain<true>(x, mu, sigma, lp);
     return stan::math::add(lp, lub_t(stan::math::sum(xx)));
   };
 
@@ -32,22 +33,23 @@ void expect(const T1& x, const T2& mu, const T3& sigma) {
 template <typename T1, typename T2, typename T3>
 void expect_vec(const T1& x, const T2& mu, const T3& sigma) {
   auto f1 = [](const auto& x, const auto& mu, const auto& sigma) {
-    return stan::math::offset_multiplier_constrain(x, mu, sigma);
+    stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)> lp = 0;
+    return stan::math::offset_multiplier_constrain<false>(x, mu, sigma, lp);
   };
   auto f2 = [](const auto& x, const auto& mu, const auto& sigma) {
     stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)> lp = 0;
-    return stan::math::offset_multiplier_constrain(x, mu, sigma, lp);
+    return stan::math::offset_multiplier_constrain<true>(x, mu, sigma, lp);
   };
   auto f3 = [](const auto& x, const auto& mu, const auto& sigma) {
     stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)> lp = 0;
-    stan::math::offset_multiplier_constrain(x, mu, sigma, lp);
+    stan::math::offset_multiplier_constrain<true>(x, mu, sigma, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& mu, const auto& sigma) {
     using lub_t
         = stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)>;
     lub_t lp = 0;
-    auto xx = stan::math::offset_multiplier_constrain(x, mu, sigma, lp);
+    auto xx = stan::math::offset_multiplier_constrain<true>(x, mu, sigma, lp);
     lub_t xx_acc = 0;
     for (size_t i = 0; i < xx.size(); ++i) {
       xx_acc += stan::math::sum(xx[i]);

--- a/test/unit/math/mix/fun/offset_multiplier_constrain_matvar_helpers.hpp
+++ b/test/unit/math/mix/fun/offset_multiplier_constrain_matvar_helpers.hpp
@@ -5,22 +5,23 @@ namespace offset_multiplier_constrain_tests {
 template <typename T1, typename T2, typename T3>
 void expect_matvar(const T1& x, const T2& mu, const T3& sigma) {
   auto f1 = [](const auto& x, const auto& mu, const auto& sigma) {
-    return stan::math::offset_multiplier_constrain(x, mu, sigma);
+    stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)> lp = 0;
+    return stan::math::offset_multiplier_constrain<false>(x, mu, sigma, lp);
   };
   auto f2 = [](const auto& x, const auto& mu, const auto& sigma) {
     stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)> lp = 0;
-    return stan::math::offset_multiplier_constrain(x, mu, sigma, lp);
+    return stan::math::offset_multiplier_constrain<true>(x, mu, sigma, lp);
   };
   auto f3 = [](const auto& x, const auto& mu, const auto& sigma) {
     stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)> lp = 0;
-    stan::math::offset_multiplier_constrain(x, mu, sigma, lp);
+    stan::math::offset_multiplier_constrain<true>(x, mu, sigma, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& mu, const auto& sigma) {
     using lub_t
         = stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)>;
     lub_t lp = 0;
-    auto xx = stan::math::offset_multiplier_constrain(x, mu, sigma, lp);
+    auto xx = stan::math::offset_multiplier_constrain<true>(x, mu, sigma, lp);
     return stan::math::add(lp, lub_t(stan::math::sum(xx)));
   };
 
@@ -32,22 +33,23 @@ void expect_matvar(const T1& x, const T2& mu, const T3& sigma) {
 template <typename T1, typename T2, typename T3>
 void expect_vec_matvar(const T1& x, const T2& mu, const T3& sigma) {
   auto f1 = [](const auto& x, const auto& mu, const auto& sigma) {
-    return stan::math::offset_multiplier_constrain(x, mu, sigma);
+    stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)> lp = 0;
+    return stan::math::offset_multiplier_constrain<false>(x, mu, sigma, lp);
   };
   auto f2 = [](const auto& x, const auto& mu, const auto& sigma) {
     stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)> lp = 0;
-    return stan::math::offset_multiplier_constrain(x, mu, sigma, lp);
+    return stan::math::offset_multiplier_constrain<true>(x, mu, sigma, lp);
   };
   auto f3 = [](const auto& x, const auto& mu, const auto& sigma) {
     stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)> lp = 0;
-    stan::math::offset_multiplier_constrain(x, mu, sigma, lp);
+    stan::math::offset_multiplier_constrain<true>(x, mu, sigma, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& mu, const auto& sigma) {
     using lub_t
         = stan::return_type_t<decltype(x), decltype(mu), decltype(sigma)>;
     lub_t lp = 0;
-    auto xx = stan::math::offset_multiplier_constrain(x, mu, sigma, lp);
+    auto xx = stan::math::offset_multiplier_constrain<true>(x, mu, sigma, lp);
     lub_t xx_acc = 0;
     for (size_t i = 0; i < xx.size(); ++i) {
       xx_acc += stan::math::sum(xx[i]);

--- a/test/unit/math/mix/fun/ordered_constrain_test.cpp
+++ b/test/unit/math/mix/fun/ordered_constrain_test.cpp
@@ -3,17 +3,18 @@
 namespace ordered_constrain_test {
 template <typename T>
 T g1(const T& x) {
-  return stan::math::ordered_constrain(x);
+  stan::scalar_type_t<T> lp = 0;
+  return stan::math::ordered_constrain<false>(x, lp);
 }
 template <typename T>
 T g2(const T& x) {
-  typename stan::scalar_type<T>::type lp = 0;
-  return stan::math::ordered_constrain(x, lp);
+  stan::scalar_type_t<T> lp = 0;
+  return stan::math::ordered_constrain<true>(x, lp);
 }
 template <typename T>
-typename stan::scalar_type<T>::type g3(const T& x) {
-  typename stan::scalar_type<T>::type lp = 0;
-  stan::math::ordered_constrain(x, lp);
+stan::scalar_type_t<T> g3(const T& x) {
+  stan::scalar_type_t<T> lp = 0;
+  stan::math::ordered_constrain<true>(x, lp);
   return lp;
 }
 

--- a/test/unit/math/mix/fun/positive_ordered_constrain_test.cpp
+++ b/test/unit/math/mix/fun/positive_ordered_constrain_test.cpp
@@ -3,17 +3,18 @@
 namespace positive_ordered_constrain_test {
 template <typename T>
 T g1(const T& x) {
-  return stan::math::positive_ordered_constrain(x);
+  stan::scalar_type_t<T> lp = 0;
+  return stan::math::positive_ordered_constrain<false>(x, lp);
 }
 template <typename T>
 T g2(const T& x) {
-  typename stan::scalar_type<T>::type lp = 0;
-  return stan::math::positive_ordered_constrain(x, lp);
+  stan::scalar_type_t<T> lp = 0;
+  return stan::math::positive_ordered_constrain<true>(x, lp);
 }
 template <typename T>
-typename stan::scalar_type<T>::type g3(const T& x) {
+stan::scalar_type_t<T> g3(const T& x) {
   typename stan::scalar_type<T>::type lp = 0;
-  stan::math::positive_ordered_constrain(x, lp);
+  stan::math::positive_ordered_constrain<true>(x, lp);
   return lp;
 }
 

--- a/test/unit/math/mix/fun/simplex_constrain_test.cpp
+++ b/test/unit/math/mix/fun/simplex_constrain_test.cpp
@@ -3,17 +3,18 @@
 namespace simplex_constrain_test {
 template <typename T>
 T g1(const T& x) {
-  return stan::math::simplex_constrain(x);
+  stan::scalar_type_t<T> lp = 0;
+  return stan::math::simplex_constrain<false>(x, lp);
 }
 template <typename T>
 T g2(const T& x) {
-  typename stan::scalar_type<T>::type lp = 0;
-  return stan::math::simplex_constrain(x, lp);
+  stan::scalar_type_t<T> lp = 0;
+  return stan::math::simplex_constrain<true>(x, lp);
 }
 template <typename T>
 typename stan::scalar_type<T>::type g3(const T& x) {
-  typename stan::scalar_type<T>::type lp = 0;
-  stan::math::simplex_constrain(x, lp);
+  stan::scalar_type_t<T> lp = 0;
+  stan::math::simplex_constrain<true>(x, lp);
   return lp;
 }
 

--- a/test/unit/math/mix/fun/ub_constrain_matvar_test.cpp
+++ b/test/unit/math/mix/fun/ub_constrain_matvar_test.cpp
@@ -5,20 +5,21 @@ namespace ub_constrain_test {
 template <typename T1, typename T2>
 void expect_matvar(const T1& x, const T2& ub) {
   auto f1 = [](const auto& x, const auto& ub) {
-    return stan::math::ub_constrain(x, ub);
+    stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
+    return stan::math::ub_constrain<false>(x, ub, lp);
   };
   auto f2 = [](const auto& x, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
-    return stan::math::ub_constrain(x, ub, lp);
+    return stan::math::ub_constrain<true>(x, ub, lp);
   };
   auto f3 = [](const auto& x, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
-    stan::math::ub_constrain(x, ub, lp);
+    stan::math::ub_constrain<true>(x, ub, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
-    auto xx = stan::math::ub_constrain(x, ub, lp);
+    auto xx = stan::math::ub_constrain<true>(x, ub, lp);
     return stan::math::add(lp, stan::math::sum(xx));
   };
 
@@ -31,20 +32,21 @@ void expect_matvar(const T1& x, const T2& ub) {
 template <typename T1, typename T2>
 void expect_vec_matvar(const T1& x, const T2& ub) {
   auto f1 = [](const auto& x, const auto& ub) {
-    return stan::math::ub_constrain(x, ub);
+    stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
+    return stan::math::ub_constrain<false>(x, ub, lp);
   };
   auto f2 = [](const auto& x, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
-    return stan::math::ub_constrain(x, ub, lp);
+    return stan::math::ub_constrain<true>(x, ub, lp);
   };
   auto f3 = [](const auto& x, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
-    stan::math::ub_constrain(x, ub, lp);
+    stan::math::ub_constrain<true>(x, ub, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
-    auto xx = stan::math::eval(stan::math::ub_constrain(x, ub, lp));
+    auto xx = stan::math::eval(stan::math::ub_constrain<true>(x, ub, lp));
     stan::return_type_t<decltype(x), decltype(ub)> xx_acc = 0;
     for (size_t i = 0; i < xx.size(); ++i) {
       xx_acc += stan::math::sum(xx[i]);

--- a/test/unit/math/mix/fun/ub_constrain_test.cpp
+++ b/test/unit/math/mix/fun/ub_constrain_test.cpp
@@ -5,20 +5,21 @@ namespace ub_constrain_test {
 template <typename T1, typename T2>
 void expect(const T1& x, const T2& ub) {
   auto f1 = [](const auto& x, const auto& ub) {
-    return stan::math::ub_constrain(x, ub);
+    stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
+    return stan::math::ub_constrain<false>(x, ub, lp);
   };
   auto f2 = [](const auto& x, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
-    return stan::math::ub_constrain(x, ub, lp);
+    return stan::math::ub_constrain<true>(x, ub, lp);
   };
   auto f3 = [](const auto& x, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
-    stan::math::ub_constrain(x, ub, lp);
+    stan::math::ub_constrain<true>(x, ub, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
-    auto xx = stan::math::ub_constrain(x, ub, lp);
+    auto xx = stan::math::ub_constrain<true>(x, ub, lp);
     return stan::math::add(lp, stan::math::sum(xx));
   };
 
@@ -31,20 +32,21 @@ void expect(const T1& x, const T2& ub) {
 template <typename T1, typename T2>
 void expect_vec(const T1& x, const T2& ub) {
   auto f1 = [](const auto& x, const auto& ub) {
-    return stan::math::ub_constrain(x, ub);
+    stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
+    return stan::math::ub_constrain<false>(x, ub, lp);
   };
   auto f2 = [](const auto& x, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
-    return stan::math::ub_constrain(x, ub, lp);
+    return stan::math::ub_constrain<true>(x, ub, lp);
   };
   auto f3 = [](const auto& x, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
-    stan::math::ub_constrain(x, ub, lp);
+    stan::math::ub_constrain<true>(x, ub, lp);
     return lp;
   };
   auto f4 = [](const auto& x, const auto& ub) {
     stan::return_type_t<decltype(x), decltype(ub)> lp = 0;
-    auto xx = stan::math::eval(stan::math::ub_constrain(x, ub, lp));
+    auto xx = stan::math::eval(stan::math::ub_constrain<true>(x, ub, lp));
     stan::return_type_t<decltype(x), decltype(ub)> xx_acc = 0;
     for (size_t i = 0; i < xx.size(); ++i) {
       xx_acc += stan::math::sum(xx[i]);

--- a/test/unit/math/mix/fun/unit_vector_constrain_test.cpp
+++ b/test/unit/math/mix/fun/unit_vector_constrain_test.cpp
@@ -3,19 +3,20 @@
 
 namespace unit_vector_constrain_test {
 template <typename T>
-stan::plain_type_t<T> g1(const T& x) {
-  return stan::math::unit_vector_constrain(x);
+auto g1(const T& x) {
+  stan::scalar_type_t<T> lp = 0;
+  return stan::math::unit_vector_constrain<false>(x, lp);
 }
 template <typename T>
-typename stan::plain_type_t<T> g2(const T& x) {
+auto g2(const T& x) {
   stan::scalar_type_t<T> lp = 0;
-  auto a = stan::math::unit_vector_constrain(x, lp);
+  auto a = stan::math::unit_vector_constrain<true>(x, lp);
   return a;
 }
 template <typename T>
-typename stan::scalar_type_t<T> g3(const T& x) {
+auto g3(const T& x) {
   stan::scalar_type_t<T> lp = 0;
-  stan::math::unit_vector_constrain(x, lp);
+  stan::math::unit_vector_constrain<true>(x, lp);
   return lp;
 }
 


### PR DESCRIPTION

## Summary

Related to https://github.com/stan-dev/stanc3/pull/947 this PR allows stanc3 to pass a bool template parameter to the constraints to decide whether or not they should accumulate the jacobian calculation into  the `lp` parameter. See the PR above to note see examples of how this is used.

All I really did here was add a new overload to the `*_constrain` functions that has a `bool Jacobian` template parameter. If that is flipped to `true` then we do the jacobian calculation.

## Tests

I changed all of the current constrain tests to use the new `Jacobian` interface, which should still cover all the current test examples and the new API.

## Side Effects


## Release notes

Adds an overload for the constrain functions on whether to accumulate jacobians into log probability argument.

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
