### PR TITLE
Removing Windows from OpenCL tests - avoid fails on develop

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -268,7 +268,7 @@ pipeline {
                     }
                 }
                 stage('OpenCL GPU tests') {
-                    agent { label "gelman-group-win2 || linux-gpu" }
+                    agent { label "inux-gpu" }
                     steps {
                         script {
                             if (isUnix()) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -230,12 +230,12 @@ pipeline {
                     post { always { retry(3) { deleteDir() } } }
                 }
                 stage('OpenCL CPU tests') {
-                    when {
-                        expression {
-                            !skipOpenCL
-                        }
-                    }
-                    agent { label "gelman-group-win2 || linux-gpu" }
+                    // when {
+                    //     expression {
+                    //         !skipOpenCL
+                    //     }
+                    // }
+                    agent { label "linux-gpu" }
                     steps {
                         script {
                             if (isUnix()) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -230,11 +230,11 @@ pipeline {
                     post { always { retry(3) { deleteDir() } } }
                 }
                 stage('OpenCL CPU tests') {
-                    // when {
-                    //     expression {
-                    //         !skipOpenCL
-                    //     }
-                    // }
+                    when {
+                        expression {
+                            !skipOpenCL
+                        }
+                    }
                     agent { label "linux-gpu" }
                     steps {
                         script {
@@ -268,7 +268,7 @@ pipeline {
                     }
                 }
                 stage('OpenCL GPU tests') {
-                    agent { label "inux-gpu" }
+                    agent { label "linux-gpu" }
                     steps {
                         script {
                             if (isUnix()) {


### PR DESCRIPTION
## Summary

There are some issue with the Windows OpenCL tests on Jenkins. Develop tests are failing due to that. I am unable to reproduce it locally on Windows so I am going to remove the Windows machine from tests for now and then investigate.

## Tests

/

## Side Effects

/

## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
