### PR TITLE
to_complex constexpr; fixes #2567

### DIFF
--- a/stan/math/prim/fun/to_complex.hpp
+++ b/stan/math/prim/fun/to_complex.hpp
@@ -19,8 +19,8 @@ namespace math {
  * @return complex value with specified real and imaginary components
  */
 template <typename T = double, typename S = double>
-constexpr inline std::complex<stan::real_return_t<T, S>>
-to_complex(const T& re = 0, const S& im = 0) {
+constexpr inline std::complex<stan::real_return_t<T, S>> to_complex(
+    const T& re = 0, const S& im = 0) {
   return std::complex<stan::real_return_t<T, S>>(re, im);
 }
 

--- a/test/unit/math/prim/fun/to_complex_test.cpp
+++ b/test/unit/math/prim/fun/to_complex_test.cpp
@@ -9,7 +9,6 @@ void test_constructor(const T& re, const S& im) {
   EXPECT_EQ(z1, z2);
 }
 
-
 TEST(mathPrimFunToComplex, isconstexpr) {
   using stan::math::to_complex;
   // using in static assert tests that constexpr really is const


### PR DESCRIPTION
## Summary

Adds `constexpr` qualifier to `stan::math::to_complex`. 


## Tests

Add primitive-based tests for function and also test that `constexpr` works.

## Side Effects

No.

## Release notes

n/a as this feature hasn't been previously released.

## Checklist

- [x] Math issue #2567

- [x] Copyright holder: Simons Foundation

- [x] the basic tests are passing
    - the new unit tests for `prim` and old unit tests for `mix` pass.  
    - I didn't run the rest

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
