### PR TITLE
Multi normal derivatives

### DIFF
--- a/stan/math/prim/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_lpdf.hpp
@@ -76,6 +76,18 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(const T_y& y,
   check_symmetric(function, "Covariance matrix", Sigma_ref);
 
   auto L_Sigma = cholesky(Sigma_ref);
+
+    if (size_y == 0) {
+    return lp;
+  }
+
+    if (include_summand<propto>::value) {
+    lp += NEG_LOG_SQRT_TWO_PI * size_y * size_vec;
+  }
+
+  if (include_summand<propto, T_covar_elem>::value) {
+    lp -= 0.5 * log_determinant_ldlt(ldlt_Sigma) * size_vec;
+  }
   
   template <typename T_y, typename T_loc, typename T_covar>
 inline return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(

--- a/stan/math/prim/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_lpdf.hpp
@@ -77,23 +77,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(const T_y& y,
 
   auto L_Sigma = cholesky(Sigma_ref);
 
-    if (size_y == 0) {
-    return lp;
-  }
-
-    if (include_summand<propto>::value) {
-    lp += NEG_LOG_SQRT_TWO_PI * size_y * size_vec;
-  }
-
-  if (include_summand<propto, T_covar_elem>::value) {
-    lp -= 0.5 * log_determinant_ldlt(ldlt_Sigma) * size_vec;
-  }
-  
-  template <typename T_y, typename T_loc, typename T_covar>
-inline return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
-    const T_y& y, const T_loc& mu, const T_covar& L) {
-  return multi_normal_cholesky_lpdf<false>(y, mu, L);
-}
+ 
 
   // auto ldlt_Sigma = make_ldlt_factor(Sigma_ref);
   // check_ldlt_factor(function, "LDLT_Factor of covariance parameter",
@@ -123,11 +107,11 @@ inline return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
 //   return lp;
 // }
 
-// template <typename T_y, typename T_loc, typename T_covar>
-// inline return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(
-//     const T_y& y, const T_loc& mu, const T_covar& Sigma) {
-//   return multi_normal_lpdf<false>(y, mu, Sigma);
-// }
+template <typename T_y, typename T_loc, typename T_covar>
+inline return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(
+    const T_y& y, const T_loc& mu, const T_covar& L_Sigma) {
+  return multi_normal_cholesky_lpdf<false>(y, mu, L_Sigma);
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_lpdf.hpp
@@ -16,49 +16,60 @@
 namespace stan {
 namespace math {
 
-template <bool propto, typename T_y, typename T_loc, typename T_covar>
-return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(const T_y& y,
-                                                     const T_loc& mu,
-                                                     const T_covar& Sigma) {
-  using T_covar_elem = typename scalar_type<T_covar>::type;
-  using lp_type = return_type_t<T_y, T_loc, T_covar>;
-  using Eigen::Dynamic;
+template <bool propto, typename T_y, typename T_loc, typename T_covar,
+          require_any_not_vector_vt<is_stan_scalar, T_y, T_loc>* = nullptr,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_covar>* = nullptr>
+return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(
+    const T_y& y, const T_loc& mu, const T_covar& Sigma) {
   static const char* function = "multi_normal_lpdf";
-  check_positive(function, "Covariance matrix rows", Sigma.rows());
+  using T_covar_elem = typename scalar_type<T_covar>::type;
+  using T_return = return_type_t<T_y, T_loc, T_covar>;
+  using T_partials_return = partials_return_t<T_y, T_loc, T_covar>;
+  using matrix_partials_t
+      = Eigen::Matrix<T_partials_return, Eigen::Dynamic, Eigen::Dynamic>;
+  using T_y_ref = ref_type_t<T_y>;
+  using T_mu_ref = ref_type_t<T_loc>;
+  using T_L_ref = ref_type_t<T_covar>;
 
   check_consistent_sizes_mvt(function, "y", y, "mu", mu);
   size_t number_of_y = size_mvt(y);
   size_t number_of_mu = size_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0) {
-    return 0.0;
+    return 0;
   }
 
-  lp_type lp(0.0);
-  vector_seq_view<T_y> y_vec(y);
-  vector_seq_view<T_loc> mu_vec(mu);
-  size_t size_vec = max_size_mvt(y, mu);
+  T_y_ref y_ref = y;
+  T_mu_ref mu_ref = mu;
+  auto L = stan::math::cholesky_decompose(Sigma);
+  T_L_ref L_ref = L;
+  vector_seq_view<T_y_ref> y_vec(y_ref);
+  vector_seq_view<T_mu_ref> mu_vec(mu_ref);
+  const size_t size_vec = max_size_mvt(y, mu);
 
-  int size_y = y_vec[0].size();
-  int size_mu = mu_vec[0].size();
-  if (size_vec > 1) {
-    for (size_t i = 1, size_mvt_y = size_mvt(y); i < size_mvt_y; i++) {
-      check_size_match(function,
-                       "Size of one of the vectors of "
-                       "the random variable",
-                       y_vec[i].size(),
-                       "Size of the first vector of the "
-                       "random variable",
-                       size_y);
-    }
-    for (size_t i = 1, size_mvt_mu = size_mvt(mu); i < size_mvt_mu; i++) {
-      check_size_match(function,
-                       "Size of one of the vectors of "
-                       "the location variable",
-                       mu_vec[i].size(),
-                       "Size of the first vector of the "
-                       "location variable",
-                       size_mu);
-    }
+  const int size_y = y_vec[0].size();
+  const int size_mu = mu_vec[0].size();
+
+
+  // check size consistency of all random variables y
+  for (size_t i = 1, size_mvt_y = size_mvt(y); i < size_mvt_y; i++) {
+    check_size_match(function,
+                     "Size of one of the vectors of "
+                     "the random variable",
+                     y_vec[i].size(),
+                     "Size of the first vector of the "
+                     "random variable",
+                     size_y);
+  }
+  // check size consistency of all means mu
+  for (size_t i = 1, size_mvt_mu = size_mvt(mu); i < size_mvt_mu; i++) {
+    check_size_match(function,
+                     "Size of one of the vectors of "
+                     "the location variable",
+                     mu_vec[i].size(),
+                     "Size of the first vector of the "
+                     "location variable",
+                     size_mu);
   }
 
   check_size_match(function, "Size of random variable", size_y,
@@ -72,45 +83,199 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(const T_y& y,
     check_finite(function, "Location parameter", mu_vec[i]);
     check_not_nan(function, "Random variable", y_vec[i]);
   }
-  const auto& Sigma_ref = to_ref(Sigma);
-  check_symmetric(function, "Covariance matrix", Sigma_ref);
 
-  auto L_Sigma = cholesky(Sigma_ref);
+  if (unlikely(size_y == 0)) {
+    return T_return(0);
+  }
 
- 
+  operands_and_partials<T_y_ref, T_mu_ref, T_L_ref> ops_partials(y_ref, mu_ref,
+                                                                 L_ref);
 
-  // auto ldlt_Sigma = make_ldlt_factor(Sigma_ref);
-  // check_ldlt_factor(function, "LDLT_Factor of covariance parameter",
-  //                   ldlt_Sigma);
+  T_partials_return logp(0);
+  if (include_summand<propto>::value) {
+    logp += NEG_LOG_SQRT_TWO_PI * size_y * size_vec;
+  }
 
-//   if (size_y == 0) {
-//     return lp;
-//   }
+  if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
+    Eigen::Matrix<T_partials_return, Eigen::Dynamic, Eigen::Dynamic>
+        y_val_minus_mu_val(size_y, size_vec);
 
-//   if (include_summand<propto>::value) {
-//     lp += NEG_LOG_SQRT_TWO_PI * size_y * size_vec;
-//   }
+    for (size_t i = 0; i < size_vec; i++) {
+      decltype(auto) y_val = as_value_column_vector_or_scalar(y_vec[i]);
+      decltype(auto) mu_val = as_value_column_vector_or_scalar(mu_vec[i]);
+      y_val_minus_mu_val.col(i) = y_val - mu_val;
+    }
 
-//   if (include_summand<propto, T_covar_elem>::value) {
-//     lp -= 0.5 * log_determinant_ldlt(ldlt_Sigma) * size_vec;
-//   }
+    matrix_partials_t half;
+    matrix_partials_t scaled_diff;
 
-//   if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
-//     lp_type sum_lp_vec(0.0);
-//     for (size_t i = 0; i < size_vec; i++) {
-//       const auto& y_col = as_column_vector_or_scalar(y_vec[i]);
-//       const auto& mu_col = as_column_vector_or_scalar(mu_vec[i]);
-//       sum_lp_vec += trace_inv_quad_form_ldlt(ldlt_Sigma, y_col - mu_col);
-//     }
-//     lp -= 0.5 * sum_lp_vec;
-//   }
-//   return lp;
-// }
+    // If the covariance is not autodiff, we can avoid computing a matrix
+    // inverse
+    if (is_constant<T_covar_elem>::value) {
+      matrix_partials_t L_val = value_of(L_ref);
+
+      half = mdivide_left_tri<Eigen::Lower>(L_val, y_val_minus_mu_val)
+                 .transpose();
+
+      scaled_diff = mdivide_right_tri<Eigen::Lower>(half, L_val).transpose();
+
+      if (include_summand<propto>::value) {
+        logp -= sum(log(L_val.diagonal())) * size_vec;
+      }
+    } else {
+      matrix_partials_t inv_L_val
+          = mdivide_left_tri<Eigen::Lower>(value_of(L_ref));
+
+      half = (inv_L_val.template triangularView<Eigen::Lower>()
+              * y_val_minus_mu_val)
+                 .transpose();
+
+      scaled_diff = (half * inv_L_val.template triangularView<Eigen::Lower>())
+                        .transpose();
+
+      logp += sum(log(inv_L_val.diagonal())) * size_vec;
+      ops_partials.edge3_.partials_ -= size_vec * inv_L_val.transpose();
+
+      for (size_t i = 0; i < size_vec; i++) {
+        ops_partials.edge3_.partials_vec_[i]
+            += scaled_diff.col(i) * half.row(i);
+      }
+    }
+
+    logp -= 0.5 * sum(columns_dot_self(half));
+
+    for (size_t i = 0; i < size_vec; i++) {
+      if (!is_constant_all<T_y>::value) {
+        ops_partials.edge1_.partials_vec_[i] -= scaled_diff.col(i);
+      }
+      if (!is_constant_all<T_loc>::value) {
+        ops_partials.edge2_.partials_vec_[i] += scaled_diff.col(i);
+      }
+    }
+  }
+
+  return ops_partials.build(logp);
+}
+
+/** \ingroup multivar_dists
+ * The log of the multivariate normal density for the given y, mu, and
+ * a Cholesky factor L of the variance matrix.
+ * Sigma = LL', a square, semi-positive definite matrix.
+ *
+ * Analytic expressions taken from
+ * http://qwone.com/~jason/writing/multivariateNormal.pdf
+ * written by Jason D. M. Rennie.
+ *
+ * @param y A scalar vector
+ * @param mu The mean vector of the multivariate normal distribution.
+ * @param L The Cholesky decomposition of a variance matrix
+ * of the multivariate normal distribution
+ * @return The log of the multivariate normal density.
+ * @throw std::domain_error if LL' is not square, not symmetric,
+ * or not semi-positive definite.
+ * @tparam T_y Type of scalar.
+ * @tparam T_loc Type of location.
+ * @tparam T_covar Type of scale.
+ */
+template <bool propto, typename T_y, typename T_loc, typename T_covar,
+          require_all_vector_vt<is_stan_scalar, T_y, T_loc>* = nullptr,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_covar>* = nullptr>
+return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(
+    const T_y& y, const T_loc& mu, const T_covar& L) {
+  static const char* function = "multi_normal_lpdf";
+  using T_covar_elem = typename scalar_type<T_covar>::type;
+  using T_return = return_type_t<T_y, T_loc, T_covar>;
+  using T_partials_return = partials_return_t<T_y, T_loc, T_covar>;
+  using matrix_partials_t
+      = Eigen::Matrix<T_partials_return, Eigen::Dynamic, Eigen::Dynamic>;
+  using vector_partials_t = Eigen::Matrix<T_partials_return, Eigen::Dynamic, 1>;
+  using row_vector_partials_t
+      = Eigen::Matrix<T_partials_return, 1, Eigen::Dynamic>;
+  using T_y_ref = ref_type_t<T_y>;
+  using T_mu_ref = ref_type_t<T_loc>;
+  using T_L_ref = ref_type_t<T_covar>;
+
+  T_y_ref y_ref = y;
+  T_mu_ref mu_ref = mu;
+  T_L_ref L_ref = L;
+  decltype(auto) y_val = as_value_column_vector_or_scalar(y_ref);
+  decltype(auto) mu_val = as_value_column_vector_or_scalar(mu_ref);
+
+  const int size_y = y_ref.size();
+  const int size_mu = mu_ref.size();
+
+  check_size_match(function, "Size of random variable", size_y,
+                   "size of location parameter", size_mu);
+  check_size_match(function, "Size of random variable", size_y,
+                   "rows of covariance parameter", L.rows());
+  check_size_match(function, "Size of random variable", size_y,
+                   "columns of covariance parameter", L.cols());
+
+  check_finite(function, "Location parameter", mu_val);
+  check_not_nan(function, "Random variable", y_val);
+
+  if (unlikely(size_y == 0)) {
+    return T_return(0);
+  }
+
+  operands_and_partials<T_y_ref, T_mu_ref, T_L_ref> ops_partials(y_ref, mu_ref,
+                                                                 L_ref);
+
+  T_partials_return logp(0);
+  if (include_summand<propto>::value) {
+    logp += NEG_LOG_SQRT_TWO_PI * size_y;
+  }
+
+  if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
+    row_vector_partials_t half;
+    vector_partials_t scaled_diff;
+
+    // If the covariance is not autodiff, we can avoid computing a matrix
+    // inverse
+    if (is_constant<T_covar_elem>::value) {
+      matrix_partials_t L_val = value_of(L_ref);
+
+      half = mdivide_left_tri<Eigen::Lower>(L_val, y_val - mu_val).transpose();
+
+      scaled_diff = mdivide_right_tri<Eigen::Lower>(half, L_val).transpose();
+
+      if (include_summand<propto>::value) {
+        logp -= sum(log(L_val.diagonal()));
+      }
+    } else {
+      matrix_partials_t inv_L_val
+          = mdivide_left_tri<Eigen::Lower>(value_of(L_ref));
+
+      half = (inv_L_val.template triangularView<Eigen::Lower>()
+              * (y_val - mu_val).template cast<T_partials_return>())
+                 .transpose();
+
+      scaled_diff = (half * inv_L_val.template triangularView<Eigen::Lower>())
+                        .transpose();
+
+      logp += sum(log(inv_L_val.diagonal()));
+      ops_partials.edge3_.partials_
+          += scaled_diff * half - inv_L_val.transpose();
+    }
+
+    logp -= 0.5 * sum(dot_self(half));
+
+    if (!is_constant_all<T_y>::value) {
+      ops_partials.edge1_.partials_ -= scaled_diff;
+    }
+    if (!is_constant_all<T_loc>::value) {
+      ops_partials.edge2_.partials_ += scaled_diff;
+    }
+  }
+
+  return ops_partials.build(logp);
+}
 
 template <typename T_y, typename T_loc, typename T_covar>
 inline return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(
-    const T_y& y, const T_loc& mu, const T_covar& L_Sigma) {
-  return multi_normal_cholesky_lpdf<false>(y, mu, L_Sigma);
+    const T_y& y, const T_loc& mu, const T_covar& L) {
+  return multi_normal_lpdf<false>(y, mu, L);
 }
 
 }  // namespace math

--- a/stan/math/prim/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_lpdf.hpp
@@ -11,7 +11,7 @@
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/trace_inv_quad_form_ldlt.hpp>
 #include <stan/math/prim/fun/vector_seq_view.hpp>
-#include <stan/math/prim/fun/cholesky.hpp>
+#include <stan/math/prim/fun/cholesky_decompose.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_lpdf.hpp
@@ -41,7 +41,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(
 
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;
-  auto L = stan::math::cholesky_decompose(Sigma);
+  auto L = cholesky_decompose(Sigma);
   T_L_ref L_ref = L;
   vector_seq_view<T_y_ref> y_vec(y_ref);
   vector_seq_view<T_mu_ref> mu_vec(mu_ref);


### PR DESCRIPTION
## Summary

This shows that `multi_normal` should just take the cholesky decomposition and call `multi_normal_cholesky`. 

I just copied all the `multi_normal_cholesky_lpdf` code over. I wasn't sure how to just call it. That should be updated. The unit tests that call `multi_normal_log` fail. 

Question: Would it be better to form the cholesky decomposition using `ldlt` instead of `cholesky_decompose()`? 

## Tests

No new tests.

Here's a benchmark vs the current `multi_normal_lpdf`

![plot_mvn](https://user-images.githubusercontent.com/23704057/131254667-06c6e743-2734-4e01-a102-73adbb034b2d.png)


## Side Effects

None

## Release notes

`multi_normal_lpdf` now takes the Cholesky decomposition of the covariance matrix and calls `multi_normal_cholesky_lpdf` under the hood 

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
