### PR TITLE
Add vectorized versions of the free functions

### DIFF
--- a/stan/math/prim/fun/cholesky_corr_free.hpp
+++ b/stan/math/prim/fun/cholesky_corr_free.hpp
@@ -33,6 +33,13 @@ auto cholesky_corr_free(const T& x) {
   return z;
 }
 
+/**
+ * Overload of `cholesky_corr_free()` to untransform each matrix
+ * in a standard vector.
+ * @tparam T A standard vector with with a `value_type` which inherits from
+ *  `Eigen::MatrixBase`.
+ * @param x The standard vector to untransform.
+ */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto cholesky_corr_free(const T& x) {
   std::vector<decltype(cholesky_corr_free(x[0]))> x_free(x.size());

--- a/stan/math/prim/fun/cholesky_corr_free.hpp
+++ b/stan/math/prim/fun/cholesky_corr_free.hpp
@@ -43,9 +43,8 @@ auto cholesky_corr_free(const T& x) {
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto cholesky_corr_free(const T& x) {
   std::vector<decltype(cholesky_corr_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
-    return cholesky_corr_free(xx);
-  });
+  std::transform(x.begin(), x.end(), x_free.begin(),
+                 [](auto&& xx) { return cholesky_corr_free(xx); });
   return x_free;
 }
 

--- a/stan/math/prim/fun/cholesky_corr_free.hpp
+++ b/stan/math/prim/fun/cholesky_corr_free.hpp
@@ -42,10 +42,8 @@ auto cholesky_corr_free(const T& x) {
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto cholesky_corr_free(const T& x) {
-  std::vector<decltype(cholesky_corr_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(),
-                 [](auto&& xx) { return cholesky_corr_free(xx); });
-  return x_free;
+  return apply_vector_unary<T>::apply(
+      x, [](auto&& v) { return cholesky_corr_free(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cholesky_corr_free.hpp
+++ b/stan/math/prim/fun/cholesky_corr_free.hpp
@@ -33,6 +33,15 @@ auto cholesky_corr_free(const T& x) {
   return z;
 }
 
+template <typename T, require_std_vector_t<T>* = nullptr>
+auto cholesky_corr_free(const T& x) {
+  std::vector<decltype(cholesky_corr_free(x[0]))> x_free(x.size());
+  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
+    return cholesky_corr_free(xx);
+  });
+  return x_free;
+}
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/fun/cholesky_factor_free.hpp
+++ b/stan/math/prim/fun/cholesky_factor_free.hpp
@@ -48,6 +48,13 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cholesky_factor_free(
   return x;
 }
 
+/**
+ * Overload of `cholesky_factor_free()` to untransform each matrix
+ * in a standard vector.
+ * @tparam T A standard vector with with a `value_type` which inherits from
+ *  `Eigen::MatrixBase`.
+ * @param x The standard vector to untransform.
+ */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto cholesky_factor_free(const T& x) {
   std::vector<decltype(cholesky_factor_free(x[0]))> x_free(x.size());

--- a/stan/math/prim/fun/cholesky_factor_free.hpp
+++ b/stan/math/prim/fun/cholesky_factor_free.hpp
@@ -58,9 +58,8 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cholesky_factor_free(
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto cholesky_factor_free(const T& x) {
   std::vector<decltype(cholesky_factor_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
-    return cholesky_factor_free(xx);
-  });
+  std::transform(x.begin(), x.end(), x_free.begin(),
+                 [](auto&& xx) { return cholesky_factor_free(xx); });
   return x_free;
 }
 

--- a/stan/math/prim/fun/cholesky_factor_free.hpp
+++ b/stan/math/prim/fun/cholesky_factor_free.hpp
@@ -57,10 +57,8 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cholesky_factor_free(
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto cholesky_factor_free(const T& x) {
-  std::vector<decltype(cholesky_factor_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(),
-                 [](auto&& xx) { return cholesky_factor_free(xx); });
-  return x_free;
+  return apply_vector_unary<T>::apply(
+      x, [](auto&& v) { return cholesky_factor_free(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cholesky_factor_free.hpp
+++ b/stan/math/prim/fun/cholesky_factor_free.hpp
@@ -48,6 +48,15 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cholesky_factor_free(
   return x;
 }
 
+template <typename T, require_std_vector_t<T>* = nullptr>
+auto cholesky_factor_free(const T& x) {
+  std::vector<decltype(cholesky_factor_free(x[0]))> x_free(x.size());
+  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
+    return cholesky_factor_free(xx);
+  });
+  return x_free;
+}
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/corr_matrix_free.hpp
+++ b/stan/math/prim/fun/corr_matrix_free.hpp
@@ -52,6 +52,16 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> corr_matrix_free(const T& y) {
   return x;
 }
 
+template <typename T, require_std_vector_t<T>* = nullptr>
+auto corr_matrix_free(const T& x) {
+  std::vector<decltype(corr_matrix_free(x[0]))> x_free(x.size());
+  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
+    return corr_matrix_free(xx);
+  });
+  return x_free;
+}
+
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/corr_matrix_free.hpp
+++ b/stan/math/prim/fun/corr_matrix_free.hpp
@@ -62,12 +62,10 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> corr_matrix_free(const T& y) {
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto corr_matrix_free(const T& x) {
   std::vector<decltype(corr_matrix_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
-    return corr_matrix_free(xx);
-  });
+  std::transform(x.begin(), x.end(), x_free.begin(),
+                 [](auto&& xx) { return corr_matrix_free(xx); });
   return x_free;
 }
-
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/corr_matrix_free.hpp
+++ b/stan/math/prim/fun/corr_matrix_free.hpp
@@ -52,6 +52,13 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> corr_matrix_free(const T& y) {
   return x;
 }
 
+/**
+ * Overload of `corr_matrix_free()` to untransform each matrix
+ * in a standard vector.
+ * @tparam T A standard vector with with a `value_type` which inherits from
+ *  `Eigen::MatrixBase`.
+ * @param x The standard vector to untransform.
+ */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto corr_matrix_free(const T& x) {
   std::vector<decltype(corr_matrix_free(x[0]))> x_free(x.size());

--- a/stan/math/prim/fun/corr_matrix_free.hpp
+++ b/stan/math/prim/fun/corr_matrix_free.hpp
@@ -61,10 +61,8 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> corr_matrix_free(const T& y) {
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto corr_matrix_free(const T& x) {
-  std::vector<decltype(corr_matrix_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(),
-                 [](auto&& xx) { return corr_matrix_free(xx); });
-  return x_free;
+  return apply_vector_unary<T>::apply(
+      x, [](auto&& v) { return corr_matrix_free(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cov_matrix_free.hpp
+++ b/stan/math/prim/fun/cov_matrix_free.hpp
@@ -58,6 +58,15 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cov_matrix_free(const T& y) {
   return x;
 }
 
+template <typename T, require_std_vector_t<T>* = nullptr>
+auto cov_matrix_free(const T& x) {
+  std::vector<decltype(cov_matrix_free(x[0]))> x_free(x.size());
+  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
+    return cov_matrix_free(xx);
+  });
+  return x_free;
+}
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/cov_matrix_free.hpp
+++ b/stan/math/prim/fun/cov_matrix_free.hpp
@@ -67,10 +67,8 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cov_matrix_free(const T& y) {
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto cov_matrix_free(const T& x) {
-  std::vector<decltype(cov_matrix_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(),
-                 [](auto&& xx) { return cov_matrix_free(xx); });
-  return x_free;
+  return apply_vector_unary<T>::apply(
+      x, [](auto&& v) { return cov_matrix_free(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cov_matrix_free.hpp
+++ b/stan/math/prim/fun/cov_matrix_free.hpp
@@ -58,6 +58,13 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cov_matrix_free(const T& y) {
   return x;
 }
 
+/**
+ * Overload of `cov_matrix_free()` to untransform each matrix
+ * in a standard vector.
+ * @tparam T A standard vector with with a `value_type` which inherits from
+ *  `Eigen::MatrixBase`.
+ * @param x The standard vector to untransform.
+ */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto cov_matrix_free(const T& x) {
   std::vector<decltype(cov_matrix_free(x[0]))> x_free(x.size());

--- a/stan/math/prim/fun/cov_matrix_free.hpp
+++ b/stan/math/prim/fun/cov_matrix_free.hpp
@@ -68,9 +68,8 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cov_matrix_free(const T& y) {
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto cov_matrix_free(const T& x) {
   std::vector<decltype(cov_matrix_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
-    return cov_matrix_free(xx);
-  });
+  std::transform(x.begin(), x.end(), x_free.begin(),
+                 [](auto&& xx) { return cov_matrix_free(xx); });
   return x_free;
 }
 

--- a/stan/math/prim/fun/cov_matrix_free_lkj.hpp
+++ b/stan/math/prim/fun/cov_matrix_free_lkj.hpp
@@ -59,9 +59,8 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cov_matrix_free_lkj(
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto cov_matrix_free_lkj(const T& x) {
   std::vector<decltype(cov_matrix_free_lkj(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
-    return cov_matrix_free_lkj(xx);
-  });
+  std::transform(x.begin(), x.end(), x_free.begin(),
+                 [](auto&& xx) { return cov_matrix_free_lkj(xx); });
   return x_free;
 }
 

--- a/stan/math/prim/fun/cov_matrix_free_lkj.hpp
+++ b/stan/math/prim/fun/cov_matrix_free_lkj.hpp
@@ -49,6 +49,15 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cov_matrix_free_lkj(
   return x;
 }
 
+template <typename T, require_std_vector_t<T>* = nullptr>
+auto cov_matrix_free_lkj(const T& x) {
+  std::vector<decltype(cov_matrix_free_lkj(x[0]))> x_free(x.size());
+  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
+    return cov_matrix_free_lkj(xx);
+  });
+  return x_free;
+}
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/cov_matrix_free_lkj.hpp
+++ b/stan/math/prim/fun/cov_matrix_free_lkj.hpp
@@ -58,10 +58,8 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cov_matrix_free_lkj(
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto cov_matrix_free_lkj(const T& x) {
-  std::vector<decltype(cov_matrix_free_lkj(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(),
-                 [](auto&& xx) { return cov_matrix_free_lkj(xx); });
-  return x_free;
+  return apply_vector_unary<T>::apply(
+      x, [](auto&& v) { return cov_matrix_free_lkj(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cov_matrix_free_lkj.hpp
+++ b/stan/math/prim/fun/cov_matrix_free_lkj.hpp
@@ -49,6 +49,13 @@ Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cov_matrix_free_lkj(
   return x;
 }
 
+/**
+ * Overload of `cov_matrix_free_lkj()` to untransform each matrix
+ * in a standard vector.
+ * @tparam T A standard vector with with a `value_type` which inherits from
+ *  `Eigen::MatrixBase`.
+ * @param x The standard vector to untransform.
+ */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto cov_matrix_free_lkj(const T& x) {
   std::vector<decltype(cov_matrix_free_lkj(x[0]))> x_free(x.size());

--- a/stan/math/prim/fun/lb_free.hpp
+++ b/stan/math/prim/fun/lb_free.hpp
@@ -85,9 +85,7 @@ inline auto lb_free(const std::vector<T> y, const L& lb) {
   auto&& lb_ref = to_ref(lb);
   std::vector<decltype(lb_free(y[0], lb))> ret(y.size());
   std::transform(y.begin(), y.end(), ret.begin(),
-   [&lb](auto&& yy) {
-     return lb_free(yy, lb);
-   });
+                 [&lb](auto&& yy) { return lb_free(yy, lb); });
   return ret;
 }
 
@@ -109,9 +107,7 @@ template <typename T, typename L>
 inline auto lb_free(const std::vector<T> y, const std::vector<L>& lb) {
   std::vector<decltype(lb_free(y[0], lb[0]))> ret(y.size());
   std::transform(y.begin(), y.end(), lb.begin(), ret.begin(),
-   [](auto&& yy, auto&& lbb) {
-     return lb_free(yy, lbb);
-   });
+                 [](auto&& yy, auto&& lbb) { return lb_free(yy, lbb); });
   return ret;
 }
 

--- a/stan/math/prim/fun/lb_free.hpp
+++ b/stan/math/prim/fun/lb_free.hpp
@@ -84,9 +84,10 @@ template <typename T, typename L, require_not_std_vector_t<L>* = nullptr>
 inline auto lb_free(const std::vector<T> y, const L& lb) {
   auto&& lb_ref = to_ref(lb);
   std::vector<decltype(lb_free(y[0], lb))> ret(y.size());
-  for (Eigen::Index i = 0; i < y.size(); ++i) {
-    ret[i] = lb_free(y[i], lb_ref);
-  }
+  std::transform(y.begin(), y.end(), ret.begin(),
+   [&lb](auto&& yy) {
+     return lb_free(yy, lb);
+   });
   return ret;
 }
 
@@ -107,9 +108,10 @@ inline auto lb_free(const std::vector<T> y, const L& lb) {
 template <typename T, typename L>
 inline auto lb_free(const std::vector<T> y, const std::vector<L>& lb) {
   std::vector<decltype(lb_free(y[0], lb[0]))> ret(y.size());
-  for (Eigen::Index i = 0; i < y.size(); ++i) {
-    ret[i] = lb_free(y[i], lb[i]);
-  }
+  std::transform(y.begin(), y.end(), lb.begin(), ret.begin(),
+   [](auto&& yy, auto&& lbb) {
+     return lb_free(yy, lbb);
+   });
   return ret;
 }
 

--- a/stan/math/prim/fun/ordered_free.hpp
+++ b/stan/math/prim/fun/ordered_free.hpp
@@ -51,9 +51,8 @@ plain_type_t<EigVec> ordered_free(const EigVec& y) {
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto ordered_free(const T& x) {
   std::vector<decltype(ordered_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
-    return ordered_free(xx);
-  });
+  std::transform(x.begin(), x.end(), x_free.begin(),
+                 [](auto&& xx) { return ordered_free(xx); });
   return x_free;
 }
 

--- a/stan/math/prim/fun/ordered_free.hpp
+++ b/stan/math/prim/fun/ordered_free.hpp
@@ -41,6 +41,13 @@ plain_type_t<EigVec> ordered_free(const EigVec& y) {
   return x;
 }
 
+/**
+ * Overload of `ordered_free()` to untransform each Eigen vector
+ * in a standard vector.
+ * @tparam T A standard vector with with a `value_type` which inherits from
+ *  `Eigen::MatrixBase` with compile time rows or columns equal to 1.
+ * @param x The standard vector to untransform.
+ */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto ordered_free(const T& x) {
   std::vector<decltype(ordered_free(x[0]))> x_free(x.size());

--- a/stan/math/prim/fun/ordered_free.hpp
+++ b/stan/math/prim/fun/ordered_free.hpp
@@ -50,10 +50,8 @@ plain_type_t<EigVec> ordered_free(const EigVec& y) {
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto ordered_free(const T& x) {
-  std::vector<decltype(ordered_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(),
-                 [](auto&& xx) { return ordered_free(xx); });
-  return x_free;
+  return apply_vector_unary<T>::apply(
+      x, [](auto&& v) { return ordered_free(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/ordered_free.hpp
+++ b/stan/math/prim/fun/ordered_free.hpp
@@ -41,6 +41,15 @@ plain_type_t<EigVec> ordered_free(const EigVec& y) {
   return x;
 }
 
+template <typename T, require_std_vector_t<T>* = nullptr>
+auto ordered_free(const T& x) {
+  std::vector<decltype(ordered_free(x[0]))> x_free(x.size());
+  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
+    return ordered_free(xx);
+  });
+  return x_free;
+}
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/ordered_free.hpp
+++ b/stan/math/prim/fun/ordered_free.hpp
@@ -50,8 +50,8 @@ plain_type_t<EigVec> ordered_free(const EigVec& y) {
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto ordered_free(const T& x) {
-  return apply_vector_unary<T>::apply(
-      x, [](auto&& v) { return ordered_free(v); });
+  return apply_vector_unary<T>::apply(x,
+                                      [](auto&& v) { return ordered_free(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/positive_ordered_free.hpp
+++ b/stan/math/prim/fun/positive_ordered_free.hpp
@@ -36,9 +36,7 @@ auto positive_ordered_free(const EigVec& y) {
     return x;
   }
   x.coeffRef(0) = log(y_ref.coeff(0));
-  for (Eigen::Index i = 1; i < k; ++i) {
-    x.coeffRef(i) = log(y_ref.coeff(i) - y_ref.coeff(i - 1));
-  }
+  x.tail(k - 1) = (y_ref.tail(k - 1) - y_ref.head(k - 1)).array().log().matrix();
   return x;
 }
 
@@ -51,10 +49,8 @@ auto positive_ordered_free(const EigVec& y) {
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto positive_ordered_free(const T& x) {
-  std::vector<decltype(positive_ordered_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(),
-                 [](auto&& xx) { return positive_ordered_free(xx); });
-  return x_free;
+  return apply_vector_unary<T>::apply(
+      x, [](auto&& v) { return positive_ordered_free(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/positive_ordered_free.hpp
+++ b/stan/math/prim/fun/positive_ordered_free.hpp
@@ -42,7 +42,6 @@ auto positive_ordered_free(const EigVec& y) {
   return x;
 }
 
-
 /**
  * Overload of `positive_ordered_free()` to untransform each Eigen vector
  * in a standard vector.
@@ -53,9 +52,8 @@ auto positive_ordered_free(const EigVec& y) {
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto positive_ordered_free(const T& x) {
   std::vector<decltype(positive_ordered_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
-    return positive_ordered_free(xx);
-  });
+  std::transform(x.begin(), x.end(), x_free.begin(),
+                 [](auto&& xx) { return positive_ordered_free(xx); });
   return x_free;
 }
 

--- a/stan/math/prim/fun/positive_ordered_free.hpp
+++ b/stan/math/prim/fun/positive_ordered_free.hpp
@@ -42,6 +42,15 @@ auto positive_ordered_free(const EigVec& y) {
   return x;
 }
 
+template <typename T, require_std_vector_t<T>* = nullptr>
+auto positive_ordered_free(const T& x) {
+  std::vector<decltype(positive_ordered_free(x[0]))> x_free(x.size());
+  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
+    return positive_ordered_free(xx);
+  });
+  return x_free;
+}
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/positive_ordered_free.hpp
+++ b/stan/math/prim/fun/positive_ordered_free.hpp
@@ -36,7 +36,8 @@ auto positive_ordered_free(const EigVec& y) {
     return x;
   }
   x.coeffRef(0) = log(y_ref.coeff(0));
-  x.tail(k - 1) = (y_ref.tail(k - 1) - y_ref.head(k - 1)).array().log().matrix();
+  x.tail(k - 1)
+      = (y_ref.tail(k - 1) - y_ref.head(k - 1)).array().log().matrix();
   return x;
 }
 

--- a/stan/math/prim/fun/positive_ordered_free.hpp
+++ b/stan/math/prim/fun/positive_ordered_free.hpp
@@ -42,6 +42,14 @@ auto positive_ordered_free(const EigVec& y) {
   return x;
 }
 
+
+/**
+ * Overload of `positive_ordered_free()` to untransform each Eigen vector
+ * in a standard vector.
+ * @tparam T A standard vector with with a `value_type` which inherits from
+ *  `Eigen::MatrixBase` with compile time rows or columns equal to 1.
+ * @param x The standard vector to untransform.
+ */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto positive_ordered_free(const T& x) {
   std::vector<decltype(positive_ordered_free(x[0]))> x_free(x.size());

--- a/stan/math/prim/fun/simplex_free.hpp
+++ b/stan/math/prim/fun/simplex_free.hpp
@@ -45,6 +45,13 @@ auto simplex_free(const Vec& x) {
   return y;
 }
 
+/**
+ * Overload of `simplex_free()` to untransform each Eigen vector
+ * in a standard vector.
+ * @tparam T A standard vector with with a `value_type` which inherits from
+ *  `Eigen::MatrixBase` with compile time rows or columns equal to 1.
+ * @param x The standard vector to untransform.
+ */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto simplex_free(const T& x) {
   std::vector<decltype(simplex_free(x[0]))> x_free(x.size());

--- a/stan/math/prim/fun/simplex_free.hpp
+++ b/stan/math/prim/fun/simplex_free.hpp
@@ -54,8 +54,8 @@ auto simplex_free(const Vec& x) {
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto simplex_free(const T& x) {
-  return apply_vector_unary<T>::apply(
-      x, [](auto&& v) { return simplex_free(v); });
+  return apply_vector_unary<T>::apply(x,
+                                      [](auto&& v) { return simplex_free(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/simplex_free.hpp
+++ b/stan/math/prim/fun/simplex_free.hpp
@@ -55,9 +55,8 @@ auto simplex_free(const Vec& x) {
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto simplex_free(const T& x) {
   std::vector<decltype(simplex_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
-    return simplex_free(xx);
-  });
+  std::transform(x.begin(), x.end(), x_free.begin(),
+                 [](auto&& xx) { return simplex_free(xx); });
   return x_free;
 }
 

--- a/stan/math/prim/fun/simplex_free.hpp
+++ b/stan/math/prim/fun/simplex_free.hpp
@@ -45,6 +45,15 @@ auto simplex_free(const Vec& x) {
   return y;
 }
 
+template <typename T, require_std_vector_t<T>* = nullptr>
+auto simplex_free(const T& x) {
+  std::vector<decltype(simplex_free(x[0]))> x_free(x.size());
+  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
+    return simplex_free(xx);
+  });
+  return x_free;
+}
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/simplex_free.hpp
+++ b/stan/math/prim/fun/simplex_free.hpp
@@ -54,10 +54,8 @@ auto simplex_free(const Vec& x) {
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto simplex_free(const T& x) {
-  std::vector<decltype(simplex_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(),
-                 [](auto&& xx) { return simplex_free(xx); });
-  return x_free;
+  return apply_vector_unary<T>::apply(
+      x, [](auto&& v) { return simplex_free(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/unit_vector_free.hpp
+++ b/stan/math/prim/fun/unit_vector_free.hpp
@@ -28,6 +28,13 @@ inline auto unit_vector_free(EigVec&& x) {
   return x_ref;
 }
 
+/**
+ * Overload of `unit_vector_free()` to untransform each Eigen vector
+ * in a standard vector.
+ * @tparam T A standard vector with with a `value_type` which inherits from
+ *  `Eigen::MatrixBase` with compile time rows or columns equal to 1.
+ * @param x The standard vector to untransform.
+ */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto unit_vector_free(const T& x) {
   std::vector<decltype(unit_vector_free(x[0]))> x_free(x.size());

--- a/stan/math/prim/fun/unit_vector_free.hpp
+++ b/stan/math/prim/fun/unit_vector_free.hpp
@@ -28,6 +28,15 @@ inline auto unit_vector_free(EigVec&& x) {
   return x_ref;
 }
 
+template <typename T, require_std_vector_t<T>* = nullptr>
+auto unit_vector_free(const T& x) {
+  std::vector<decltype(unit_vector_free(x[0]))> x_free(x.size());
+  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
+    return unit_vector_free(xx);
+  });
+  return x_free;
+}
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/unit_vector_free.hpp
+++ b/stan/math/prim/fun/unit_vector_free.hpp
@@ -38,9 +38,8 @@ inline auto unit_vector_free(EigVec&& x) {
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto unit_vector_free(const T& x) {
   std::vector<decltype(unit_vector_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
-    return unit_vector_free(xx);
-  });
+  std::transform(x.begin(), x.end(), x_free.begin(),
+                 [](auto&& xx) { return unit_vector_free(xx); });
   return x_free;
 }
 

--- a/stan/math/prim/fun/unit_vector_free.hpp
+++ b/stan/math/prim/fun/unit_vector_free.hpp
@@ -37,10 +37,8 @@ inline auto unit_vector_free(EigVec&& x) {
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
 auto unit_vector_free(const T& x) {
-  std::vector<decltype(unit_vector_free(x[0]))> x_free(x.size());
-  std::transform(x.begin(), x.end(), x_free.begin(),
-                 [](auto&& xx) { return unit_vector_free(xx); });
-  return x_free;
+  return apply_vector_unary<T>::apply(
+      x, [](auto&& v) { return unit_vector_free(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/functor/apply_vector_unary.hpp
+++ b/stan/math/prim/functor/apply_vector_unary.hpp
@@ -190,10 +190,9 @@ struct apply_vector_unary<
     using T_return
         = plain_type_t<decltype(apply_vector_unary<T_vt>::apply(x[0], f))>;
     std::vector<T_return> result(x.size());
-    std::transform(x.begin(), x.end(), result.begin(),
-     [&f](auto&& xx) {
-       return apply_vector_unary<T_vt>::apply_no_holder(xx, f);
-     });
+    std::transform(x.begin(), x.end(), result.begin(), [&f](auto&& xx) {
+      return apply_vector_unary<T_vt>::apply_no_holder(xx, f);
+    });
     return result;
   }
 

--- a/stan/math/prim/functor/apply_vector_unary.hpp
+++ b/stan/math/prim/functor/apply_vector_unary.hpp
@@ -187,12 +187,13 @@ struct apply_vector_unary<
    */
   template <typename F>
   static inline auto apply(const T& x, const F& f) {
-    size_t x_size = x.size();
     using T_return
         = plain_type_t<decltype(apply_vector_unary<T_vt>::apply(x[0], f))>;
-    std::vector<T_return> result(x_size);
-    for (size_t i = 0; i < x_size; ++i)
-      result[i] = apply_vector_unary<T_vt>::apply_no_holder(x[i], f);
+    std::vector<T_return> result(x.size());
+    std::transform(x.begin(), x.end(), result.begin(),
+     [&f](auto&& xx) {
+       return apply_vector_unary<T_vt>::apply_no_holder(xx, f);
+     });
     return result;
   }
 

--- a/test/unit/math/prim/fun/cholesky_corr_transform_test.cpp
+++ b/test/unit/math/prim/fun/cholesky_corr_transform_test.cpp
@@ -39,7 +39,9 @@ void test_cholesky_correlation_values(
   Matrix<double, Dynamic, 1> y = stan::math::cholesky_corr_free(L);
   EXPECT_EQ(K_choose_2, y.size());
 
-  std::vector<Matrix<double, Dynamic, 1>> y_vec = stan::math::cholesky_corr_free(std::vector<Matrix<double, Dynamic, Dynamic>>{L, L, L});
+  std::vector<Matrix<double, Dynamic, 1>> y_vec
+      = stan::math::cholesky_corr_free(
+          std::vector<Matrix<double, Dynamic, Dynamic>>{L, L, L});
   for (int i = 0; i < y_vec.size(); ++i) {
     EXPECT_EQ(K_choose_2, y_vec[i].size());
   }

--- a/test/unit/math/prim/fun/cholesky_corr_transform_test.cpp
+++ b/test/unit/math/prim/fun/cholesky_corr_transform_test.cpp
@@ -39,6 +39,11 @@ void test_cholesky_correlation_values(
   Matrix<double, Dynamic, 1> y = stan::math::cholesky_corr_free(L);
   EXPECT_EQ(K_choose_2, y.size());
 
+  std::vector<Matrix<double, Dynamic, 1>> y_vec = stan::math::cholesky_corr_free(std::vector<Matrix<double, Dynamic, Dynamic>>{L, L, L});
+  for (int i = 0; i < y_vec.size(); ++i) {
+    EXPECT_EQ(K_choose_2, y_vec[i].size());
+  }
+
   // test transform roundtrip without Jacobian
   Matrix<double, Dynamic, Dynamic> x
       = stan::math::cholesky_corr_constrain(y, K);

--- a/test/unit/math/prim/fun/cholesky_factor_transform_test.cpp
+++ b/test/unit/math/prim/fun/cholesky_factor_transform_test.cpp
@@ -20,6 +20,13 @@ TEST(ProbTransform, choleskyFactor) {
   EXPECT_EQ(x2.cols(), x.cols());
   for (int i = 0; i < 3; ++i)
     EXPECT_FLOAT_EQ(x(i), x2(i));
+
+  std::vector<Matrix<double, Dynamic, 1>> x_vec = stan::math::cholesky_factor_free(std::vector<Matrix<double, Dynamic, Dynamic>>{y, y, y});
+  for (int i = 0; i < x_vec.size(); ++i) {
+    EXPECT_EQ(x_vec[i].size(), x.size());
+    EXPECT_EQ(x_vec[i].rows(), x.rows());
+    EXPECT_EQ(x_vec[i].cols(), x.cols());
+  }
 }
 TEST(ProbTransform, choleskyFactorLogJacobian) {
   using Eigen::Dynamic;

--- a/test/unit/math/prim/fun/cholesky_factor_transform_test.cpp
+++ b/test/unit/math/prim/fun/cholesky_factor_transform_test.cpp
@@ -21,7 +21,9 @@ TEST(ProbTransform, choleskyFactor) {
   for (int i = 0; i < 3; ++i)
     EXPECT_FLOAT_EQ(x(i), x2(i));
 
-  std::vector<Matrix<double, Dynamic, 1>> x_vec = stan::math::cholesky_factor_free(std::vector<Matrix<double, Dynamic, Dynamic>>{y, y, y});
+  std::vector<Matrix<double, Dynamic, 1>> x_vec
+      = stan::math::cholesky_factor_free(
+          std::vector<Matrix<double, Dynamic, Dynamic>>{y, y, y});
   for (int i = 0; i < x_vec.size(); ++i) {
     EXPECT_EQ(x_vec[i].size(), x.size());
     EXPECT_EQ(x_vec[i].rows(), x.rows());

--- a/test/unit/math/prim/fun/corr_matrix_transform_test.cpp
+++ b/test/unit/math/prim/fun/corr_matrix_transform_test.cpp
@@ -2,15 +2,17 @@
 #include <test/unit/util.hpp>
 #include <gtest/gtest.h>
 
-TEST(prob_transform, corr_matrix_j) {
+TEST(prob_transform, stdvec_corr_matrix_j) {
   size_t K = 4;
   size_t K_choose_2 = 6;
   Eigen::VectorXd x(K_choose_2);
   x << -1.0, 2.0, 0.0, 1.0, 3.0, -1.5;
   double lp = -12.9;
   Eigen::MatrixXd y = stan::math::corr_matrix_constrain(x, K, lp);
-  Eigen::VectorXd xrt = stan::math::corr_matrix_free(y);
-  EXPECT_MATRIX_FLOAT_EQ(x, xrt);
+  std::vector<Eigen::VectorXd> xrt = stan::math::corr_matrix_free(std::vector<Eigen::MatrixXd>{y, y, y});
+  for (auto&& x_i : xrt) {
+    EXPECT_MATRIX_FLOAT_EQ(x, x_i);
+  }
 }
 
 TEST(prob_transform, corr_matrix_j2x2) {

--- a/test/unit/math/prim/fun/corr_matrix_transform_test.cpp
+++ b/test/unit/math/prim/fun/corr_matrix_transform_test.cpp
@@ -9,7 +9,8 @@ TEST(prob_transform, stdvec_corr_matrix_j) {
   x << -1.0, 2.0, 0.0, 1.0, 3.0, -1.5;
   double lp = -12.9;
   Eigen::MatrixXd y = stan::math::corr_matrix_constrain(x, K, lp);
-  std::vector<Eigen::VectorXd> xrt = stan::math::corr_matrix_free(std::vector<Eigen::MatrixXd>{y, y, y});
+  std::vector<Eigen::VectorXd> xrt
+      = stan::math::corr_matrix_free(std::vector<Eigen::MatrixXd>{y, y, y});
   for (auto&& x_i : xrt) {
     EXPECT_MATRIX_FLOAT_EQ(x, x_i);
   }

--- a/test/unit/math/prim/fun/cov_matrix_transform_test.cpp
+++ b/test/unit/math/prim/fun/cov_matrix_transform_test.cpp
@@ -12,7 +12,8 @@ TEST(prob_transform, cov_matrix_rt) {
   Matrix<double, Dynamic, 1> x(K_choose_2 + K);
   x << -1.0, 2.0, 0.0, 1.0, 3.0, -1.5, 1.0, 2.0, -1.5, 2.5;
   Matrix<double, Dynamic, Dynamic> y = stan::math::cov_matrix_constrain(x, K);
-  std::vector<Eigen::VectorXd> xrt = stan::math::cov_matrix_free(std::vector<Eigen::MatrixXd>{y, y, y});
+  std::vector<Eigen::VectorXd> xrt
+      = stan::math::cov_matrix_free(std::vector<Eigen::MatrixXd>{y, y, y});
   for (auto&& x_i : xrt) {
     EXPECT_EQ(x.size(), x_i.size());
     EXPECT_MATRIX_FLOAT_EQ(x, x_i);

--- a/test/unit/math/prim/fun/cov_matrix_transform_test.cpp
+++ b/test/unit/math/prim/fun/cov_matrix_transform_test.cpp
@@ -12,10 +12,10 @@ TEST(prob_transform, cov_matrix_rt) {
   Matrix<double, Dynamic, 1> x(K_choose_2 + K);
   x << -1.0, 2.0, 0.0, 1.0, 3.0, -1.5, 1.0, 2.0, -1.5, 2.5;
   Matrix<double, Dynamic, Dynamic> y = stan::math::cov_matrix_constrain(x, K);
-  Matrix<double, Dynamic, 1> xrt = stan::math::cov_matrix_free(y);
-  EXPECT_EQ(x.size(), xrt.size());
-  for (int i = 0; i < x.size(); ++i) {
-    EXPECT_FLOAT_EQ(x[i], xrt[i]);
+  std::vector<Eigen::VectorXd> xrt = stan::math::cov_matrix_free(std::vector<Eigen::MatrixXd>{y, y, y});
+  for (auto&& x_i : xrt) {
+    EXPECT_EQ(x.size(), x_i.size());
+    EXPECT_MATRIX_FLOAT_EQ(x, x_i);
   }
 }
 TEST(prob_transform, cov_matrix_constrain_exception) {

--- a/test/unit/math/prim/fun/ordered_transform_test.cpp
+++ b/test/unit/math/prim/fun/ordered_transform_test.cpp
@@ -54,9 +54,9 @@ TEST(prob_transform, ordered_rt) {
   Matrix<double, Dynamic, 1> x(3);
   x << -1.0, 8.0, -3.9;
   Matrix<double, Dynamic, 1> y = stan::math::ordered_constrain(x);
-  Matrix<double, Dynamic, 1> xrt = stan::math::ordered_free(y);
-  EXPECT_EQ(x.size(), xrt.size());
-  for (int i = 0; i < x.size(); ++i) {
-    EXPECT_FLOAT_EQ(x[i], xrt[i]);
+  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::ordered_free(std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
+  for (auto&& x_i : xrt) {
+    EXPECT_EQ(x.size(), x_i.size());
+    EXPECT_MATRIX_FLOAT_EQ(x, x_i);
   }
 }

--- a/test/unit/math/prim/fun/ordered_transform_test.cpp
+++ b/test/unit/math/prim/fun/ordered_transform_test.cpp
@@ -54,7 +54,8 @@ TEST(prob_transform, ordered_rt) {
   Matrix<double, Dynamic, 1> x(3);
   x << -1.0, 8.0, -3.9;
   Matrix<double, Dynamic, 1> y = stan::math::ordered_constrain(x);
-  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::ordered_free(std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
+  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::ordered_free(
+      std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
   for (auto&& x_i : xrt) {
     EXPECT_EQ(x.size(), x_i.size());
     EXPECT_MATRIX_FLOAT_EQ(x, x_i);

--- a/test/unit/math/prim/fun/positive_ordered_transform_test.cpp
+++ b/test/unit/math/prim/fun/positive_ordered_transform_test.cpp
@@ -54,9 +54,9 @@ TEST(prob_transform, positive_ordered_rt) {
   Matrix<double, Dynamic, 1> x(3);
   x << -1.0, 8.0, -3.9;
   Matrix<double, Dynamic, 1> y = stan::math::positive_ordered_constrain(x);
-  Matrix<double, Dynamic, 1> xrt = stan::math::positive_ordered_free(y);
-  EXPECT_EQ(x.size(), xrt.size());
-  for (int i = 0; i < x.size(); ++i) {
-    EXPECT_FLOAT_EQ(x[i], xrt[i]);
+  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::positive_ordered_free(std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
+  for (auto&& x_i : xrt) {
+    EXPECT_EQ(x.size(), x_i.size());
+    EXPECT_MATRIX_FLOAT_EQ(x, x_i);
   }
 }

--- a/test/unit/math/prim/fun/positive_ordered_transform_test.cpp
+++ b/test/unit/math/prim/fun/positive_ordered_transform_test.cpp
@@ -54,7 +54,9 @@ TEST(prob_transform, positive_ordered_rt) {
   Matrix<double, Dynamic, 1> x(3);
   x << -1.0, 8.0, -3.9;
   Matrix<double, Dynamic, 1> y = stan::math::positive_ordered_constrain(x);
-  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::positive_ordered_free(std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
+  std::vector<Matrix<double, Dynamic, 1>> xrt
+      = stan::math::positive_ordered_free(
+          std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
   for (auto&& x_i : xrt) {
     EXPECT_EQ(x.size(), x_i.size());
     EXPECT_MATRIX_FLOAT_EQ(x, x_i);

--- a/test/unit/math/prim/fun/simplex_transform_test.cpp
+++ b/test/unit/math/prim/fun/simplex_transform_test.cpp
@@ -14,11 +14,13 @@ TEST(prob_transform, simplex_rt0) {
   EXPECT_FLOAT_EQ(1.0 / 5.0, y(3));
   EXPECT_FLOAT_EQ(1.0 / 5.0, y(4));
 
-  Matrix<double, Dynamic, 1> xrt = stan::math::simplex_free(y);
+  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::simplex_free(std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
   EXPECT_EQ(x.size() + 1, y.size());
-  EXPECT_EQ(x.size(), xrt.size());
-  for (int i = 0; i < x.size(); ++i) {
-    EXPECT_NEAR(x[i], xrt[i], 1E-10);
+  for (auto&& x_i : xrt) {
+    EXPECT_EQ(x.size(), x_i.size());
+    for (int i = 0; i < x.size(); ++i) {
+      EXPECT_NEAR(x[i], x_i[i], 1E-10);
+    }
   }
 }
 TEST(prob_transform, simplex_rt) {

--- a/test/unit/math/prim/fun/simplex_transform_test.cpp
+++ b/test/unit/math/prim/fun/simplex_transform_test.cpp
@@ -14,7 +14,8 @@ TEST(prob_transform, simplex_rt0) {
   EXPECT_FLOAT_EQ(1.0 / 5.0, y(3));
   EXPECT_FLOAT_EQ(1.0 / 5.0, y(4));
 
-  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::simplex_free(std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
+  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::simplex_free(
+      std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
   EXPECT_EQ(x.size() + 1, y.size());
   for (auto&& x_i : xrt) {
     EXPECT_EQ(x.size(), x_i.size());

--- a/test/unit/math/prim/fun/unit_vector_transform_test.cpp
+++ b/test/unit/math/prim/fun/unit_vector_transform_test.cpp
@@ -15,7 +15,8 @@ TEST(prob_transform, unit_vector_rt0) {
   EXPECT_NEAR(x(1), y(1), 1e-8);
   EXPECT_NEAR(x(2), y(2), 1e-8);
   EXPECT_NEAR(x(3), y(3), 1e-8);
-  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::unit_vector_free(std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
+  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::unit_vector_free(
+      std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
   EXPECT_EQ(x.size(), y.size());
   for (auto&& x_i : xrt) {
     EXPECT_EQ(x.size(), x_i.size());

--- a/test/unit/math/prim/fun/unit_vector_transform_test.cpp
+++ b/test/unit/math/prim/fun/unit_vector_transform_test.cpp
@@ -15,12 +15,13 @@ TEST(prob_transform, unit_vector_rt0) {
   EXPECT_NEAR(x(1), y(1), 1e-8);
   EXPECT_NEAR(x(2), y(2), 1e-8);
   EXPECT_NEAR(x(3), y(3), 1e-8);
-
-  Matrix<double, Dynamic, 1> xrt = stan::math::unit_vector_free(y);
+  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::unit_vector_free(std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
   EXPECT_EQ(x.size(), y.size());
-  EXPECT_EQ(x.size(), xrt.size());
-  for (int i = 0; i < x.size(); ++i) {
-    EXPECT_NEAR(x[i], xrt[i], 1E-10);
+  for (auto&& x_i : xrt) {
+    EXPECT_EQ(x.size(), x_i.size());
+    for (int i = 0; i < x.size(); ++i) {
+      EXPECT_NEAR(x[i], x_i[i], 1E-10);
+    }
   }
 }
 TEST(prob_transform, unit_vector_rt) {


### PR DESCRIPTION
## Summary

This is for https://github.com/stan-dev/stanc3/pull/947 and allows the compiler to simply call the free functions for standard vectors holding containers instead of generating a for loop and iterating over them.

All the functions here are pretty much the same with the scheme being

```cpp
template <typename T, require_std_vector_t<T>* = nullptr>
auto <constrain>_free(const T& x) {
  std::vector<decltype(<constrain>_free(x[0]))> x_free(x.size());
  std::transform(x.begin(), x.end(), x_free.begin(), [](auto&& xx) {
    return <constrain>_free(xx);
  });
  return x_free;
}
```

## Tests

Tests are added in each `*_constrain_test.cpp` to run the standard test to check input/output but instead uses a standard vector of eigen types. Change tests can be run using 

```bash
./runTests.py -j4 test/unit/math/prim/fun/cholesky_corr_transform_test.cpp \
test/unit/math/prim/fun/cholesky_factor_transform_test.cpp \
test/unit/math/prim/fun/corr_matrix_transform_test.cpp \
test/unit/math/prim/fun/cov_matrix_transform_test.cpp \
test/unit/math/prim/fun/ordered_transform_test.cpp \
test/unit/math/prim/fun/positive_ordered_transform_test.cpp \
test/unit/math/prim/fun/simplex_transform_test.cpp \
test/unit/math/prim/fun/unit_vector_transform_test.cpp

```

## Side Effects

Nope!

## Release notes

Vectorize unconstrain functions

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
