### PR TITLE
Small optimization of multi_normal_cholesky derivative

### DIFF
--- a/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
@@ -253,13 +253,14 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
   if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
     row_vector_partials_t half;
     vector_partials_t scaled_diff;
+    vector_partials_t y_val_minus_mu_val = y_val - mu_val;
 
     // If the covariance is not autodiff, we can avoid computing a matrix
     // inverse
     if (is_constant<T_covar_elem>::value) {
       matrix_partials_t L_val = value_of(L_ref);
 
-      half = mdivide_left_tri<Eigen::Lower>(L_val, y_val - mu_val).transpose();
+      half = mdivide_left_tri<Eigen::Lower>(L_val, y_val_minus_mu_val).transpose();
 
       scaled_diff = mdivide_right_tri<Eigen::Lower>(half, L_val).transpose();
 
@@ -271,7 +272,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
           = mdivide_left_tri<Eigen::Lower>(value_of(L_ref));
 
       half = (inv_L_val.template triangularView<Eigen::Lower>()
-              * (y_val - mu_val).template cast<T_partials_return>())
+              * y_val_minus_mu_val.template cast<T_partials_return>())
                  .transpose();
 
       scaled_diff = (half * inv_L_val.template triangularView<Eigen::Lower>())

--- a/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
@@ -260,7 +260,8 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
     if (is_constant<T_covar_elem>::value) {
       matrix_partials_t L_val = value_of(L_ref);
 
-      half = mdivide_left_tri<Eigen::Lower>(L_val, y_val_minus_mu_val).transpose();
+      half = mdivide_left_tri<Eigen::Lower>(L_val, y_val_minus_mu_val)
+                 .transpose();
 
       scaled_diff = mdivide_right_tri<Eigen::Lower>(half, L_val).transpose();
 


### PR DESCRIPTION
Added a vector of partials for `y - mu`. Instead of computing this value twice it is now computed once.

## Tests

No new tests, it passes all the current ones.

## Side Effects

Faster. Especially for y prim vector, mu prim vector, L rev matrix (on 15in, 2017 macbook pro, 2.8 ghz quad core intel core i7 running Big Sur 11.5.2):

![plot_base 7 37 36 AM](https://user-images.githubusercontent.com/23704057/132339737-a8680905-ca86-478f-a91a-30510a0577cb.png)

## Release notes

Small optimization in `multi_normal_cholesky' derivatives which results in slightly faster computation.

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Sean Pinkney

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
