### PR TITLE
Fix templates for check_greater/less for var<Matrix> types

### DIFF
--- a/stan/math/prim/err/check_greater.hpp
+++ b/stan/math/prim/err/check_greater.hpp
@@ -66,7 +66,7 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  */
  template <typename T_y, typename T_low, require_stan_scalar_t<T_y>* = nullptr,
            require_vector_t<T_low>* = nullptr,
-           require_not_std_vector_vt<is_container, T_low>* = nullptr,
+           require_not_std_vector_vt<is_container_or_var_matrix, T_low>* = nullptr,
            typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {
@@ -143,7 +143,7 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  * element of y or low is `NaN`
  */
  template <typename T_y, typename T_low, require_vector_t<T_y>* = nullptr,
-           require_not_std_vector_vt<is_container, T_y>* = nullptr,
+           require_not_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
            require_stan_scalar_t<T_low>* = nullptr, typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {
@@ -224,7 +224,7 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  */
  template <typename T_y, typename T_low,
            require_all_vector_t<T_y, T_low>* = nullptr,
-           require_all_not_std_vector_vt<is_container, T_y, T_low>* = nullptr,
+           require_all_not_std_vector_vt<is_container_or_var_matrix, T_y, T_low>* = nullptr,
            typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {
@@ -305,7 +305,7 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  * element of y or low is `NaN`
  */
 template <typename T_y, typename T_low,
-          require_std_vector_vt<is_container, T_y>* = nullptr,
+          require_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
           require_not_std_vector_t<T_low>* = nullptr, typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {
@@ -333,7 +333,7 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  */
 template <
     typename T_y, typename T_low, require_not_std_vector_t<T_y>* = nullptr,
-    require_std_vector_vt<is_container, T_low>* = nullptr, typename... Idxs>
+    require_std_vector_vt<is_container_or_var_matrix, T_low>* = nullptr, typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {
   for (size_t i = 0; i < low.size(); ++i) {
@@ -360,7 +360,7 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  * element of y or low is `NaN`
  */
 template <typename T_y, typename T_low,
-          require_any_std_vector_vt<is_container, T_y, T_low>* = nullptr,
+          require_any_std_vector_vt<is_container_or_var_matrix, T_y, T_low>* = nullptr,
           require_all_std_vector_t<T_y, T_low>* = nullptr, typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {

--- a/stan/math/prim/err/check_greater.hpp
+++ b/stan/math/prim/err/check_greater.hpp
@@ -64,10 +64,11 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
- template <typename T_y, typename T_low, require_stan_scalar_t<T_y>* = nullptr,
-           require_vector_t<T_low>* = nullptr,
-           require_not_std_vector_vt<is_container_or_var_matrix, T_low>* = nullptr,
-           typename... Idxs>
+template <
+    typename T_y, typename T_low, require_stan_scalar_t<T_y>* = nullptr,
+    require_vector_t<T_low>* = nullptr,
+    require_not_std_vector_vt<is_container_or_var_matrix, T_low>* = nullptr,
+    typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {
   auto&& low_arr = value_of_rec(as_array_or_scalar(to_ref(low)));
@@ -142,9 +143,9 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
- template <typename T_y, typename T_low, require_vector_t<T_y>* = nullptr,
-           require_not_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
-           require_stan_scalar_t<T_low>* = nullptr, typename... Idxs>
+template <typename T_y, typename T_low, require_vector_t<T_y>* = nullptr,
+          require_not_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
+          require_stan_scalar_t<T_low>* = nullptr, typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {
   auto&& y_arr = value_of_rec(as_array_or_scalar(to_ref(y)));
@@ -222,10 +223,11 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
- template <typename T_y, typename T_low,
-           require_all_vector_t<T_y, T_low>* = nullptr,
-           require_all_not_std_vector_vt<is_container_or_var_matrix, T_y, T_low>* = nullptr,
-           typename... Idxs>
+template <typename T_y, typename T_low,
+          require_all_vector_t<T_y, T_low>* = nullptr,
+          require_all_not_std_vector_vt<is_container_or_var_matrix, T_y,
+                                        T_low>* = nullptr,
+          typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {
   auto&& y_arr = value_of_rec(as_array_or_scalar(to_ref(y)));
@@ -331,9 +333,10 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
-template <
-    typename T_y, typename T_low, require_not_std_vector_t<T_y>* = nullptr,
-    require_std_vector_vt<is_container_or_var_matrix, T_low>* = nullptr, typename... Idxs>
+template <typename T_y, typename T_low,
+          require_not_std_vector_t<T_y>* = nullptr,
+          require_std_vector_vt<is_container_or_var_matrix, T_low>* = nullptr,
+          typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {
   for (size_t i = 0; i < low.size(); ++i) {
@@ -360,7 +363,8 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  * element of y or low is `NaN`
  */
 template <typename T_y, typename T_low,
-          require_any_std_vector_vt<is_container_or_var_matrix, T_y, T_low>* = nullptr,
+          require_any_std_vector_vt<is_container_or_var_matrix, T_y,
+                                    T_low>* = nullptr,
           require_all_std_vector_t<T_y, T_low>* = nullptr, typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {

--- a/stan/math/prim/err/check_greater.hpp
+++ b/stan/math/prim/err/check_greater.hpp
@@ -64,8 +64,10 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
-template <typename T_y, typename T_low, require_stan_scalar_t<T_y>* = nullptr,
-          require_vector_vt<is_stan_scalar, T_low>* = nullptr, typename... Idxs>
+ template <typename T_y, typename T_low, require_stan_scalar_t<T_y>* = nullptr,
+           require_vector_t<T_low>* = nullptr,
+           require_not_std_vector_vt<is_container, T_low>* = nullptr,
+           typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {
   auto&& low_arr = value_of_rec(as_array_or_scalar(to_ref(low)));
@@ -140,9 +142,9 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
-template <typename T_y, typename T_low,
-          require_vector_vt<is_stan_scalar, T_y>* = nullptr,
-          require_stan_scalar_t<T_low>* = nullptr, typename... Idxs>
+ template <typename T_y, typename T_low, require_vector_t<T_y>* = nullptr,
+           require_not_std_vector_vt<is_container, T_y>* = nullptr,
+           require_stan_scalar_t<T_low>* = nullptr, typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {
   auto&& y_arr = value_of_rec(as_array_or_scalar(to_ref(y)));
@@ -220,9 +222,10 @@ inline void check_greater(const char* function, const char* name, const T_y& y,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
-template <typename T_y, typename T_low,
-          require_all_vector_vt<is_stan_scalar, T_y, T_low>* = nullptr,
-          typename... Idxs>
+ template <typename T_y, typename T_low,
+           require_all_vector_t<T_y, T_low>* = nullptr,
+           require_all_not_std_vector_vt<is_container, T_y, T_low>* = nullptr,
+           typename... Idxs>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low, Idxs... idxs) {
   auto&& y_arr = value_of_rec(as_array_or_scalar(to_ref(y)));

--- a/stan/math/prim/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/err/check_greater_or_equal.hpp
@@ -66,8 +66,10 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
-template <typename T_y, typename T_low, require_stan_scalar_t<T_y>* = nullptr,
-          require_vector_vt<is_stan_scalar, T_low>* = nullptr, typename... Idxs>
+ template <typename T_y, typename T_low, require_stan_scalar_t<T_y>* = nullptr,
+           require_vector_t<T_low>* = nullptr,
+           require_not_std_vector_vt<is_container, T_low>* = nullptr,
+           typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,
                                    Idxs... idxs) {
@@ -145,9 +147,9 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
-template <typename T_y, typename T_low,
-          require_vector_vt<is_stan_scalar, T_y>* = nullptr,
-          require_stan_scalar_t<T_low>* = nullptr, typename... Idxs>
+ template <typename T_y, typename T_low, require_vector_t<T_y>* = nullptr,
+           require_not_std_vector_vt<is_container, T_y>* = nullptr,
+           require_stan_scalar_t<T_low>* = nullptr, typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,
                                    Idxs... idxs) {
@@ -228,9 +230,10 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
-template <typename T_y, typename T_low,
-          require_all_vector_vt<is_stan_scalar, T_y, T_low>* = nullptr,
-          typename... Idxs>
+ template <typename T_y, typename T_low,
+           require_all_vector_t<T_y, T_low>* = nullptr,
+           require_all_not_std_vector_vt<is_container, T_y, T_low>* = nullptr,
+           typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,
                                    Idxs... idxs) {

--- a/stan/math/prim/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/err/check_greater_or_equal.hpp
@@ -68,7 +68,7 @@ inline void check_greater_or_equal(const char* function, const char* name,
  */
  template <typename T_y, typename T_low, require_stan_scalar_t<T_y>* = nullptr,
            require_vector_t<T_low>* = nullptr,
-           require_not_std_vector_vt<is_container, T_low>* = nullptr,
+           require_not_std_vector_vt<is_container_or_var_matrix, T_low>* = nullptr,
            typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,
@@ -148,7 +148,7 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * element of y or low is `NaN`
  */
  template <typename T_y, typename T_low, require_vector_t<T_y>* = nullptr,
-           require_not_std_vector_vt<is_container, T_y>* = nullptr,
+           require_not_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
            require_stan_scalar_t<T_low>* = nullptr, typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,
@@ -232,7 +232,7 @@ inline void check_greater_or_equal(const char* function, const char* name,
  */
  template <typename T_y, typename T_low,
            require_all_vector_t<T_y, T_low>* = nullptr,
-           require_all_not_std_vector_vt<is_container, T_y, T_low>* = nullptr,
+           require_all_not_std_vector_vt<is_container_or_var_matrix, T_y, T_low>* = nullptr,
            typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,
@@ -316,7 +316,7 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * element of y or low is `NaN`
  */
 template <typename T_y, typename T_low,
-          require_std_vector_vt<is_container, T_y>* = nullptr,
+          require_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
           require_not_std_vector_t<T_low>* = nullptr, typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,
@@ -345,7 +345,7 @@ inline void check_greater_or_equal(const char* function, const char* name,
  */
 template <
     typename T_y, typename T_low, require_not_std_vector_t<T_y>* = nullptr,
-    require_std_vector_vt<is_container, T_low>* = nullptr, typename... Idxs>
+    require_std_vector_vt<is_container_or_var_matrix, T_low>* = nullptr, typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,
                                    Idxs... idxs) {
@@ -371,7 +371,7 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * element of y or low is `NaN`
  */
 template <typename T_y, typename T_low,
-          require_any_std_vector_vt<is_container, T_y, T_low>* = nullptr,
+          require_any_std_vector_vt<is_container_or_var_matrix, T_y, T_low>* = nullptr,
           require_all_std_vector_t<T_y, T_low>* = nullptr, typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,

--- a/stan/math/prim/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/err/check_greater_or_equal.hpp
@@ -66,10 +66,11 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
- template <typename T_y, typename T_low, require_stan_scalar_t<T_y>* = nullptr,
-           require_vector_t<T_low>* = nullptr,
-           require_not_std_vector_vt<is_container_or_var_matrix, T_low>* = nullptr,
-           typename... Idxs>
+template <
+    typename T_y, typename T_low, require_stan_scalar_t<T_y>* = nullptr,
+    require_vector_t<T_low>* = nullptr,
+    require_not_std_vector_vt<is_container_or_var_matrix, T_low>* = nullptr,
+    typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,
                                    Idxs... idxs) {
@@ -147,9 +148,9 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
- template <typename T_y, typename T_low, require_vector_t<T_y>* = nullptr,
-           require_not_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
-           require_stan_scalar_t<T_low>* = nullptr, typename... Idxs>
+template <typename T_y, typename T_low, require_vector_t<T_y>* = nullptr,
+          require_not_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
+          require_stan_scalar_t<T_low>* = nullptr, typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,
                                    Idxs... idxs) {
@@ -230,10 +231,11 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is `NaN`
  */
- template <typename T_y, typename T_low,
-           require_all_vector_t<T_y, T_low>* = nullptr,
-           require_all_not_std_vector_vt<is_container_or_var_matrix, T_y, T_low>* = nullptr,
-           typename... Idxs>
+template <typename T_y, typename T_low,
+          require_all_vector_t<T_y, T_low>* = nullptr,
+          require_all_not_std_vector_vt<is_container_or_var_matrix, T_y,
+                                        T_low>* = nullptr,
+          typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,
                                    Idxs... idxs) {
@@ -343,9 +345,10 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not greater or equal to low or if any
  * element of y or low is NaN
  */
-template <
-    typename T_y, typename T_low, require_not_std_vector_t<T_y>* = nullptr,
-    require_std_vector_vt<is_container_or_var_matrix, T_low>* = nullptr, typename... Idxs>
+template <typename T_y, typename T_low,
+          require_not_std_vector_t<T_y>* = nullptr,
+          require_std_vector_vt<is_container_or_var_matrix, T_low>* = nullptr,
+          typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,
                                    Idxs... idxs) {
@@ -371,7 +374,8 @@ inline void check_greater_or_equal(const char* function, const char* name,
  * element of y or low is `NaN`
  */
 template <typename T_y, typename T_low,
-          require_any_std_vector_vt<is_container_or_var_matrix, T_y, T_low>* = nullptr,
+          require_any_std_vector_vt<is_container_or_var_matrix, T_y,
+                                    T_low>* = nullptr,
           require_all_std_vector_t<T_y, T_low>* = nullptr, typename... Idxs>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low,

--- a/stan/math/prim/err/check_less.hpp
+++ b/stan/math/prim/err/check_less.hpp
@@ -63,9 +63,10 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  * @throw `domain_error` if y is not less than high or if any element of y or
  * high is `NaN`
  */
-template <typename T_y, typename T_high, require_stan_scalar_t<T_y>* = nullptr,
-          require_vector_vt<is_stan_scalar, T_high>* = nullptr,
-          typename... Idxs>
+ template <typename T_y, typename T_high, require_stan_scalar_t<T_y>* = nullptr,
+           require_vector_t<T_high>* = nullptr,
+           require_not_std_vector_vt<is_container, T_high>* = nullptr,
+           typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {
   auto&& high_arr = as_array_or_scalar(value_of_rec(to_ref(high)));
@@ -140,9 +141,9 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  * @throw `domain_error` if y is not less than high or if any element of y or
  * high is `NaN`
  */
-template <typename T_y, typename T_high,
-          require_vector_vt<is_stan_scalar, T_y>* = nullptr,
-          require_stan_scalar_t<T_high>* = nullptr, typename... Idxs>
+ template <typename T_y, typename T_high, require_vector_t<T_y>* = nullptr,
+           require_not_std_vector_vt<is_container, T_y>* = nullptr,
+           require_stan_scalar_t<T_high>* = nullptr, typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {
   auto&& y_arr = value_of_rec(as_array_or_scalar(to_ref(y)));
@@ -220,9 +221,10 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  * @throw `domain_error` if y is not less than high or if any element of y or
  * high is `NaN`
  */
-template <typename T_y, typename T_high,
-          require_all_vector_vt<is_stan_scalar, T_y, T_high>* = nullptr,
-          typename... Idxs>
+ template <typename T_y, typename T_high,
+           require_all_vector_t<T_y, T_high>* = nullptr,
+           require_all_not_std_vector_vt<is_container, T_y, T_high>* = nullptr,
+           typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {
   auto&& y_arr = value_of_rec(to_ref(y));

--- a/stan/math/prim/err/check_less.hpp
+++ b/stan/math/prim/err/check_less.hpp
@@ -65,7 +65,7 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  */
  template <typename T_y, typename T_high, require_stan_scalar_t<T_y>* = nullptr,
            require_vector_t<T_high>* = nullptr,
-           require_not_std_vector_vt<is_container, T_high>* = nullptr,
+           require_not_std_vector_vt<is_container_or_var_matrix, T_high>* = nullptr,
            typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {
@@ -142,7 +142,7 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  * high is `NaN`
  */
  template <typename T_y, typename T_high, require_vector_t<T_y>* = nullptr,
-           require_not_std_vector_vt<is_container, T_y>* = nullptr,
+           require_not_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
            require_stan_scalar_t<T_high>* = nullptr, typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {
@@ -223,7 +223,7 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  */
  template <typename T_y, typename T_high,
            require_all_vector_t<T_y, T_high>* = nullptr,
-           require_all_not_std_vector_vt<is_container, T_y, T_high>* = nullptr,
+           require_all_not_std_vector_vt<is_container_or_var_matrix, T_y, T_high>* = nullptr,
            typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {
@@ -304,7 +304,7 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  * high is `NaN`
  */
 template <typename T_y, typename T_high,
-          require_std_vector_vt<is_container, T_y>* = nullptr,
+          require_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
           require_not_std_vector_t<T_high>* = nullptr, typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {
@@ -332,7 +332,7 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  */
 template <
     typename T_y, typename T_high, require_not_std_vector_t<T_y>* = nullptr,
-    require_std_vector_vt<is_container, T_high>* = nullptr, typename... Idxs>
+    require_std_vector_vt<is_container_or_var_matrix, T_high>* = nullptr, typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {
   for (size_t i = 0; i < high.size(); ++i) {
@@ -359,7 +359,7 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  * high is `NaN`
  */
 template <typename T_y, typename T_high,
-          require_any_std_vector_vt<is_container, T_y, T_high>* = nullptr,
+          require_any_std_vector_vt<is_container_or_var_matrix, T_y, T_high>* = nullptr,
           require_all_std_vector_t<T_y, T_high>* = nullptr, typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {

--- a/stan/math/prim/err/check_less.hpp
+++ b/stan/math/prim/err/check_less.hpp
@@ -63,10 +63,11 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  * @throw `domain_error` if y is not less than high or if any element of y or
  * high is `NaN`
  */
- template <typename T_y, typename T_high, require_stan_scalar_t<T_y>* = nullptr,
-           require_vector_t<T_high>* = nullptr,
-           require_not_std_vector_vt<is_container_or_var_matrix, T_high>* = nullptr,
-           typename... Idxs>
+template <
+    typename T_y, typename T_high, require_stan_scalar_t<T_y>* = nullptr,
+    require_vector_t<T_high>* = nullptr,
+    require_not_std_vector_vt<is_container_or_var_matrix, T_high>* = nullptr,
+    typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {
   auto&& high_arr = as_array_or_scalar(value_of_rec(to_ref(high)));
@@ -141,9 +142,9 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  * @throw `domain_error` if y is not less than high or if any element of y or
  * high is `NaN`
  */
- template <typename T_y, typename T_high, require_vector_t<T_y>* = nullptr,
-           require_not_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
-           require_stan_scalar_t<T_high>* = nullptr, typename... Idxs>
+template <typename T_y, typename T_high, require_vector_t<T_y>* = nullptr,
+          require_not_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
+          require_stan_scalar_t<T_high>* = nullptr, typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {
   auto&& y_arr = value_of_rec(as_array_or_scalar(to_ref(y)));
@@ -221,10 +222,11 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  * @throw `domain_error` if y is not less than high or if any element of y or
  * high is `NaN`
  */
- template <typename T_y, typename T_high,
-           require_all_vector_t<T_y, T_high>* = nullptr,
-           require_all_not_std_vector_vt<is_container_or_var_matrix, T_y, T_high>* = nullptr,
-           typename... Idxs>
+template <typename T_y, typename T_high,
+          require_all_vector_t<T_y, T_high>* = nullptr,
+          require_all_not_std_vector_vt<is_container_or_var_matrix, T_y,
+                                        T_high>* = nullptr,
+          typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {
   auto&& y_arr = value_of_rec(to_ref(y));
@@ -330,9 +332,10 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  * @throw `domain_error` if y is not less than high or if any element of y or
  * high is `NaN`
  */
-template <
-    typename T_y, typename T_high, require_not_std_vector_t<T_y>* = nullptr,
-    require_std_vector_vt<is_container_or_var_matrix, T_high>* = nullptr, typename... Idxs>
+template <typename T_y, typename T_high,
+          require_not_std_vector_t<T_y>* = nullptr,
+          require_std_vector_vt<is_container_or_var_matrix, T_high>* = nullptr,
+          typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {
   for (size_t i = 0; i < high.size(); ++i) {
@@ -359,7 +362,8 @@ inline void check_less(const char* function, const char* name, const T_y& y,
  * high is `NaN`
  */
 template <typename T_y, typename T_high,
-          require_any_std_vector_vt<is_container_or_var_matrix, T_y, T_high>* = nullptr,
+          require_any_std_vector_vt<is_container_or_var_matrix, T_y,
+                                    T_high>* = nullptr,
           require_all_std_vector_t<T_y, T_high>* = nullptr, typename... Idxs>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high, Idxs... idxs) {

--- a/stan/math/prim/err/check_less_or_equal.hpp
+++ b/stan/math/prim/err/check_less_or_equal.hpp
@@ -66,10 +66,11 @@ inline void check_less_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not less than high or if any element of y
  * or high is `NaN`
  */
- template <typename T_y, typename T_high, require_stan_scalar_t<T_y>* = nullptr,
-           require_vector_t<T_high>* = nullptr,
-           require_not_std_vector_vt<is_container_or_var_matrix, T_high>* = nullptr,
-           typename... Idxs>
+template <
+    typename T_y, typename T_high, require_stan_scalar_t<T_y>* = nullptr,
+    require_vector_t<T_high>* = nullptr,
+    require_not_std_vector_vt<is_container_or_var_matrix, T_high>* = nullptr,
+    typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,
                                 Idxs... idxs) {
@@ -147,9 +148,9 @@ inline void check_less_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not less than high or if any element of y
  * or high is `NaN`
  */
- template <typename T_y, typename T_high, require_vector_t<T_y>* = nullptr,
-           require_not_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
-           require_stan_scalar_t<T_high>* = nullptr, typename... Idxs>
+template <typename T_y, typename T_high, require_vector_t<T_y>* = nullptr,
+          require_not_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
+          require_stan_scalar_t<T_high>* = nullptr, typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,
                                 Idxs... idxs) {
@@ -231,10 +232,11 @@ inline void check_less_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not less than high or if any element of y
  * or high is `NaN`
  */
- template <typename T_y, typename T_high,
-           require_all_vector_t<T_y, T_high>* = nullptr,
-           require_all_not_std_vector_vt<is_container_or_var_matrix, T_y, T_high>* = nullptr,
-           typename... Idxs>
+template <typename T_y, typename T_high,
+          require_all_vector_t<T_y, T_high>* = nullptr,
+          require_all_not_std_vector_vt<is_container_or_var_matrix, T_y,
+                                        T_high>* = nullptr,
+          typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,
                                 Idxs... idxs) {
@@ -344,9 +346,10 @@ inline void check_less_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not less than high or if any element of y
  * or high is `NaN`
  */
-template <
-    typename T_y, typename T_high, require_not_std_vector_t<T_y>* = nullptr,
-    require_std_vector_vt<is_container_or_var_matrix, T_high>* = nullptr, typename... Idxs>
+template <typename T_y, typename T_high,
+          require_not_std_vector_t<T_y>* = nullptr,
+          require_std_vector_vt<is_container_or_var_matrix, T_high>* = nullptr,
+          typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,
                                 Idxs... idxs) {
@@ -374,7 +377,8 @@ inline void check_less_or_equal(const char* function, const char* name,
  * or high is `NaN`
  */
 template <typename T_y, typename T_high,
-          require_any_std_vector_vt<is_container_or_var_matrix, T_y, T_high>* = nullptr,
+          require_any_std_vector_vt<is_container_or_var_matrix, T_y,
+                                    T_high>* = nullptr,
           require_all_std_vector_t<T_y, T_high>* = nullptr, typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,

--- a/stan/math/prim/err/check_less_or_equal.hpp
+++ b/stan/math/prim/err/check_less_or_equal.hpp
@@ -68,7 +68,7 @@ inline void check_less_or_equal(const char* function, const char* name,
  */
  template <typename T_y, typename T_high, require_stan_scalar_t<T_y>* = nullptr,
            require_vector_t<T_high>* = nullptr,
-           require_not_std_vector_vt<is_container, T_high>* = nullptr,
+           require_not_std_vector_vt<is_container_or_var_matrix, T_high>* = nullptr,
            typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,
@@ -148,7 +148,7 @@ inline void check_less_or_equal(const char* function, const char* name,
  * or high is `NaN`
  */
  template <typename T_y, typename T_high, require_vector_t<T_y>* = nullptr,
-           require_not_std_vector_vt<is_container, T_y>* = nullptr,
+           require_not_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
            require_stan_scalar_t<T_high>* = nullptr, typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,
@@ -233,7 +233,7 @@ inline void check_less_or_equal(const char* function, const char* name,
  */
  template <typename T_y, typename T_high,
            require_all_vector_t<T_y, T_high>* = nullptr,
-           require_all_not_std_vector_vt<is_container, T_y, T_high>* = nullptr,
+           require_all_not_std_vector_vt<is_container_or_var_matrix, T_y, T_high>* = nullptr,
            typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,
@@ -317,7 +317,7 @@ inline void check_less_or_equal(const char* function, const char* name,
  * or high is `NaN`
  */
 template <typename T_y, typename T_high,
-          require_std_vector_vt<is_container, T_y>* = nullptr,
+          require_std_vector_vt<is_container_or_var_matrix, T_y>* = nullptr,
           require_not_std_vector_t<T_high>* = nullptr, typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,
@@ -346,7 +346,7 @@ inline void check_less_or_equal(const char* function, const char* name,
  */
 template <
     typename T_y, typename T_high, require_not_std_vector_t<T_y>* = nullptr,
-    require_std_vector_vt<is_container, T_high>* = nullptr, typename... Idxs>
+    require_std_vector_vt<is_container_or_var_matrix, T_high>* = nullptr, typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,
                                 Idxs... idxs) {
@@ -374,7 +374,7 @@ inline void check_less_or_equal(const char* function, const char* name,
  * or high is `NaN`
  */
 template <typename T_y, typename T_high,
-          require_any_std_vector_vt<is_container, T_y, T_high>* = nullptr,
+          require_any_std_vector_vt<is_container_or_var_matrix, T_y, T_high>* = nullptr,
           require_all_std_vector_t<T_y, T_high>* = nullptr, typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,

--- a/stan/math/prim/err/check_less_or_equal.hpp
+++ b/stan/math/prim/err/check_less_or_equal.hpp
@@ -66,9 +66,10 @@ inline void check_less_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not less than high or if any element of y
  * or high is `NaN`
  */
-template <typename T_y, typename T_high, require_stan_scalar_t<T_y>* = nullptr,
-          require_vector_vt<is_stan_scalar, T_high>* = nullptr,
-          typename... Idxs>
+ template <typename T_y, typename T_high, require_stan_scalar_t<T_y>* = nullptr,
+           require_vector_t<T_high>* = nullptr,
+           require_not_std_vector_vt<is_container, T_high>* = nullptr,
+           typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,
                                 Idxs... idxs) {
@@ -146,9 +147,9 @@ inline void check_less_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not less than high or if any element of y
  * or high is `NaN`
  */
-template <typename T_y, typename T_high,
-          require_vector_vt<is_stan_scalar, T_y>* = nullptr,
-          require_stan_scalar_t<T_high>* = nullptr, typename... Idxs>
+ template <typename T_y, typename T_high, require_vector_t<T_y>* = nullptr,
+           require_not_std_vector_vt<is_container, T_y>* = nullptr,
+           require_stan_scalar_t<T_high>* = nullptr, typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,
                                 Idxs... idxs) {
@@ -230,9 +231,10 @@ inline void check_less_or_equal(const char* function, const char* name,
  * @throw `std::domain_error` if y is not less than high or if any element of y
  * or high is `NaN`
  */
-template <typename T_y, typename T_high,
-          require_all_vector_vt<is_stan_scalar, T_y, T_high>* = nullptr,
-          typename... Idxs>
+ template <typename T_y, typename T_high,
+           require_all_vector_t<T_y, T_high>* = nullptr,
+           require_all_not_std_vector_vt<is_container, T_y, T_high>* = nullptr,
+           typename... Idxs>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high,
                                 Idxs... idxs) {

--- a/stan/math/prim/err/check_ordered.hpp
+++ b/stan/math/prim/err/check_ordered.hpp
@@ -25,7 +25,8 @@ namespace math {
  * @throw `std::domain_error` if the vector elements are not ordered, if there
  * are duplicated values, or if any element is `NaN`
  */
-template <typename T_y, require_eigen_vector_t<T_y>* = nullptr>
+ template <typename T_y, require_vector_t<T_y>* = nullptr,
+           require_not_std_vector_t<T_y>* = nullptr>
 void check_ordered(const char* function, const char* name, const T_y& y) {
   const auto& y_ref = to_ref(value_of_rec(y));
   for (Eigen::Index n = 1; n < y_ref.size(); n++) {

--- a/stan/math/prim/err/check_ordered.hpp
+++ b/stan/math/prim/err/check_ordered.hpp
@@ -25,8 +25,8 @@ namespace math {
  * @throw `std::domain_error` if the vector elements are not ordered, if there
  * are duplicated values, or if any element is `NaN`
  */
- template <typename T_y, require_vector_t<T_y>* = nullptr,
-           require_not_std_vector_t<T_y>* = nullptr>
+template <typename T_y, require_vector_t<T_y>* = nullptr,
+          require_not_std_vector_t<T_y>* = nullptr>
 void check_ordered(const char* function, const char* name, const T_y& y) {
   const auto& y_ref = to_ref(value_of_rec(y));
   for (Eigen::Index n = 1; n < y_ref.size(); n++) {

--- a/stan/math/prim/err/check_pos_semidefinite.hpp
+++ b/stan/math/prim/err/check_pos_semidefinite.hpp
@@ -26,7 +26,7 @@ namespace math {
  *   or if it is not positive semi-definite,
  *   or if any element of the matrix is <code>NaN</code>.
  */
-template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
+template <typename EigMat, require_matrix_t<EigMat>* = nullptr>
 inline void check_pos_semidefinite(const char* function, const char* name,
                                    const EigMat& y) {
   const auto& y_ref = to_ref(y);

--- a/stan/math/prim/err/check_simplex.hpp
+++ b/stan/math/prim/err/check_simplex.hpp
@@ -38,7 +38,7 @@ void check_simplex(const char* function, const char* name, const T& theta) {
   if (!(fabs(1.0 - theta_ref.sum()) <= CONSTRAINT_TOLERANCE)) {
     [&]() STAN_COLD_PATH {
       std::stringstream msg;
-      value_type_t<T> sum = theta_ref.sum();
+      scalar_type_t<T> sum = theta_ref.sum();
       msg << "is not a valid simplex.";
       msg.precision(10);
       msg << " sum(" << name << ") = " << sum << ", but should be ";

--- a/stan/math/prim/err/check_unit_vector.hpp
+++ b/stan/math/prim/err/check_unit_vector.hpp
@@ -38,7 +38,7 @@ void check_unit_vector(const char* function, const char* name,
                        const Vec& theta) {
   check_nonzero_size(function, name, theta);
   using std::fabs;
-  value_type_t<Vec> ssq = value_of_rec(theta).squaredNorm();
+  scalar_type_t<Vec> ssq = value_of_rec(theta).squaredNorm();
   if (!(fabs(1.0 - ssq) <= CONSTRAINT_TOLERANCE)) {
     [&]() STAN_COLD_PATH {
       std::stringstream msg;

--- a/test/unit/math/rev/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/err/check_greater_or_equal_test.cpp
@@ -360,3 +360,23 @@ TEST(AgradRevErrorHandlingMatrix, CheckGreaterOrEqualVarMatrix) {
       << "check_greater_or_equal: double, matrix<3, 1>";
   stan::math::recover_memory();
 }
+
+TEST(AgradRevErrorHandlingMatrix, CheckGreaterOrEqualVarMatrix2) {
+  using stan::math::var;
+std::vector<
+  std::vector<
+    stan::conditional_var_value_t<var,
+      Eigen::Matrix<var, -1, -1>>>> ar_mat =
+   std::vector<
+     std::vector<
+       stan::conditional_var_value_t<var,
+         Eigen::Matrix<var, -1, -1>>>>(4,
+     std::vector<
+       stan::conditional_var_value_t<var,
+         Eigen::Matrix<var, -1, -1>>>(5,
+       stan::conditional_var_value_t<var,
+         Eigen::Matrix<var, -1, -1>>(
+         Eigen::Matrix<double, -1, -1>::Constant(2, 3,
+           std::numeric_limits<double>::quiet_NaN()))));
+stan::math::check_greater_or_equal("test_ge", "ar_mat", ar_mat, 0);
+}

--- a/test/unit/math/rev/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/err/check_greater_or_equal_test.cpp
@@ -217,3 +217,146 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterOrEqualVarCheckUnivariate) {
 
   stan::math::recover_memory();
 }
+
+TEST(AgradRevErrorHandlingMatrix, CheckGreaterOrEqualVarMatrix) {
+  using stan::math::check_greater_or_equal;
+  using stan::math::var;
+  using stan::math::var_value;
+  const char* function = "check_greater_or_equal";
+  var x;
+  var low;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_vec_val(3, 1);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> low_vec_val(3, 1);
+  var_value<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> x_vec(x_vec_val);
+  var_value<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> low_vec(low_vec_val);
+
+  // x_vec, low_vec
+  x_vec_val << -1, 0, 1;
+  low_vec_val << -2, -1, 0;
+  x_vec = x_vec_val;
+  low_vec = low_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec))
+      << "check_greater_or_equal: matrix<3, 1>, matrix<3, 1>";
+
+  x_vec_val << -1, 0, 1;
+  low_vec_val << -1.1, -0.1, 0.9;
+  x_vec = x_vec_val;
+  low_vec = low_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec))
+      << "check_greater_or_equal: matrix<3, 1>, matrix<3, 1>";
+
+  x_vec_val << -1, 0, std::numeric_limits<double>::infinity();
+  low_vec_val << -2, -1, 0;
+  x_vec = x_vec_val;
+  low_vec = low_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec))
+      << "check_greater_or_equal: matrix<3, 1>, matrix<3, 1>, y has infinity";
+
+  x_vec_val << -1, 0, 1;
+  low_vec_val << -2, 0, 0;
+  x_vec = x_vec_val;
+  low_vec = low_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec))
+      << "check_greater_or_equal: matrix<3, 1>, matrix<3, 1>, "
+      << "should pass for index 1";
+
+  x_vec_val << -1, 0, 1;
+  low_vec_val << -2, -1, std::numeric_limits<double>::infinity();
+  x_vec = x_vec_val;
+  low_vec = low_vec_val;
+  EXPECT_THROW(check_greater_or_equal(function, "x", x_vec, low_vec),
+               std::domain_error)
+      << "check_greater_or_equal: matrix<3, 1>, matrix<3, 1>, "
+      << "should fail with infinity";
+
+  x_vec_val << -1, 0, std::numeric_limits<double>::infinity();
+  low_vec_val << -2, -1, std::numeric_limits<double>::infinity();
+  x_vec = x_vec_val;
+  low_vec = low_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec))
+      << "check_greater_or_equal: matrix<3, 1>, matrix<3, 1>, "
+      << "both bound and value infinity";
+
+  x_vec_val << -1, 0, 1;
+  low_vec_val << -2, -1, -std::numeric_limits<double>::infinity();
+  x_vec = x_vec_val;
+  low_vec = low_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec))
+      << "check_greater_or_equal: matrix<3, 1>, matrix<3, 1>, "
+      << "should pass with -infinity";
+
+  // x_vec, low
+  x_vec_val << -1, 0, 1;
+  low = -2;
+  x_vec = x_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low))
+      << "check_greater_or_equal: matrix<3, 1>, double";
+
+  x_vec_val << -1, 0, 1;
+  low = -std::numeric_limits<double>::infinity();
+  x_vec = x_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low))
+      << "check_greater_or_equal: matrix<3, 1>, double";
+
+  x_vec_val << -1, 0, 1;
+  low = 0;
+  x_vec = x_vec_val;
+  EXPECT_THROW(check_greater_or_equal(function, "x", x_vec, low),
+               std::domain_error)
+      << "check_greater_or_equal: matrix<3, 1>, double, "
+      << "should fail for index 1/2";
+
+  x_vec_val << -1, 0, 1;
+  low = std::numeric_limits<double>::infinity();
+  x_vec = x_vec_val;
+  EXPECT_THROW(check_greater_or_equal(function, "x", x_vec, low),
+               std::domain_error)
+      << "check_greater_or_equal: matrix<3, 1>, double, "
+      << "should fail with infinity";
+
+  // x, low_vec
+  x = 2;
+  low_vec_val << -1, 0, 1;
+  low_vec = low_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec))
+      << "check_greater_or_equal: double, matrix<3, 1>";
+
+  x = 10;
+  low_vec_val << -1, 0, -std::numeric_limits<double>::infinity();
+  low_vec = low_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec))
+      << "check_greater_or_equal: double, matrix<3, 1>, low has -inf";
+
+  x = 10;
+  low_vec_val << -1, 0, std::numeric_limits<double>::infinity();
+  low_vec = low_vec_val;
+  EXPECT_THROW(check_greater_or_equal(function, "x", x, low_vec),
+               std::domain_error)
+      << "check_greater_or_equal: double, matrix<3, 1>, low has inf";
+
+  x = std::numeric_limits<double>::infinity();
+  low_vec_val << -1, 0, std::numeric_limits<double>::infinity();
+  low_vec = low_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec))
+      << "check_greater_or_equal: double, matrix<3, 1>, x is inf, low has inf";
+
+  x = std::numeric_limits<double>::infinity();
+  low_vec_val << -1, 0, 1;
+  low_vec = low_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec))
+      << "check_greater_or_equal: double, matrix<3, 1>, x is inf";
+
+  x = 1.1;
+  low_vec_val << -1, 0, 1;
+  low_vec = low_vec_val;
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec))
+      << "check_greater_or_equal: double, matrix<3, 1>";
+
+  x = 0.9;
+  low_vec_val << -1, 0, 1;
+  low_vec = low_vec_val;
+  EXPECT_THROW(check_greater_or_equal(function, "x", x, low_vec),
+               std::domain_error)
+      << "check_greater_or_equal: double, matrix<3, 1>";
+  stan::math::recover_memory();
+}

--- a/test/unit/math/rev/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/err/check_greater_or_equal_test.cpp
@@ -227,8 +227,10 @@ TEST(AgradRevErrorHandlingMatrix, CheckGreaterOrEqualVarMatrix) {
   var low;
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_vec_val(3, 1);
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> low_vec_val(3, 1);
-  var_value<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> x_vec(x_vec_val);
-  var_value<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> low_vec(low_vec_val);
+  var_value<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> x_vec(
+      x_vec_val);
+  var_value<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> low_vec(
+      low_vec_val);
 
   // x_vec, low_vec
   x_vec_val << -1, 0, 1;
@@ -363,20 +365,17 @@ TEST(AgradRevErrorHandlingMatrix, CheckGreaterOrEqualVarMatrix) {
 
 TEST(AgradRevErrorHandlingMatrix, CheckGreaterOrEqualStdVecVarMatrix) {
   using stan::math::var;
-std::vector<
-  std::vector<
-    stan::conditional_var_value_t<var,
-      Eigen::Matrix<var, -1, -1>>>> ar_mat =
-   std::vector<
-     std::vector<
-       stan::conditional_var_value_t<var,
-         Eigen::Matrix<var, -1, -1>>>>(4,
-     std::vector<
-       stan::conditional_var_value_t<var,
-         Eigen::Matrix<var, -1, -1>>>(5,
-       stan::conditional_var_value_t<var,
-         Eigen::Matrix<var, -1, -1>>(
-         Eigen::Matrix<double, -1, -1>::Constant(2, 3,
-           std::numeric_limits<double>::quiet_NaN()))));
-EXPECT_THROW(stan::math::check_greater_or_equal("test_ge", "ar_mat", ar_mat, 0), std::domain_error);
+  std::vector<std::vector<
+      stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>>>
+      ar_mat = std::vector<std::vector<
+          stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>>>(
+          4,
+          std::vector<
+              stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>>(
+              5, stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>(
+                     Eigen::Matrix<double, -1, -1>::Constant(
+                         2, 3, std::numeric_limits<double>::quiet_NaN()))));
+  EXPECT_THROW(
+      stan::math::check_greater_or_equal("test_ge", "ar_mat", ar_mat, 0),
+      std::domain_error);
 }

--- a/test/unit/math/rev/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/err/check_greater_or_equal_test.cpp
@@ -361,7 +361,7 @@ TEST(AgradRevErrorHandlingMatrix, CheckGreaterOrEqualVarMatrix) {
   stan::math::recover_memory();
 }
 
-TEST(AgradRevErrorHandlingMatrix, CheckGreaterOrEqualVarMatrix2) {
+TEST(AgradRevErrorHandlingMatrix, CheckGreaterOrEqualStdVecVarMatrix) {
   using stan::math::var;
 std::vector<
   std::vector<
@@ -378,5 +378,5 @@ std::vector<
          Eigen::Matrix<var, -1, -1>>(
          Eigen::Matrix<double, -1, -1>::Constant(2, 3,
            std::numeric_limits<double>::quiet_NaN()))));
-stan::math::check_greater_or_equal("test_ge", "ar_mat", ar_mat, 0);
+EXPECT_THROW(stan::math::check_greater_or_equal("test_ge", "ar_mat", ar_mat, 0), std::domain_error);
 }

--- a/test/unit/math/rev/err/check_greater_test.cpp
+++ b/test/unit/math/rev/err/check_greater_test.cpp
@@ -206,3 +206,23 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterVarCheckUnivariate) {
 
   stan::math::recover_memory();
 }
+
+TEST(AgradRevErrorHandlingMatrix, CheckGreaterStdVecVarMatrix) {
+  using stan::math::var;
+std::vector<
+  std::vector<
+    stan::conditional_var_value_t<var,
+      Eigen::Matrix<var, -1, -1>>>> ar_mat =
+   std::vector<
+     std::vector<
+       stan::conditional_var_value_t<var,
+         Eigen::Matrix<var, -1, -1>>>>(4,
+     std::vector<
+       stan::conditional_var_value_t<var,
+         Eigen::Matrix<var, -1, -1>>>(5,
+       stan::conditional_var_value_t<var,
+         Eigen::Matrix<var, -1, -1>>(
+         Eigen::Matrix<double, -1, -1>::Constant(2, 3,
+           std::numeric_limits<double>::quiet_NaN()))));
+EXPECT_THROW(stan::math::check_greater("test_g", "ar_mat", ar_mat, 0), std::domain_error);
+}

--- a/test/unit/math/rev/err/check_greater_test.cpp
+++ b/test/unit/math/rev/err/check_greater_test.cpp
@@ -209,20 +209,16 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterVarCheckUnivariate) {
 
 TEST(AgradRevErrorHandlingMatrix, CheckGreaterStdVecVarMatrix) {
   using stan::math::var;
-std::vector<
-  std::vector<
-    stan::conditional_var_value_t<var,
-      Eigen::Matrix<var, -1, -1>>>> ar_mat =
-   std::vector<
-     std::vector<
-       stan::conditional_var_value_t<var,
-         Eigen::Matrix<var, -1, -1>>>>(4,
-     std::vector<
-       stan::conditional_var_value_t<var,
-         Eigen::Matrix<var, -1, -1>>>(5,
-       stan::conditional_var_value_t<var,
-         Eigen::Matrix<var, -1, -1>>(
-         Eigen::Matrix<double, -1, -1>::Constant(2, 3,
-           std::numeric_limits<double>::quiet_NaN()))));
-EXPECT_THROW(stan::math::check_greater("test_g", "ar_mat", ar_mat, 0), std::domain_error);
+  std::vector<std::vector<
+      stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>>>
+      ar_mat = std::vector<std::vector<
+          stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>>>(
+          4,
+          std::vector<
+              stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>>(
+              5, stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>(
+                     Eigen::Matrix<double, -1, -1>::Constant(
+                         2, 3, std::numeric_limits<double>::quiet_NaN()))));
+  EXPECT_THROW(stan::math::check_greater("test_g", "ar_mat", ar_mat, 0),
+               std::domain_error);
 }

--- a/test/unit/math/rev/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/err/check_less_or_equal_test.cpp
@@ -186,3 +186,23 @@ TEST(AgradRevErrorHandlingScalar, CheckLessOrEqualVarCheckUnivariate) {
 
   stan::math::recover_memory();
 }
+
+TEST(AgradRevErrorHandlingMatrix, CheckLessOrEqualStdVecVarMatrix) {
+  using stan::math::var;
+std::vector<
+  std::vector<
+    stan::conditional_var_value_t<var,
+      Eigen::Matrix<var, -1, -1>>>> ar_mat =
+   std::vector<
+     std::vector<
+       stan::conditional_var_value_t<var,
+         Eigen::Matrix<var, -1, -1>>>>(4,
+     std::vector<
+       stan::conditional_var_value_t<var,
+         Eigen::Matrix<var, -1, -1>>>(5,
+       stan::conditional_var_value_t<var,
+         Eigen::Matrix<var, -1, -1>>(
+         Eigen::Matrix<double, -1, -1>::Constant(2, 3,
+           std::numeric_limits<double>::quiet_NaN()))));
+EXPECT_THROW(stan::math::check_less_or_equal("test_g", "ar_mat", ar_mat, 0), std::domain_error);
+}

--- a/test/unit/math/rev/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/err/check_less_or_equal_test.cpp
@@ -189,20 +189,16 @@ TEST(AgradRevErrorHandlingScalar, CheckLessOrEqualVarCheckUnivariate) {
 
 TEST(AgradRevErrorHandlingMatrix, CheckLessOrEqualStdVecVarMatrix) {
   using stan::math::var;
-std::vector<
-  std::vector<
-    stan::conditional_var_value_t<var,
-      Eigen::Matrix<var, -1, -1>>>> ar_mat =
-   std::vector<
-     std::vector<
-       stan::conditional_var_value_t<var,
-         Eigen::Matrix<var, -1, -1>>>>(4,
-     std::vector<
-       stan::conditional_var_value_t<var,
-         Eigen::Matrix<var, -1, -1>>>(5,
-       stan::conditional_var_value_t<var,
-         Eigen::Matrix<var, -1, -1>>(
-         Eigen::Matrix<double, -1, -1>::Constant(2, 3,
-           std::numeric_limits<double>::quiet_NaN()))));
-EXPECT_THROW(stan::math::check_less_or_equal("test_g", "ar_mat", ar_mat, 0), std::domain_error);
+  std::vector<std::vector<
+      stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>>>
+      ar_mat = std::vector<std::vector<
+          stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>>>(
+          4,
+          std::vector<
+              stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>>(
+              5, stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>(
+                     Eigen::Matrix<double, -1, -1>::Constant(
+                         2, 3, std::numeric_limits<double>::quiet_NaN()))));
+  EXPECT_THROW(stan::math::check_less_or_equal("test_g", "ar_mat", ar_mat, 0),
+               std::domain_error);
 }

--- a/test/unit/math/rev/err/check_less_test.cpp
+++ b/test/unit/math/rev/err/check_less_test.cpp
@@ -176,3 +176,23 @@ TEST(AgradRevErrorHandlingScalar, CheckLessVarCheckUnivariate) {
 
   stan::math::recover_memory();
 }
+
+TEST(AgradRevErrorHandlingMatrix, CheckLessStdVecVarMatrix) {
+  using stan::math::var;
+std::vector<
+  std::vector<
+    stan::conditional_var_value_t<var,
+      Eigen::Matrix<var, -1, -1>>>> ar_mat =
+   std::vector<
+     std::vector<
+       stan::conditional_var_value_t<var,
+         Eigen::Matrix<var, -1, -1>>>>(4,
+     std::vector<
+       stan::conditional_var_value_t<var,
+         Eigen::Matrix<var, -1, -1>>>(5,
+       stan::conditional_var_value_t<var,
+         Eigen::Matrix<var, -1, -1>>(
+         Eigen::Matrix<double, -1, -1>::Constant(2, 3,
+           std::numeric_limits<double>::quiet_NaN()))));
+EXPECT_THROW(stan::math::check_less("test_g", "ar_mat", ar_mat, 0), std::domain_error);
+}

--- a/test/unit/math/rev/err/check_less_test.cpp
+++ b/test/unit/math/rev/err/check_less_test.cpp
@@ -179,20 +179,16 @@ TEST(AgradRevErrorHandlingScalar, CheckLessVarCheckUnivariate) {
 
 TEST(AgradRevErrorHandlingMatrix, CheckLessStdVecVarMatrix) {
   using stan::math::var;
-std::vector<
-  std::vector<
-    stan::conditional_var_value_t<var,
-      Eigen::Matrix<var, -1, -1>>>> ar_mat =
-   std::vector<
-     std::vector<
-       stan::conditional_var_value_t<var,
-         Eigen::Matrix<var, -1, -1>>>>(4,
-     std::vector<
-       stan::conditional_var_value_t<var,
-         Eigen::Matrix<var, -1, -1>>>(5,
-       stan::conditional_var_value_t<var,
-         Eigen::Matrix<var, -1, -1>>(
-         Eigen::Matrix<double, -1, -1>::Constant(2, 3,
-           std::numeric_limits<double>::quiet_NaN()))));
-EXPECT_THROW(stan::math::check_less("test_g", "ar_mat", ar_mat, 0), std::domain_error);
+  std::vector<std::vector<
+      stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>>>
+      ar_mat = std::vector<std::vector<
+          stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>>>(
+          4,
+          std::vector<
+              stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>>(
+              5, stan::conditional_var_value_t<var, Eigen::Matrix<var, -1, -1>>(
+                     Eigen::Matrix<double, -1, -1>::Constant(
+                         2, 3, std::numeric_limits<double>::quiet_NaN()))));
+  EXPECT_THROW(stan::math::check_less("test_g", "ar_mat", ar_mat, 0),
+               std::domain_error);
 }


### PR DESCRIPTION
## Summary

This is for https://github.com/stan-dev/stanc3/pull/955 to do a little bug fix for the templates of `check_greater/less` / `check_greater/less_or_equal` so they can take in `var<Matrix>` types. This just uses `is_container_or_var_matrix` in the requires to make sure that `std::vector`'s holding `var<Matrix>` types use the correct overload.

## Tests

Tests added in the `rev/err` test folder to run over the same code generated by the compiler for an `matrix[N, M] X[I, J]` (or equivalently `std::vector<std::vector<var_value<Eigen::MatrixXd>>>`. Tests can be run with 

```bash
./runTests.py -j4 test/unit/math/rev/err/check_greater_or_equal_test.cpp \
 test/unit/math/rev/err/check_greater_test.cpp \
 test/unit/math/rev/err/check_less_or_equal_test.cpp \
 test/unit/math/rev/err/check_less_test.cpp

```

## Side Effects

Nope

## Release notes

## Checklist

- [x] Math issue #1805 

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
