### PR TITLE
Adds vectorized versions of the constrain functions

### DIFF
--- a/stan/math/prim/fun/cholesky_corr_constrain.hpp
+++ b/stan/math/prim/fun/cholesky_corr_constrain.hpp
@@ -90,7 +90,7 @@ cholesky_corr_constrain(const EigVec& y, int K, return_type_t<EigVec>& lp) {
  * @param K The size of the matrix to return
  * @param[in,out] lp log density accumulator
  */
-template <bool Jacobian, typename T>
+template <bool Jacobian, typename T, require_not_std_vector_t<T>* = nullptr>
 inline auto cholesky_corr_constrain(const T& y, int K, return_type_t<T>& lp) {
   if (Jacobian) {
     return cholesky_corr_constrain(y, K, lp);
@@ -98,6 +98,27 @@ inline auto cholesky_corr_constrain(const T& y, int K, return_type_t<T>& lp) {
     return cholesky_corr_constrain(y, K);
   }
 }
+
+/**
+ * Return The cholesky of a `KxK` correlation matrix. If the `Jacobian`
+ * parameter is `true`, the log density accumulator is incremented with the log
+ * absolute Jacobian determinant of the transform.  All of the transforms are
+ * specified with their Jacobians in the *Stan Reference Manual* chapter
+ * Constraint Transforms.
+ * @tparam Jacobian if `true`, increment log density accumulator with log
+ * absolute Jacobian determinant of constraining transform
+ * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows and 1 column
+ * @param y Linearly Serialized vector of size `(K * (K - 1))/2` holding the
+ *  column major order elements of the lower triangurlar
+ * @param K The size of the matrix to return
+ * @param[in,out] lp log density accumulator
+ */
+template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
+inline auto cholesky_corr_constrain(const T& y, int K, return_type_t<T>& lp) {
+  return apply_vector_unary<T>::apply(
+      y, [&lp, K](auto&& v) { return cholesky_corr_constrain<Jacobian>(v, K, lp); });
+}
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/fun/cholesky_corr_constrain.hpp
+++ b/stan/math/prim/fun/cholesky_corr_constrain.hpp
@@ -107,7 +107,9 @@ inline auto cholesky_corr_constrain(const T& y, int K, return_type_t<T>& lp) {
  * Constraint Transforms.
  * @tparam Jacobian if `true`, increment log density accumulator with log
  * absolute Jacobian determinant of constraining transform
- * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows and 1 column
+ * @tparam T A standard vector with inner type inheriting from
+ * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
+ * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @param y Linearly Serialized vector of size `(K * (K - 1))/2` holding the
  *  column major order elements of the lower triangurlar
  * @param K The size of the matrix to return
@@ -115,8 +117,9 @@ inline auto cholesky_corr_constrain(const T& y, int K, return_type_t<T>& lp) {
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto cholesky_corr_constrain(const T& y, int K, return_type_t<T>& lp) {
-  return apply_vector_unary<T>::apply(
-      y, [&lp, K](auto&& v) { return cholesky_corr_constrain<Jacobian>(v, K, lp); });
+  return apply_vector_unary<T>::apply(y, [&lp, K](auto&& v) {
+    return cholesky_corr_constrain<Jacobian>(v, K, lp);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cholesky_factor_constrain.hpp
+++ b/stan/math/prim/fun/cholesky_factor_constrain.hpp
@@ -127,7 +127,9 @@ inline auto cholesky_factor_constrain(const T& x, int M, int N,
  *
  * @tparam Jacobian if `true`, increment log density accumulator with log
  * absolute Jacobian determinant of constraining transform
- * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows and 1 column
+ * @tparam T A standard vector with inner type inheriting from
+ * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
+ * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @param x Vector of unconstrained values
  * @param M number of rows
  * @param N number of columns
@@ -135,9 +137,11 @@ inline auto cholesky_factor_constrain(const T& x, int M, int N,
  * @return Cholesky factor
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
-inline auto cholesky_factor_constrain(const T& x, int M, int N, return_type_t<T>& lp) {
-  return apply_vector_unary<T>::apply(
-      x, [&lp, M, N](auto&& v) { return cholesky_factor_constrain<Jacobian>(v, M, N, lp); });
+inline auto cholesky_factor_constrain(const T& x, int M, int N,
+                                      return_type_t<T>& lp) {
+  return apply_vector_unary<T>::apply(x, [&lp, M, N](auto&& v) {
+    return cholesky_factor_constrain<Jacobian>(v, M, N, lp);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cholesky_factor_constrain.hpp
+++ b/stan/math/prim/fun/cholesky_factor_constrain.hpp
@@ -106,7 +106,7 @@ cholesky_factor_constrain(const T& x, int M, int N, return_type_t<T>& lp) {
  * @param[in,out] lp log density accumulator
  * @return Cholesky factor
  */
-template <bool Jacobian, typename T>
+template <bool Jacobian, typename T, require_not_std_vector_t<T>* = nullptr>
 inline auto cholesky_factor_constrain(const T& x, int M, int N,
                                       return_type_t<T>& lp) {
   if (Jacobian) {
@@ -114,6 +114,30 @@ inline auto cholesky_factor_constrain(const T& x, int M, int N,
   } else {
     return cholesky_factor_constrain(x, M, N);
   }
+}
+
+/**
+ * Return the Cholesky factor of the specified size read from the specified
+ * vector. A total of (N choose 2) + N + N * (M - N) free parameters are
+ * required to read an M by N Cholesky factor. If the `Jacobian` parameter is
+ * `true`, the log density accumulator is incremented with the log absolute
+ * Jacobian determinant of the transform.  All of the transforms are specified
+ * with their Jacobians in the *Stan Reference Manual* chapter Constraint
+ * Transforms.
+ *
+ * @tparam Jacobian if `true`, increment log density accumulator with log
+ * absolute Jacobian determinant of constraining transform
+ * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows and 1 column
+ * @param x Vector of unconstrained values
+ * @param M number of rows
+ * @param N number of columns
+ * @param[in,out] lp log density accumulator
+ * @return Cholesky factor
+ */
+template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
+inline auto cholesky_factor_constrain(const T& x, int M, int N, return_type_t<T>& lp) {
+  return apply_vector_unary<T>::apply(
+      x, [&lp, M, N](auto&& v) { return cholesky_factor_constrain<Jacobian>(v, M, N, lp); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/corr_matrix_constrain.hpp
+++ b/stan/math/prim/fun/corr_matrix_constrain.hpp
@@ -115,7 +115,7 @@ inline auto corr_matrix_constrain(const T& x, Eigen::Index k,
  *
  * @tparam Jacobian if `true`, increment log density accumulator with log
  * absolute Jacobian determinant of constraining transform
- * @tparam T A type inheriting from `Eigen::DenseBase` or a `var_value` with
+ * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with
  *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
  *  and 1 column
  * @param x Vector of unconstrained partial correlations

--- a/stan/math/prim/fun/corr_matrix_constrain.hpp
+++ b/stan/math/prim/fun/corr_matrix_constrain.hpp
@@ -93,7 +93,7 @@ corr_matrix_constrain(const T& x, Eigen::Index k, return_type_t<T>& lp) {
  * @param k Dimensionality of returned correlation matrix
  * @param[in,out] lp log density accumulator
  */
-template <bool Jacobian, typename T>
+template <bool Jacobian, typename T, require_not_std_vector_t<T>* = nullptr>
 inline auto corr_matrix_constrain(const T& x, Eigen::Index k,
                                   return_type_t<T>& lp) {
   if (Jacobian) {
@@ -101,6 +101,31 @@ inline auto corr_matrix_constrain(const T& x, Eigen::Index k,
   } else {
     return corr_matrix_constrain(x, k);
   }
+}
+
+/**
+ * Return the correlation matrix of the specified dimensionality derived from
+ * the specified vector of unconstrained values. The input vector must be of
+ * length \f${k \choose 2} = \frac{k(k-1)}{2}\f$.  The values in the input
+ * vector represent unconstrained (partial) correlations among the dimensions.
+ * If the `Jacobian` parameter is `true`, the log density accumulator is
+ * incremented with the log absolute Jacobian determinant of the transform.  All
+ * of the transforms are specified with their Jacobians in the *Stan Reference
+ * Manual* chapter Constraint Transforms.
+ *
+ * @tparam Jacobian if `true`, increment log density accumulator with log
+ * absolute Jacobian determinant of constraining transform
+ * @tparam T A type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column
+ * @param x Vector of unconstrained partial correlations
+ * @param k Dimensionality of returned correlation matrix
+ * @param[in,out] lp log density accumulator
+ */
+template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
+inline auto corr_matrix_constrain(const T& y, int K, return_type_t<T>& lp) {
+  return apply_vector_unary<T>::apply(
+      y, [&lp, K](auto&& v) { return corr_matrix_constrain<Jacobian>(v, K, lp); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/corr_matrix_constrain.hpp
+++ b/stan/math/prim/fun/corr_matrix_constrain.hpp
@@ -115,17 +115,18 @@ inline auto corr_matrix_constrain(const T& x, Eigen::Index k,
  *
  * @tparam Jacobian if `true`, increment log density accumulator with log
  * absolute Jacobian determinant of constraining transform
- * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with
- *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
- *  and 1 column
+ * @tparam T A standard vector with inner type inheriting from
+ * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
+ * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @param x Vector of unconstrained partial correlations
  * @param k Dimensionality of returned correlation matrix
  * @param[in,out] lp log density accumulator
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto corr_matrix_constrain(const T& y, int K, return_type_t<T>& lp) {
-  return apply_vector_unary<T>::apply(
-      y, [&lp, K](auto&& v) { return corr_matrix_constrain<Jacobian>(v, K, lp); });
+  return apply_vector_unary<T>::apply(y, [&lp, K](auto&& v) {
+    return corr_matrix_constrain<Jacobian>(v, K, lp);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cov_matrix_constrain.hpp
+++ b/stan/math/prim/fun/cov_matrix_constrain.hpp
@@ -113,6 +113,24 @@ inline auto cov_matrix_constrain(const T& x, Eigen::Index K, return_type_t<T>& l
   }
 }
 
+/**
+ * Return the symmetric, positive-definite matrix of dimensions K by K resulting
+ * from transforming the specified finite vector of size K plus (K choose 2). If
+ * the `Jacobian` parameter is `true`, the log density accumulator is
+ * incremented with the log absolute Jacobian determinant of the transform.  All
+ * of the transforms are specified with their Jacobians in the *Stan Reference
+ * Manual* chapter Constraint Transforms.
+ *
+ * @tparam Jacobian if `true`, increment log density accumulator with log
+ * absolute Jacobian determinant of constraining transform
+ * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column
+ * @param x The vector to convert to a covariance matrix
+ * @param K The dimensions of the resulting covariance matrix
+ * @param[in, out] lp log density accumulator
+ * @throws std::domain_error if (x.size() != K + (K choose 2)).
+ */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto cov_matrix_constrain(const T& x, Eigen::Index K, return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(x, [&lp, K](auto&& v) {

--- a/stan/math/prim/fun/cov_matrix_constrain.hpp
+++ b/stan/math/prim/fun/cov_matrix_constrain.hpp
@@ -105,7 +105,8 @@ cov_matrix_constrain(const T& x, Eigen::Index K, return_type_t<T>& lp) {
  * @throws std::domain_error if (x.size() != K + (K choose 2)).
  */
 template <bool Jacobian, typename T, require_not_std_vector_t<T>* = nullptr>
-inline auto cov_matrix_constrain(const T& x, Eigen::Index K, return_type_t<T>& lp) {
+inline auto cov_matrix_constrain(const T& x, Eigen::Index K,
+                                 return_type_t<T>& lp) {
   if (Jacobian) {
     return cov_matrix_constrain(x, K, lp);
   } else {
@@ -123,19 +124,20 @@ inline auto cov_matrix_constrain(const T& x, Eigen::Index K, return_type_t<T>& l
  *
  * @tparam Jacobian if `true`, increment log density accumulator with log
  * absolute Jacobian determinant of constraining transform
- * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with
- *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
- *  and 1 column
+ * @tparam T A standard vector with inner type inheriting from
+ * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
+ * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @param x The vector to convert to a covariance matrix
  * @param K The dimensions of the resulting covariance matrix
  * @param[in, out] lp log density accumulator
  * @throws std::domain_error if (x.size() != K + (K choose 2)).
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
-inline auto cov_matrix_constrain(const T& x, Eigen::Index K, return_type_t<T>& lp) {
+inline auto cov_matrix_constrain(const T& x, Eigen::Index K,
+                                 return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(x, [&lp, K](auto&& v) {
-     return cov_matrix_constrain<Jacobian>(v, K, lp);
-   });
+    return cov_matrix_constrain<Jacobian>(v, K, lp);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cov_matrix_constrain.hpp
+++ b/stan/math/prim/fun/cov_matrix_constrain.hpp
@@ -104,14 +104,20 @@ cov_matrix_constrain(const T& x, Eigen::Index K, return_type_t<T>& lp) {
  * @param[in, out] lp log density accumulator
  * @throws std::domain_error if (x.size() != K + (K choose 2)).
  */
-template <bool Jacobian, typename T>
-inline auto cov_matrix_constrain(const T& x, Eigen::Index K,
-                                 return_type_t<T>& lp) {
+template <bool Jacobian, typename T, require_not_std_vector_t<T>* = nullptr>
+inline auto cov_matrix_constrain(const T& x, Eigen::Index K, return_type_t<T>& lp) {
   if (Jacobian) {
     return cov_matrix_constrain(x, K, lp);
   } else {
     return cov_matrix_constrain(x, K);
   }
+}
+
+template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
+inline auto cov_matrix_constrain(const T& x, Eigen::Index K, return_type_t<T>& lp) {
+  return apply_vector_unary<T>::apply(x, [&lp, K](auto&& v) {
+     return cov_matrix_constrain<Jacobian>(v, K, lp);
+   });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cov_matrix_constrain_lkj.hpp
+++ b/stan/math/prim/fun/cov_matrix_constrain_lkj.hpp
@@ -92,10 +92,30 @@ inline auto cov_matrix_constrain_lkj(const T& x, size_t k, return_type_t<T>& lp)
   }
 }
 
+/**
+ * Return the covariance matrix of the specified dimensionality derived from
+ * constraining the specified vector of unconstrained values. If the `Jacobian`
+ * parameter is `true`, the log density accumulator is incremented with the log
+ * absolute Jacobian determinant of the transform.  All of the transforms are
+ * specified with their Jacobians in the *Stan Reference Manual* chapter
+ * Constraint Transforms.
+ *
+ * @tparam Jacobian if `true`, increment log density accumulator with log
+ * absolute Jacobian determinant of constraining transform
+ * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time rows or
+ * columns equal to 1
+ * @param x Input vector of unconstrained partial correlations and
+ * standard deviations
+ * @param k Dimensionality of returned covariance matrix
+ * @param[in, out] lp log density accumulator
+ * @return Covariance matrix derived from the unconstrained partial
+ * correlations and deviations.
+ */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto cov_matrix_constrain_lkj(const T& x, size_t k, return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(x, [&lp, k](auto&& v) {
-     return cov_matrix_constrain_lkj<Jacobian>(v, k, lp); 
+     return cov_matrix_constrain_lkj<Jacobian>(v, k, lp);
    });
 }
 

--- a/stan/math/prim/fun/cov_matrix_constrain_lkj.hpp
+++ b/stan/math/prim/fun/cov_matrix_constrain_lkj.hpp
@@ -83,14 +83,20 @@ cov_matrix_constrain_lkj(const T& x, size_t k, return_type_t<T>& lp) {
  * @return Covariance matrix derived from the unconstrained partial
  * correlations and deviations.
  */
-template <bool Jacobian, typename T>
-inline auto cov_matrix_constrain_lkj(const T& x, size_t k,
-                                     return_type_t<T>& lp) {
+template <bool Jacobian, typename T, require_not_std_vector_t<T>* = nullptr>
+inline auto cov_matrix_constrain_lkj(const T& x, size_t k, return_type_t<T>& lp) {
   if (Jacobian) {
     return cov_matrix_constrain_lkj(x, k, lp);
   } else {
     return cov_matrix_constrain_lkj(x, k);
   }
+}
+
+template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
+inline auto cov_matrix_constrain_lkj(const T& x, size_t k, return_type_t<T>& lp) {
+  return apply_vector_unary<T>::apply(x, [&lp, k](auto&& v) {
+     return cov_matrix_constrain_lkj<Jacobian>(v, k, lp); 
+   });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cov_matrix_constrain_lkj.hpp
+++ b/stan/math/prim/fun/cov_matrix_constrain_lkj.hpp
@@ -84,7 +84,8 @@ cov_matrix_constrain_lkj(const T& x, size_t k, return_type_t<T>& lp) {
  * correlations and deviations.
  */
 template <bool Jacobian, typename T, require_not_std_vector_t<T>* = nullptr>
-inline auto cov_matrix_constrain_lkj(const T& x, size_t k, return_type_t<T>& lp) {
+inline auto cov_matrix_constrain_lkj(const T& x, size_t k,
+                                     return_type_t<T>& lp) {
   if (Jacobian) {
     return cov_matrix_constrain_lkj(x, k, lp);
   } else {
@@ -102,9 +103,9 @@ inline auto cov_matrix_constrain_lkj(const T& x, size_t k, return_type_t<T>& lp)
  *
  * @tparam Jacobian if `true`, increment log density accumulator with log
  * absolute Jacobian determinant of constraining transform
- * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with
- *  inner type inheriting from `Eigen::DenseBase` with compile time rows or
- * columns equal to 1
+ * @tparam T A standard vector with inner type inheriting from
+ * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
+ * `Eigen::DenseBase` with compile time rows or columns equal to 1
  * @param x Input vector of unconstrained partial correlations and
  * standard deviations
  * @param k Dimensionality of returned covariance matrix
@@ -113,10 +114,11 @@ inline auto cov_matrix_constrain_lkj(const T& x, size_t k, return_type_t<T>& lp)
  * correlations and deviations.
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
-inline auto cov_matrix_constrain_lkj(const T& x, size_t k, return_type_t<T>& lp) {
+inline auto cov_matrix_constrain_lkj(const T& x, size_t k,
+                                     return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(x, [&lp, k](auto&& v) {
-     return cov_matrix_constrain_lkj<Jacobian>(v, k, lp);
-   });
+    return cov_matrix_constrain_lkj<Jacobian>(v, k, lp);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/ordered_constrain.hpp
+++ b/stan/math/prim/fun/ordered_constrain.hpp
@@ -86,6 +86,24 @@ inline auto ordered_constrain(const T& x, return_type_t<T>& lp) {
   }
 }
 
+/**
+ * Return a positive valued, increasing ordered vector derived from the
+ * specified free vector. The returned constrained vector will have the same
+ * dimensionality as the specified free vector. If the `Jacobian` parameter is
+ * `true`, the log density accumulator is incremented with the log absolute
+ * Jacobian determinant of the transform. All of the transforms are specified
+ * with their Jacobians in the *Stan Reference Manual* chapter Constraint
+ * Transforms.
+ *
+ * @tparam Jacobian if `true`, increment log density accumulator with log
+ * absolute Jacobian determinant of constraining transform
+ * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column
+ * @param x Free vector of scalars
+ * @param[in, out] lp log density accumulator
+ * @return Positive, increasing ordered vector.
+ */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto ordered_constrain(const T& x, return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(x, [&lp](auto&& v) {

--- a/stan/math/prim/fun/ordered_constrain.hpp
+++ b/stan/math/prim/fun/ordered_constrain.hpp
@@ -97,18 +97,17 @@ inline auto ordered_constrain(const T& x, return_type_t<T>& lp) {
  *
  * @tparam Jacobian if `true`, increment log density accumulator with log
  * absolute Jacobian determinant of constraining transform
- * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with
- *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
- *  and 1 column
+ * @tparam T A standard vector with inner type inheriting from
+ * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
+ * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @param x Free vector of scalars
  * @param[in, out] lp log density accumulator
  * @return Positive, increasing ordered vector.
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto ordered_constrain(const T& x, return_type_t<T>& lp) {
-  return apply_vector_unary<T>::apply(x, [&lp](auto&& v) {
-     return ordered_constrain<Jacobian>(v, lp);
-   });
+  return apply_vector_unary<T>::apply(
+      x, [&lp](auto&& v) { return ordered_constrain<Jacobian>(v, lp); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/ordered_constrain.hpp
+++ b/stan/math/prim/fun/ordered_constrain.hpp
@@ -77,13 +77,20 @@ inline auto ordered_constrain(const EigVec& x, value_type_t<EigVec>& lp) {
  * @param[in, out] lp log density accumulator
  * @return Positive, increasing ordered vector.
  */
-template <bool Jacobian, typename T>
+template <bool Jacobian, typename T, require_not_std_vector_t<T>* = nullptr>
 inline auto ordered_constrain(const T& x, return_type_t<T>& lp) {
   if (Jacobian) {
     return ordered_constrain(x, lp);
   } else {
     return ordered_constrain(x);
   }
+}
+
+template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
+inline auto ordered_constrain(const T& x, return_type_t<T>& lp) {
+  return apply_vector_unary<T>::apply(x, [&lp](auto&& v) {
+     return ordered_constrain<Jacobian>(v, lp);
+   });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/positive_constrain.hpp
+++ b/stan/math/prim/fun/positive_constrain.hpp
@@ -79,17 +79,17 @@ inline auto positive_constrain(const T& x, return_type_t<T>& lp) {
  *
  * @tparam Jacobian if `true`, increment log density accumulator with log
  * absolute Jacobian determinant of constraining transform
- * @tparam T A standard vector with inner type inheriting from `Eigen::EigenBase`, a `var_value` with inner
- * type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @tparam T A standard vector with inner type inheriting from
+ * `Eigen::EigenBase`, a `var_value` with inner type inheriting from
+ * `Eigen::EigenBase`, a standard vector, or a scalar
  * @param x unconstrained value or container
  * @param[in, out] lp log density accumulator
  * @return positive constrained version of unconstrained value(s)
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto positive_constrain(const T& x, return_type_t<T>& lp) {
-  return apply_vector_unary<T>::apply(x, [&lp](auto&& v) {
-     return positive_constrain<Jacobian>(v, lp);
-   });
+  return apply_vector_unary<T>::apply(
+      x, [&lp](auto&& v) { return positive_constrain<Jacobian>(v, lp); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/positive_constrain.hpp
+++ b/stan/math/prim/fun/positive_constrain.hpp
@@ -61,13 +61,20 @@ inline auto positive_constrain(const T& x, S& lp) {
  * @param[in, out] lp log density accumulator
  * @return positive constrained version of unconstrained value(s)
  */
-template <bool Jacobian, typename T>
+template <bool Jacobian, typename T, require_not_std_vector_t<T>* = nullptr>
 inline auto positive_constrain(const T& x, return_type_t<T>& lp) {
   if (Jacobian) {
     return positive_constrain(x, lp);
   } else {
     return positive_constrain(x);
   }
+}
+
+template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
+inline auto positive_constrain(const T& x, return_type_t<T>& lp) {
+  return apply_vector_unary<T>::apply(x, [&lp](auto&& v) {
+     return positive_constrain<Jacobian>(v, lp);
+   });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/positive_constrain.hpp
+++ b/stan/math/prim/fun/positive_constrain.hpp
@@ -70,6 +70,21 @@ inline auto positive_constrain(const T& x, return_type_t<T>& lp) {
   }
 }
 
+/**
+ * Return the positive value for the specified unconstrained input. If the
+ * `Jacobian` parameter is `true`, the log density accumulator is incremented
+ * with the log absolute Jacobian determinant of the transform.  All of the
+ * transforms are specified with their Jacobians in the *Stan Reference Manual*
+ * chapter Constraint Transforms.
+ *
+ * @tparam Jacobian if `true`, increment log density accumulator with log
+ * absolute Jacobian determinant of constraining transform
+ * @tparam T A standard vector with inner type inheriting from `Eigen::EigenBase`, a `var_value` with inner
+ * type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
+ * @param x unconstrained value or container
+ * @param[in, out] lp log density accumulator
+ * @return positive constrained version of unconstrained value(s)
+ */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto positive_constrain(const T& x, return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(x, [&lp](auto&& v) {

--- a/stan/math/prim/fun/positive_free.hpp
+++ b/stan/math/prim/fun/positive_free.hpp
@@ -27,7 +27,6 @@ namespace math {
  */
 template <typename T>
 inline T positive_free(const T& y) {
-  using std::log;
   check_positive("positive_free", "Positive variable", y);
   return log(y);
 }

--- a/stan/math/prim/fun/positive_ordered_constrain.hpp
+++ b/stan/math/prim/fun/positive_ordered_constrain.hpp
@@ -72,7 +72,7 @@ inline auto positive_ordered_constrain(const Vec& x, return_type_t<Vec>& lp) {
  * @param[in, out] lp log density accumulato
  * @return Positive, increasing ordered vector
  */
-template <bool Jacobian, typename Vec>
+template <bool Jacobian, typename Vec, require_not_std_vector_t<Vec>* = nullptr>
 inline auto positive_ordered_constrain(const Vec& x, return_type_t<Vec>& lp) {
   if (Jacobian) {
     return positive_ordered_constrain(x, lp);
@@ -80,6 +80,14 @@ inline auto positive_ordered_constrain(const Vec& x, return_type_t<Vec>& lp) {
     return positive_ordered_constrain(x);
   }
 }
+
+template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
+inline auto positive_ordered_constrain(const T& x, return_type_t<T>& lp) {
+  return apply_vector_unary<T>::apply(x, [&lp](auto&& v) {
+     return positive_ordered_constrain<Jacobian>(v, lp);
+   });
+}
+
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/positive_ordered_constrain.hpp
+++ b/stan/math/prim/fun/positive_ordered_constrain.hpp
@@ -81,6 +81,23 @@ inline auto positive_ordered_constrain(const Vec& x, return_type_t<Vec>& lp) {
   }
 }
 
+/**
+ * Return a positive valued, increasing positive ordered vector derived from the
+ * specified free vector. The returned constrained vector will have the same
+ * dimensionality as the specified free vector. If the `Jacobian` parameter is
+ * `true`, the log density accumulator is incremented with the log absolute
+ * Jacobian determinant of the transform.  All of the transforms are specified
+ * with their Jacobians in the *Stan Reference Manual* chapter Constraint
+ * Transforms.
+ *
+ * @tparam Jacobian if `true`, increment log density accumulator with log
+ * absolute Jacobian determinant of constraining transform
+ * @tparam Vec A standard vector with inner type inheriting from `Eigen::EigenBase`, a `var_value` with
+ * inner type inheriting from `Eigen::EigenBase`
+ * @param x Free vector of scalars
+ * @param[in, out] lp log density accumulato
+ * @return Positive, increasing ordered vector
+ */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto positive_ordered_constrain(const T& x, return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(x, [&lp](auto&& v) {

--- a/stan/math/prim/fun/positive_ordered_constrain.hpp
+++ b/stan/math/prim/fun/positive_ordered_constrain.hpp
@@ -92,8 +92,9 @@ inline auto positive_ordered_constrain(const Vec& x, return_type_t<Vec>& lp) {
  *
  * @tparam Jacobian if `true`, increment log density accumulator with log
  * absolute Jacobian determinant of constraining transform
- * @tparam Vec A standard vector with inner type inheriting from `Eigen::EigenBase`, a `var_value` with
- * inner type inheriting from `Eigen::EigenBase`
+ * @tparam Vec A standard vector with inner type inheriting from
+ * `Eigen::EigenBase`, a `var_value` with inner type inheriting from
+ * `Eigen::EigenBase`
  * @param x Free vector of scalars
  * @param[in, out] lp log density accumulato
  * @return Positive, increasing ordered vector
@@ -101,10 +102,9 @@ inline auto positive_ordered_constrain(const Vec& x, return_type_t<Vec>& lp) {
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto positive_ordered_constrain(const T& x, return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(x, [&lp](auto&& v) {
-     return positive_ordered_constrain<Jacobian>(v, lp);
-   });
+    return positive_ordered_constrain<Jacobian>(v, lp);
+  });
 }
-
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/simplex_constrain.hpp
+++ b/stan/math/prim/fun/simplex_constrain.hpp
@@ -106,6 +106,22 @@ auto simplex_constrain(const Vec& y, return_type_t<Vec>& lp) {
   }
 }
 
+/**
+ * Return the simplex corresponding to the specified free vector. If the
+ * `Jacobian` parameter is `true`, the log density accumulator is incremented
+ * with the log absolute Jacobian determinant of the transform.  All of the
+ * transforms are specified with their Jacobians in the *Stan Reference Manual*
+ * chapter Constraint Transforms.
+ *
+ * @tparam Jacobian if `true`, increment log density accumulator with log
+ * absolute Jacobian determinant of constraining transform
+ * @tparam Vec A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column
+ * @param[in] y free vector
+ * @param[in, out] lp log density accumulator
+ * @return simplex of dimensionality one greater than `y`
+ */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto simplex_constrain(const T& y, return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(y, [&lp](auto&& v) {

--- a/stan/math/prim/fun/simplex_constrain.hpp
+++ b/stan/math/prim/fun/simplex_constrain.hpp
@@ -97,7 +97,7 @@ inline auto simplex_constrain(const Vec& y, value_type_t<Vec>& lp) {
  * @param[in, out] lp log density accumulator
  * @return simplex of dimensionality one greater than `y`
  */
-template <bool Jacobian, typename Vec>
+template <bool Jacobian, typename Vec, require_not_std_vector_t<Vec>* = nullptr>
 auto simplex_constrain(const Vec& y, return_type_t<Vec>& lp) {
   if (Jacobian) {
     return simplex_constrain(y, lp);
@@ -105,6 +105,14 @@ auto simplex_constrain(const Vec& y, return_type_t<Vec>& lp) {
     return simplex_constrain(y);
   }
 }
+
+template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
+inline auto simplex_constrain(const T& y, return_type_t<T>& lp) {
+  return apply_vector_unary<T>::apply(y, [&lp](auto&& v) {
+     return simplex_constrain<Jacobian>(v, lp);
+   });
+}
+
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/simplex_constrain.hpp
+++ b/stan/math/prim/fun/simplex_constrain.hpp
@@ -115,20 +115,18 @@ auto simplex_constrain(const Vec& y, return_type_t<Vec>& lp) {
  *
  * @tparam Jacobian if `true`, increment log density accumulator with log
  * absolute Jacobian determinant of constraining transform
- * @tparam Vec A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with
- *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
- *  and 1 column
+ * @tparam Vec A standard vector with inner type inheriting from
+ * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
+ * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @param[in] y free vector
  * @param[in, out] lp log density accumulator
  * @return simplex of dimensionality one greater than `y`
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto simplex_constrain(const T& y, return_type_t<T>& lp) {
-  return apply_vector_unary<T>::apply(y, [&lp](auto&& v) {
-     return simplex_constrain<Jacobian>(v, lp);
-   });
+  return apply_vector_unary<T>::apply(
+      y, [&lp](auto&& v) { return simplex_constrain<Jacobian>(v, lp); });
 }
-
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/unit_vector_constrain.hpp
+++ b/stan/math/prim/fun/unit_vector_constrain.hpp
@@ -81,6 +81,22 @@ inline auto unit_vector_constrain(const T& y, return_type_t<T>& lp) {
   }
 }
 
+/**
+ * Return the unit length vector corresponding to the free vector y. If the
+ * `Jacobian` parameter is `true`, the log density accumulator is incremented
+ * with the log absolute Jacobian determinant of the transform.  All of the
+ * transforms are specified with their Jacobians in the *Stan Reference Manual*
+ * chapter Constraint Transforms.
+ *
+ * @tparam Jacobian if `true`, increment log density accumulator with log
+ * absolute Jacobian determinant of constraining transform
+ * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column
+ * @param y vector of K unrestricted variables
+ * @param[in, out] lp log density accumulator
+ * @return Unit length vector of dimension K
+ */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto unit_vector_constrain(const T& y, return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(y, [&lp](auto&& v) {

--- a/stan/math/prim/fun/unit_vector_constrain.hpp
+++ b/stan/math/prim/fun/unit_vector_constrain.hpp
@@ -90,18 +90,17 @@ inline auto unit_vector_constrain(const T& y, return_type_t<T>& lp) {
  *
  * @tparam Jacobian if `true`, increment log density accumulator with log
  * absolute Jacobian determinant of constraining transform
- * @tparam T A standard vector with inner type inheriting from `Eigen::DenseBase` or a `var_value` with
- *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
- *  and 1 column
+ * @tparam T A standard vector with inner type inheriting from
+ * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
+ * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @param y vector of K unrestricted variables
  * @param[in, out] lp log density accumulator
  * @return Unit length vector of dimension K
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto unit_vector_constrain(const T& y, return_type_t<T>& lp) {
-  return apply_vector_unary<T>::apply(y, [&lp](auto&& v) {
-     return unit_vector_constrain<Jacobian>(v, lp);
-   });
+  return apply_vector_unary<T>::apply(
+      y, [&lp](auto&& v) { return unit_vector_constrain<Jacobian>(v, lp); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/unit_vector_constrain.hpp
+++ b/stan/math/prim/fun/unit_vector_constrain.hpp
@@ -72,13 +72,20 @@ inline plain_type_t<T1> unit_vector_constrain(const T1& y, T2& lp) {
  * @param[in, out] lp log density accumulator
  * @return Unit length vector of dimension K
  */
-template <bool Jacobian, typename T>
+template <bool Jacobian, typename T, require_not_std_vector_t<T>* = nullptr>
 inline auto unit_vector_constrain(const T& y, return_type_t<T>& lp) {
   if (Jacobian) {
     return unit_vector_constrain(y, lp);
   } else {
     return unit_vector_constrain(y);
   }
+}
+
+template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
+inline auto unit_vector_constrain(const T& y, return_type_t<T>& lp) {
+  return apply_vector_unary<T>::apply(y, [&lp](auto&& v) {
+     return unit_vector_constrain<Jacobian>(v, lp);
+   });
 }
 
 }  // namespace math

--- a/test/unit/math/prim/fun/cholesky_corr_transform_test.cpp
+++ b/test/unit/math/prim/fun/cholesky_corr_transform_test.cpp
@@ -51,7 +51,8 @@ void test_cholesky_correlation_values(
   std::vector<Matrix<double, Dynamic, Dynamic>> x_vec
       = stan::math::cholesky_corr_constrain<false>(y_vec, K, lp);
 
-  std::vector<Matrix<double, Dynamic, 1>> yrt = stan::math::cholesky_corr_free(x_vec);
+  std::vector<Matrix<double, Dynamic, 1>> yrt
+      = stan::math::cholesky_corr_free(x_vec);
 
   EXPECT_EQ(y.size(), yrt[0].size());
   for (int i = 0; i < yrt.size(); ++i) {
@@ -71,7 +72,8 @@ void test_cholesky_correlation_values(
   std::vector<Matrix<double, Dynamic, Dynamic>> x2_vec
       = stan::math::cholesky_corr_constrain<true>(y_vec, K, lp);
 
-  std::vector<Matrix<double, Dynamic, 1>> yrt2 = stan::math::cholesky_corr_free(x2_vec);
+  std::vector<Matrix<double, Dynamic, 1>> yrt2
+      = stan::math::cholesky_corr_free(x2_vec);
 
   for (auto&& yrt_i : yrt2) {
     EXPECT_EQ(y.size(), yrt_i.size());

--- a/test/unit/math/prim/fun/cholesky_corr_transform_test.cpp
+++ b/test/unit/math/prim/fun/cholesky_corr_transform_test.cpp
@@ -32,6 +32,7 @@ void test_cholesky_correlation_values(
   using stan::math::cholesky_corr_constrain;
   using stan::math::cholesky_corr_free;
   using std::vector;
+  double lp = 0;
   int K = L.rows();
   int K_choose_2 = (K * (K - 1)) / 2;
 
@@ -47,33 +48,44 @@ void test_cholesky_correlation_values(
   }
 
   // test transform roundtrip without Jacobian
-  Matrix<double, Dynamic, Dynamic> x
-      = stan::math::cholesky_corr_constrain(y, K);
+  std::vector<Matrix<double, Dynamic, Dynamic>> x_vec
+      = stan::math::cholesky_corr_constrain<false>(y_vec, K, lp);
 
-  Matrix<double, Dynamic, 1> yrt = stan::math::cholesky_corr_free(x);
+  std::vector<Matrix<double, Dynamic, 1>> yrt = stan::math::cholesky_corr_free(x_vec);
 
-  EXPECT_EQ(y.size(), yrt.size());
-  for (int i = 0; i < yrt.size(); ++i)
-    EXPECT_FLOAT_EQ(y(i), yrt(i));
-
-  for (int m = 0; m < K; ++m)
-    for (int n = 0; n < K; ++n)
-      EXPECT_FLOAT_EQ(L(m, n), x(m, n));
+  EXPECT_EQ(y.size(), yrt[0].size());
+  for (int i = 0; i < yrt.size(); ++i) {
+    for (int j = 0; j < yrt[i].size(); ++j) {
+      EXPECT_FLOAT_EQ(y_vec[i](j), yrt[i](j));
+    }
+  }
+  for (auto&& x_i : x_vec) {
+    for (int m = 0; m < K; ++m) {
+      for (int n = 0; n < K; ++n) {
+        EXPECT_FLOAT_EQ(L(m, n), x_i(m, n));
+      }
+    }
+  }
 
   // test transform roundtrip with Jacobian (Jacobian itself tested above)
-  double lp = 0;
-  Matrix<double, Dynamic, Dynamic> x2
-      = stan::math::cholesky_corr_constrain(y, K, lp);
+  std::vector<Matrix<double, Dynamic, Dynamic>> x2_vec
+      = stan::math::cholesky_corr_constrain<true>(y_vec, K, lp);
 
-  Matrix<double, Dynamic, 1> yrt2 = stan::math::cholesky_corr_free(x2);
+  std::vector<Matrix<double, Dynamic, 1>> yrt2 = stan::math::cholesky_corr_free(x2_vec);
 
-  EXPECT_EQ(y.size(), yrt2.size());
-  for (int i = 0; i < yrt2.size(); ++i)
-    EXPECT_FLOAT_EQ(y(i), yrt2(i));
-
-  for (int m = 0; m < K; ++m)
-    for (int n = 0; n < K; ++n)
-      EXPECT_FLOAT_EQ(L(m, n), x2(m, n));
+  for (auto&& yrt_i : yrt2) {
+    EXPECT_EQ(y.size(), yrt_i.size());
+    for (int i = 0; i < yrt_i.size(); ++i) {
+      EXPECT_FLOAT_EQ(y(i), yrt_i(i));
+    }
+  }
+  for (auto&& x2_i : x2_vec) {
+    for (int m = 0; m < K; ++m) {
+      for (int n = 0; n < K; ++n) {
+        EXPECT_FLOAT_EQ(L(m, n), x2_i(m, n));
+      }
+    }
+  }
 }
 
 TEST(ProbTransform, CholeskyCorrelationRoundTrips) {

--- a/test/unit/math/prim/fun/cholesky_factor_transform_test.cpp
+++ b/test/unit/math/prim/fun/cholesky_factor_transform_test.cpp
@@ -11,7 +11,8 @@ TEST(ProbTransform, choleskyFactor) {
   Matrix<double, Dynamic, 1> x(3);
   x << 1, 2, 3;
   std::vector<Matrix<double, Dynamic, 1>> x_vec = {x, x, x};
-  std::vector<Matrix<double, Dynamic, Dynamic>> y_vec = cholesky_factor_constrain<false>(x_vec, 2, 2, lp);
+  std::vector<Matrix<double, Dynamic, Dynamic>> y_vec
+      = cholesky_factor_constrain<false>(x_vec, 2, 2, lp);
 
   std::vector<Matrix<double, Dynamic, 1>> x2_vec = cholesky_factor_free(y_vec);
 

--- a/test/unit/math/prim/fun/cholesky_factor_transform_test.cpp
+++ b/test/unit/math/prim/fun/cholesky_factor_transform_test.cpp
@@ -7,23 +7,23 @@ TEST(ProbTransform, choleskyFactor) {
   using Eigen::Matrix;
   using stan::math::cholesky_factor_constrain;
   using stan::math::cholesky_factor_free;
-
+  double lp = 0;
   Matrix<double, Dynamic, 1> x(3);
   x << 1, 2, 3;
+  std::vector<Matrix<double, Dynamic, 1>> x_vec = {x, x, x};
+  std::vector<Matrix<double, Dynamic, Dynamic>> y_vec = cholesky_factor_constrain<false>(x_vec, 2, 2, lp);
 
-  Matrix<double, Dynamic, Dynamic> y = cholesky_factor_constrain(x, 2, 2);
+  std::vector<Matrix<double, Dynamic, 1>> x2_vec = cholesky_factor_free(y_vec);
 
-  Matrix<double, Dynamic, 1> x2 = cholesky_factor_free(y);
+  for (int i = 0; i < x2_vec.size(); ++i) {
+    EXPECT_EQ(x2_vec[i].size(), x.size());
+    EXPECT_EQ(x2_vec[i].rows(), x.rows());
+    EXPECT_EQ(x2_vec[i].cols(), x.cols());
+    for (int j = 0; j < 3; ++j)
+      EXPECT_FLOAT_EQ(x(j), x2_vec[i](j));
+  }
 
-  EXPECT_EQ(x2.size(), x.size());
-  EXPECT_EQ(x2.rows(), x.rows());
-  EXPECT_EQ(x2.cols(), x.cols());
-  for (int i = 0; i < 3; ++i)
-    EXPECT_FLOAT_EQ(x(i), x2(i));
-
-  std::vector<Matrix<double, Dynamic, 1>> x_vec
-      = stan::math::cholesky_factor_free(
-          std::vector<Matrix<double, Dynamic, Dynamic>>{y, y, y});
+  x_vec = stan::math::cholesky_factor_free(y_vec);
   for (int i = 0; i < x_vec.size(); ++i) {
     EXPECT_EQ(x_vec[i].size(), x.size());
     EXPECT_EQ(x_vec[i].rows(), x.rows());

--- a/test/unit/math/prim/fun/corr_matrix_transform_test.cpp
+++ b/test/unit/math/prim/fun/corr_matrix_transform_test.cpp
@@ -7,11 +7,12 @@ TEST(prob_transform, stdvec_corr_matrix_j) {
   size_t K_choose_2 = 6;
   Eigen::VectorXd x(K_choose_2);
   x << -1.0, 2.0, 0.0, 1.0, 3.0, -1.5;
+  std::vector<Eigen::VectorXd> x_vec = {x, x, x};
   double lp = -12.9;
-  Eigen::MatrixXd y = stan::math::corr_matrix_constrain(x, K, lp);
-  std::vector<Eigen::VectorXd> xrt
-      = stan::math::corr_matrix_free(std::vector<Eigen::MatrixXd>{y, y, y});
-  for (auto&& x_i : xrt) {
+  std::vector<Eigen::MatrixXd> y_vec = stan::math::corr_matrix_constrain<true>(x_vec, K, lp);
+  std::vector<Eigen::VectorXd> xrt_vec
+      = stan::math::corr_matrix_free(y_vec);
+  for (auto&& x_i : xrt_vec) {
     EXPECT_MATRIX_FLOAT_EQ(x, x_i);
   }
 }

--- a/test/unit/math/prim/fun/corr_matrix_transform_test.cpp
+++ b/test/unit/math/prim/fun/corr_matrix_transform_test.cpp
@@ -9,9 +9,9 @@ TEST(prob_transform, stdvec_corr_matrix_j) {
   x << -1.0, 2.0, 0.0, 1.0, 3.0, -1.5;
   std::vector<Eigen::VectorXd> x_vec = {x, x, x};
   double lp = -12.9;
-  std::vector<Eigen::MatrixXd> y_vec = stan::math::corr_matrix_constrain<true>(x_vec, K, lp);
-  std::vector<Eigen::VectorXd> xrt_vec
-      = stan::math::corr_matrix_free(y_vec);
+  std::vector<Eigen::MatrixXd> y_vec
+      = stan::math::corr_matrix_constrain<true>(x_vec, K, lp);
+  std::vector<Eigen::VectorXd> xrt_vec = stan::math::corr_matrix_free(y_vec);
   for (auto&& x_i : xrt_vec) {
     EXPECT_MATRIX_FLOAT_EQ(x, x_i);
   }

--- a/test/unit/math/prim/fun/cov_matrix_transform_test.cpp
+++ b/test/unit/math/prim/fun/cov_matrix_transform_test.cpp
@@ -13,7 +13,8 @@ TEST(prob_transform, cov_matrix_rt) {
   Matrix<double, Dynamic, 1> x(K_choose_2 + K);
   x << -1.0, 2.0, 0.0, 1.0, 3.0, -1.5, 1.0, 2.0, -1.5, 2.5;
   std::vector<Matrix<double, Dynamic, 1>> x_vec = {x, x, x};
-  std::vector<Matrix<double, Dynamic, Dynamic>> y_vec = stan::math::cov_matrix_constrain<false>(x_vec, K, lp);
+  std::vector<Matrix<double, Dynamic, Dynamic>> y_vec
+      = stan::math::cov_matrix_constrain<false>(x_vec, K, lp);
   std::vector<Eigen::VectorXd> xrt = stan::math::cov_matrix_free(y_vec);
   for (auto&& x_i : xrt) {
     EXPECT_EQ(x.size(), x_i.size());

--- a/test/unit/math/prim/fun/cov_matrix_transform_test.cpp
+++ b/test/unit/math/prim/fun/cov_matrix_transform_test.cpp
@@ -8,12 +8,13 @@ TEST(prob_transform, cov_matrix_rt) {
   using Eigen::MatrixXd;
   using Eigen::VectorXd;
   unsigned int K = 4;
+  double lp = 0;
   unsigned int K_choose_2 = 6;
   Matrix<double, Dynamic, 1> x(K_choose_2 + K);
   x << -1.0, 2.0, 0.0, 1.0, 3.0, -1.5, 1.0, 2.0, -1.5, 2.5;
-  Matrix<double, Dynamic, Dynamic> y = stan::math::cov_matrix_constrain(x, K);
-  std::vector<Eigen::VectorXd> xrt
-      = stan::math::cov_matrix_free(std::vector<Eigen::MatrixXd>{y, y, y});
+  std::vector<Matrix<double, Dynamic, 1>> x_vec = {x, x, x};
+  std::vector<Matrix<double, Dynamic, Dynamic>> y_vec = stan::math::cov_matrix_constrain<false>(x_vec, K, lp);
+  std::vector<Eigen::VectorXd> xrt = stan::math::cov_matrix_free(y_vec);
   for (auto&& x_i : xrt) {
     EXPECT_EQ(x.size(), x_i.size());
     EXPECT_MATRIX_FLOAT_EQ(x, x_i);

--- a/test/unit/math/prim/fun/ordered_transform_test.cpp
+++ b/test/unit/math/prim/fun/ordered_transform_test.cpp
@@ -65,8 +65,9 @@ TEST(prob_transform, ordered_rt) {
 TEST(prob_transform, ordered_vectorized) {
   double lp = 0;
   Eigen::VectorXd x = Eigen::VectorXd::Random(4);
-  std::vector<Eigen::VectorXd> x_vec ={x, x, x};
-  std::vector<Eigen::VectorXd> y_vec = stan::math::ordered_constrain<false>(x_vec, lp);
+  std::vector<Eigen::VectorXd> x_vec = {x, x, x};
+  std::vector<Eigen::VectorXd> y_vec
+      = stan::math::ordered_constrain<false>(x_vec, lp);
   std::vector<Eigen::VectorXd> x_free_vec = stan::math::ordered_free(y_vec);
   for (int i = 0; i < x_vec.size(); ++i) {
     EXPECT_MATRIX_FLOAT_EQ(x_vec[i], x_free_vec[i]);

--- a/test/unit/math/prim/fun/ordered_transform_test.cpp
+++ b/test/unit/math/prim/fun/ordered_transform_test.cpp
@@ -61,3 +61,14 @@ TEST(prob_transform, ordered_rt) {
     EXPECT_MATRIX_FLOAT_EQ(x, x_i);
   }
 }
+
+TEST(prob_transform, ordered_vectorized) {
+  double lp = 0;
+  Eigen::VectorXd x = Eigen::VectorXd::Random(4);
+  std::vector<Eigen::VectorXd> x_vec ={x, x, x};
+  std::vector<Eigen::VectorXd> y_vec = stan::math::ordered_constrain<false>(x_vec, lp);
+  std::vector<Eigen::VectorXd> x_free_vec = stan::math::ordered_free(y_vec);
+  for (int i = 0; i < x_vec.size(); ++i) {
+    EXPECT_MATRIX_FLOAT_EQ(x_vec[i], x_free_vec[i]);
+  }
+}

--- a/test/unit/math/prim/fun/positive_ordered_transform_test.cpp
+++ b/test/unit/math/prim/fun/positive_ordered_transform_test.cpp
@@ -62,3 +62,15 @@ TEST(prob_transform, positive_ordered_rt) {
     EXPECT_MATRIX_FLOAT_EQ(x, x_i);
   }
 }
+
+
+TEST(prob_transform, positive_ordered_vectorized) {
+  double lp = 0;
+  Eigen::VectorXd x = Eigen::VectorXd::Random(4);
+  std::vector<Eigen::VectorXd> x_vec ={x, x, x};
+  std::vector<Eigen::VectorXd> y_vec = stan::math::positive_ordered_constrain<false>(x_vec, lp);
+  std::vector<Eigen::VectorXd> x_free_vec = stan::math::positive_ordered_free(y_vec);
+  for (int i = 0; i < x_vec.size(); ++i) {
+    EXPECT_MATRIX_FLOAT_EQ(x_vec[i], x_free_vec[i]);
+  }
+}

--- a/test/unit/math/prim/fun/positive_ordered_transform_test.cpp
+++ b/test/unit/math/prim/fun/positive_ordered_transform_test.cpp
@@ -63,13 +63,14 @@ TEST(prob_transform, positive_ordered_rt) {
   }
 }
 
-
 TEST(prob_transform, positive_ordered_vectorized) {
   double lp = 0;
   Eigen::VectorXd x = Eigen::VectorXd::Random(4);
-  std::vector<Eigen::VectorXd> x_vec ={x, x, x};
-  std::vector<Eigen::VectorXd> y_vec = stan::math::positive_ordered_constrain<false>(x_vec, lp);
-  std::vector<Eigen::VectorXd> x_free_vec = stan::math::positive_ordered_free(y_vec);
+  std::vector<Eigen::VectorXd> x_vec = {x, x, x};
+  std::vector<Eigen::VectorXd> y_vec
+      = stan::math::positive_ordered_constrain<false>(x_vec, lp);
+  std::vector<Eigen::VectorXd> x_free_vec
+      = stan::math::positive_ordered_free(y_vec);
   for (int i = 0; i < x_vec.size(); ++i) {
     EXPECT_MATRIX_FLOAT_EQ(x_vec[i], x_free_vec[i]);
   }

--- a/test/unit/math/prim/fun/positive_transform_test.cpp
+++ b/test/unit/math/prim/fun/positive_transform_test.cpp
@@ -27,8 +27,9 @@ TEST(prob_transform, positive_rt) {
 TEST(prob_transform, positive_vectorized) {
   double lp = 0;
   Eigen::VectorXd x = Eigen::VectorXd::Random(4);
-  std::vector<Eigen::VectorXd> x_vec ={x, x, x};
-  std::vector<Eigen::VectorXd> y_vec = stan::math::positive_constrain<false>(x_vec, lp);
+  std::vector<Eigen::VectorXd> x_vec = {x, x, x};
+  std::vector<Eigen::VectorXd> y_vec
+      = stan::math::positive_constrain<false>(x_vec, lp);
   std::vector<Eigen::VectorXd> x_free_vec = stan::math::positive_free(y_vec);
   for (int i = 0; i < x_vec.size(); ++i) {
     EXPECT_MATRIX_FLOAT_EQ(x_vec[i], x_free_vec[i]);

--- a/test/unit/math/prim/fun/positive_transform_test.cpp
+++ b/test/unit/math/prim/fun/positive_transform_test.cpp
@@ -24,3 +24,13 @@ TEST(prob_transform, positive_rt) {
   double xcfc = stan::math::positive_constrain(xcf);
   EXPECT_FLOAT_EQ(xc, xcfc);
 }
+TEST(prob_transform, positive_vectorized) {
+  double lp = 0;
+  Eigen::VectorXd x = Eigen::VectorXd::Random(4);
+  std::vector<Eigen::VectorXd> x_vec ={x, x, x};
+  std::vector<Eigen::VectorXd> y_vec = stan::math::positive_constrain<false>(x_vec, lp);
+  std::vector<Eigen::VectorXd> x_free_vec = stan::math::positive_free(y_vec);
+  for (int i = 0; i < x_vec.size(); ++i) {
+    EXPECT_MATRIX_FLOAT_EQ(x_vec[i], x_free_vec[i]);
+  }
+}

--- a/test/unit/math/prim/fun/simplex_transform_test.cpp
+++ b/test/unit/math/prim/fun/simplex_transform_test.cpp
@@ -9,9 +9,10 @@ TEST(prob_transform, simplex_rt0) {
   Matrix<double, Dynamic, 1> x(4);
   x << 0.0, 0.0, 0.0, 0.0;
   std::vector<Matrix<double, Dynamic, 1>> x_vec{x, x, x};
-  std::vector<Matrix<double, Dynamic, 1>> y_vec = stan::math::simplex_constrain<false>(x_vec, lp);
+  std::vector<Matrix<double, Dynamic, 1>> y_vec
+      = stan::math::simplex_constrain<false>(x_vec, lp);
   for (auto&& y_i : y_vec) {
-    EXPECT_MATRIX_FLOAT_EQ(Eigen::VectorXd::Constant(5, 1.0/5.0), y_i);
+    EXPECT_MATRIX_FLOAT_EQ(Eigen::VectorXd::Constant(5, 1.0 / 5.0), y_i);
   }
   std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::simplex_free(y_vec);
   EXPECT_EQ(x.size() + 1, y_vec[2].size());

--- a/test/unit/math/prim/fun/simplex_transform_test.cpp
+++ b/test/unit/math/prim/fun/simplex_transform_test.cpp
@@ -5,18 +5,16 @@
 TEST(prob_transform, simplex_rt0) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
+  double lp = 0;
   Matrix<double, Dynamic, 1> x(4);
   x << 0.0, 0.0, 0.0, 0.0;
-  Matrix<double, Dynamic, 1> y = stan::math::simplex_constrain(x);
-  EXPECT_FLOAT_EQ(1.0 / 5.0, y(0));
-  EXPECT_FLOAT_EQ(1.0 / 5.0, y(1));
-  EXPECT_FLOAT_EQ(1.0 / 5.0, y(2));
-  EXPECT_FLOAT_EQ(1.0 / 5.0, y(3));
-  EXPECT_FLOAT_EQ(1.0 / 5.0, y(4));
-
-  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::simplex_free(
-      std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
-  EXPECT_EQ(x.size() + 1, y.size());
+  std::vector<Matrix<double, Dynamic, 1>> x_vec{x, x, x};
+  std::vector<Matrix<double, Dynamic, 1>> y_vec = stan::math::simplex_constrain<false>(x_vec, lp);
+  for (auto&& y_i : y_vec) {
+    EXPECT_MATRIX_FLOAT_EQ(Eigen::VectorXd::Constant(5, 1.0/5.0), y_i);
+  }
+  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::simplex_free(y_vec);
+  EXPECT_EQ(x.size() + 1, y_vec[2].size());
   for (auto&& x_i : xrt) {
     EXPECT_EQ(x.size(), x_i.size());
     for (int i = 0; i < x.size(); ++i) {

--- a/test/unit/math/prim/fun/unit_vector_transform_test.cpp
+++ b/test/unit/math/prim/fun/unit_vector_transform_test.cpp
@@ -6,24 +6,32 @@
 TEST(prob_transform, unit_vector_rt0) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
-
+  double lp = 0;
   Matrix<double, Dynamic, 1> x(4);
   x << sqrt(0.1), -sqrt(0.2), -sqrt(0.3), sqrt(0.4);
+  std::vector<Matrix<double, Dynamic, 1>> x_vec{x, x, x};
   using stan::math::unit_vector_constrain;
-  Matrix<double, Dynamic, 1> y = unit_vector_constrain(x);
-  EXPECT_NEAR(x(0), y(0), 1e-8);
-  EXPECT_NEAR(x(1), y(1), 1e-8);
-  EXPECT_NEAR(x(2), y(2), 1e-8);
-  EXPECT_NEAR(x(3), y(3), 1e-8);
-  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::unit_vector_free(
-      std::vector<Matrix<double, Dynamic, 1>>{y, y, y});
-  EXPECT_EQ(x.size(), y.size());
+  std::vector<Matrix<double, Dynamic, 1>> y_vec = unit_vector_constrain<false>(x_vec, lp);
+  for (int i = 0; i < x_vec.size(); ++i) {
+    EXPECT_EQ(x_vec[i].size(), y_vec[i].size());
+    for (int j = 0; j < x_vec[i].size(); ++j) {
+        EXPECT_NEAR(x_vec[i](j), y_vec[i](j), 1e-8);
+    }
+  }
+  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::unit_vector_free(y_vec);
+  for (int i = 0; i < x_vec.size(); ++i) {
+    EXPECT_EQ(x_vec[i].size(), xrt[i].size());
+    for (int j = 0; j < x_vec[i].size(); ++j) {
+        EXPECT_NEAR(x_vec[i](j), xrt[i](j), 1e-10);
+    }
+  }
+  /*
   for (auto&& x_i : xrt) {
-    EXPECT_EQ(x.size(), x_i.size());
     for (int i = 0; i < x.size(); ++i) {
       EXPECT_NEAR(x[i], x_i[i], 1E-10);
     }
   }
+  */
 }
 TEST(prob_transform, unit_vector_rt) {
   using Eigen::Dynamic;

--- a/test/unit/math/prim/fun/unit_vector_transform_test.cpp
+++ b/test/unit/math/prim/fun/unit_vector_transform_test.cpp
@@ -11,18 +11,20 @@ TEST(prob_transform, unit_vector_rt0) {
   x << sqrt(0.1), -sqrt(0.2), -sqrt(0.3), sqrt(0.4);
   std::vector<Matrix<double, Dynamic, 1>> x_vec{x, x, x};
   using stan::math::unit_vector_constrain;
-  std::vector<Matrix<double, Dynamic, 1>> y_vec = unit_vector_constrain<false>(x_vec, lp);
+  std::vector<Matrix<double, Dynamic, 1>> y_vec
+      = unit_vector_constrain<false>(x_vec, lp);
   for (int i = 0; i < x_vec.size(); ++i) {
     EXPECT_EQ(x_vec[i].size(), y_vec[i].size());
     for (int j = 0; j < x_vec[i].size(); ++j) {
-        EXPECT_NEAR(x_vec[i](j), y_vec[i](j), 1e-8);
+      EXPECT_NEAR(x_vec[i](j), y_vec[i](j), 1e-8);
     }
   }
-  std::vector<Matrix<double, Dynamic, 1>> xrt = stan::math::unit_vector_free(y_vec);
+  std::vector<Matrix<double, Dynamic, 1>> xrt
+      = stan::math::unit_vector_free(y_vec);
   for (int i = 0; i < x_vec.size(); ++i) {
     EXPECT_EQ(x_vec[i].size(), xrt[i].size());
     for (int j = 0; j < x_vec[i].size(); ++j) {
-        EXPECT_NEAR(x_vec[i](j), xrt[i](j), 1e-10);
+      EXPECT_NEAR(x_vec[i](j), xrt[i](j), 1e-10);
     }
   }
   /*


### PR DESCRIPTION
## Summary

Adds vectorized versions of the constrain functions that can take in containers of containers. This uses the same pattern as #2578 's `*_free` functions but with the `*_constrain` functions

## Tests

Tests were added to check that going from untransformed -> constrained -> free'd of containers gives back the original values. Tests can be run with

```
./runTests.py -j4 test/unit/math/prim/fun/cholesky_corr_transform_test.cpp \
test/unit/math/prim/fun/cholesky_factor_transform_test.cpp \
test/unit/math/prim/fun/corr_matrix_transform_test.cpp \
test/unit/math/prim/fun/cov_matrix_transform_test.cpp \
test/unit/math/prim/fun/ordered_transform_test.cpp \
test/unit/math/prim/fun/positive_ordered_transform_test.cpp \
test/unit/math/prim/fun/simplex_transform_test.cpp \
test/unit/math/prim/fun/unit_vector_transform_test.cpp
```

## Side Effects

Nope!

## Release notes

Adds vectorized versions of the `*_constrain` functions

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
