### PR TITLE
[Fix] includes for OpenCL qr decomp

### DIFF
--- a/stan/math/opencl/qr_decomposition.hpp
+++ b/stan/math/opencl/qr_decomposition.hpp
@@ -10,7 +10,7 @@
 #include <stan/math/opencl/prim/multiply.hpp>
 #include <stan/math/opencl/prim/sum.hpp>
 #include <stan/math/opencl/copy.hpp>
-#include <CL/cl.hpp>
+#include <CL/opencl.hpp>
 #include <algorithm>
 #include <vector>
 #include <cmath>


### PR DESCRIPTION
## Summary

Just a quick fix for the OpenCL headers which were pulling from the old versions in the OpenCL QR decomposition.

## Release notes

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
