### PR TITLE
Signed log_sum_exp function

### DIFF
--- a/stan/math/fwd/fun.hpp
+++ b/stan/math/fwd/fun.hpp
@@ -74,6 +74,7 @@
 #include <stan/math/fwd/fun/log_rising_factorial.hpp>
 #include <stan/math/fwd/fun/log_softmax.hpp>
 #include <stan/math/fwd/fun/log_sum_exp.hpp>
+#include <stan/math/fwd/fun/log_sum_exp_signed.hpp>
 #include <stan/math/fwd/fun/logit.hpp>
 #include <stan/math/fwd/fun/mdivide_left.hpp>
 #include <stan/math/fwd/fun/mdivide_left_ldlt.hpp>

--- a/stan/math/fwd/fun/log_sum_exp_signed.hpp
+++ b/stan/math/fwd/fun/log_sum_exp_signed.hpp
@@ -1,0 +1,56 @@
+#ifndef STAN_MATH_FWD_FUN_LOG_SUM_EXP_SIGNED_HPP
+#define STAN_MATH_FWD_FUN_LOG_SUM_EXP_SIGNED_HPP
+
+#include <stan/math/fwd/meta.hpp>
+#include <stan/math/fwd/core.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/to_vector.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/log_sum_exp_signed.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <cmath>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the log of the sum of the exponentiated values of the specified
+ * matrix of values.  The matrix may be a full matrix, a vector,
+ * or a row vector. Additionally, a matching container of 'signs' indicates
+ * whether the exponentiated input should be added or substracted.
+ *
+ * The function is defined as follows to prevent overflow in exponential
+ * calculations.
+ *
+ * \f$\log \sum_{n=1}^N \exp(x_n) = \max(x) + \log \sum_{n=1}^N \exp(x_n -
+ * \max(x))\f$.
+ *
+ * @tparam T Type of input vector or matrix.
+ * @param[in] x Matrix of specified values.
+ * @return The log of the sum of the exponentiated vector values.
+ */
+template <typename T1, typename T2,
+          require_container_st<is_fvar, T1>* = nullptr,
+          require_container_st<std::is_integral, T2>* = nullptr>
+inline auto log_sum_exp_signed(const T1& x, const T2& signs) {
+  return apply_vector_unary<ref_type_t<decltype(to_vector(x))>>::reduce(
+      to_ref(to_vector(x)), [&](const auto& v) {
+        using T_fvar_inner = typename value_type_t<decltype(v)>::Scalar;
+        using vec_type = Eigen::Matrix<T_fvar_inner, -1, 1>;
+        Eigen::Map<const Eigen::VectorXi> int_vec_map(signs.data(),
+                                                      signs.size());
+        vec_type vals = v.val();
+        vec_type exp_vals = vals.array().exp().matrix()
+                                              .cwiseProduct(int_vec_map);
+
+        return fvar<T_fvar_inner>(
+            log_sum_exp_signed(vals, int_vec_map),
+            v.d().cwiseProduct(exp_vals).sum() / exp_vals.sum());
+      });
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/fwd/fun/log_sum_exp_signed.hpp
+++ b/stan/math/fwd/fun/log_sum_exp_signed.hpp
@@ -42,8 +42,8 @@ inline auto log_sum_exp_signed(const T1& x, const T2& signs) {
         Eigen::Map<const Eigen::VectorXi> int_vec_map(signs.data(),
                                                       signs.size());
         vec_type vals = v.val();
-        vec_type exp_vals = vals.array().exp().matrix()
-                                              .cwiseProduct(int_vec_map);
+        vec_type exp_vals
+            = vals.array().exp().matrix().cwiseProduct(int_vec_map);
 
         return fvar<T_fvar_inner>(
             log_sum_exp_signed(vals, int_vec_map),

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -187,6 +187,7 @@
 #include <stan/math/prim/fun/log_rising_factorial.hpp>
 #include <stan/math/prim/fun/log_softmax.hpp>
 #include <stan/math/prim/fun/log_sum_exp.hpp>
+#include <stan/math/prim/fun/log_sum_exp_signed.hpp>
 #include <stan/math/prim/fun/logical_and.hpp>
 #include <stan/math/prim/fun/logical_eq.hpp>
 #include <stan/math/prim/fun/logical_gt.hpp>

--- a/stan/math/prim/fun/log_sum_exp_signed.hpp
+++ b/stan/math/prim/fun/log_sum_exp_signed.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/to_vector.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/log1p_exp.hpp>
 #include <cmath>

--- a/stan/math/prim/fun/log_sum_exp_signed.hpp
+++ b/stan/math/prim/fun/log_sum_exp_signed.hpp
@@ -11,7 +11,6 @@
 namespace stan {
 namespace math {
 
-
 /**
  * Return the log of the sum of the exponentiated values of the specified
  * matrix of values.  The matrix may be a full matrix, a vector,
@@ -44,9 +43,12 @@ inline auto log_sum_exp_signed(const T1& x, const T2& signs) {
     if (!std::isfinite(max)) {
       return max;
     }
-    return max + std::log((v_ref.array() - max).exp()
-                                               .matrix()
-                                               .cwiseProduct(signs_ref).sum());
+    return max
+           + std::log((v_ref.array() - max)
+                          .exp()
+                          .matrix()
+                          .cwiseProduct(signs_ref)
+                          .sum());
   });
 }
 

--- a/stan/math/prim/fun/log_sum_exp_signed.hpp
+++ b/stan/math/prim/fun/log_sum_exp_signed.hpp
@@ -1,0 +1,49 @@
+#ifndef STAN_MATH_PRIM_FUN_LOG_SUM_EXP_SIGNED_HPP
+#define STAN_MATH_PRIM_FUN_LOG_SUM_EXP_SIGNED_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/log1p_exp.hpp>
+#include <cmath>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+
+/**
+ * Return the log of the sum of the exponentiated values of the specified
+ * matrix of values.  The matrix may be a full matrix, a vector,
+ * a row vector, or a container of these.
+ *
+ * The function is defined as follows to prevent overflow in exponential
+ * calculations.
+ *
+ * \f$\log \sum_{n=1}^N \exp(x_n) = \max(x) + \log \sum_{n=1}^N \exp(x_n -
+ * \max(x))\f$.
+ *
+ * @tparam T type of input vector or matrix
+ * @param[in] x matrix of specified values
+ * @return The log of the sum of the exponentiated vector values.
+ */
+template <typename T1, typename T2, require_container_st<std::is_arithmetic, T1>* = nullptr,
+          require_container_st<std::is_integral, T2>* = nullptr>
+inline auto log_sum_exp_signed(const T1& x, const T2& signs) {
+  return apply_vector_unary<T1>::reduce(x, [&](const auto& v) {
+    if (v.size() == 0) {
+      return NEGATIVE_INFTY;
+    }
+    const auto& v_ref = to_ref(v);
+    const double max = v_ref.cwiseProduct(signs).maxCoeff();
+    if (!std::isfinite(max)) {
+      return max;
+    }
+    return max + std::log((v_ref.array() - max).exp().cwiseProduct(signs).sum());
+  });
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/log_sum_exp_signed.hpp
+++ b/stan/math/prim/fun/log_sum_exp_signed.hpp
@@ -34,12 +34,12 @@ inline auto log_sum_exp_signed(const T1& x, const T2& signs) {
     if (v.size() == 0) {
       return NEGATIVE_INFTY;
     }
-    const auto& v_ref = to_ref(v);
-    const double max = v_ref.cwiseProduct(signs).maxCoeff();
+    const auto& v_ref = to_ref(to_vector(v));
+    const double max = v_ref.cwiseProduct(to_vector(signs)).maxCoeff();
     if (!std::isfinite(max)) {
       return max;
     }
-    return max + std::log((v_ref.array() - max).exp().cwiseProduct(signs).sum());
+    return max + std::log((v_ref.array() - max).exp().matrix().cwiseProduct(to_vector(signs)).sum());
   });
 }
 

--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -115,6 +115,7 @@
 #include <stan/math/rev/fun/log_rising_factorial.hpp>
 #include <stan/math/rev/fun/log_softmax.hpp>
 #include <stan/math/rev/fun/log_sum_exp.hpp>
+#include <stan/math/rev/fun/log_sum_exp_signed.hpp>
 #include <stan/math/rev/fun/logit.hpp>
 #include <stan/math/rev/fun/lub_constrain.hpp>
 #include <stan/math/rev/fun/matrix_exp_multiply.hpp>

--- a/stan/math/rev/fun/log_sum_exp_signed.hpp
+++ b/stan/math/rev/fun/log_sum_exp_signed.hpp
@@ -1,0 +1,89 @@
+#ifndef STAN_MATH_REV_FUN_LOG_SUM_EXP_SIGNED_HPP
+#define STAN_MATH_REV_FUN_LOG_SUM_EXP_SIGNED_HPP
+
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/core/typedefs.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/inv_logit.hpp>
+#include <stan/math/prim/fun/log_sum_exp.hpp>
+#include <cmath>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the log sum of exponentials of the input, with the sign of
+ *   the exponential provided (i.e., whether to add or subtract)
+ *
+ * @tparam T1 A type inheriting from EigenBase with scalar type var
+ * @tparam T2 A type inheriting from EigenBase with scalar type int
+ * @param v input
+ * @param signs sign of exponentiated input
+ */
+template <typename T1, typename T2, require_eigen_st<is_var, T1>* = nullptr,
+          require_eigen_st<std::is_integral, T2>* = nullptr,
+          require_not_var_matrix_t<T1>* = nullptr>
+inline var log_sum_exp_signed(const T1& v, const T2& signs) {
+  arena_t<decltype(v)> arena_v = v;
+  arena_t<decltype(v.val())> arena_v_val = arena_v.val();
+  arena_t<T2> arena_signs = signs;
+  var res = log_sum_exp_signed(arena_v.val(), signs);
+
+  reverse_pass_callback([arena_v, arena_v_val, arena_signs, res]() mutable {
+    arena_v.adj()
+        += res.adj() *
+              (arena_v_val.array().val() - res.val()).exp()
+                                                    .matrix()
+                                                    .cwiseProduct(arena_signs);
+  });
+
+  return res;
+}
+
+/**
+ * Returns the log sum of exponentials of the input, with the sign of
+ *   the exponential provided (i.e., whether to add or subtract)
+ *
+ * @tparam T1 A `var_value` with an input vector or matrix
+ * @tparam T2 A type inheriting from EigenBase with scalar type int
+ * @param x input
+ * @param signs sign of exponentiated input
+ */
+template <typename T1, typename T2, require_var_matrix_t<T1>* = nullptr,
+          require_eigen_st<std::is_integral, T2>* = nullptr>
+inline var log_sum_exp_signed(const T1& x, const T2& signs) {
+  return make_callback_vari(log_sum_exp_signed(x.val(), signs),
+                            [x, signs](const auto& res) mutable {
+    x.adj() += res.adj() *
+                (x.val().array().val() - res.val()).exp().matrix()
+                                                         .cwiseProduct(signs);
+  });
+}
+
+/**
+ * Returns the log sum of exponentials of the input, with the sign of
+ *   the exponential provided (i.e., whether to add or subtract)
+ *
+ * @tparam T1 Type of input vector or matrix
+ * @tparam T2 A type inheriting from EigenBase with scalar type int
+ * @param x matrix
+ * @param signs sign of exponentiated input
+ */
+template <typename T1, typename T2,
+          require_std_vector_st<is_var, T1>* = nullptr,
+          require_std_vector_st<std::is_integral, T2>* = nullptr>
+inline auto log_sum_exp_signed(const T1& x, const T2& signs) {
+  return apply_vector_unary<T1>::reduce(
+      x, [&](const auto& v) {
+          Eigen::Map<const Eigen::VectorXi> int_vec_map(signs.data(),
+                                                        signs.size());
+          return log_sum_exp_signed(v, int_vec_map); });
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/fun/log_sum_exp_signed.hpp
+++ b/stan/math/rev/fun/log_sum_exp_signed.hpp
@@ -34,11 +34,11 @@ inline var log_sum_exp_signed(const T1& v, const T2& signs) {
   var res = log_sum_exp_signed(arena_v.val(), signs);
 
   reverse_pass_callback([arena_v, arena_v_val, arena_signs, res]() mutable {
-    arena_v.adj()
-        += res.adj() *
-              (arena_v_val.array().val() - res.val()).exp()
-                                                    .matrix()
-                                                    .cwiseProduct(arena_signs);
+    arena_v.adj() += res.adj()
+                     * (arena_v_val.array().val() - res.val())
+                           .exp()
+                           .matrix()
+                           .cwiseProduct(arena_signs);
   });
 
   return res;
@@ -58,10 +58,12 @@ template <typename T1, typename T2, require_var_matrix_t<T1>* = nullptr,
 inline var log_sum_exp_signed(const T1& x, const T2& signs) {
   return make_callback_vari(log_sum_exp_signed(x.val(), signs),
                             [x, signs](const auto& res) mutable {
-    x.adj() += res.adj() *
-                (x.val().array().val() - res.val()).exp().matrix()
-                                                         .cwiseProduct(signs);
-  });
+                              x.adj() += res.adj()
+                                         * (x.val().array().val() - res.val())
+                                               .exp()
+                                               .matrix()
+                                               .cwiseProduct(signs);
+                            });
 }
 
 /**
@@ -77,11 +79,10 @@ template <typename T1, typename T2,
           require_std_vector_st<is_var, T1>* = nullptr,
           require_std_vector_st<std::is_integral, T2>* = nullptr>
 inline auto log_sum_exp_signed(const T1& x, const T2& signs) {
-  return apply_vector_unary<T1>::reduce(
-      x, [&](const auto& v) {
-          Eigen::Map<const Eigen::VectorXi> int_vec_map(signs.data(),
-                                                        signs.size());
-          return log_sum_exp_signed(v, int_vec_map); });
+  return apply_vector_unary<T1>::reduce(x, [&](const auto& v) {
+    Eigen::Map<const Eigen::VectorXi> int_vec_map(signs.data(), signs.size());
+    return log_sum_exp_signed(v, int_vec_map);
+  });
 }
 
 }  // namespace math

--- a/test/unit/math/mix/fun/log_sum_exp_signed_test.cpp
+++ b/test/unit/math/mix/fun/log_sum_exp_signed_test.cpp
@@ -4,9 +4,8 @@
 
 TEST(MathMixMatFun, logSumExp_signed) {
   auto f = [](const auto x2) {
-    return [=](const auto& x1) {
-      return stan::math::log_sum_exp_signed(x1, x2);
-    };
+    return
+        [=](const auto& x1) { return stan::math::log_sum_exp_signed(x1, x2); };
   };
 
   Eigen::VectorXd x0(0);
@@ -55,8 +54,8 @@ TEST(MathMixMatFun, logSumExp_signed) {
   tols.hessian_fvar_hessian_ = 1e-2;
 
   std::vector<Eigen::VectorXd> inputs{x1, x2, x2b, x2c, x4};
-  std::vector<Eigen::VectorXi> signs{x1_signs, x2_signs, x2b_signs,
-                                     x2c_signs, x4_signs};
+  std::vector<Eigen::VectorXi> signs{x1_signs, x2_signs, x2b_signs, x2c_signs,
+                                     x4_signs};
 
   for (int i = 0; i < 5; i++) {
     stan::test::expect_ad(tols, f(signs[i]), inputs[i]);
@@ -65,12 +64,10 @@ TEST(MathMixMatFun, logSumExp_signed) {
     Eigen::RowVectorXi rsigns = signs[i];
     stan::test::expect_ad(tols, f(rsigns), rx);
     stan::test::expect_ad_matvar(tols, f(rsigns), rx);
-    std::vector<double> stx
-        = std::vector<double>(inputs[i].data(),
-                              inputs[i].data() + inputs[i].size());
-    std::vector<int> stsigns
-        = std::vector<int>(inputs[i].data(),
-                           inputs[i].data() + inputs[i].size());
+    std::vector<double> stx = std::vector<double>(
+        inputs[i].data(), inputs[i].data() + inputs[i].size());
+    std::vector<int> stsigns = std::vector<int>(
+        inputs[i].data(), inputs[i].data() + inputs[i].size());
     stan::test::expect_ad(tols, f(stsigns), stx);
   }
 

--- a/test/unit/math/mix/fun/log_sum_exp_signed_test.cpp
+++ b/test/unit/math/mix/fun/log_sum_exp_signed_test.cpp
@@ -1,0 +1,83 @@
+#include <test/unit/math/test_ad.hpp>
+#include <limits>
+#include <vector>
+
+TEST(MathMixMatFun, logSumExp_signed) {
+  auto f = [](const auto x2) {
+    return [=](const auto& x1) {
+      return stan::math::log_sum_exp_signed(x1, x2);
+    };
+  };
+
+  Eigen::VectorXd x0(0);
+  Eigen::VectorXi x0_signs(0);
+  stan::test::expect_ad(f(x0_signs), x0);
+  stan::test::expect_ad_matvar(f(x0_signs), x0);
+
+  Eigen::VectorXd x1(1);
+  x1 << 0;
+  Eigen::VectorXi x1_signs(1);
+  x1_signs << 1;
+  stan::test::expect_ad(f(x1_signs), x1);
+  stan::test::expect_ad_matvar(f(x1_signs), x1);
+
+  Eigen::VectorXd x2(2);
+  x2 << 5, 2;
+  Eigen::VectorXi x2_signs(2);
+  x2_signs << 1, -1;
+  stan::test::expect_ad(f(x2_signs), x2);
+  stan::test::expect_ad_matvar(f(x2_signs), x2);
+
+  Eigen::VectorXd x2b(2);
+  x2b << 4.9, -std::numeric_limits<double>::infinity();
+  Eigen::VectorXi x2b_signs(2);
+  x2b_signs << -1, 1;
+  stan::test::expect_ad(f(x2b_signs), x2b);
+  stan::test::expect_ad_matvar(f(x2b_signs), x2b);
+
+  Eigen::VectorXd x2c(2);
+  x2c << std::numeric_limits<double>::infinity(),
+      std::numeric_limits<double>::infinity();
+  Eigen::VectorXi x2c_signs(2);
+  x2c_signs << 1, -1;
+  stan::test::expect_ad(f(x2c_signs), x2c);
+  stan::test::expect_ad_matvar(f(x2c_signs), x2c);
+
+  Eigen::VectorXd x4(4);
+  x4 << 1, 2, 3, 4;
+  Eigen::VectorXi x4_signs(4);
+  x4 << -1, 1, -1, 1;
+  stan::test::expect_ad(f(x4_signs), x4);
+  stan::test::expect_ad_matvar(f(x4_signs), x4);
+
+  stan::test::ad_tolerances tols;
+  tols.hessian_hessian_ = 1e-2;
+  tols.hessian_fvar_hessian_ = 1e-2;
+
+  std::vector<Eigen::VectorXd> inputs{x1, x2, x2b, x2c, x4};
+  std::vector<Eigen::VectorXi> signs{x1_signs, x2_signs, x2b_signs,
+                                     x2c_signs, x4_signs};
+
+  for (int i = 0; i < 5; i++) {
+    stan::test::expect_ad(tols, f(signs[i]), inputs[i]);
+    stan::test::expect_ad_matvar(tols, f(signs[i]), inputs[i]);
+    Eigen::RowVectorXd rx = inputs[i];
+    Eigen::RowVectorXi rsigns = signs[i];
+    stan::test::expect_ad(tols, f(rsigns), rx);
+    stan::test::expect_ad_matvar(tols, f(rsigns), rx);
+    std::vector<double> stx
+        = std::vector<double>(inputs[i].data(),
+                              inputs[i].data() + inputs[i].size());
+    std::vector<int> stsigns
+        = std::vector<int>(inputs[i].data(),
+                           inputs[i].data() + inputs[i].size());
+    stan::test::expect_ad(tols, f(stsigns), stx);
+  }
+
+  Eigen::MatrixXd x23(2, 2);
+  x23 << 1, 2, 3, 4;
+  Eigen::MatrixXi x23_signs(2, 2);
+  x23_signs << 1, -1, 1, -1;
+  stan::test::expect_ad(f(x23_signs), x23);
+  stan::test::expect_ad_matvar(f(x23_signs), x23);
+}

--- a/test/unit/math/prim/fun/log_sum_exp_signed_test.cpp
+++ b/test/unit/math/prim/fun/log_sum_exp_signed_test.cpp
@@ -20,4 +20,34 @@ TEST(MathFunctions, log_sum_exp_signed) {
   signs << 1, 1, 1, 1;
   
   EXPECT_FLOAT_EQ(log_sum_exp(m1), log_sum_exp_signed(m1, signs));
+
+  signs << 1, -1, -1, 1;
+
+  EXPECT_FLOAT_EQ(log(dot_product(exp(m1), signs)),
+                  log_sum_exp_signed(m1, signs));
+}
+
+TEST(MathFunctions, log_sum_exp_signed_matrix) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::log_sum_exp_signed;
+  using stan::math::log_sum_exp;
+  using stan::math::dot_product;
+  using stan::math::log;
+  using stan::math::exp;
+  using stan::math::sum;
+  using stan::math::elt_multiply;
+
+  Eigen::MatrixXd m1(2,2);
+  m1 << 4, 6, 10, 5;
+
+  Eigen::MatrixXi signs(2,2);
+  signs << 1, 1, 1, 1;
+  
+  EXPECT_FLOAT_EQ(log_sum_exp(m1), log_sum_exp_signed(m1, signs));
+
+  signs << -1, -1, 1, 1;
+
+  EXPECT_FLOAT_EQ(log(sum(elt_multiply(exp(m1), signs))),
+                  log_sum_exp_signed(m1, signs));
 }

--- a/test/unit/math/prim/fun/log_sum_exp_signed_test.cpp
+++ b/test/unit/math/prim/fun/log_sum_exp_signed_test.cpp
@@ -7,11 +7,11 @@
 TEST(MathFunctions, log_sum_exp_signed) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  using stan::math::log_sum_exp_signed;
-  using stan::math::log_sum_exp;
   using stan::math::dot_product;
-  using stan::math::log;
   using stan::math::exp;
+  using stan::math::log;
+  using stan::math::log_sum_exp;
+  using stan::math::log_sum_exp_signed;
 
   Eigen::VectorXd m1(4);
   m1 << 1, 2, 3, 4;
@@ -30,13 +30,13 @@ TEST(MathFunctions, log_sum_exp_signed) {
 TEST(MathFunctions, log_sum_exp_signed_matrix) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  using stan::math::log_sum_exp_signed;
-  using stan::math::log_sum_exp;
   using stan::math::dot_product;
-  using stan::math::log;
-  using stan::math::exp;
-  using stan::math::sum;
   using stan::math::elt_multiply;
+  using stan::math::exp;
+  using stan::math::log;
+  using stan::math::log_sum_exp;
+  using stan::math::log_sum_exp_signed;
+  using stan::math::sum;
 
   Eigen::MatrixXd m1(2, 2);
   m1 << 4, 6, 10, 5;

--- a/test/unit/math/prim/fun/log_sum_exp_signed_test.cpp
+++ b/test/unit/math/prim/fun/log_sum_exp_signed_test.cpp
@@ -18,7 +18,7 @@ TEST(MathFunctions, log_sum_exp_signed) {
 
   Eigen::VectorXi signs(4);
   signs << 1, 1, 1, 1;
-  
+
   EXPECT_FLOAT_EQ(log_sum_exp(m1), log_sum_exp_signed(m1, signs));
 
   signs << 1, -1, -1, 1;
@@ -38,12 +38,12 @@ TEST(MathFunctions, log_sum_exp_signed_matrix) {
   using stan::math::sum;
   using stan::math::elt_multiply;
 
-  Eigen::MatrixXd m1(2,2);
+  Eigen::MatrixXd m1(2, 2);
   m1 << 4, 6, 10, 5;
 
-  Eigen::MatrixXi signs(2,2);
+  Eigen::MatrixXi signs(2, 2);
   signs << 1, 1, 1, 1;
-  
+
   EXPECT_FLOAT_EQ(log_sum_exp(m1), log_sum_exp_signed(m1, signs));
 
   signs << -1, -1, 1, 1;

--- a/test/unit/math/prim/fun/log_sum_exp_signed_test.cpp
+++ b/test/unit/math/prim/fun/log_sum_exp_signed_test.cpp
@@ -1,0 +1,23 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+TEST(MathFunctions, log_sum_exp_signed) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::log_sum_exp_signed;
+  using stan::math::log_sum_exp;
+  using stan::math::dot_product;
+  using stan::math::log;
+  using stan::math::exp;
+
+  Eigen::VectorXd m1(4);
+  m1 << 1, 2, 3, 4;
+
+  Eigen::VectorXi signs(4);
+  signs << 1, 1, 1, 1;
+  
+  EXPECT_FLOAT_EQ(log_sum_exp(m1), log_sum_exp_signed(m1, signs));
+}


### PR DESCRIPTION
## Summary

This PR adds a signed implementation of the `log_sum_exp` function, which allows the user to specify whether the given input should be added or subtracted in the final aggregation.

The function takes a container of inputs as the first argument, and an integral container as the second argument. The integral container comprises values of `-1` or `1`.

## Tests

Tests for both `prim` and `mix` have been added, as well as for compatibility with `varmat` types

## Side Effects

N/A

## Release notes

Adds a signed implementation of `log_sum_exp`

## Checklist

- [x] Math issue #2592 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
