### PR TITLE
Ignore lchoose in expression tests

### DIFF
--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -138,6 +138,7 @@ special_arg_values = {
 # list of functions we do not test. These are mainly functions implemented in compiler
 # (not in Stan Math).
 ignored = [
+    "lchoose",
     "lmultiply",
     "assign_add",
     "assign_divide",


### PR DESCRIPTION
## Summary

https://github.com/stan-dev/stanc3/pull/1010 will add lchoose for vectors, row vectors and arrays. Because lchoose is generated as binomial_coefficient_log in stanc3 we need to add an exception to the expressions tests. 

## Tests

/

## Side Effects

/

## Checklist

- [x] Copyright holder: Rok Češnovar
