### PR TITLE
bugfix for issue 2615: use Pade approx for matrix_exp_2x2 when cosh & sinh ops overflow

### DIFF
--- a/stan/math/prim/fun/matrix_exp_2x2.hpp
+++ b/stan/math/prim/fun/matrix_exp_2x2.hpp
@@ -48,7 +48,7 @@ matrix_exp_2x2(const EigMat& A) {
   B(1, 1) = exp_half_a_plus_d * (delta_cosh - ad_sinh_half_delta);
 
   // use pade approximation if cosh & sinh ops overflow to NaN
-  if ((B.array() != B.array()).any()) {
+  if (B.hasNaN()) {
     return matrix_exp_pade(A);
   } else {
     return B / delta;    

--- a/stan/math/prim/fun/matrix_exp_2x2.hpp
+++ b/stan/math/prim/fun/matrix_exp_2x2.hpp
@@ -47,7 +47,12 @@ matrix_exp_2x2(const EigMat& A) {
   B(1, 0) = c * Two_exp_sinh;
   B(1, 1) = exp_half_a_plus_d * (delta_cosh - ad_sinh_half_delta);
 
-  return B / delta;
+  // use pade approximation if cosh & sinh ops overflow to NaN
+  if ((B.array() != B.array()).any()) {
+    return matrix_exp_pade(A);
+  } else {
+    return B / delta;    
+  }
 }
 
 }  // namespace math

--- a/test/unit/math/prim/fun/matrix_exp_2x2_test.cpp
+++ b/test/unit/math/prim/fun/matrix_exp_2x2_test.cpp
@@ -20,3 +20,12 @@ TEST(MathMatrixPrimMat, matrix_exp_2x2_2x2_2) {
 
   EXPECT_MATRIX_FLOAT_EQ(m2, stan::math::matrix_exp_2x2(m1));
 }
+
+TEST(MathMatrixPrimMat, matrix_exp_2x2_2x2_overflow) {
+  // example from issue https://github.com/stan-dev/math/issues/2615
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m1(2, 2), m2(2, 2);
+  m1 << -3.3228,0.533302,1.2242,-4.04844;
+  double t = 800.0;
+  m2 << 0.0, 0.0, 0.0, 0.0;
+  EXPECT_MATRIX_FLOAT_EQ(m2, stan::math::matrix_exp_2x2(m1 * t));
+}


### PR DESCRIPTION
## Summary
This PR addresses https://github.com/stan-dev/math/issues/2615 where a matrix with large eigenvalues may cause overflow in the naive implementation for 2x2 matrices. In the fix we check if the 2x2 algorithm outputs `NaN` and use Pade approximation result if it does.

## Tests

An additional unit test in `matrix_exp_2x2_test.cpp` for the pathological case.

## Side Effects

N/A

## Release notes

Bugfix: 2x2 matrix exponential function outputs NaN for matrices with large eigenvalues.

## Checklist

- [x] Math issue #2615

- [x] Copyright holder: Metrum Research Group
- [x] 
    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
