### PR TITLE
Allow forcing use of Boost lgamma on Unix

### DIFF
--- a/stan/math/prim/fun/lgamma.hpp
+++ b/stan/math/prim/fun/lgamma.hpp
@@ -12,7 +12,7 @@
  * back. For details on the speed evaluations, please refer to
  * https://github.com/stan-dev/math/pull/1255 .
  */
-#if !__MINGW32__ || !_BOOST_LGAMMA
+#if !__MINGW32__ && !_BOOST_LGAMMA
 // _REENTRANT must be defined during compilation to ensure that cmath
 // exports the reentrant safe lgamma_r version.
 #if !_REENTRANT
@@ -61,7 +61,7 @@ namespace math {
 * argument
 */
 inline double lgamma(double x) {
-#if !__MINGW32__ || !_BOOST_LGAMMA
+#if !__MINGW32__ && !_BOOST_LGAMMA
   int sign = 1;
   return ::lgamma_r(x, &sign);
 #else
@@ -80,7 +80,7 @@ inline double lgamma(double x) {
  * argument
  */
 inline double lgamma(int x) {
-#if !__MINGW32__ || !_BOOST_LGAMMA
+#if !__MINGW32__ && !_BOOST_LGAMMA
   int sign = 1;
   return ::lgamma_r(x, &sign);
 #else

--- a/stan/math/prim/fun/lgamma.hpp
+++ b/stan/math/prim/fun/lgamma.hpp
@@ -12,7 +12,7 @@
  * back. For details on the speed evaluations, please refer to
  * https://github.com/stan-dev/math/pull/1255 .
  */
-#if !__MINGW32__
+#if !__MINGW32__ || !_BOOST_LGAMMA
 // _REENTRANT must be defined during compilation to ensure that cmath
 // exports the reentrant safe lgamma_r version.
 #if !_REENTRANT
@@ -61,7 +61,7 @@ namespace math {
 * argument
 */
 inline double lgamma(double x) {
-#if !__MINGW32__
+#if !__MINGW32__ || !_BOOST_LGAMMA
   int sign = 1;
   return ::lgamma_r(x, &sign);
 #else
@@ -80,7 +80,7 @@ inline double lgamma(double x) {
  * argument
  */
 inline double lgamma(int x) {
-#if !__MINGW32__
+#if !__MINGW32__ || !_BOOST_LGAMMA
   int sign = 1;
   return ::lgamma_r(x, &sign);
 #else


### PR DESCRIPTION
## Summary

`lgamma` currently defaults to the implementation of `lgamma_r` in cmath, unless being called from MinGW on windows. However, this implementation does not appear to always be available. This PR adds the compiler flag `-D_BOOST_LGAMMA` to allow the user to manually call the Boost implementation.

## Tests

N/A

## Side Effects

N/A

## Release notes

Add compiler flag `-D_BOOST_LGAMMA` to allow users to force use of Boost `lgamma` implementation

## Checklist

- [x] Math issue #2617

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
