### PR TITLE
Add the CXX flag for only running rev tests with the test_ad

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,9 @@ jobs:
     - name: Add TBB to PATH
       shell: powershell
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Disable running fwd/mix tests
+      shell: powershell
+      run: echo "CXXFLAGS+= -DSTAN_MATH_TESTS_REV_ONLY" | Out-File -Append -FilePath make/local -Encoding utf8      
     - name: Run fwd unit tests and all the mix tests except those in mix/fun
       shell: powershell
       run: |
@@ -139,6 +142,9 @@ jobs:
     - name: Add TBB to PATH
       shell: powershell
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Disable running fwd/mix tests
+      shell: powershell
+      run: echo "CXXFLAGS+= -DSTAN_MATH_TESTS_REV_ONLY" | Out-File -Append -FilePath make/local -Encoding utf8      
     - name: Run mix/fun unit tests
       shell: powershell
       run: |

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -138,6 +138,7 @@ void test_gradient(const ad_tolerances& tols, const F& f,
                   grad_ad, tols.gradient_grad_);
 }
 
+#ifndef STAN_MATH_TESTS_REV_ONLY
 /**
  * Tests that the specified function applied to the specified argument
  * yields the values and gradients consistent with finite differences
@@ -309,6 +310,7 @@ void test_grad_hessian(const ad_tolerances& tols, const F& f,
     expect_near_rel("grad_hessian() grad Hessian", grad_H_fd[i], grad_H_ad[i],
                     tols.grad_hessian_grad_hessian_);
 }
+#endif
 
 /**
  * For the specified functor and argument, test that automatic
@@ -332,10 +334,12 @@ void expect_ad_derivatives(const ad_tolerances& tols, const G& g,
                            const Eigen::VectorXd& x) {
   double gx = g(x);
   test_gradient(tols, g, x, gx);
+#ifndef STAN_MATH_TESTS_REV_ONLY
   test_gradient_fvar(tols, g, x, gx);
   test_hessian(tols, g, x, gx);
   test_hessian_fvar(tols, g, x, gx);
   test_grad_hessian(tols, g, x, gx);
+#endif
 }
 
 /**
@@ -379,10 +383,12 @@ void expect_all_throw(const F& f, const Eigen::VectorXd& x) {
   using stan::math::var;
   expect_throw<double>(f, x, "double");
   expect_throw<var>(f, x, "var");
+#ifndef STAN_MATH_TESTS_REV_ONLY
   expect_throw<fvar<double>>(f, x, "fvar<double>");
   expect_throw<fvar<fvar<double>>>(f, x, "fvar<fvar<double>>");
   expect_throw<fvar<var>>(f, x, "fvar<var>");
   expect_throw<fvar<fvar<var>>>(f, x, "fvar<fvar<var>>");
+#endif
 }
 
 /**


### PR DESCRIPTION
## Summary

This adds a CXX flag that can be used in Stan Math tests to not compile and run fwd & mix tests if the tests are using the test_ad utility. 

I am primarily trying to add this so we can remove compiling & running fwd & mix tests with Windows and Rtools 3.5 (the tests that run with Github Actions). Particularly our mix tests are on the limit of what g++ 4.9.3 can handle, which is why we sometimes have to split tests files so that 4.9.3 can compile them. 

I doubt anyone is using g++ 4.9.3 with fwd and mix. It is still used with Stan, but we only need rev tests to check compatibility there.

There is no Math issue for this PR. I can make one if needed.

## Tests

This will decrease our testing with Windows Rtools 3.5 (`g++ 4.9.3`). Given that we using g++ 4.9.3 outside of the use in Stan is not really recommended, I think this should be fine.

## Side Effects

/

## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
