### PR TITLE
update value_of_rec to return a reference for varmat types

### DIFF
--- a/stan/math/rev/fun/value_of_rec.hpp
+++ b/stan/math/rev/fun/value_of_rec.hpp
@@ -13,10 +13,10 @@ namespace math {
  * @param v Variable.
  * @return Value of variable.
  */
-template <typename T>
-inline auto value_of_rec(const var_value<T>& v) {
-  return v.vi_->val_;
-}
+ template <typename T>
+ inline auto& value_of_rec(const var_value<T>& v) {
+   return v.vi_->val_;
+ }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/fun/value_of_rec.hpp
+++ b/stan/math/rev/fun/value_of_rec.hpp
@@ -13,10 +13,10 @@ namespace math {
  * @param v Variable.
  * @return Value of variable.
  */
- template <typename T>
- inline auto& value_of_rec(const var_value<T>& v) {
-   return v.vi_->val_;
- }
+template <typename T>
+inline auto& value_of_rec(const var_value<T>& v) {
+  return v.vi_->val_;
+}
 
 }  // namespace math
 }  // namespace stan


### PR DESCRIPTION

## Summary

Just a small bugfix for var matrix types to return back a reference when calling `value_of_rec()` on them. Fixes the error upstream in stanc3 https://github.com/stan-dev/stanc3/pull/955

## Tests

No new tests

## Side Effects

`value_of_rec(var_value<Eigen::MatrixXd> x)` now returns a reference to the value instead of a copy

## Release notes

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
