### PR TITLE
Feature: L1 and L2 norms

### DIFF
--- a/stan/math/fwd/fun.hpp
+++ b/stan/math/fwd/fun.hpp
@@ -87,6 +87,8 @@
 #include <stan/math/fwd/fun/multiply_log.hpp>
 #include <stan/math/fwd/fun/multiply_lower_tri_self_transpose.hpp>
 #include <stan/math/fwd/fun/norm.hpp>
+#include <stan/math/fwd/fun/norm1.hpp>
+#include <stan/math/fwd/fun/norm2.hpp>
 #include <stan/math/fwd/fun/owens_t.hpp>
 #include <stan/math/fwd/fun/Phi.hpp>
 #include <stan/math/fwd/fun/Phi_approx.hpp>

--- a/stan/math/fwd/fun/norm1.hpp
+++ b/stan/math/fwd/fun/norm1.hpp
@@ -1,0 +1,37 @@
+#ifndef STAN_MATH_FWD_FUN_LOG_SUM_EXP_HPP
+#define STAN_MATH_FWD_FUN_LOG_SUM_EXP_HPP
+
+#include <stan/math/fwd/meta.hpp>
+#include <stan/math/fwd/core.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/norm1.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <cmath>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * Compute the L1 norm of the specified vector of values.
+ *
+ * @tparam T Type of input vector.
+ * @param[in] x Vector of specified values.
+ * @return L1 norm of x.
+ */
+template <typename Container,
+          require_container_st<is_fvar, Container>* = nullptr>
+inline auto norm1(const Container& x) {
+  return apply_vector_unary<ref_type_t<T>>::reduce(
+      to_ref(x), [&](const auto& v) {
+        using T_fvar_inner = typename value_type_t<decltype(v)>::Scalar;
+        return fvar<T_fvar_inner>(
+            norm1(v.val().array()), v.d().array() * sign(v.val().array()));
+      });
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/fwd/fun/norm1.hpp
+++ b/stan/math/fwd/fun/norm1.hpp
@@ -24,7 +24,7 @@ namespace math {
 template <typename Container,
           require_container_st<is_fvar, Container>* = nullptr>
 inline auto norm1(const Container& x) {
-  return apply_vector_unary<ref_type_t<T>>::reduce(
+  return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [&](const auto& v) {
         using T_fvar_inner = typename value_type_t<decltype(v)>::Scalar;
         return fvar<T_fvar_inner>(

--- a/stan/math/fwd/fun/norm1.hpp
+++ b/stan/math/fwd/fun/norm1.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MATH_FWD_FUN_LOG_SUM_EXP_HPP
-#define STAN_MATH_FWD_FUN_LOG_SUM_EXP_HPP
+#ifndef STAN_MATH_FWD_FUN_NORM1_HPP
+#define STAN_MATH_FWD_FUN_NORM1_HPP
 
 #include <stan/math/fwd/meta.hpp>
 #include <stan/math/fwd/core.hpp>
@@ -7,9 +7,8 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/norm1.hpp>
+#include <stan/math/prim/fun/sign.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
-#include <cmath>
-#include <vector>
 
 namespace stan {
 namespace math {
@@ -27,8 +26,8 @@ inline auto norm1(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [&](const auto& v) {
         using T_fvar_inner = typename value_type_t<decltype(v)>::Scalar;
-        return fvar<T_fvar_inner>(norm1(v.val().array()),
-                                  v.d().array() * sign(v.val().array()));
+        return fvar<T_fvar_inner>(norm1(v.val()),
+                                  v.d().cwiseProduct(sign(v.val())).sum());
       });
 }
 

--- a/stan/math/fwd/fun/norm2.hpp
+++ b/stan/math/fwd/fun/norm2.hpp
@@ -24,7 +24,7 @@ namespace math {
 template <typename Container,
           require_container_st<is_fvar, Container>* = nullptr>
 inline auto norm2(const Container& x) {
-  return apply_vector_unary<ref_type_t<T>>::reduce(
+  return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [&](const auto& v) {
         using T_fvar_inner = typename value_type_t<decltype(v)>::Scalar;
         T_fvar_inner res = norm2(v.val().array());

--- a/stan/math/fwd/fun/norm2.hpp
+++ b/stan/math/fwd/fun/norm2.hpp
@@ -1,15 +1,12 @@
-#ifndef STAN_MATH_FWD_FUN_LOG_SUM_EXP_HPP
-#define STAN_MATH_FWD_FUN_LOG_SUM_EXP_HPP
+#ifndef STAN_MATH_FWD_FUN_NORM2_HPP
+#define STAN_MATH_FWD_FUN_NORM2_HPP
 
 #include <stan/math/fwd/meta.hpp>
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/norm2.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
-#include <cmath>
-#include <vector>
 
 namespace stan {
 namespace math {
@@ -27,8 +24,9 @@ inline auto norm2(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [&](const auto& v) {
         using T_fvar_inner = typename value_type_t<decltype(v)>::Scalar;
-        T_fvar_inner res = norm2(v.val().array());
-        return fvar<T_fvar_inner>(res, v.d().array() * (v.val().array() / res));
+        T_fvar_inner res = norm2(v.val());
+        return fvar<T_fvar_inner>(res,
+                                  v.d().cwiseProduct((v.val() / res)).sum());
       });
 }
 

--- a/stan/math/fwd/fun/norm2.hpp
+++ b/stan/math/fwd/fun/norm2.hpp
@@ -1,0 +1,37 @@
+#ifndef STAN_MATH_FWD_FUN_LOG_SUM_EXP_HPP
+#define STAN_MATH_FWD_FUN_LOG_SUM_EXP_HPP
+
+#include <stan/math/fwd/meta.hpp>
+#include <stan/math/fwd/core.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/norm2.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <cmath>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * Compute the L2 norm of the specified vector of values.
+ *
+ * @tparam T Type of input vector.
+ * @param[in] x Vector of specified values.
+ * @return L2 norm of x.
+ */
+template <typename Container,
+          require_container_st<is_fvar, Container>* = nullptr>
+inline auto norm2(const Container& x) {
+  return apply_vector_unary<ref_type_t<T>>::reduce(
+      to_ref(x), [&](const auto& v) {
+        using T_fvar_inner = typename value_type_t<decltype(v)>::Scalar;
+        T_fvar_inner res = norm2(v.val().array());
+        return fvar<T_fvar_inner>(res, v.d().array() * (v.val().array() / res));
+      });
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -227,6 +227,7 @@
 #include <stan/math/prim/fun/multiply_log.hpp>
 #include <stan/math/prim/fun/multiply_lower_tri_self_transpose.hpp>
 #include <stan/math/prim/fun/norm.hpp>
+#include <stan/math/prim/fun/norm1.hpp>
 #include <stan/math/prim/fun/num_elements.hpp>
 #include <stan/math/prim/fun/offset_multiplier_constrain.hpp>
 #include <stan/math/prim/fun/offset_multiplier_free.hpp>

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -228,6 +228,7 @@
 #include <stan/math/prim/fun/multiply_lower_tri_self_transpose.hpp>
 #include <stan/math/prim/fun/norm.hpp>
 #include <stan/math/prim/fun/norm1.hpp>
+#include <stan/math/prim/fun/norm2.hpp>
 #include <stan/math/prim/fun/num_elements.hpp>
 #include <stan/math/prim/fun/offset_multiplier_constrain.hpp>
 #include <stan/math/prim/fun/offset_multiplier_free.hpp>

--- a/stan/math/prim/fun/dot_self.hpp
+++ b/stan/math/prim/fun/dot_self.hpp
@@ -10,9 +10,10 @@
 namespace stan {
 namespace math {
 
-inline double dot_self(const std::vector<double>& x) {
-  double sum = 0.0;
-  for (double i : x) {
+template <typename T>
+inline T dot_self(const std::vector<T>& x) {
+  T sum = 0.0;
+  for (auto i : x) {
     sum += i * i;
   }
   return sum;

--- a/stan/math/prim/fun/dot_self.hpp
+++ b/stan/math/prim/fun/dot_self.hpp
@@ -10,10 +10,9 @@
 namespace stan {
 namespace math {
 
-template <typename T>
-inline T dot_self(const std::vector<T>& x) {
-  T sum = 0.0;
-  for (auto i : x) {
+inline double dot_self(const std::vector<double>& x) {
+  double sum = 0.0;
+  for (double i : x) {
     sum += i * i;
   }
   return sum;

--- a/stan/math/prim/fun/dot_self.hpp
+++ b/stan/math/prim/fun/dot_self.hpp
@@ -27,7 +27,7 @@ inline double dot_self(const std::vector<double>& x) {
  */
 template <typename T, require_eigen_t<T>* = nullptr,
           require_not_eigen_vt<is_var, T>* = nullptr>
-inline auto dot_self(const T& v) {
+inline value_type_t<T> dot_self(const T& v) {
   return v.squaredNorm();
 }
 

--- a/stan/math/prim/fun/norm1.hpp
+++ b/stan/math/prim/fun/norm1.hpp
@@ -19,7 +19,7 @@ namespace math {
  * @return L1 norm of v.
  */
 template <typename Container, require_container_t<Container>* = nullptr,
-    require_not_st_var<Container>* = nullptr>
+          require_not_st_var<Container>* = nullptr>
 inline auto norm1(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [](const auto& v) { return v.template lpNorm<1>(); });

--- a/stan/math/prim/fun/norm1.hpp
+++ b/stan/math/prim/fun/norm1.hpp
@@ -4,8 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <cstddef>
-#include <vector>
 
 namespace stan {
 namespace math {
@@ -24,6 +22,7 @@ inline auto norm1(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [](const auto& v) { return v.template lpNorm<1>(); });
 }
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/norm1.hpp
+++ b/stan/math/prim/fun/norm1.hpp
@@ -16,9 +16,7 @@ namespace math {
  * @param v Vector.
  * @return L1 norm of v.
  */
-template <typename Container, require_container_t<Container>* = nullptr,
-          require_not_st_var<Container>* = nullptr,
-          require_not_st_fvar<Container>* = nullptr>
+template <typename Container, require_st_arithmetic<Container>* = nullptr>
 inline auto norm1(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [](const auto& v) { return v.template lpNorm<1>(); });

--- a/stan/math/prim/fun/norm1.hpp
+++ b/stan/math/prim/fun/norm1.hpp
@@ -18,14 +18,12 @@ namespace math {
  * @param v Vector.
  * @return L1 norm of v.
  */
-template <typename Container, require_st_arithmetic<Container>* = nullptr,
-          require_container_t<Container>* = nullptr>
+template <typename Container, require_container_t<Container>* = nullptr,
+    require_not_st_var<Container>* = nullptr>
 inline auto norm1(const Container& x) {
-  check_nonzero_size("norm1", "v", x);
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [](const auto& v) { return v.template lpNorm<1>(); });
 }
-
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/norm1.hpp
+++ b/stan/math/prim/fun/norm1.hpp
@@ -17,7 +17,8 @@ namespace math {
  * @return L1 norm of v.
  */
 template <typename Container, require_container_t<Container>* = nullptr,
-          require_not_st_var<Container>* = nullptr>
+          require_not_st_var<Container>* = nullptr,
+          require_not_st_fvar<Container>* = nullptr>
 inline auto norm1(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [](const auto& v) { return v.template lpNorm<1>(); });

--- a/stan/math/prim/fun/norm1.hpp
+++ b/stan/math/prim/fun/norm1.hpp
@@ -16,7 +16,8 @@ namespace math {
  * @param v Vector.
  * @return L1 norm of v.
  */
-template <typename Container, require_st_arithmetic<Container>* = nullptr>
+template <typename Container, require_st_arithmetic<Container>* = nullptr,
+          require_container_t<Container>* = nullptr>
 inline auto norm1(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [](const auto& v) { return v.template lpNorm<1>(); });

--- a/stan/math/prim/fun/norm1.hpp
+++ b/stan/math/prim/fun/norm1.hpp
@@ -10,13 +10,6 @@
 namespace stan {
 namespace math {
 
-inline double norm1(const std::vector<double>& x) {
-  double norm = 0.0;
-  for (double i : x) {
-    norm += std::abs(i);
-  }
-  return norm;
-}
 
 /**
  * Returns L1 norm of a vector. For vectors that equals the
@@ -30,6 +23,12 @@ template <typename T, require_eigen_t<T>* = nullptr,
           require_not_eigen_vt<is_var, T>* = nullptr>
 inline auto norm1(const T& v) {
   return v.template lpNorm<1>();
+}
+
+template <typename T>
+inline T norm1(const std::vector<T>& x) {
+  Eigen::Map<const Eigen::Matrix<T, -1, 1>> v(x.data(), x.size());
+  return norm1(v);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/norm1.hpp
+++ b/stan/math/prim/fun/norm1.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MATH_PRIM_FUN_DOT_SELF_HPP
-#define STAN_MATH_PRIM_FUN_DOT_SELF_HPP
+#ifndef STAN_MATH_PRIM_FUN_NORM1_HPP
+#define STAN_MATH_PRIM_FUN_NORM1_HPP
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
@@ -10,25 +10,26 @@
 namespace stan {
 namespace math {
 
-inline double dot_self(const std::vector<double>& x) {
-  double sum = 0.0;
+inline double norm1(const std::vector<double>& x) {
+  double norm = 0.0;
   for (double i : x) {
-    sum += i * i;
+    norm += std::abs(i);
   }
-  return sum;
+  return norm;
 }
 
 /**
- * Returns squared norm of a vector or matrix. For vectors that equals the dot
- * product of the specified vector with itself.
+ * Returns L1 norm of a vector. For vectors that equals the
+ * sum of magnitudes of its individual elements.
  *
  * @tparam T type of the vector (must be derived from \c Eigen::MatrixBase)
  * @param v Vector.
+ * @return L1 norm of v.
  */
 template <typename T, require_eigen_t<T>* = nullptr,
           require_not_eigen_vt<is_var, T>* = nullptr>
-inline auto dot_self(const T& v) {
-  return v.squaredNorm();
+inline auto norm1(const T& v) {
+  return v.template lpNorm<1>();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/norm1.hpp
+++ b/stan/math/prim/fun/norm1.hpp
@@ -23,8 +23,7 @@ template <typename Container, require_st_arithmetic<Container>* = nullptr,
 inline auto norm1(const Container& x) {
   check_nonzero_size("norm1", "v", x);
   return apply_vector_unary<ref_type_t<Container>>::reduce(
-      to_ref(x), [](const auto& v) { return v.template lpNorm<1>(); }
-      );
+      to_ref(x), [](const auto& v) { return v.template lpNorm<1>(); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/norm1.hpp
+++ b/stan/math/prim/fun/norm1.hpp
@@ -10,7 +10,6 @@
 namespace stan {
 namespace math {
 
-
 /**
  * Returns L1 norm of a vector. For vectors that equals the
  * sum of magnitudes of its individual elements.
@@ -19,16 +18,13 @@ namespace math {
  * @param v Vector.
  * @return L1 norm of v.
  */
-template <typename T, require_eigen_t<T>* = nullptr,
-          require_not_eigen_vt<is_var, T>* = nullptr>
-inline auto norm1(const T& v) {
-  return v.template lpNorm<1>();
-}
-
-template <typename T>
-inline T norm1(const std::vector<T>& x) {
-  Eigen::Map<const Eigen::Matrix<T, -1, 1>> v(x.data(), x.size());
-  return norm1(v);
+template <typename Container, require_st_arithmetic<Container>* = nullptr,
+          require_container_t<Container>* = nullptr>
+inline auto norm1(const Container& x) {
+  check_nonzero_size("norm1", "v", x);
+  return apply_vector_unary<ref_type_t<Container>>::reduce(
+      to_ref(x), [](const auto& v) { return v.template lpNorm<1>(); }
+      );
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -10,18 +10,9 @@
 namespace stan {
 namespace math {
 
-inline double norm2(const std::vector<double>& x) {
-  double norm = 0.0;
-  for (double i : x) {
-    norm += i*i;
-  }
-  norm = sqrt(norm);
-  return norm;
-}
-
 /**
- * Returns L2 norm of a vector. For vectors that equals the
- * sum of magnitudes of its individual elements.
+ * Returns L2 norm of a vector. For vectors that equals the square-root of the
+ * sum of squares of the elements.
  *
  * @tparam T type of the vector (must be derived from \c Eigen::MatrixBase)
  * @param v Vector.
@@ -29,8 +20,14 @@ inline double norm2(const std::vector<double>& x) {
  */
 template <typename T, require_eigen_t<T>* = nullptr,
           require_not_eigen_vt<is_var, T>* = nullptr>
-inline auto norm2(const T& v) {
+inline value_type_t<T> norm2(const T& v) {
   return v.template lpNorm<2>();
+}
+
+template <typename T>
+inline T norm2(const std::vector<T>& x) {
+  Eigen::Map<const Eigen::Matrix<T, -1, 1>> v(x.data(), x.size());
+  return norm2(v);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -23,8 +23,7 @@ template <typename Container, require_st_arithmetic<Container>* = nullptr,
 inline auto norm2(const Container& x) {
   check_nonzero_size("norm2", "v", x);
   return apply_vector_unary<ref_type_t<Container>>::reduce(
-      to_ref(x), [](const auto& v) { return v.template lpNorm<2>(); }
-      );
+      to_ref(x), [](const auto& v) { return v.template lpNorm<2>(); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -19,7 +19,7 @@ namespace math {
  * @return L2 norm of v.
  */
 template <typename Container, require_st_arithmetic<Container>* = nullptr,
-          require_container_t<Container>* = nullptr>
+    require_container_t<Container>* = nullptr>
 inline auto norm2(const Container& x) {
   check_nonzero_size("norm2", "v", x);
   return apply_vector_unary<ref_type_t<Container>>::reduce(

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -16,7 +16,8 @@ namespace math {
  * @param v Vector.
  * @return L2 norm of v.
  */
-template <typename Container, require_st_arithmetic<Container>* = nullptr>
+template <typename Container, require_st_arithmetic<Container>* = nullptr,
+          require_container_t<Container>* = nullptr>
 inline auto norm2(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [](const auto& v) { return v.template lpNorm<2>(); });

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -16,9 +16,7 @@ namespace math {
  * @param v Vector.
  * @return L2 norm of v.
  */
-template <typename Container, require_container_t<Container>* = nullptr,
-          require_not_st_var<Container>* = nullptr,
-          require_not_st_fvar<Container>* = nullptr>
+template <typename Container, require_st_arithmetic<Container>* = nullptr>
 inline auto norm2(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [](const auto& v) { return v.template lpNorm<2>(); });

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -1,0 +1,39 @@
+#ifndef STAN_MATH_PRIM_FUN_NORM2_HPP
+#define STAN_MATH_PRIM_FUN_NORM2_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <cstddef>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+inline double norm2(const std::vector<double>& x) {
+  double norm = 0.0;
+  for (double i : x) {
+    norm += i*i;
+  }
+  norm = sqrt(norm);
+  return norm;
+}
+
+/**
+ * Returns L2 norm of a vector. For vectors that equals the
+ * sum of magnitudes of its individual elements.
+ *
+ * @tparam T type of the vector (must be derived from \c Eigen::MatrixBase)
+ * @param v Vector.
+ * @return L2 norm of v.
+ */
+template <typename T, require_eigen_t<T>* = nullptr,
+          require_not_eigen_vt<is_var, T>* = nullptr>
+inline auto norm2(const T& v) {
+  return v.template lpNorm<2>();
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -17,7 +17,8 @@ namespace math {
  * @return L2 norm of v.
  */
 template <typename Container, require_container_t<Container>* = nullptr,
-          require_not_st_var<Container>* = nullptr>
+          require_not_st_var<Container>* = nullptr,
+          require_not_st_fvar<Container>* = nullptr>
 inline auto norm2(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [](const auto& v) { return v.template lpNorm<2>(); });

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -18,16 +18,13 @@ namespace math {
  * @param v Vector.
  * @return L2 norm of v.
  */
-template <typename T, require_eigen_t<T>* = nullptr,
-          require_not_eigen_vt<is_var, T>* = nullptr>
-inline value_type_t<T> norm2(const T& v) {
-  return v.template lpNorm<2>();
-}
-
-template <typename T>
-inline T norm2(const std::vector<T>& x) {
-  Eigen::Map<const Eigen::Matrix<T, -1, 1>> v(x.data(), x.size());
-  return norm2(v);
+template <typename Container, require_st_arithmetic<Container>* = nullptr,
+    require_container_t<Container>* = nullptr>
+inline auto norm2(const Container& x) {
+  check_nonzero_size("norm2", "v", x);
+  return apply_vector_unary<ref_type_t<Container>>::reduce(
+      to_ref(x), [](const auto& v) { return v.template lpNorm<2>(); }
+      );
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -19,7 +19,7 @@ namespace math {
  * @return L2 norm of v.
  */
 template <typename Container, require_container_t<Container>* = nullptr,
-    require_not_st_var<Container>* = nullptr>
+          require_not_st_var<Container>* = nullptr>
 inline auto norm2(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [](const auto& v) { return v.template lpNorm<2>(); });

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -4,8 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <cstddef>
-#include <vector>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -18,10 +18,9 @@ namespace math {
  * @param v Vector.
  * @return L2 norm of v.
  */
-template <typename Container, require_st_arithmetic<Container>* = nullptr,
-    require_container_t<Container>* = nullptr>
+template <typename Container, require_container_t<Container>* = nullptr,
+    require_not_st_var<Container>* = nullptr>
 inline auto norm2(const Container& x) {
-  check_nonzero_size("norm2", "v", x);
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [](const auto& v) { return v.template lpNorm<2>(); });
 }

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -19,7 +19,7 @@ namespace math {
  * @return L2 norm of v.
  */
 template <typename Container, require_st_arithmetic<Container>* = nullptr,
-    require_container_t<Container>* = nullptr>
+          require_container_t<Container>* = nullptr>
 inline auto norm2(const Container& x) {
   check_nonzero_size("norm2", "v", x);
   return apply_vector_unary<ref_type_t<Container>>::reduce(

--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -130,6 +130,7 @@
 #include <stan/math/rev/fun/multiply_log.hpp>
 #include <stan/math/rev/fun/multiply_lower_tri_self_transpose.hpp>
 #include <stan/math/rev/fun/norm.hpp>
+#include <stan/math/rev/fun/norm1.hpp>
 #include <stan/math/rev/fun/ordered_constrain.hpp>
 #include <stan/math/rev/fun/owens_t.hpp>
 #include <stan/math/rev/fun/polar.hpp>

--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -131,6 +131,7 @@
 #include <stan/math/rev/fun/multiply_lower_tri_self_transpose.hpp>
 #include <stan/math/rev/fun/norm.hpp>
 #include <stan/math/rev/fun/norm1.hpp>
+#include <stan/math/rev/fun/norm2.hpp>
 #include <stan/math/rev/fun/ordered_constrain.hpp>
 #include <stan/math/rev/fun/owens_t.hpp>
 #include <stan/math/rev/fun/polar.hpp>

--- a/stan/math/rev/fun/norm1.hpp
+++ b/stan/math/rev/fun/norm1.hpp
@@ -24,12 +24,11 @@ template <typename T, require_eigen_vector_vt<is_var, T>* = nullptr>
 inline var norm1(const T& v) {
   const auto& v_ref = to_ref(v);
   arena_t<T> arena_v(v_ref.size());
-  double res_val = 0;
+  var res(0.);
   for (size_t i = 0; i < arena_v.size(); ++i) {
     arena_v.coeffRef(i) = v_ref.coeffRef(i);
-    res_val += abs(arena_v.coeffRef(i).val());
+    res += abs(arena_v.coeffRef(i).val());
   }
-  var res(res_val);
 
   reverse_pass_callback([res, arena_v]() mutable {
     arena_v.adj().array() += res.adj() * sign(arena_v.val().array());

--- a/stan/math/rev/fun/norm1.hpp
+++ b/stan/math/rev/fun/norm1.hpp
@@ -1,0 +1,62 @@
+#ifndef STAN_MATH_REV_FUN_NORM1_HPP
+#define STAN_MATH_REV_FUN_NORM1_HPP
+
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/core/typedefs.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/sign.hpp>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the L1 norm of a vector of var.
+ *
+ * @tparam T type of the vector (must have one compile-time dimension equal to
+ * 1)
+ * @param[in] v Vector.
+ * @return L1 norm of v.
+ */
+template <typename T, require_eigen_vector_vt<is_var, T>* = nullptr>
+inline var norm1(const T& v) {
+  const auto& v_ref = to_ref(v);
+  arena_t<T> arena_v(v_ref.size());
+  double res_val = 0;
+  for (size_t i = 0; i < arena_v.size(); ++i) {
+    arena_v.coeffRef(i) = v_ref.coeffRef(i);
+    res_val += abs(arena_v.coeffRef(i).val());
+  }
+  var res(res_val);
+
+  reverse_pass_callback([res, arena_v]() mutable {
+    arena_v.adj().array() +=  res.adj() * sign(arena_v.val().array());
+  });
+
+  return res;
+}
+
+/**
+ * Returns the L1 norm of a `var_value<Vector>`.
+ *
+ * @tparam A `var_value<>` whose inner type has one compile-time row or column.
+ * @param[in] v Vector.
+ * @return L1 norm of v.
+ */
+template <typename T, require_var_matrix_t<T>* = nullptr>
+inline var norm1(const T& v) {
+  var res = v.val().array().abs().sum();
+
+  reverse_pass_callback(
+      [res, v]() mutable {
+        v.adj().array() += res.adj() * sign(v.val().array());
+      });
+
+  return res;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/fun/norm2.hpp
+++ b/stan/math/rev/fun/norm2.hpp
@@ -1,0 +1,63 @@
+#ifndef STAN_MATH_REV_FUN_NORM2_HPP
+#define STAN_MATH_REV_FUN_NORM2_HPP
+
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/core/typedefs.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/sign.hpp>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the L2 norm of a vector of var.
+ *
+ * @tparam T type of the vector (must have one compile-time dimension equal to
+ * 1)
+ * @param[in] v Vector.
+ * @return L2 norm of v.
+ */
+template <typename T, require_eigen_vector_vt<is_var, T>* = nullptr>
+inline var norm2(const T& v) {
+  const auto& v_ref = to_ref(v);
+  arena_t<T> arena_v(v_ref.size());
+  double res_val = 0;
+  for (size_t i = 0; i < arena_v.size(); ++i) {
+    arena_v.coeffRef(i) = v_ref.coeffRef(i);
+    auto val = arena_v.coeffRef(i).val();
+    res_val += val * val;
+  }
+  var res(sqrt(res_val));
+
+  reverse_pass_callback([res, arena_v]() mutable {
+    arena_v.adj().array() +=  res.adj() * (arena_v.val().array() / res.val());
+  });
+
+  return res;
+}
+
+/**
+ * Returns the L2 norm of a `var_value<Vector>`.
+ *
+ * @tparam A `var_value<>` whose inner type has one compile-time row or column.
+ * @param[in] v Vector.
+ * @return L2 norm of v.
+ */
+template <typename T, require_var_matrix_t<T>* = nullptr>
+inline var norm2(const T& v) {
+  var res (sqrt(v.val().array().square().sum()));
+
+  reverse_pass_callback(
+      [res, v]() mutable {
+        v.adj().array() += res.adj() * (v.val().array() / res.val());
+      });
+
+  return res;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/fun/norm2.hpp
+++ b/stan/math/rev/fun/norm2.hpp
@@ -24,14 +24,13 @@ template <typename T, require_eigen_vector_vt<is_var, T>* = nullptr>
 inline var norm2(const T& v) {
   const auto& v_ref = to_ref(v);
   arena_t<T> arena_v(v_ref.size());
-  double res_val = 0;
+  value_type_t<T> res_val = 0;
+
   for (size_t i = 0; i < arena_v.size(); ++i) {
     arena_v.coeffRef(i) = v_ref.coeffRef(i);
-    auto val = arena_v.coeffRef(i).val();
-    res_val += val * val;
+    res_val += square(arena_v.coeffRef(i).val());
   }
   var res(sqrt(res_val));
-
   reverse_pass_callback([res, arena_v]() mutable {
     arena_v.adj().array() +=  res.adj() * (arena_v.val().array() / res.val());
   });

--- a/stan/math/rev/fun/norm2.hpp
+++ b/stan/math/rev/fun/norm2.hpp
@@ -32,7 +32,7 @@ inline var norm2(const T& v) {
 
   res = sqrt(res);
   reverse_pass_callback([res, arena_v]() mutable {
-  arena_v.adj().array() += res.adj() * (arena_v.val().array() / res.val());
+    arena_v.adj().array() += res.adj() * (arena_v.val().array() / res.val());
   });
 
   return res;

--- a/stan/math/rev/fun/norm2.hpp
+++ b/stan/math/rev/fun/norm2.hpp
@@ -48,7 +48,7 @@ inline var norm2(const T& v) {
  */
 template <typename T, require_var_matrix_t<T>* = nullptr>
 inline var norm2(const T& v) {
-  var res (sqrt(v.val().array().square().sum()));
+  var res = sqrt(v.val().array().square().sum());
 
   reverse_pass_callback(
       [res, v]() mutable {

--- a/stan/math/rev/fun/norm2.hpp
+++ b/stan/math/rev/fun/norm2.hpp
@@ -38,7 +38,7 @@ inline var norm2(const T& v) {
  */
 template <typename T, require_var_matrix_t<T>* = nullptr>
 inline var norm2(const T& v) {
-  return make_callback_vari(norm2(v.val()), [v](const auto& res) mutable{
+  return make_callback_vari(norm2(v.val()), [v](const auto& res) mutable {
     v.adj().array() += res.adj() * (v.val().array() / res.val());
   });
 }

--- a/stan/math/rev/fun/norm2.hpp
+++ b/stan/math/rev/fun/norm2.hpp
@@ -24,13 +24,13 @@ template <typename T, require_eigen_vector_vt<is_var, T>* = nullptr>
 inline var norm2(const T& v) {
   const auto& v_ref = to_ref(v);
   arena_t<T> arena_v(v_ref.size());
-  var res(0.);
+  value_type_t<T> res_val = 0;
+
   for (size_t i = 0; i < arena_v.size(); ++i) {
     arena_v.coeffRef(i) = v_ref.coeffRef(i);
-    res += square(arena_v.coeffRef(i).val());
+    res_val += square(arena_v.coeffRef(i).val());
   }
-
-  res = sqrt(res);
+  var res(sqrt(res_val));
   reverse_pass_callback([res, arena_v]() mutable {
     arena_v.adj().array() += res.adj() * (arena_v.val().array() / res.val());
   });

--- a/stan/math/rev/fun/norm2.hpp
+++ b/stan/math/rev/fun/norm2.hpp
@@ -24,15 +24,15 @@ template <typename T, require_eigen_vector_vt<is_var, T>* = nullptr>
 inline var norm2(const T& v) {
   const auto& v_ref = to_ref(v);
   arena_t<T> arena_v(v_ref.size());
-  value_type_t<T> res_val = 0;
-
+  var res(0.);
   for (size_t i = 0; i < arena_v.size(); ++i) {
     arena_v.coeffRef(i) = v_ref.coeffRef(i);
-    res_val += square(arena_v.coeffRef(i).val());
+    res += square(arena_v.coeffRef(i).val());
   }
-  var res(sqrt(res_val));
+
+  res = sqrt(res);
   reverse_pass_callback([res, arena_v]() mutable {
-    arena_v.adj().array() += res.adj() * (arena_v.val().array() / res.val());
+  arena_v.adj().array() += res.adj() * (arena_v.val().array() / res.val());
   });
 
   return res;

--- a/stan/math/rev/fun/norm2.hpp
+++ b/stan/math/rev/fun/norm2.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/rev/core/typedefs.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/fun/sign.hpp>
 
 namespace stan {
 namespace math {

--- a/test/unit/math/mix/fun/norm1_test.cpp
+++ b/test/unit/math/mix/fun/norm1_test.cpp
@@ -1,0 +1,22 @@
+#include <test/unit/math/test_ad.hpp>
+#include <vector>
+
+TEST(MathMixMatFun, norm1) {
+  auto f = [](const auto& y) { return stan::math::norm1(y); };
+
+  Eigen::VectorXd x0(0);
+
+  Eigen::VectorXd x1(1);
+  x1 << 2;
+
+  Eigen::VectorXd x2(2);
+  x2 << 2, 3;
+
+  Eigen::VectorXd x3(3);
+  x3 << 2, 3, 4;
+
+  for (const auto& a : std::vector<Eigen::VectorXd>{x0, x1, x2, x3}) {
+    stan::test::expect_ad(f, a);
+    stan::test::expect_ad_matvar(f, a);
+  }
+}

--- a/test/unit/math/mix/fun/norm2_test.cpp
+++ b/test/unit/math/mix/fun/norm2_test.cpp
@@ -1,0 +1,22 @@
+#include <test/unit/math/test_ad.hpp>
+#include <vector>
+
+TEST(MathMixMatFun, norm2) {
+  auto f = [](const auto& y) { return stan::math::norm2(y); };
+
+  Eigen::VectorXd x0(0);
+
+  Eigen::VectorXd x1(1);
+  x1 << 2;
+
+  Eigen::VectorXd x2(2);
+  x2 << 2, 3;
+
+  Eigen::VectorXd x3(3);
+  x3 << 2, 3, 4;
+
+  for (const auto& a : std::vector<Eigen::VectorXd>{x0, x1, x2, x3}) {
+    stan::test::expect_ad(f, a);
+    stan::test::expect_ad_matvar(f, a);
+  }
+}

--- a/test/unit/math/prim/fun/norm1_test.cpp
+++ b/test/unit/math/prim/fun/norm1_test.cpp
@@ -1,0 +1,76 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+TEST(MathFunctions, norm1) {
+  std::vector<double> x(3), y(3);
+  x[0] = 2.33;
+  x[1] = 8.88;
+  x[2] = 9.81;
+  y[0] = 2.46;
+  y[1] = 4.45;
+  y[2] = 1.03;
+
+  EXPECT_FLOAT_EQ(21.02, stan::math::norm1(x));
+  EXPECT_FLOAT_EQ(7.94, stan::math::norm1(y));
+}
+
+TEST(MathFunctions, dot_self_nan) {
+  std::vector<double> x(3);
+  x[0] = 2.33;
+  x[1] = 8.88;
+  x[2] = 9.81;
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  x[2] = nan;
+
+  EXPECT_TRUE(std::isnan(stan::math::norm1(x)));
+
+  x[0] = nan;
+  x[1] = nan;
+  x[2] = nan;
+  EXPECT_TRUE(std::isnan(stan::math::norm1(x)));
+}
+
+TEST(MathMatrixPrimMat, norm1) {
+  using stan::math::norm1;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> v1(1);
+  v1 << 2.0;
+  EXPECT_NEAR(2.0, norm1(v1), 1E-12);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> v2(2);
+  v2 << 2.0, 3.0;
+  EXPECT_NEAR(5.0, norm1(v2), 1E-12);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> v3(3);
+  v3 << 2.0, 3.0, 4.0;
+  EXPECT_NEAR(9.0, norm1(v3), 1E-12);
+
+  Eigen::Matrix<double, 1, Eigen::Dynamic> rv1(1);
+  rv1 << 2.0;
+  EXPECT_NEAR(2.0, norm1(rv1), 1E-12);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> rv2(2);
+  rv2 << 2.0, 3.0;
+  EXPECT_NEAR(5.0, norm1(rv2), 1E-12);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> rv3(3);
+  rv3 << 2.0, 3.0, 4.0;
+  EXPECT_NEAR(9.0, norm1(rv3), 1E-12);
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m1(1, 1);
+  m1 << 2.0;
+  EXPECT_NEAR(2.0, norm1(m1), 1E-12);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m2(2, 1);
+  m2 << 2.0, 3.0;
+  EXPECT_NEAR(5.0, norm1(m2), 1E-12);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m3(3, 1);
+  m3 << 2.0, 3.0, 4.0;
+  EXPECT_NEAR(9.0, norm1(m3), 1E-12);
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> mm2(1, 2);
+  mm2 << 2.0, 3.0;
+  EXPECT_NEAR(5.0, norm1(mm2), 1E-12);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> mm3(1, 3);
+  mm3 << 2.0, 3.0, 4.0;
+  EXPECT_NEAR(9.0, norm1(mm3), 1E-12);
+}

--- a/test/unit/math/prim/fun/norm1_test.cpp
+++ b/test/unit/math/prim/fun/norm1_test.cpp
@@ -17,7 +17,7 @@ TEST(MathFunctions, norm1) {
   EXPECT_FLOAT_EQ(7.94, stan::math::norm1(y));
 }
 
-TEST(MathFunctions, dot_self_nan) {
+TEST(MathFunctions, norm1_nan) {
   std::vector<double> x(3);
   x[0] = 2.33;
   x[1] = 8.88;

--- a/test/unit/math/prim/fun/norm2_test.cpp
+++ b/test/unit/math/prim/fun/norm2_test.cpp
@@ -1,0 +1,77 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+TEST(MathFunctions, norm2) {
+  std::vector<double> x(2), y(4);
+  x[0] = 3;
+  x[1] = 4;
+
+  y[0] = 1;
+  y[1] = 2;
+  y[2] = 4;
+  y[3] = 2;
+
+  EXPECT_FLOAT_EQ(5.0, stan::math::norm2(x));
+  EXPECT_FLOAT_EQ(5.0, stan::math::norm2(y));
+}
+
+TEST(MathFunctions, norm2_nan) {
+  std::vector<double> x(3);
+  x[0] = 2.33;
+  x[1] = 8.88;
+  x[2] = 9.81;
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  x[2] = nan;
+
+  EXPECT_TRUE(std::isnan(stan::math::norm2(x)));
+
+  x[0] = nan;
+  x[1] = nan;
+  x[2] = nan;
+  EXPECT_TRUE(std::isnan(stan::math::norm2(x)));
+}
+
+TEST(MathMatrixPrimMat, norm2) {
+  using stan::math::norm2;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> v1(1);
+  v1 << 2.0;
+  EXPECT_NEAR(2.0, norm2(v1), 1E-12);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> v2(2);
+  v2 << 3.0, 4.0;
+  EXPECT_NEAR(5.0, norm2(v2), 1E-12);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> v3(4);
+  v3 << 1.0, 2.0, 2.0, 4.0;
+  EXPECT_NEAR(5.0, norm2(v3), 1E-12);
+
+  Eigen::Matrix<double, 1, Eigen::Dynamic> rv1(1);
+  rv1 << 2.0;
+  EXPECT_NEAR(2.0, norm2(rv1), 1E-12);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> rv2(2);
+  rv2 << 3.0, 4.0;
+  EXPECT_NEAR(5.0, norm2(rv2), 1E-12);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> rv3(4);
+  rv3 << 1.0, 2.0, 2.0, 4.0;
+  EXPECT_NEAR(5.0, norm2(rv2), 1E-12);
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m1(1, 1);
+  m1 << 2.0;
+  EXPECT_NEAR(2.0, norm2(m1), 1E-12);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m2(2, 1);
+  m2 << 3.0, 4.0;
+  EXPECT_NEAR(5.0, norm2(m2), 1E-12);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m3(4, 1);
+  m3 << 1.0, 2.0, 2.0, 4.0;
+  EXPECT_NEAR(5.0, norm2(m3), 1E-12);
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> mm2(1, 2);
+  mm2 << 3.0, 4.0;
+  EXPECT_NEAR(5.0, norm2(mm2), 1E-12);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> mm3(1, 4);
+  mm3 << 1.0, 2.0, 2.0, 4.0;
+  EXPECT_NEAR(5.0, norm2(mm3), 1E-12);
+}

--- a/test/unit/math/prim/fun/norm2_test.cpp
+++ b/test/unit/math/prim/fun/norm2_test.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 TEST(MathFunctions, norm2) {
-  std::vector<double> x(2), y(4);
+  std::vector<float> x(2), y(4);
   x[0] = 3;
   x[1] = 4;
 

--- a/test/unit/math/prim/fun/norm2_test.cpp
+++ b/test/unit/math/prim/fun/norm2_test.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 TEST(MathFunctions, norm2) {
-  std::vector<float> x(2), y(4);
+  std::vector<double> x(2), y(4);
   x[0] = 3;
   x[1] = 4;
 


### PR DESCRIPTION
## Summary

- Adds L1- and L2-norm functionality (described in #2562)
- Includes autodiff test framework tests
- I would appreciate if someone could look over my `rev/.../norm1.hpp` and `rev/.../norm2.hpp` implementations. 
  - The derivatives are straightforward but I'm still new to the stan autodiff framework so I'm not confident I did them correctly
- @bob-carpenter mentioned: using these new functions, we should "replace other uses that calculate vector lengths with `norm2()`"
  - To do this I'll need some guidance on where this calculation might arise in the repo  

As noted in the issue:
```
norm1(x)  =def=  sum(abs(x))
norm2(x)  =def=  sqrt(sum(square(x)))
```

```
d/dx norm1(x) = signum(x)
d/dx norm2(x) = x / norm2(x)
```

## Tests

- Tests are pretty similar to `dot_self`
- Includes expected behaviour, as well as nan-handling

## Side Effects

n/a

## Release notes

n/a

## Checklist

- [x] Math issue #2562 
- [x] Copyright holder: Lyndon Duong

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)
    


- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
