### PR TITLE
Add missing deprecated cdf sigs

### DIFF
--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -347,7 +347,9 @@
 #include <stan/math/prim/prob/von_mises_log.hpp>
 #include <stan/math/prim/prob/von_mises_lpdf.hpp>
 #include <stan/math/prim/prob/von_mises_rng.hpp>
+#include <stan/math/prim/prob/von_mises_ccdf_log.hpp>
 #include <stan/math/prim/prob/von_mises_cdf.hpp>
+#include <stan/math/prim/prob/von_mises_cdf_log.hpp>
 #include <stan/math/prim/prob/von_mises_lcdf.hpp>
 #include <stan/math/prim/prob/von_mises_lccdf.hpp>
 #include <stan/math/prim/prob/weibull_ccdf_log.hpp>

--- a/stan/math/prim/prob/von_mises_ccdf_log.hpp
+++ b/stan/math/prim/prob/von_mises_ccdf_log.hpp
@@ -12,8 +12,8 @@ namespace math {
  */
 template <typename T_x, typename T_mu, typename T_k>
 inline return_type_t<T_x, T_mu, T_k> von_mises_ccdf_log(const T_x& x,
-                                                    const T_mu& mu,
-                                                    const T_k& k) {
+                                                        const T_mu& mu,
+                                                        const T_k& k) {
   return von_mises_lccdf<T_x, T_mu, T_k>(x, mu, k);
 }
 

--- a/stan/math/prim/prob/von_mises_ccdf_log.hpp
+++ b/stan/math/prim/prob/von_mises_ccdf_log.hpp
@@ -1,0 +1,23 @@
+#ifndef STAN_MATH_PRIM_PROB_VON_MISES_CCDF_LOG_HPP
+#define STAN_MATH_PRIM_PROB_VON_MISES_CCDF_LOG_HPP
+
+#include <stan/math/prim/prob/von_mises_lccdf.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/** \ingroup prob_dists
+ * @deprecated use <code>von_mises_lccdf</code>
+ */
+template <typename T_x, typename T_mu, typename T_k>
+inline return_type_t<T_x, T_mu, T_k> von_mises_ccdf_log(const T_x& x,
+                                                    const T_mu& mu,
+                                                    const T_k& k) {
+  return von_mises_lccdf<T_x, T_mu, T_k>(x, mu, k);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/prob/von_mises_cdf_log.hpp
+++ b/stan/math/prim/prob/von_mises_cdf_log.hpp
@@ -12,8 +12,8 @@ namespace math {
  */
 template <typename T_x, typename T_mu, typename T_k>
 inline return_type_t<T_x, T_mu, T_k> von_mises_cdf_log(const T_x& x,
-                                                    const T_mu& mu,
-                                                    const T_k& k) {
+                                                       const T_mu& mu,
+                                                       const T_k& k) {
   return von_mises_lcdf<T_x, T_mu, T_k>(x, mu, k);
 }
 

--- a/stan/math/prim/prob/von_mises_cdf_log.hpp
+++ b/stan/math/prim/prob/von_mises_cdf_log.hpp
@@ -1,0 +1,23 @@
+#ifndef STAN_MATH_PRIM_PROB_VON_MISES_CDF_LOG_HPP
+#define STAN_MATH_PRIM_PROB_VON_MISES_CDF_LOG_HPP
+
+#include <stan/math/prim/prob/von_mises_lcdf.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/** \ingroup prob_dists
+ * @deprecated use <code>von_mises_lcdf</code>
+ */
+template <typename T_x, typename T_mu, typename T_k>
+inline return_type_t<T_x, T_mu, T_k> von_mises_cdf_log(const T_x& x,
+                                                    const T_mu& mu,
+                                                    const T_k& k) {
+  return von_mises_lcdf<T_x, T_mu, T_k>(x, mu, k);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif


### PR DESCRIPTION
## Summary

Adds `von_mises_cdf_log` and `von_mises_ccdf_log` as calls to `von_mises_lcdf` and `von_mises_lccdf`.

## Tests

No new tests, they are done in the _lcdf and _lccdf sigs.

## Side Effects

/

## Release notes

Add missing `von_mises_cdf_log` and `von_mises_ccdf_log` signatures.

## Checklist

- [x Math issue #2639 

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
