### PR TITLE
Add missing using statement in test to fix develop

### DIFF
--- a/test/unit/math/prim_scalar_sig_test.cpp
+++ b/test/unit/math/prim_scalar_sig_test.cpp
@@ -670,6 +670,7 @@ TEST(PrimScalarSigTests, ldexp) {
 }
 
 TEST(PrimScalarSigTests, pow) {
+  using namespace std::complex_literals
   double real_1 = 0.4;
   double real_2 = 2.2;
   int int_1 = 2;

--- a/test/unit/math/prim_scalar_sig_test.cpp
+++ b/test/unit/math/prim_scalar_sig_test.cpp
@@ -670,7 +670,8 @@ TEST(PrimScalarSigTests, ldexp) {
 }
 
 TEST(PrimScalarSigTests, pow) {
-  using namespace std::complex_literals double real_1 = 0.4;
+  using namespace std::complex_literals;
+  double real_1 = 0.4;
   double real_2 = 2.2;
   int int_1 = 2;
   int int_2 = 4;

--- a/test/unit/math/prim_scalar_sig_test.cpp
+++ b/test/unit/math/prim_scalar_sig_test.cpp
@@ -670,8 +670,7 @@ TEST(PrimScalarSigTests, ldexp) {
 }
 
 TEST(PrimScalarSigTests, pow) {
-  using namespace std::complex_literals
-  double real_1 = 0.4;
+  using namespace std::complex_literals double real_1 = 0.4;
   double real_2 = 2.2;
   int int_1 = 2;
   int int_2 = 4;


### PR DESCRIPTION
## Summary

Develop failed Windows tests failed because of a missing using statement in a new test file. Not sure why this wasn't caught in our other tests.

## Tests

/

## Side Effects

/

## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
