### PR TITLE
Replace sqrt(dot_self()) with norm2

### DIFF
--- a/stan/math/fwd/fun/unit_vector_constrain.hpp
+++ b/stan/math/fwd/fun/unit_vector_constrain.hpp
@@ -23,8 +23,8 @@ inline auto unit_vector_constrain(const EigMat& y) {
   plain_type_t<EigMat> unit_vector_y(y_val.size());
   unit_vector_y.val() = unit_vector_constrain(y_val);
 
-  eig_partial squared_norm = dot_self(y_val);
-  eig_partial norm = sqrt(squared_norm);
+  eig_partial norm = norm2(y_val);
+  eig_partial squared_norm = norm*norm;
   eig_partial inv_norm = inv(norm);
   Eigen::Matrix<eig_partial, Eigen::Dynamic, Eigen::Dynamic> J
       = divide(tcrossprod(y_val), -norm * squared_norm);

--- a/stan/math/fwd/fun/unit_vector_constrain.hpp
+++ b/stan/math/fwd/fun/unit_vector_constrain.hpp
@@ -24,7 +24,7 @@ inline auto unit_vector_constrain(const EigMat& y) {
   unit_vector_y.val() = unit_vector_constrain(y_val);
 
   eig_partial norm = norm2(y_val);
-  eig_partial squared_norm = norm*norm;
+  eig_partial squared_norm = norm * norm;
   eig_partial inv_norm = inv(norm);
   Eigen::Matrix<eig_partial, Eigen::Dynamic, Eigen::Dynamic> J
       = divide(tcrossprod(y_val), -norm * squared_norm);

--- a/stan/math/prim/fun/unit_vector_constrain.hpp
+++ b/stan/math/prim/fun/unit_vector_constrain.hpp
@@ -3,8 +3,6 @@
 
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/fun/dot_self.hpp>
-#include <stan/math/prim/fun/sqrt.hpp>
 #include <cmath>
 
 namespace stan {
@@ -27,9 +25,9 @@ template <typename T, require_eigen_col_vector_t<T>* = nullptr,
 inline plain_type_t<T> unit_vector_constrain(const T& y) {
   check_nonzero_size("unit_vector_constrain", "y", y);
   auto&& y_ref = to_ref(y);
-  value_type_t<T> SN = norm2(y_ref);
-  check_positive_finite("unit_vector_constrain", "norm", SN);
-  return y_ref / SN;
+  value_type_t<T> r = norm2(y_ref);
+  check_positive_finite("unit_vector_constrain", "norm", r);
+  return y_ref / r;
 }
 
 /**
@@ -48,10 +46,10 @@ template <typename T1, typename T2, require_eigen_col_vector_t<T1>* = nullptr,
 inline plain_type_t<T1> unit_vector_constrain(const T1& y, T2& lp) {
   check_nonzero_size("unit_vector_constrain", "y", y);
   auto&& y_ref = to_ref(y);
-  value_type_t<T1> SN = norm2(y_ref);
-  check_positive_finite("unit_vector_constrain", "norm", SN);
-  lp -= 0.5 * SN;
-  return y_ref.array() / SN;
+  value_type_t<T1> r = norm2(y_ref);
+  check_positive_finite("unit_vector_constrain", "norm", r);
+  lp -= 0.5 * (r * r);
+  return y_ref.array() / r;
 }
 
 /**

--- a/stan/math/prim/fun/unit_vector_constrain.hpp
+++ b/stan/math/prim/fun/unit_vector_constrain.hpp
@@ -25,12 +25,11 @@ namespace math {
 template <typename T, require_eigen_col_vector_t<T>* = nullptr,
           require_not_vt_autodiff<T>* = nullptr>
 inline plain_type_t<T> unit_vector_constrain(const T& y) {
-  using std::sqrt;
   check_nonzero_size("unit_vector_constrain", "y", y);
   auto&& y_ref = to_ref(y);
-  value_type_t<T> SN = dot_self(y_ref);
+  value_type_t<T> SN = norm2(y_ref);
   check_positive_finite("unit_vector_constrain", "norm", SN);
-  return y_ref.array() / sqrt(SN);
+  return y_ref / SN;
 }
 
 /**
@@ -47,13 +46,12 @@ inline plain_type_t<T> unit_vector_constrain(const T& y) {
 template <typename T1, typename T2, require_eigen_col_vector_t<T1>* = nullptr,
           require_all_not_vt_autodiff<T1, T2>* = nullptr>
 inline plain_type_t<T1> unit_vector_constrain(const T1& y, T2& lp) {
-  using std::sqrt;
   check_nonzero_size("unit_vector_constrain", "y", y);
   auto&& y_ref = to_ref(y);
-  value_type_t<T1> SN = dot_self(y_ref);
+  value_type_t<T1> SN = norm2(y_ref);
   check_positive_finite("unit_vector_constrain", "norm", SN);
   lp -= 0.5 * SN;
-  return y_ref.array() / sqrt(SN);
+  return y_ref.array() / SN;
 }
 
 /**

--- a/stan/math/rev/fun/unit_vector_constrain.hpp
+++ b/stan/math/rev/fun/unit_vector_constrain.hpp
@@ -34,7 +34,7 @@ inline auto unit_vector_constrain(const T& y) {
   arena_t<T> arena_y = y;
   arena_t<promote_scalar_t<double, T>> arena_y_val = arena_y.val();
 
-  const double r = arena_y_val.norm();
+  const double r = norm2(arena_y_val);
   arena_t<ret_type> res = arena_y_val / r;
 
   reverse_pass_callback([arena_y, res, r, arena_y_val]() mutable {


### PR DESCRIPTION
## Summary

I'm hoping this one won't be too controversial. This PR addresses the remaining TODO in #2562.
PR #2636 introduced specialized prim/fwd/rev functions for L1 and L2 norms. This PR tidies some instances in the codebase where `r = sqrt(dot_self(x));` can now be replaced with `r = norm2(x);`. The main ones I found were:

- `unit_vector_constrain` in prim/fwd/rev

If there are any instances I may have missed, please let me know.

## Tests

No new tests. Existing tests pass.

## Side Effects

N/A

## Release notes

Replace this text with a short note on what will change if this pull request is merged in which case this will be included in the release notes.

## Checklist

- [x] Math issue #2562 

- [x] Copyright holder: Lyndon Duong
    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
