### PR TITLE
Use d() member for fvar scalars

### DIFF
--- a/stan/math/fwd/core/fvar.hpp
+++ b/stan/math/fwd/core/fvar.hpp
@@ -65,7 +65,7 @@ struct fvar {
    *
    * @return tangent of this variable
    */
-  T tangent() const { return d_; }
+  T d() const { return d_; }
 
   /**
    * Construct a forward variable with zero value and tangent.

--- a/stan/math/fwd/fun/sum.hpp
+++ b/stan/math/fwd/fun/sum.hpp
@@ -27,7 +27,7 @@ inline fvar<T> sum(const std::vector<fvar<T>>& m) {
   std::vector<T> tans(m.size());
   for (size_t i = 0; i < m.size(); ++i) {
     vals[i] = m[i].val();
-    tans[i] = m[i].tangent();
+    tans[i] = m[i].d();
   }
   return fvar<T>(sum(vals), sum(tans));
 }

--- a/test/expressions/expression_test_helpers.hpp
+++ b/test/expressions/expression_test_helpers.hpp
@@ -108,7 +108,7 @@ void expect_eq(math::var a, math::var b, const char* msg) {
 template <typename T, require_arithmetic_t<T>* = nullptr>
 void expect_eq(math::fvar<T> a, math::fvar<T> b, const char* msg) {
   expect_eq(a.val(), b.val(), msg);
-  expect_eq(a.tangent(), b.tangent(), msg);
+  expect_eq(a.d(), b.d(), msg);
 }
 
 template <typename T1, typename T2, require_all_eigen_t<T1, T2>* = nullptr,

--- a/test/unit/math/fwd/core/std_iterator_traits_test.cpp
+++ b/test/unit/math/fwd/core/std_iterator_traits_test.cpp
@@ -13,14 +13,14 @@ void expect_iterator_traits() {
 
   typename traits::value_type c = a;
   EXPECT_EQ(a.val(), c.val());
-  EXPECT_EQ(a.tangent(), c.tangent());
+  EXPECT_EQ(a.d(), c.d());
 
   typename traits::pointer a_ptr_copy = a_ptr;
   EXPECT_EQ(a_ptr, a_ptr_copy);
 
   typename traits::reference d_ref = a;
   EXPECT_EQ(a.val(), d_ref.val());
-  EXPECT_EQ(a.tangent(), d_ref.tangent());
+  EXPECT_EQ(a.d(), d_ref.d());
 }
 
 TEST(fwdCore, stdIteratorTraits) {

--- a/test/unit/math/mix/prob/von_mises_test.cpp
+++ b/test/unit/math/mix/prob/von_mises_test.cpp
@@ -29,7 +29,7 @@ TEST(ProbAgradDistributionsVonMises, derivatives) {
   std::vector<double> grad = test_von_mises_lpdf(0, 1, 0);
 
   fvar<double> lp = von_mises_lpdf<false>(0, 1, fvar<double>(0, 1));
-  EXPECT_FLOAT_EQ(grad[2], lp.tangent());
+  EXPECT_FLOAT_EQ(grad[2], lp.d());
 
   fvar<double> kappa1(0, 1);
   EXPECT_FLOAT_EQ(von_mises_lpdf(0, 1, kappa1).val_, -1.8378770664093453390819);


### PR DESCRIPTION
## Summary

This PR updates the member function to use `d()` for accessing tangents in `fvar` variables. I chose to replace the scalar member function (rather than changing the Eigen member to `tangent()`) as the `d()` member function is significantly more widespread in the codebase, and sees greater use

## Tests

No new tests, existing tests should still pass

## Side Effects

N/A

## Release notes
Updated member function for accessing tangents in scalar `fvar` types

## Checklist

- [x] Math issue #2650

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
