### PR TITLE
allow glm functions to accept var matrix types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,13 +22,14 @@
 /test/dummy.cpp
 /test/**/*.so
 /test/expressions/*.cpp
-
+/test/varmat-compatibility/*
+# From varmat compatability testing
+results.json
 # benchmarks
 /benchmarks/*
 !/benchmarks/*.*
 benchmarks/*.cpp
 benchmarks/*.csv
-
 # other binary
 *.o
 *.o-*

--- a/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
@@ -46,7 +46,7 @@ namespace math {
  * @throw std::invalid_argument if container sizes mismatch.
  */
 template <bool propto, typename T_y, typename T_x, typename T_alpha,
-          typename T_beta, require_eigen_t<T_x>* = nullptr>
+          typename T_beta, require_matrix_t<T_x>* = nullptr>
 return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
     const T_y& y, const T_x& x, const T_alpha& alpha, const T_beta& beta) {
   using Eigen::Array;

--- a/stan/math/prim/prob/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_logit_glm_lpmf.hpp
@@ -40,9 +40,9 @@ namespace math {
  * @throw std::invalid_argument if container sizes mismatch.
  */
 template <bool propto, typename T_y, typename T_x, typename T_alpha,
-          typename T_beta, require_eigen_t<T_x>* = nullptr,
-          require_eigen_col_vector_t<T_alpha>* = nullptr,
-          require_eigen_matrix_dynamic_t<T_beta>* = nullptr>
+          typename T_beta, require_matrix_t<T_x>* = nullptr,
+          require_col_vector_t<T_alpha>* = nullptr,
+          require_matrix_t<T_beta>* = nullptr>
 return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_lpmf(
     const T_y& y, const T_x& x, const T_alpha& alpha, const T_beta& beta) {
   using T_partials_return = partials_return_t<T_x, T_alpha, T_beta>;

--- a/stan/math/prim/prob/categorical_logit_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_logit_lpmf.hpp
@@ -13,8 +13,7 @@ namespace stan {
 namespace math {
 
 // CategoricalLog(n|theta)  [0 < n <= N, theta unconstrained], no checking
-template <bool propto, typename T_prob,
-          require_col_vector_t<T_prob>* = nullptr>
+template <bool propto, typename T_prob, require_col_vector_t<T_prob>* = nullptr>
 return_type_t<T_prob> categorical_logit_lpmf(int n, const T_prob& beta) {
   static const char* function = "categorical_logit_lpmf";
   check_bounded(function, "categorical outcome out of support", n, 1,
@@ -31,8 +30,7 @@ return_type_t<T_prob> categorical_logit_lpmf(int n, const T_prob& beta) {
          - log_sum_exp(beta_ref);  // == log_softmax(beta)(n-1);
 }
 
-template <bool propto, typename T_prob,
-          require_col_vector_t<T_prob>* = nullptr>
+template <bool propto, typename T_prob, require_col_vector_t<T_prob>* = nullptr>
 return_type_t<T_prob> categorical_logit_lpmf(const std::vector<int>& ns,
                                              const T_prob& beta) {
   static const char* function = "categorical_logit_lpmf";

--- a/stan/math/prim/prob/categorical_logit_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_logit_lpmf.hpp
@@ -14,7 +14,7 @@ namespace math {
 
 // CategoricalLog(n|theta)  [0 < n <= N, theta unconstrained], no checking
 template <bool propto, typename T_prob,
-          require_eigen_col_vector_t<T_prob>* = nullptr>
+          require_col_vector_t<T_prob>* = nullptr>
 return_type_t<T_prob> categorical_logit_lpmf(int n, const T_prob& beta) {
   static const char* function = "categorical_logit_lpmf";
   check_bounded(function, "categorical outcome out of support", n, 1,
@@ -32,7 +32,7 @@ return_type_t<T_prob> categorical_logit_lpmf(int n, const T_prob& beta) {
 }
 
 template <bool propto, typename T_prob,
-          require_eigen_col_vector_t<T_prob>* = nullptr>
+          require_col_vector_t<T_prob>* = nullptr>
 return_type_t<T_prob> categorical_logit_lpmf(const std::vector<int>& ns,
                                              const T_prob& beta) {
   static const char* function = "categorical_logit_lpmf";
@@ -50,8 +50,7 @@ return_type_t<T_prob> categorical_logit_lpmf(const std::vector<int>& ns,
     return 0.0;
   }
 
-  Eigen::Matrix<value_type_t<T_prob>, Eigen::Dynamic, 1> log_softmax_beta
-      = log_softmax(beta_ref);
+  auto log_softmax_beta = to_ref(log_softmax(beta_ref));
 
   // FIXME:  replace with more efficient sum()
   Eigen::Matrix<return_type_t<T_prob>, Eigen::Dynamic, 1> results(ns.size());
@@ -62,7 +61,7 @@ return_type_t<T_prob> categorical_logit_lpmf(const std::vector<int>& ns,
 }
 
 template <typename T_n, typename T_prob, require_st_integral<T_n>* = nullptr,
-          require_eigen_col_vector_t<T_prob>* = nullptr>
+          require_col_vector_t<T_prob>* = nullptr>
 inline return_type_t<T_prob> categorical_logit_lpmf(const T_n& ns,
                                                     const T_prob& beta) {
   return categorical_logit_lpmf<false>(ns, beta);

--- a/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -62,7 +62,7 @@ namespace math {
  */
 template <bool propto, typename T_y, typename T_x, typename T_alpha,
           typename T_beta, typename T_precision,
-          require_eigen_t<T_x>* = nullptr>
+          require_matrix_t<T_x>* = nullptr>
 return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
     const T_y& y, const T_x& x, const T_alpha& alpha, const T_beta& beta,
     const T_precision& phi) {

--- a/stan/math/prim/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/prob/normal_id_glm_lpdf.hpp
@@ -51,7 +51,7 @@ namespace math {
  * @throw std::invalid_argument if container sizes mismatch.
  */
 template <bool propto, typename T_y, typename T_x, typename T_alpha,
-          typename T_beta, typename T_scale, require_eigen_t<T_x>* = nullptr>
+          typename T_beta, typename T_scale, require_matrix_t<T_x>* = nullptr>
 return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
     const T_y& y, const T_x& x, const T_alpha& alpha, const T_beta& beta,
     const T_scale& sigma) {
@@ -113,7 +113,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   const auto& beta_val_vec = to_ref_if<!is_constant<T_x>::value>(
       as_column_vector_or_scalar(beta_val));
 
-  T_scale_val inv_sigma = 1 / as_array_or_scalar(sigma_val_vec);
+  T_scale_val inv_sigma = 1.0 / as_array_or_scalar(sigma_val_vec);
 
   // the most efficient way to calculate this depends on template parameters
   double y_scaled_sq_sum;

--- a/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
@@ -43,8 +43,8 @@ namespace math {
  * @throw std::invalid_argument if container sizes mismatch.
  */
 template <bool propto, typename T_y, typename T_x, typename T_beta,
-          typename T_cuts, require_eigen_t<T_x>* = nullptr,
-          require_all_eigen_col_vector_t<T_beta, T_cuts>* = nullptr>
+          typename T_cuts, require_matrix_t<T_x>* = nullptr,
+          require_all_col_vector_t<T_beta, T_cuts>* = nullptr>
 return_type_t<T_x, T_beta, T_cuts> ordered_logistic_glm_lpmf(
     const T_y& y, const T_x& x, const T_beta& beta, const T_cuts& cuts) {
   using Eigen::Array;

--- a/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
@@ -48,7 +48,7 @@ namespace math {
  * @throw std::invalid_argument if container sizes mismatch.
  */
 template <bool propto, typename T_y, typename T_x, typename T_alpha,
-          typename T_beta, require_eigen_t<T_x>* = nullptr>
+          typename T_beta, require_matrix_t<T_x>* = nullptr>
 return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(const T_y& y,
                                                          const T_x& x,
                                                          const T_alpha& alpha,

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -961,7 +961,6 @@ class var_value<T, internal::require_matrix_var_value<T>> {
     return var_sub(new vari_sub(vi_->matrix()));
   }
 
-
   /**
    * Write the value of this autodiff variable and its adjoint to
    * the specified output stream.

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -92,7 +92,7 @@ class var_value<T, require_floating_point_t<T>> {
    *
    * @return The value of this variable.
    */
-  inline const auto& val() const { return vi_->val(); }
+  inline const auto& val() const noexcept { return vi_->val(); }
 
   /**
    * Return a reference of the derivative of the root expression with
@@ -102,7 +102,7 @@ class var_value<T, require_floating_point_t<T>> {
    *
    * @return Adjoint for this variable.
    */
-  inline auto& adj() const { return vi_->adj(); }
+  inline auto& adj() const noexcept { return vi_->adj(); }
 
   /**
    * Return a reference to the derivative of the root expression with
@@ -112,7 +112,7 @@ class var_value<T, require_floating_point_t<T>> {
    *
    * @return Adjoint for this variable.
    */
-  inline auto& adj() { return vi_->adj_; }
+  inline auto& adj() noexcept { return vi_->adj_; }
 
   /**
    * Compute the gradient of this (dependent) variable with respect to
@@ -344,7 +344,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
    * @return <code>true</code> if this variable does not yet have
    * a defined variable.
    */
-  inline bool is_uninitialized() { return (vi_ == nullptr); }
+  inline bool is_uninitialized() noexcept { return (vi_ == nullptr); }
 
   /**
    * Construct a variable for later assignment.
@@ -404,8 +404,8 @@ class var_value<T, internal::require_matrix_var_value<T>> {
    *
    * @return The value of this variable.
    */
-  inline const auto& val() const { return vi_->val(); }
-  inline auto& val_op() { return vi_->val_op(); }
+  inline const auto& val() const noexcept { return vi_->val(); }
+  inline auto& val_op() noexcept { return vi_->val_op(); }
 
   /**
    * Return a reference to the derivative of the root expression with
@@ -415,13 +415,13 @@ class var_value<T, internal::require_matrix_var_value<T>> {
    *
    * @return Adjoint for this variable.
    */
-  inline auto& adj() { return vi_->adj(); }
-  inline auto& adj() const { return vi_->adj(); }
-  inline auto& adj_op() { return vi_->adj(); }
+  inline auto& adj() noexcept { return vi_->adj(); }
+  inline auto& adj() const noexcept { return vi_->adj(); }
+  inline auto& adj_op() noexcept { return vi_->adj(); }
 
-  inline Eigen::Index rows() const { return vi_->rows(); }
-  inline Eigen::Index cols() const { return vi_->cols(); }
-  inline Eigen::Index size() const { return vi_->size(); }
+  inline Eigen::Index rows() const noexcept { return vi_->rows(); }
+  inline Eigen::Index cols() const noexcept { return vi_->cols(); }
+  inline Eigen::Index size() const noexcept { return vi_->size(); }
 
   // POINTER OVERRIDES
 
@@ -948,6 +948,21 @@ class var_value<T, internal::require_matrix_var_value<T>> {
   }
 
   /**
+   * Return an Matrix.
+   */
+  inline auto matrix() const {
+    using vari_sub = decltype(vi_->matrix());
+    using var_sub = var_value<value_type_t<vari_sub>>;
+    return var_sub(new vari_sub(vi_->matrix()));
+  }
+  inline auto matrix() {
+    using vari_sub = decltype(vi_->matrix());
+    using var_sub = var_value<value_type_t<vari_sub>>;
+    return var_sub(new vari_sub(vi_->matrix()));
+  }
+
+
+  /**
    * Write the value of this autodiff variable and its adjoint to
    * the specified output stream.
    *
@@ -968,7 +983,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
    */
   template <typename U = T,
             require_any_t<is_eigen<U>, is_matrix_cl<U>>* = nullptr>
-  inline auto rows() const {
+  inline auto rows() const noexcept {
     return vi_->rows();
   }
 
@@ -978,7 +993,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
    */
   template <typename U = T,
             require_any_t<is_eigen<U>, is_matrix_cl<U>>* = nullptr>
-  inline auto cols() const {
+  inline auto cols() const noexcept {
     return vi_->cols();
   }
 
@@ -1035,7 +1050,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
     return *this;
   }
   template <typename T_ = T, require_plain_type_t<T_>* = nullptr>
-  inline const auto& eval() const {
+  inline const auto& eval() const noexcept {
     return *this;
   }
 
@@ -1043,7 +1058,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
    * For non-plain types evaluate to the plain type
    */
   template <typename T_ = T, require_not_plain_type_t<T_>* = nullptr>
-  inline auto eval() noexcept {
+  inline auto eval() {
     return var_value<plain_type_t<T>>(*this);
   }
   template <typename T_ = T, require_not_plain_type_t<T_>* = nullptr>

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -555,6 +555,20 @@ class vari_view_eigen {
   }
 
   /**
+   * Return a Matrix expression
+   */
+  inline auto matrix() const {
+    using inner_type = decltype(derived().val_.matrix());
+    return vari_view<inner_type>(derived().val_.matrix(),
+                                 derived().adj_.matrix());
+  }
+  inline auto matrix() {
+    using inner_type = decltype(derived().val_.matrix());
+    return vari_view<inner_type>(derived().val_.matrix(),
+                                 derived().adj_.matrix());
+  }
+
+  /**
    * Return the number of rows for this class's `val_` member
    */
   inline Eigen::Index rows() const { return derived().val_.rows(); }
@@ -597,8 +611,8 @@ class vari_view<
    *
    * @return The value of this vari.
    */
-  inline const auto& val() const { return val_; }
-  inline auto& val_op() { return val_; }
+  inline const auto& val() const noexcept { return val_; }
+  inline auto& val_op() noexcept { return val_; }
 
   /**
    * Return a reference to the derivative of the root expression with
@@ -608,9 +622,9 @@ class vari_view<
    *
    * @return Adjoint for this vari.
    */
-  inline auto& adj() { return adj_; }
-  inline auto& adj() const { return adj_; }
-  inline auto& adj_op() { return adj_; }
+  inline auto& adj() noexcept { return adj_; }
+  inline auto& adj() const noexcept { return adj_; }
+  inline auto& adj_op() noexcept { return adj_; }
 
   void set_zero_adjoint() {}
   void chain() {}
@@ -674,7 +688,14 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
    * @param x Value of the constructed variable.
    */
   template <typename S, require_assignable_t<T, S>* = nullptr>
-  explicit vari_value(const S& x) : val_(x), adj_(x.rows(), x.cols()) {
+  explicit vari_value(const S& x) : val_(x), adj_((RowsAtCompileTime == 1 && S::ColsAtCompileTime == 1)
+          || (ColsAtCompileTime == 1 && S::RowsAtCompileTime == 1)
+      ? x.cols()
+      : x.rows(),
+  (RowsAtCompileTime == 1 && S::ColsAtCompileTime == 1)
+          || (ColsAtCompileTime == 1 && S::RowsAtCompileTime == 1)
+      ? x.rows()
+      : x.cols()) {
     adj_.setZero();
     ChainableStack::instance_->var_stack_.push_back(this);
   }
@@ -695,7 +716,14 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
    * that its `chain()` method is not called.
    */
   template <typename S, require_assignable_t<T, S>* = nullptr>
-  vari_value(const S& x, bool stacked) : val_(x), adj_(x.rows(), x.cols()) {
+  vari_value(const S& x, bool stacked) : val_(x), adj_((RowsAtCompileTime == 1 && S::ColsAtCompileTime == 1)
+          || (ColsAtCompileTime == 1 && S::RowsAtCompileTime == 1)
+      ? x.cols()
+      : x.rows(),
+  (RowsAtCompileTime == 1 && S::ColsAtCompileTime == 1)
+          || (ColsAtCompileTime == 1 && S::RowsAtCompileTime == 1)
+      ? x.rows()
+      : x.cols()) {
     adj_.setZero();
     if (stacked) {
       ChainableStack::instance_->var_stack_.push_back(this);
@@ -709,8 +737,8 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
    *
    * @return The value of this vari.
    */
-  inline const auto& val() const { return val_; }
-  inline auto& val_op() { return val_; }
+  inline const auto& val() const noexcept { return val_; }
+  inline auto& val_op() noexcept { return val_; }
 
   /**
    * Return a reference to the derivative of the root expression with
@@ -720,9 +748,9 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
    *
    * @return Adjoint for this vari.
    */
-  inline auto& adj() { return adj_; }
-  inline auto& adj() const { return adj_; }
-  inline auto& adj_op() { return adj_; }
+  inline auto& adj() noexcept { return adj_; }
+  inline auto& adj() const noexcept { return adj_; }
+  inline auto& adj_op() noexcept { return adj_; }
 
   virtual void chain() {}
   /**

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -688,14 +688,16 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
    * @param x Value of the constructed variable.
    */
   template <typename S, require_assignable_t<T, S>* = nullptr>
-  explicit vari_value(const S& x) : val_(x), adj_((RowsAtCompileTime == 1 && S::ColsAtCompileTime == 1)
-          || (ColsAtCompileTime == 1 && S::RowsAtCompileTime == 1)
-      ? x.cols()
-      : x.rows(),
-  (RowsAtCompileTime == 1 && S::ColsAtCompileTime == 1)
-          || (ColsAtCompileTime == 1 && S::RowsAtCompileTime == 1)
-      ? x.rows()
-      : x.cols()) {
+  explicit vari_value(const S& x)
+      : val_(x),
+        adj_((RowsAtCompileTime == 1 && S::ColsAtCompileTime == 1)
+                     || (ColsAtCompileTime == 1 && S::RowsAtCompileTime == 1)
+                 ? x.cols()
+                 : x.rows(),
+             (RowsAtCompileTime == 1 && S::ColsAtCompileTime == 1)
+                     || (ColsAtCompileTime == 1 && S::RowsAtCompileTime == 1)
+                 ? x.rows()
+                 : x.cols()) {
     adj_.setZero();
     ChainableStack::instance_->var_stack_.push_back(this);
   }
@@ -716,14 +718,16 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
    * that its `chain()` method is not called.
    */
   template <typename S, require_assignable_t<T, S>* = nullptr>
-  vari_value(const S& x, bool stacked) : val_(x), adj_((RowsAtCompileTime == 1 && S::ColsAtCompileTime == 1)
-          || (ColsAtCompileTime == 1 && S::RowsAtCompileTime == 1)
-      ? x.cols()
-      : x.rows(),
-  (RowsAtCompileTime == 1 && S::ColsAtCompileTime == 1)
-          || (ColsAtCompileTime == 1 && S::RowsAtCompileTime == 1)
-      ? x.rows()
-      : x.cols()) {
+  vari_value(const S& x, bool stacked)
+      : val_(x),
+        adj_((RowsAtCompileTime == 1 && S::ColsAtCompileTime == 1)
+                     || (ColsAtCompileTime == 1 && S::RowsAtCompileTime == 1)
+                 ? x.cols()
+                 : x.rows(),
+             (RowsAtCompileTime == 1 && S::ColsAtCompileTime == 1)
+                     || (ColsAtCompileTime == 1 && S::RowsAtCompileTime == 1)
+                 ? x.rows()
+                 : x.cols()) {
     adj_.setZero();
     if (stacked) {
       ChainableStack::instance_->var_stack_.push_back(this);

--- a/stan/math/rev/fun/multiply.hpp
+++ b/stan/math/rev/fun/multiply.hpp
@@ -197,8 +197,10 @@ inline auto multiply(const T1& A, const T2& B) {
 /**
  * Operator overload for multiplying a `var_value<Matrix>`. At least one input
  *  must be a `var_value<Matrix>` type.
- * @tparam T1 Either a `var_value<Matrix>`, type inheriting from `Eigen::DenseMatrix`, or a scalar
- * @tparam T2 Either a `var_value<Matrix>`, type inheriting from `Eigen::DenseMatrix`, or a scalar
+ * @tparam T1 Either a `var_value<Matrix>`, type inheriting from
+ * `Eigen::DenseMatrix`, or a scalar
+ * @tparam T2 Either a `var_value<Matrix>`, type inheriting from
+ * `Eigen::DenseMatrix`, or a scalar
  * @param a The left hand side of the multiplication
  * @param b The right hand side of the multiplication
  */

--- a/stan/math/rev/fun/multiply.hpp
+++ b/stan/math/rev/fun/multiply.hpp
@@ -194,6 +194,19 @@ inline auto multiply(const T1& A, const T2& B) {
   return multiply(B, A);
 }
 
+/**
+ * Operator overload for multiplying a `var_value<Matrix>`. At least one input
+ *  must be a `var_value<Matrix>` type.
+ * @tparam T1 Either a `var_value<Matrix>`, type inheriting from `Eigen::DenseMatrix`, or a scalar
+ * @tparam T2 Either a `var_value<Matrix>`, type inheriting from `Eigen::DenseMatrix`, or a scalar
+ * @param a The left hand side of the multiplication
+ * @param b The right hand side of the multiplication
+ */
+template <typename T1, typename T2, require_any_var_matrix_t<T1, T2>* = nullptr>
+inline auto operator*(const T1& a, const T2& b) {
+  return multiply(a, b);
+}
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/test/unit/math/rev/core/var_test.cpp
+++ b/test/unit/math/rev/core/var_test.cpp
@@ -684,6 +684,11 @@ TEST_F(AgradRev, var_matrix_array) {
   Eigen::Array<double, -1, -1> B_v = A_v.array().val();
 }
 
+TEST_F(AgradRev, var_matrix_vector_rowvector_assign) {
+  Eigen::RowVectorXd A = Eigen::RowVectorXd(4);
+  stan::math::var_value<Eigen::VectorXd> A_v(A);
+}
+
 TEST_F(AgradRev, a_eq_x) {
   stan::math::var a = 5.0;
   EXPECT_FLOAT_EQ(5.0, a.val());

--- a/test/unit/math/rev/prob/bernoulli_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/bernoulli_logit_glm_lpmf_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev.hpp>
 #include <stan/math/prim.hpp>
+#include <test/unit/math/rev/util.hpp>
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>
@@ -59,13 +60,20 @@ TEST(ProbDistributionsBernoulliLogitGLM,
   }
 }
 
+template <class T>
+class ProbDistributionsBernoulliLogitGLM : public stan::math::test::VarMatrixTypedTests<T> {};
+
+TYPED_TEST_SUITE(ProbDistributionsBernoulliLogitGLM, stan::math::test::VarMatImpls);
+
+
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TEST(ProbDistributionsBernoulliLogitGLM, glm_matches_bernoulli_logit_vars) {
+TYPED_TEST(ProbDistributionsBernoulliLogitGLM, glm_matches_bernoulli_logit_vars) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+
   vector<int> y{1, 0, 1};
   Matrix<var, Dynamic, Dynamic> x(3, 2);
   x << -1234, 46, -42, 24, 25, 27;
@@ -92,11 +100,16 @@ TEST(ProbDistributionsBernoulliLogitGLM, glm_matches_bernoulli_logit_vars) {
 
   stan::math::recover_memory();
 
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   vector<int> y2{1, 0, 1};
-  Matrix<var, Dynamic, Dynamic> x2(3, 2);
-  x2 << -1234, 46, -42, 24, 25, 27;
-  Matrix<var, Dynamic, 1> beta2(2, 1);
-  beta2 << 0.3, 2000;
+  Matrix<double, Dynamic, Dynamic> x2_val(3, 2);
+  x2_val << -1234, 46, -42, 24, 25, 27;
+  matrix_v x2 = x2_val;
+  Matrix<double, Dynamic, 1> beta2_val(2, 1);
+  beta2_val << 0.3, 2000;
+  vector_v beta2 = beta2_val;
   var alpha2 = 0.3;
 
   var lp2 = stan::math::bernoulli_logit_glm_lpmf(y2, x2, alpha2, beta2);
@@ -105,27 +118,30 @@ TEST(ProbDistributionsBernoulliLogitGLM, glm_matches_bernoulli_logit_vars) {
   EXPECT_FLOAT_EQ(lp_val, lp2.val());
   EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
   for (size_t i = 0; i < 2; i++) {
-    EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+    EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
     for (size_t j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
+      EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
     }
   }
 }
 
-TEST(ProbDistributionsBernoulliLogitGLM, broadcast_x) {
+TYPED_TEST(ProbDistributionsBernoulliLogitGLM, broadcast_x) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   vector<int> y{1, 0, 1};
   Matrix<double, 1, Dynamic> x(1, 2);
   x << -12, 46;
-  Matrix<var, 1, Dynamic> x1 = x;
-  Matrix<var, Dynamic, Dynamic> x_mat = x.replicate(3, 1);
+  row_vector_v x1 = x;
+  matrix_v x_mat = x.replicate(3, 1);
   Matrix<double, Dynamic, 1> beta(2, 1);
   beta << 0.3, 2;
-  Matrix<var, Dynamic, 1> beta1 = beta;
-  Matrix<var, Dynamic, 1> beta2 = beta;
+  vector_v beta1 = beta;
+  vector_v beta2 = beta;
   var alpha1 = 0.3;
   var alpha2 = 0.3;
 
@@ -137,27 +153,30 @@ TEST(ProbDistributionsBernoulliLogitGLM, broadcast_x) {
   (lp1 + lp2).grad();
 
   for (int i = 0; i < 2; i++) {
-    EXPECT_DOUBLE_EQ(x1[i].adj(), x_mat.col(i).adj().sum());
-    EXPECT_DOUBLE_EQ(beta1[i].adj(), beta2[i].adj());
+    EXPECT_DOUBLE_EQ(x1.adj()[i], x_mat.col(i).adj().sum());
+    EXPECT_DOUBLE_EQ(beta1.adj()[i], beta2.adj()[i]);
   }
   EXPECT_DOUBLE_EQ(alpha1.adj(), alpha2.adj());
 }
 
-TEST(ProbDistributionsBernoulliLogitGLM, broadcast_y) {
+TYPED_TEST(ProbDistributionsBernoulliLogitGLM, broadcast_y) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   int y = 1;
   Matrix<int, Dynamic, 1> y_vec = Matrix<int, Dynamic, 1>::Constant(3, 1, y);
   Matrix<double, Dynamic, Dynamic> x(3, 2);
   x << -12, 46, -42, 24, 25, 27;
-  Matrix<var, Dynamic, Dynamic> x1 = x;
-  Matrix<var, Dynamic, Dynamic> x2 = x;
+  matrix_v x1 = x;
+  matrix_v x2 = x;
   Matrix<double, Dynamic, 1> beta(2, 1);
   beta << 0.3, 2;
-  Matrix<var, Dynamic, 1> beta1 = beta;
-  Matrix<var, Dynamic, 1> beta2 = beta;
+  vector_v beta1 = beta;
+  vector_v beta2 = beta;
   var alpha1 = 0.3;
   var alpha2 = 0.3;
 
@@ -170,19 +189,22 @@ TEST(ProbDistributionsBernoulliLogitGLM, broadcast_y) {
 
   for (int i = 0; i < 2; i++) {
     for (int j = 0; j < 2; j++) {
-      EXPECT_DOUBLE_EQ(x1(j, i).adj(), x2(j, i).adj());
+      EXPECT_DOUBLE_EQ(x1.adj()(j, i), x2.adj()(j, i));
     }
-    EXPECT_DOUBLE_EQ(beta1[i].adj(), beta2[i].adj());
+    EXPECT_DOUBLE_EQ(beta1.adj()[i], beta2.adj()[i]);
   }
   EXPECT_DOUBLE_EQ(alpha1.adj(), alpha2.adj());
 }
 
-TEST(ProbDistributionsBernoulliLogitGLM,
+TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
      glm_matches_bernoulli_logit_vars_zero_instances) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   vector<int> y{};
   Matrix<var, Dynamic, Dynamic> x(0, 2);
   Matrix<var, Dynamic, 1> beta(2, 1);
@@ -203,9 +225,11 @@ TEST(ProbDistributionsBernoulliLogitGLM,
   stan::math::recover_memory();
 
   vector<int> y2{};
-  Matrix<var, Dynamic, Dynamic> x2(0, 2);
-  Matrix<var, Dynamic, 1> beta2(2, 1);
-  beta2 << 0.3, 2000;
+  Matrix<double, Dynamic, Dynamic> x2_val(0, 2);
+  matrix_v x2 = x2_val;
+  Matrix<double, Dynamic, 1> beta2_val(2, 1);
+  beta2_val << 0.3, 2000;
+  vector_v beta2 = beta2_val;
   var alpha2 = 0.3;
 
   var lp2 = stan::math::bernoulli_logit_glm_lpmf(y2, x2, alpha2, beta2);
@@ -214,16 +238,20 @@ TEST(ProbDistributionsBernoulliLogitGLM,
   EXPECT_FLOAT_EQ(lp_val, lp2.val());
   EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
   for (size_t i = 0; i < 2; i++) {
-    EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+    EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
   }
 }
 
-TEST(ProbDistributionsBernoulliLogitGLM,
+TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
      glm_matches_bernoulli_logit_vars_zero_attributes) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   vector<int> y{1, 0, 1};
   Matrix<var, Dynamic, Dynamic> x(3, 0);
   Matrix<var, Dynamic, 1> beta(0, 1);
@@ -241,8 +269,10 @@ TEST(ProbDistributionsBernoulliLogitGLM,
   stan::math::recover_memory();
 
   vector<int> y2{1, 0, 1};
-  Matrix<var, Dynamic, Dynamic> x2(3, 0);
-  Matrix<var, Dynamic, 1> beta2(0, 1);
+  Matrix<double, Dynamic, Dynamic> x2_val(3, 0);
+  matrix_v x2 = x2_val;
+  Matrix<double, Dynamic, 1> beta2_val(0, 1);
+  vector_v beta2 = beta2_val;
   var alpha2 = 0.3;
 
   var lp2 = stan::math::bernoulli_logit_glm_lpmf(y2, x2, alpha2, beta2);
@@ -254,12 +284,15 @@ TEST(ProbDistributionsBernoulliLogitGLM,
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TEST(ProbDistributionsBernoulliLogitGLM,
+TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
      glm_matches_bernoulli_logit_vars_rand) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   for (size_t ii = 0; ii < 42; ii++) {
     vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
@@ -295,8 +328,8 @@ TEST(ProbDistributionsBernoulliLogitGLM,
 
     stan::math::recover_memory();
 
-    Matrix<var, Dynamic, 1> beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
+    vector_v beta2 = betareal;
+    matrix_v x2 = xreal;
     var alpha2 = alphareal[0];
 
     var lp2 = stan::math::bernoulli_logit_glm_lpmf(y, x2, alpha2, beta2);
@@ -305,9 +338,9 @@ TEST(ProbDistributionsBernoulliLogitGLM,
     EXPECT_FLOAT_EQ(lp_val, lp2.val());
     EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
     for (size_t i = 0; i < 2; i++) {
-      EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+      EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
       for (size_t j = 0; j < 3; j++) {
-        EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
+        EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
       }
     }
   }
@@ -315,12 +348,16 @@ TEST(ProbDistributionsBernoulliLogitGLM,
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, in case beta is a scalar.
-TEST(ProbDistributionsBernoulliLogitGLM,
+TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
      glm_matches_bernoulli_logit_vars_rand_scal_beta) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   for (size_t ii = 0; ii < 42; ii++) {
     vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
@@ -350,7 +387,7 @@ TEST(ProbDistributionsBernoulliLogitGLM,
     stan::math::recover_memory();
 
     var beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
+    matrix_v x2 = xreal;
     var alpha2 = alphareal[0];
     var lp2 = stan::math::bernoulli_logit_glm_lpmf(y, x2, alpha2, beta2);
     lp2.grad();
@@ -358,19 +395,23 @@ TEST(ProbDistributionsBernoulliLogitGLM,
     EXPECT_FLOAT_EQ(beta_adj, beta2.adj());
     EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
     for (size_t j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(x_adj(j, 0), x2(j, 0).adj());
+      EXPECT_FLOAT_EQ(x_adj(j, 0), x2.adj()(j, 0));
     }
   }
 }
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, for the GLM with varying intercept.
-TEST(ProbDistributionsBernoulliLogitGLM,
+TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
      glm_matches_bernoulli_varying_intercept) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   for (size_t ii = 0; ii < 42; ii++) {
     vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
@@ -408,33 +449,37 @@ TEST(ProbDistributionsBernoulliLogitGLM,
 
     stan::math::recover_memory();
 
-    Matrix<var, Dynamic, 1> beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
-    Matrix<var, Dynamic, 1> alpha2 = alphareal;
+    vector_v beta2 = betareal;
+    matrix_v x2 = xreal;
+    vector_v alpha2 = alphareal;
 
     var lp2 = stan::math::bernoulli_logit_glm_lpmf(y, x2, alpha2, beta2);
     lp2.grad();
 
     EXPECT_FLOAT_EQ(lp_val, lp2.val());
     for (size_t i = 0; i < 2; i++) {
-      EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+      EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
       for (size_t j = 0; j < 3; j++) {
-        EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
+        EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
       }
     }
     for (size_t j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(alpha_adj[j], alpha2[j].adj());
+      EXPECT_FLOAT_EQ(alpha_adj[j], alpha2.adj()[j]);
     }
   }
 }
 
 //  We check that we can instantiate all different interface types.
-TEST(ProbDistributionsBernoulliLogitGLM,
+TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
      glm_matches_bernoulli_logit_interface_types) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double value = 0;
   double value2 = 0;
 
@@ -458,15 +503,18 @@ TEST(ProbDistributionsBernoulliLogitGLM,
 
   var v = 1.0;
   std::vector<var> vv = {{1.0, 2.0}};
-  Eigen::Matrix<var, -1, 1> evv(2);
-  Eigen::Matrix<var, 1, -1> rvv(2);
-  Eigen::Matrix<var, -1, -1> m1v(1, 1);
-  m1v << 1.0;
-  Eigen::Matrix<var, -1, -1> mv(2, 2);
-  evv << 1.0, 2.0;
-  rvv << 1.0, 2.0;
-  mv << 1.0, 2.0, 3.0, 4.0;
-
+  Eigen::Matrix<double, -1, 1> evv_val(2);
+  evv_val << 1.0, 2.0;
+  vector_v evv = evv_val;
+  Eigen::Matrix<double, 1, -1> rvv_val(2);
+  rvv_val << 1.0, 2.0;
+  row_vector_v rvv = rvv_val;
+  Eigen::Matrix<double, -1, -1> m1v_val(1, 1);
+  m1v_val << 1.0;
+  matrix_v m1v = m1v_val;
+  Eigen::Matrix<double, -1, -1> mv_val(2, 2);
+  mv_val << 1.0, 2.0, 3.0, 4.0;
+  matrix_v mv = mv_val;
   value2 += stan::math::bernoulli_logit_glm_lpmf(i, m1v, v, v).val();
   value2 += stan::math::bernoulli_logit_glm_lpmf(vi, mv, vv, vv).val();
   value2 += stan::math::bernoulli_logit_glm_lpmf(vi, mv, evv, evv).val();
@@ -476,7 +524,7 @@ TEST(ProbDistributionsBernoulliLogitGLM,
 }
 
 //  We check that the right errors are thrown.
-TEST(ProbDistributionsBernoulliLogitGLM,
+TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
      glm_matches_bernoulli_logit_error_checking) {
   using Eigen::Dynamic;
   using Eigen::Matrix;

--- a/test/unit/math/rev/prob/bernoulli_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/bernoulli_logit_glm_lpmf_test.cpp
@@ -61,14 +61,16 @@ TEST(ProbDistributionsBernoulliLogitGLM,
 }
 
 template <class T>
-class ProbDistributionsBernoulliLogitGLM : public stan::math::test::VarMatrixTypedTests<T> {};
+class ProbDistributionsBernoulliLogitGLM
+    : public stan::math::test::VarMatrixTypedTests<T> {};
 
-TYPED_TEST_SUITE(ProbDistributionsBernoulliLogitGLM, stan::math::test::VarMatImpls);
-
+TYPED_TEST_SUITE(ProbDistributionsBernoulliLogitGLM,
+                 stan::math::test::VarMatImpls);
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TYPED_TEST(ProbDistributionsBernoulliLogitGLM, glm_matches_bernoulli_logit_vars) {
+TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
+           glm_matches_bernoulli_logit_vars) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -197,7 +199,7 @@ TYPED_TEST(ProbDistributionsBernoulliLogitGLM, broadcast_y) {
 }
 
 TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
-     glm_matches_bernoulli_logit_vars_zero_instances) {
+           glm_matches_bernoulli_logit_vars_zero_instances) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -243,7 +245,7 @@ TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
 }
 
 TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
-     glm_matches_bernoulli_logit_vars_zero_attributes) {
+           glm_matches_bernoulli_logit_vars_zero_attributes) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -285,7 +287,7 @@ TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
 TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
-     glm_matches_bernoulli_logit_vars_rand) {
+           glm_matches_bernoulli_logit_vars_rand) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -349,7 +351,7 @@ TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, in case beta is a scalar.
 TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
-     glm_matches_bernoulli_logit_vars_rand_scal_beta) {
+           glm_matches_bernoulli_logit_vars_rand_scal_beta) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -403,7 +405,7 @@ TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, for the GLM with varying intercept.
 TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
-     glm_matches_bernoulli_varying_intercept) {
+           glm_matches_bernoulli_varying_intercept) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -471,7 +473,7 @@ TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
 
 //  We check that we can instantiate all different interface types.
 TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
-     glm_matches_bernoulli_logit_interface_types) {
+           glm_matches_bernoulli_logit_interface_types) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -525,7 +527,7 @@ TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
 
 //  We check that the right errors are thrown.
 TYPED_TEST(ProbDistributionsBernoulliLogitGLM,
-     glm_matches_bernoulli_logit_error_checking) {
+           glm_matches_bernoulli_logit_error_checking) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;

--- a/test/unit/math/rev/prob/categorical_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/categorical_logit_glm_lpmf_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev.hpp>
 #include <stan/math/prim.hpp>
+#include <test/unit/math/rev/util.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <vector>
@@ -7,9 +8,9 @@
 template <bool propto, typename T_x, typename T_alpha, typename T_beta>
 stan::return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_simple_lpmf(
     const std::vector<int>& y,
-    const Eigen::Matrix<T_x, Eigen::Dynamic, Eigen::Dynamic>& x,
+    const T_x& x,
     const T_alpha& alpha,
-    const Eigen::Matrix<T_beta, Eigen::Dynamic, Eigen::Dynamic>& beta) {
+    const T_beta& beta) {
   using T_x_beta = stan::return_type_t<T_x, T_beta>;
   using T_return = stan::return_type_t<T_x, T_beta, T_alpha>;
 
@@ -18,11 +19,8 @@ stan::return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_simple_lpmf(
   const auto& alpha_row
       = stan::math::as_column_vector_or_scalar(alpha).transpose();
 
-  Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic> tmp
-      = (x.template cast<T_x_beta>() * beta.template cast<T_x_beta>())
-            .array()
-            .rowwise()
-        + alpha_row.array();
+  auto tmp
+      = stan::math::to_ref(stan::math::multiply(x, beta) + stan::math::rep_matrix<std::decay_t<decltype(alpha_row)>>(alpha_row, x.rows()));
 
   T_return lpmf = 0;
   // iterate overt instances
@@ -61,7 +59,12 @@ TEST(ProbDistributionsCategoricalLogitGLM,
               (categorical_logit_glm_lpmf<true>(y, x, alpha, beta)), eps);
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, glm_matches_categorical_logit_vars) {
+template <class T>
+class ProbDistributionsCategoricalLogitGLM : public stan::math::test::VarMatrixTypedTests<T> {};
+
+TYPED_TEST_SUITE(ProbDistributionsCategoricalLogitGLM, stan::math::test::VarMatImpls);
+
+TYPED_TEST(ProbDistributionsCategoricalLogitGLM, glm_matches_categorical_logit_vars) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -70,22 +73,26 @@ TEST(ProbDistributionsCategoricalLogitGLM, glm_matches_categorical_logit_vars) {
   using stan::math::categorical_logit_glm_lpmf;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   double eps = 1e-13;
   const size_t N_instances = 5;
   const size_t N_attributes = 2;
   const size_t N_classes = 3;
   vector<int> y{1, 3, 1, 2, 2};
-  Matrix<var, Dynamic, Dynamic> x1(N_instances, N_attributes),
-      x2(N_instances, N_attributes);
-  x1 << -12, 46, -42, 24, 25, 27, -14, -11, 5, 18;
-  x2 << -12, 46, -42, 24, 25, 27, -14, -11, 5, 18;
-  Matrix<var, Dynamic, Dynamic> beta1(N_attributes, N_classes),
-      beta2(N_attributes, N_classes);
-  beta1 << 0.3, 2, 0.4, -0.1, -1.3, 1;
-  beta2 << 0.3, 2, 0.4, -0.1, -1.3, 1;
-  Matrix<var, Dynamic, 1> alpha1(N_classes), alpha2(N_classes);
-  alpha1 << 0.5, -2, 4;
-  alpha2 << 0.5, -2, 4;
+  Matrix<double, Dynamic, Dynamic> x1_val(N_instances, N_attributes);
+  x1_val << -12, 46, -42, 24, 25, 27, -14, -11, 5, 18;
+  matrix_v x1 = x1_val;
+  matrix_v x2 = x1.val();
+  Matrix<double, Dynamic, Dynamic> beta1_val(N_attributes, N_classes);
+  beta1_val << 0.3, 2, 0.4, -0.1, -1.3, 1;
+  matrix_v beta1 = beta1_val;
+  matrix_v beta2 = beta1.val();
+  Matrix<double, Dynamic, 1> alpha1_val(N_classes);
+  alpha1_val << 0.5, -2, 4;
+  vector_v alpha1 = alpha1_val;
+  vector_v alpha2 = alpha1.val();
 
   var res1 = categorical_logit_glm_simple_lpmf<false>(y, x1, alpha1, beta1);
   var res2 = categorical_logit_glm_lpmf(y, x2, alpha2, beta2);
@@ -93,14 +100,14 @@ TEST(ProbDistributionsCategoricalLogitGLM, glm_matches_categorical_logit_vars) {
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < N_attributes; i++) {
     for (int j = 0; j < N_instances; j++) {
-      EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+      EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
     }
     for (int j = 0; j < N_classes; j++) {
-      EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+      EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
     }
   }
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 
   stan::math::set_zero_all_adjoints();
@@ -111,18 +118,18 @@ TEST(ProbDistributionsCategoricalLogitGLM, glm_matches_categorical_logit_vars) {
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < N_attributes; i++) {
     for (int j = 0; j < N_instances; j++) {
-      EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+      EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
     }
     for (int j = 0; j < N_classes; j++) {
-      EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+      EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
     }
   }
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, single_instance) {
+TYPED_TEST(ProbDistributionsCategoricalLogitGLM, single_instance) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -131,37 +138,41 @@ TEST(ProbDistributionsCategoricalLogitGLM, single_instance) {
   using stan::math::categorical_logit_glm_lpmf;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double eps = 1e-13;
   const size_t N_instances = 1;
   const size_t N_attributes = 2;
   const size_t N_classes = 3;
   vector<int> y{1};
-  Matrix<var, Dynamic, Dynamic> x1(N_instances, N_attributes),
-      x2(N_instances, N_attributes);
-  x1 << -12, 46;
-  x2 << -12, 46;
-  Matrix<var, Dynamic, Dynamic> beta1(N_attributes, N_classes),
-      beta2(N_attributes, N_classes);
-  beta1 << 0.3, 2, 0.4, -0.1, -1.3, 1;
-  beta2 << 0.3, 2, 0.4, -0.1, -1.3, 1;
-  Matrix<var, Dynamic, 1> alpha1(N_classes), alpha2(N_classes);
-  alpha1 << 0.5, -2, 4;
-  alpha2 << 0.5, -2, 4;
-
+  Matrix<double, Dynamic, Dynamic> x1_val(N_instances, N_attributes);
+  x1_val << -12, 46;
+  matrix_v x1 = x1_val;
+  matrix_v x2 = x1.val();
+  Matrix<double, Dynamic, Dynamic> beta1_val(N_attributes, N_classes);
+  beta1_val << 0.3, 2, 0.4, -0.1, -1.3, 1;
+  matrix_v beta1 = beta1_val;
+  matrix_v beta2 = beta1_val;
+  Matrix<double, Dynamic, 1> alpha1_val(N_classes);
+  alpha1_val << 0.5, -2, 4;
+  vector_v alpha1 = alpha1_val;
+  vector_v alpha2 = alpha1.val();
   var res1 = categorical_logit_glm_simple_lpmf<false>(y, x1, alpha1, beta1);
   var res2 = categorical_logit_glm_lpmf(y, x2, alpha2, beta2);
   (res1 + res2).grad();
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < N_attributes; i++) {
     for (int j = 0; j < N_instances; j++) {
-      EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+      EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
     }
     for (int j = 0; j < N_classes; j++) {
-      EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+      EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
     }
   }
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 
   stan::math::set_zero_all_adjoints();
@@ -172,18 +183,18 @@ TEST(ProbDistributionsCategoricalLogitGLM, single_instance) {
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < N_attributes; i++) {
     for (int j = 0; j < N_instances; j++) {
-      EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+      EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
     }
     for (int j = 0; j < N_classes; j++) {
-      EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+      EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
     }
   }
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, zero_instances) {
+TYPED_TEST(ProbDistributionsCategoricalLogitGLM, zero_instances) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -192,20 +203,24 @@ TEST(ProbDistributionsCategoricalLogitGLM, zero_instances) {
   using stan::math::categorical_logit_glm_lpmf;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   double eps = 1e-13;
   const size_t N_instances = 0;
   const size_t N_attributes = 2;
   const size_t N_classes = 3;
   std::vector<int> y{};
-  Matrix<var, Dynamic, Dynamic> x1(N_instances, N_attributes),
-      x2(N_instances, N_attributes);
-  Matrix<var, Dynamic, Dynamic> beta1(N_attributes, N_classes),
-      beta2(N_attributes, N_classes);
-  beta1 << 0.3, 2, 0.4, -0.1, -1.3, 1;
-  beta2 << 0.3, 2, 0.4, -0.1, -1.3, 1;
-  Matrix<var, Dynamic, 1> alpha1(N_classes), alpha2(N_classes);
-  alpha1 << 0.5, -2, 4;
-  alpha2 << 0.5, -2, 4;
+  matrix_v x1 = Matrix<double, Dynamic, Dynamic>(N_instances, N_attributes);
+  matrix_v x2 = x1.val();
+  Matrix<double, Dynamic, Dynamic> beta1_val(N_attributes, N_classes);
+  beta1_val << 0.3, 2, 0.4, -0.1, -1.3, 1;
+  matrix_v beta1 = beta1_val;
+  matrix_v beta2 = beta1_val;
+  Matrix<double, Dynamic, 1> alpha1_val(N_classes);
+  alpha1_val << 0.5, -2, 4;
+  vector_v alpha1 = alpha1_val;
+  vector_v alpha2 = alpha1.val();
 
   var res1 = categorical_logit_glm_simple_lpmf<false>(y, x1, alpha1, beta1);
   var res2 = categorical_logit_glm_lpmf(y, x2, alpha2, beta2);
@@ -213,11 +228,11 @@ TEST(ProbDistributionsCategoricalLogitGLM, zero_instances) {
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < N_attributes; i++) {
     for (int j = 0; j < N_classes; j++) {
-      EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+      EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
     }
   }
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 
   stan::math::set_zero_all_adjoints();
@@ -228,15 +243,15 @@ TEST(ProbDistributionsCategoricalLogitGLM, zero_instances) {
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < N_attributes; i++) {
     for (int j = 0; j < N_classes; j++) {
-      EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+      EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
     }
   }
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, single_class) {
+TYPED_TEST(ProbDistributionsCategoricalLogitGLM, single_class) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -245,22 +260,26 @@ TEST(ProbDistributionsCategoricalLogitGLM, single_class) {
   using stan::math::categorical_logit_glm_lpmf;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   double eps = 1e-13;
   const size_t N_instances = 5;
   const size_t N_attributes = 2;
   const size_t N_classes = 1;
   vector<int> y{1, 1, 1, 1, 1};
-  Matrix<var, Dynamic, Dynamic> x1(N_instances, N_attributes),
-      x2(N_instances, N_attributes);
-  x1 << -12, 46, -42, 24, 25, 27, -14, -11, 5, 18;
-  x2 << -12, 46, -42, 24, 25, 27, -14, -11, 5, 18;
-  Matrix<var, Dynamic, Dynamic> beta1(N_attributes, N_classes),
-      beta2(N_attributes, N_classes);
-  beta1 << 0.3, 2;
-  beta2 << 0.3, 2;
-  Matrix<var, Dynamic, 1> alpha1(N_classes), alpha2(N_classes);
-  alpha1 << 0.5;
-  alpha2 << 0.5;
+  Matrix<double, Dynamic, Dynamic> x1_val(N_instances, N_attributes);
+  x1_val << -12, 46, -42, 24, 25, 27, -14, -11, 5, 18;
+  matrix_v x1 = x1_val;
+  matrix_v x2 = x1.val();
+  Matrix<double, Dynamic, Dynamic> beta1_val(N_attributes, N_classes);
+  beta1_val << 0.3, 2;
+  matrix_v beta1 = beta1_val;
+  matrix_v beta2 = beta1_val;
+  Matrix<double, Dynamic, 1> alpha1_val(N_classes);
+  alpha1_val << 0.5;
+  vector_v alpha1 = alpha1_val;
+  vector_v alpha2 = alpha1.val();
 
   var res1 = categorical_logit_glm_simple_lpmf<false>(y, x1, alpha1, beta1);
   var res2 = categorical_logit_glm_lpmf(y, x2, alpha2, beta2);
@@ -268,14 +287,14 @@ TEST(ProbDistributionsCategoricalLogitGLM, single_class) {
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < N_attributes; i++) {
     for (int j = 0; j < N_instances; j++) {
-      EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+      EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
     }
     for (int j = 0; j < N_classes; j++) {
-      EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+      EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
     }
   }
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 
   stan::math::set_zero_all_adjoints();
@@ -286,18 +305,18 @@ TEST(ProbDistributionsCategoricalLogitGLM, single_class) {
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < N_attributes; i++) {
     for (int j = 0; j < N_instances; j++) {
-      EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+      EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
     }
     for (int j = 0; j < N_classes; j++) {
-      EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+      EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
     }
   }
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, zero_attributes) {
+TYPED_TEST(ProbDistributionsCategoricalLogitGLM, zero_attributes) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -306,37 +325,45 @@ TEST(ProbDistributionsCategoricalLogitGLM, zero_attributes) {
   using stan::math::categorical_logit_glm_lpmf;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   double eps = 1e-13;
   const size_t N_instances = 5;
   const size_t N_attributes = 0;
   const size_t N_classes = 3;
   vector<int> y{1, 3, 1, 2, 2};
-  Matrix<var, Dynamic, Dynamic> x(N_instances, N_attributes);
-  Matrix<var, Dynamic, Dynamic> beta(N_attributes, N_classes);
-  Matrix<var, Dynamic, 1> alpha1(N_classes), alpha2(N_classes);
-  alpha1 << 0.5, -2, 4;
-  alpha2 << 0.5, -2, 4;
+  Matrix<double, Dynamic, Dynamic> x_val(N_instances, N_attributes);
+  matrix_v x1 = x_val;
+  matrix_v x2 = x_val;
+  Matrix<double, Dynamic, Dynamic> beta_val(N_attributes, N_classes);
+  matrix_v beta1 = beta_val;
+  matrix_v beta2 = beta_val;
+  Matrix<double, Dynamic, 1> alpha1_val(N_classes);
+  alpha1_val << 0.5, -2, 4;
+  vector_v alpha1 = alpha1_val;
+  vector_v alpha2 = alpha1.val();
 
-  var res1 = categorical_logit_glm_simple_lpmf<false>(y, x, alpha1, beta);
-  var res2 = categorical_logit_glm_lpmf(y, x, alpha2, beta);
+  var res1 = categorical_logit_glm_simple_lpmf<false>(y, x1, alpha1, beta1);
+  var res2 = categorical_logit_glm_lpmf(y, x2, alpha2, beta2);
   (res1 + res2).grad();
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 
   stan::math::set_zero_all_adjoints();
 
-  res1 = categorical_logit_glm_simple_lpmf<true>(y, x, alpha1, beta);
-  res2 = categorical_logit_glm_lpmf<true>(y, x, alpha2, beta);
+  res1 = categorical_logit_glm_simple_lpmf<true>(y, x1, alpha1, beta1);
+  res2 = categorical_logit_glm_lpmf<true>(y, x2, alpha2, beta2);
   (res1 + res2).grad();
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, x_broadcasting) {
+TYPED_TEST(ProbDistributionsCategoricalLogitGLM, x_broadcasting) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -345,6 +372,9 @@ TEST(ProbDistributionsCategoricalLogitGLM, x_broadcasting) {
   using stan::math::categorical_logit_glm_lpmf;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   double eps = 1e-13;
   const size_t N_instances = 5;
   const size_t N_attributes = 2;
@@ -352,16 +382,16 @@ TEST(ProbDistributionsCategoricalLogitGLM, x_broadcasting) {
   vector<int> y{1, 3, 1, 2, 2};
   Matrix<double, 1, Dynamic> x_double(N_attributes);
   x_double << -12, 46;
-  Matrix<var, 1, Dynamic> x_row = x_double;
-  Matrix<var, Dynamic, Dynamic> x = x_double.replicate(N_instances, 1);
-  Matrix<var, Dynamic, Dynamic> beta1(N_attributes, N_classes),
-      beta2(N_attributes, N_classes);
-  beta1 << 0.3, 2, 0.4, -0.1, -1.3, 1;
-  beta2 << 0.3, 2, 0.4, -0.1, -1.3, 1;
-  Matrix<var, Dynamic, 1> alpha1(N_classes), alpha2(N_classes);
-  alpha1 << 0.5, -2, 4;
-  alpha2 << 0.5, -2, 4;
-
+  row_vector_v x_row = x_double;
+  matrix_v x = x_double.replicate(N_instances, 1);
+  Matrix<double, Dynamic, Dynamic> beta_val(N_attributes, N_classes);
+  beta_val << 0.3, 2, 0.4, -0.1, -1.3, 1;
+  matrix_v beta1 = beta_val;
+  matrix_v beta2 = beta_val;
+  Matrix<double, Dynamic, 1> alpha_val(N_classes);
+  alpha_val << 0.5, -2, 4;
+  vector_v alpha1 = alpha_val;
+  vector_v alpha2 = alpha_val;
   var res1 = categorical_logit_glm_lpmf(y, x_row, alpha1, beta1);
   var res2 = categorical_logit_glm_lpmf(y, x, alpha2, beta2);
   (res1 + res2).grad();
@@ -369,15 +399,15 @@ TEST(ProbDistributionsCategoricalLogitGLM, x_broadcasting) {
   for (int i = 0; i < N_attributes; i++) {
     double x_sum = 0;
     for (int j = 0; j < N_instances; j++) {
-      x_sum += x(j, i).adj();
+      x_sum += x.adj()(j, i);
     }
-    EXPECT_NEAR(x_row[i].adj(), x_sum, eps);
+    EXPECT_NEAR(x_row.adj()[i], x_sum, eps);
     for (int j = 0; j < N_classes; j++) {
-      EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+      EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
     }
   }
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 
   stan::math::set_zero_all_adjoints();
@@ -389,19 +419,19 @@ TEST(ProbDistributionsCategoricalLogitGLM, x_broadcasting) {
   for (int i = 0; i < N_attributes; i++) {
     double x_sum = 0;
     for (int j = 0; j < N_instances; j++) {
-      x_sum += x(j, i).adj();
+      x_sum += x.adj()(j, i);
     }
-    EXPECT_NEAR(x_row[i].adj(), x_sum, eps);
+    EXPECT_NEAR(x_row.adj()[i], x_sum, eps);
     for (int j = 0; j < N_classes; j++) {
-      EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+      EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
     }
   }
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, y_broadcasting) {
+TYPED_TEST(ProbDistributionsCategoricalLogitGLM, y_broadcasting) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -410,22 +440,25 @@ TEST(ProbDistributionsCategoricalLogitGLM, y_broadcasting) {
   using stan::math::categorical_logit_glm_lpmf;
   using stan::math::var;
   using std::vector;
+using matrix_v = typename TypeParam::matrix_v;
+using vector_v = typename TypeParam::vector_v;
+using row_vector_v = typename TypeParam::row_vector_v;
   double eps = 1e-13;
   const size_t N_instances = 5;
   const size_t N_attributes = 2;
   const size_t N_classes = 3;
-  Matrix<var, Dynamic, Dynamic> x1(N_instances, N_attributes),
-      x2(N_instances, N_attributes);
-  x1 << -12, 46, -42, 24, 25, 27, -14, -11, 5, 18;
-  x2 << -12, 46, -42, 24, 25, 27, -14, -11, 5, 18;
-  Matrix<var, Dynamic, Dynamic> beta1(N_attributes, N_classes),
-      beta2(N_attributes, N_classes);
-  beta1 << 0.3, 2, 0.4, -0.1, -1.3, 1;
-  beta2 << 0.3, 2, 0.4, -0.1, -1.3, 1;
-  Matrix<var, Dynamic, 1> alpha1(N_classes), alpha2(N_classes);
-  alpha1 << 0.5, -2, 4;
-  alpha2 << 0.5, -2, 4;
-
+  Matrix<double, Dynamic, Dynamic> x_val(N_instances, N_attributes);
+  x_val << -12, 46, -42, 24, 25, 27, -14, -11, 5, 18;
+  matrix_v x1 = x_val;
+  matrix_v x2 = x_val;
+  Matrix<double, Dynamic, Dynamic> beta_val(N_attributes, N_classes);
+  beta_val << 0.3, 2, 0.4, -0.1, -1.3, 1;
+  matrix_v beta1 = beta_val;
+  matrix_v beta2 = beta_val;
+  Matrix<double, Dynamic, 1> alpha_val(N_classes);
+  alpha_val << 0.5, -2, 4;
+  vector_v alpha1 = alpha_val;
+  vector_v alpha2 = alpha_val;
   for (int y_scal = 1; y_scal <= N_classes; y_scal++) {
     vector<int> y(N_instances, y_scal);
     var res1 = categorical_logit_glm_lpmf(y_scal, x1, alpha1, beta1);
@@ -434,37 +467,35 @@ TEST(ProbDistributionsCategoricalLogitGLM, y_broadcasting) {
     EXPECT_NEAR(res1.val(), res2.val(), eps);
     for (int i = 0; i < N_attributes; i++) {
       for (int j = 0; j < N_instances; j++) {
-        EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+        EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
       }
       for (int j = 0; j < N_classes; j++) {
-        EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+        EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
       }
     }
     for (int i = 0; i < N_classes; i++) {
-      EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+      EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
     }
-
     stan::math::set_zero_all_adjoints();
-
     res1 = categorical_logit_glm_lpmf<true>(y_scal, x1, alpha1, beta1);
     res2 = categorical_logit_glm_lpmf<true>(y, x2, alpha2, beta2);
     (res1 + res2).grad();
     EXPECT_NEAR(res1.val(), res2.val(), eps);
     for (int i = 0; i < N_attributes; i++) {
       for (int j = 0; j < N_instances; j++) {
-        EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+        EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
       }
       for (int j = 0; j < N_classes; j++) {
-        EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+        EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
       }
     }
     for (int i = 0; i < N_classes; i++) {
-      EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+      EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
     }
   }
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM,
+TYPED_TEST(ProbDistributionsCategoricalLogitGLM,
      glm_matches_categorical_logit_vars_big) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -474,6 +505,9 @@ TEST(ProbDistributionsCategoricalLogitGLM,
   using stan::math::categorical_logit_glm_lpmf;
   using stan::math::var;
   using std::vector;
+using matrix_v = typename TypeParam::matrix_v;
+using vector_v = typename TypeParam::vector_v;
+using row_vector_v = typename TypeParam::row_vector_v;
   double eps = 1e-11;
   const size_t N_instances = 89;
   const size_t N_attributes = 23;
@@ -483,11 +517,14 @@ TEST(ProbDistributionsCategoricalLogitGLM,
     y[i] = Matrix<int, Dynamic, 1>::Random(1)[0] % N_classes + 1;
   }
   MatrixXd x_double = MatrixXd::Random(N_instances, N_attributes);
-  Matrix<var, Dynamic, Dynamic> x1 = x_double, x2 = x_double;
+  matrix_v x1 = x_double;
+  matrix_v x2 = x_double;
   MatrixXd beta_double = MatrixXd::Random(N_attributes, N_classes);
-  Matrix<var, Dynamic, Dynamic> beta1 = beta_double, beta2 = beta_double;
+  matrix_v beta1 = beta_double;
+  matrix_v beta2 = beta_double;
   RowVectorXd alpha_double = RowVectorXd::Random(N_classes);
-  Matrix<var, Dynamic, 1> alpha1 = alpha_double, alpha2 = alpha_double;
+  vector_v alpha1 = alpha_double.transpose();
+  vector_v alpha2 = alpha_double.transpose();
 
   var res1 = categorical_logit_glm_simple_lpmf<false>(y, x1, alpha1, beta1);
   var res2 = categorical_logit_glm_lpmf(y, x2, alpha2, beta2);
@@ -495,14 +532,14 @@ TEST(ProbDistributionsCategoricalLogitGLM,
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < N_attributes; i++) {
     for (int j = 0; j < N_instances; j++) {
-      EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+      EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
     }
     for (int j = 0; j < N_classes; j++) {
-      EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+      EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
     }
   }
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 
   stan::math::set_zero_all_adjoints();
@@ -513,18 +550,18 @@ TEST(ProbDistributionsCategoricalLogitGLM,
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < N_attributes; i++) {
     for (int j = 0; j < N_instances; j++) {
-      EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+      EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
     }
     for (int j = 0; j < N_classes; j++) {
-      EXPECT_NEAR(beta1(i, j).adj(), beta2(i, j).adj(), eps);
+      EXPECT_NEAR(beta1.adj()(i, j), beta2.adj()(i, j), eps);
     }
   }
   for (int i = 0; i < N_classes; i++) {
-    EXPECT_NEAR(alpha1[i].adj(), alpha2[i].adj(), eps);
+    EXPECT_NEAR(alpha1.adj()[i], alpha2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, glm_interfaces) {
+TYPED_TEST(ProbDistributionsCategoricalLogitGLM, glm_interfaces) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -533,6 +570,9 @@ TEST(ProbDistributionsCategoricalLogitGLM, glm_interfaces) {
   using stan::math::categorical_logit_glm_lpmf;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   const size_t N_instances = 5;
   const size_t N_attributes = 2;
   const size_t N_classes = 3;
@@ -546,10 +586,10 @@ TEST(ProbDistributionsCategoricalLogitGLM, glm_interfaces) {
   alpha_double << 0.5, -2, 4;
 
   RowVectorXd x_double_row = x_double.row(0);
-  Matrix<var, Dynamic, Dynamic> x_var = x_double;
-  Matrix<var, 1, Dynamic> x_var_row = x_double_row;
-  Matrix<var, Dynamic, Dynamic> beta_var = beta_double;
-  Matrix<var, Dynamic, 1> alpha_var = alpha_double;
+  matrix_v x_var = x_double;
+  row_vector_v x_var_row = x_double_row;
+  matrix_v beta_var = beta_double;
+  vector_v alpha_var = alpha_double;
 
   EXPECT_NO_THROW(
       categorical_logit_glm_lpmf(y, x_double, alpha_double, beta_double));

--- a/test/unit/math/rev/prob/categorical_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/categorical_logit_glm_lpmf_test.cpp
@@ -7,9 +7,7 @@
 
 template <bool propto, typename T_x, typename T_alpha, typename T_beta>
 stan::return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_simple_lpmf(
-    const std::vector<int>& y,
-    const T_x& x,
-    const T_alpha& alpha,
+    const std::vector<int>& y, const T_x& x, const T_alpha& alpha,
     const T_beta& beta) {
   using T_x_beta = stan::return_type_t<T_x, T_beta>;
   using T_return = stan::return_type_t<T_x, T_beta, T_alpha>;
@@ -19,8 +17,10 @@ stan::return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_simple_lpmf(
   const auto& alpha_row
       = stan::math::as_column_vector_or_scalar(alpha).transpose();
 
-  auto tmp
-      = stan::math::to_ref(stan::math::multiply(x, beta) + stan::math::rep_matrix<std::decay_t<decltype(alpha_row)>>(alpha_row, x.rows()));
+  auto tmp = stan::math::to_ref(
+      stan::math::multiply(x, beta)
+      + stan::math::rep_matrix<std::decay_t<decltype(alpha_row)>>(alpha_row,
+                                                                  x.rows()));
 
   T_return lpmf = 0;
   // iterate overt instances
@@ -60,11 +60,14 @@ TEST(ProbDistributionsCategoricalLogitGLM,
 }
 
 template <class T>
-class ProbDistributionsCategoricalLogitGLM : public stan::math::test::VarMatrixTypedTests<T> {};
+class ProbDistributionsCategoricalLogitGLM
+    : public stan::math::test::VarMatrixTypedTests<T> {};
 
-TYPED_TEST_SUITE(ProbDistributionsCategoricalLogitGLM, stan::math::test::VarMatImpls);
+TYPED_TEST_SUITE(ProbDistributionsCategoricalLogitGLM,
+                 stan::math::test::VarMatImpls);
 
-TYPED_TEST(ProbDistributionsCategoricalLogitGLM, glm_matches_categorical_logit_vars) {
+TYPED_TEST(ProbDistributionsCategoricalLogitGLM,
+           glm_matches_categorical_logit_vars) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -440,9 +443,9 @@ TYPED_TEST(ProbDistributionsCategoricalLogitGLM, y_broadcasting) {
   using stan::math::categorical_logit_glm_lpmf;
   using stan::math::var;
   using std::vector;
-using matrix_v = typename TypeParam::matrix_v;
-using vector_v = typename TypeParam::vector_v;
-using row_vector_v = typename TypeParam::row_vector_v;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   double eps = 1e-13;
   const size_t N_instances = 5;
   const size_t N_attributes = 2;
@@ -496,7 +499,7 @@ using row_vector_v = typename TypeParam::row_vector_v;
 }
 
 TYPED_TEST(ProbDistributionsCategoricalLogitGLM,
-     glm_matches_categorical_logit_vars_big) {
+           glm_matches_categorical_logit_vars_big) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -505,9 +508,9 @@ TYPED_TEST(ProbDistributionsCategoricalLogitGLM,
   using stan::math::categorical_logit_glm_lpmf;
   using stan::math::var;
   using std::vector;
-using matrix_v = typename TypeParam::matrix_v;
-using vector_v = typename TypeParam::vector_v;
-using row_vector_v = typename TypeParam::row_vector_v;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   double eps = 1e-11;
   const size_t N_instances = 89;
   const size_t N_attributes = 23;

--- a/test/unit/math/rev/prob/neg_binomial_2_log_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/neg_binomial_2_log_glm_lpmf_test.cpp
@@ -63,13 +63,16 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
 }
 
 template <class T>
-class ProbDistributionsNegBinomial2LogGLM : public stan::math::test::VarMatrixTypedTests<T> {};
+class ProbDistributionsNegBinomial2LogGLM
+    : public stan::math::test::VarMatrixTypedTests<T> {};
 // For testing var_value<Matrix> and Matrix<var>
-TYPED_TEST_SUITE(ProbDistributionsNegBinomial2LogGLM, stan::math::test::VarMatImpls);
+TYPED_TEST_SUITE(ProbDistributionsNegBinomial2LogGLM,
+                 stan::math::test::VarMatImpls);
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TYPED_TEST(ProbDistributionsNegBinomial2LogGLM, glm_matches_neg_binomial_2_log_vars) {
+TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
+           glm_matches_neg_binomial_2_log_vars) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -210,7 +213,7 @@ TYPED_TEST(ProbDistributionsNegBinomial2LogGLM, broadcast_y) {
 }
 
 TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
-     glm_matches_neg_binomial_2_log_vars_zero_instances) {
+           glm_matches_neg_binomial_2_log_vars_zero_instances) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -257,7 +260,7 @@ TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
 }
 
 TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
-     glm_matches_neg_binomial_2_log_vars_zero_attributes) {
+           glm_matches_neg_binomial_2_log_vars_zero_attributes) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -299,7 +302,7 @@ TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
 TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
-     glm_matches_neg_binomial_2_log_vars_rand) {
+           glm_matches_neg_binomial_2_log_vars_rand) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -366,7 +369,7 @@ TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, in case beta is a scalar.
 TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
-     glm_matches_neg_binomial_2_log_vars_rand_scal_beta) {
+           glm_matches_neg_binomial_2_log_vars_rand_scal_beta) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -426,7 +429,7 @@ TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
 TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
-     glm_matches_neg_binomial_2_log_varying_intercept) {
+           glm_matches_neg_binomial_2_log_varying_intercept) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -498,7 +501,7 @@ TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
 
 //  We check that we can instantiate all different interface types.
 TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
-     glm_matches_neg_binomial_2_log_interface_types) {
+           glm_matches_neg_binomial_2_log_interface_types) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;

--- a/test/unit/math/rev/prob/neg_binomial_2_log_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/neg_binomial_2_log_glm_lpmf_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev.hpp>
 #include <stan/math/prim.hpp>
+#include <test/unit/math/rev/util.hpp>
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>
@@ -60,18 +61,30 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
                                                                    beta, phi)));
   }
 }
+
+template <class T>
+class ProbDistributionsNegBinomial2LogGLM : public stan::math::test::VarMatrixTypedTests<T> {};
+// For testing var_value<Matrix> and Matrix<var>
+TYPED_TEST_SUITE(ProbDistributionsNegBinomial2LogGLM, stan::math::test::VarMatImpls);
+
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TEST(ProbDistributionsNegBinomial2LogGLM, glm_matches_neg_binomial_2_log_vars) {
+TYPED_TEST(ProbDistributionsNegBinomial2LogGLM, glm_matches_neg_binomial_2_log_vars) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   vector<int> y{1, 0, 1};
-  Matrix<var, Dynamic, Dynamic> x(3, 2);
-  x << -12, 46, -42, 24, 25, 27;
-  Matrix<var, Dynamic, 1> beta(2, 1);
-  beta << 0.3, 2;
+  Matrix<double, Dynamic, Dynamic> x_val(3, 2);
+  x_val << -12, 46, -42, 24, 25, 27;
+  Matrix<var, Dynamic, Dynamic> x = x_val;
+  Matrix<double, Dynamic, 1> beta_val(2, 1);
+  beta_val << 0.3, 2;
+  Matrix<var, Dynamic, 1> beta = beta_val;
   var alpha = 0.3;
   Matrix<var, Dynamic, 1> alphavec = alpha * Matrix<double, 3, 1>::Ones();
   Matrix<var, Dynamic, 1> theta(3, 1);
@@ -95,10 +108,8 @@ TEST(ProbDistributionsNegBinomial2LogGLM, glm_matches_neg_binomial_2_log_vars) {
   stan::math::recover_memory();
 
   vector<int> y2{1, 0, 1};
-  Matrix<var, Dynamic, Dynamic> x2(3, 2);
-  x2 << -12, 46, -42, 24, 25, 27;
-  Matrix<var, Dynamic, 1> beta2(2, 1);
-  beta2 << 0.3, 2;
+  matrix_v x2 = x_val;
+  vector_v beta2 = beta_val;
   var alpha2 = 0.3;
   var phi2 = 2;
   var lp2
@@ -106,31 +117,35 @@ TEST(ProbDistributionsNegBinomial2LogGLM, glm_matches_neg_binomial_2_log_vars) {
   lp2.grad();
   EXPECT_FLOAT_EQ(lp_val, lp2.val());
   for (size_t i = 0; i < 2; i++) {
-    EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+    EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
   }
   EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
   EXPECT_FLOAT_EQ(phi_adj, phi2.adj());
   for (size_t j = 0; j < 3; j++) {
     for (size_t i = 0; i < 2; i++) {
-      EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
+      EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
     }
   }
 }
 
-TEST(ProbDistributionsNegBinomial2LogGLM, broadcast_x) {
+TYPED_TEST(ProbDistributionsNegBinomial2LogGLM, broadcast_x) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   vector<int> y{1, 0, 5};
   Matrix<double, 1, Dynamic> x(1, 2);
   x << -12, 46;
-  Matrix<var, 1, Dynamic> x1 = x;
-  Matrix<var, Dynamic, Dynamic> x_mat = x.replicate(3, 1);
+  row_vector_v x1 = x;
+  matrix_v x_mat = x.replicate(3, 1);
   Matrix<double, Dynamic, 1> beta(2, 1);
   beta << 0.3, 2;
-  Matrix<var, Dynamic, 1> beta1 = beta;
-  Matrix<var, Dynamic, 1> beta2 = beta;
+  vector_v beta1 = beta;
+  vector_v beta2 = beta;
   var alpha1 = 0.3;
   var alpha2 = 0.3;
   var phi1 = 10;
@@ -145,28 +160,32 @@ TEST(ProbDistributionsNegBinomial2LogGLM, broadcast_x) {
   (lp1 + lp2).grad();
 
   for (int i = 0; i < 2; i++) {
-    EXPECT_DOUBLE_EQ(x1[i].adj(), x_mat.col(i).adj().sum());
-    EXPECT_DOUBLE_EQ(beta1[i].adj(), beta2[i].adj());
+    EXPECT_DOUBLE_EQ(x1.adj()[i], x_mat.col(i).adj().sum());
+    EXPECT_DOUBLE_EQ(beta1.adj()[i], beta2.adj()[i]);
   }
   EXPECT_DOUBLE_EQ(alpha1.adj(), alpha2.adj());
   EXPECT_DOUBLE_EQ(phi1.adj(), phi2.adj());
 }
 
-TEST(ProbDistributionsNegBinomial2LogGLM, broadcast_y) {
+TYPED_TEST(ProbDistributionsNegBinomial2LogGLM, broadcast_y) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   int y = 13;
   Matrix<int, Dynamic, 1> y_vec = Matrix<int, Dynamic, 1>::Constant(3, 1, y);
   Matrix<double, Dynamic, Dynamic> x(3, 2);
   x << -12, 46, -42, 24, 25, 27;
-  Matrix<var, Dynamic, Dynamic> x1 = x;
-  Matrix<var, Dynamic, Dynamic> x2 = x;
+  matrix_v x1 = x;
+  matrix_v x2 = x;
   Matrix<double, Dynamic, 1> beta(2, 1);
   beta << 0.3, 2;
-  Matrix<var, Dynamic, 1> beta1 = beta;
-  Matrix<var, Dynamic, 1> beta2 = beta;
+  vector_v beta1 = beta;
+  vector_v beta2 = beta;
   var alpha1 = 0.3;
   var alpha2 = 0.3;
   var phi1 = 10;
@@ -182,24 +201,29 @@ TEST(ProbDistributionsNegBinomial2LogGLM, broadcast_y) {
 
   for (int i = 0; i < 2; i++) {
     for (int j = 0; j < 2; j++) {
-      EXPECT_DOUBLE_EQ(x1(j, i).adj(), x2(j, i).adj());
+      EXPECT_DOUBLE_EQ(x1.adj()(j, i), x2.adj()(j, i));
     }
-    EXPECT_DOUBLE_EQ(beta1[i].adj(), beta2[i].adj());
+    EXPECT_DOUBLE_EQ(beta1.adj()[i], beta2.adj()[i]);
   }
   EXPECT_DOUBLE_EQ(alpha1.adj(), alpha2.adj());
   EXPECT_DOUBLE_EQ(phi1.adj(), phi2.adj());
 }
 
-TEST(ProbDistributionsNegBinomial2LogGLM,
+TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
      glm_matches_neg_binomial_2_log_vars_zero_instances) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   vector<int> y{};
   Matrix<var, Dynamic, Dynamic> x(0, 2);
-  Matrix<var, Dynamic, 1> beta(2, 1);
-  beta << 0.3, 2;
+  Matrix<double, Dynamic, 1> beta_val(2, 1);
+  beta_val << 0.3, 2;
+  Matrix<var, Dynamic, 1> beta = beta_val;
   var alpha = 0.3;
   Matrix<var, Dynamic, 1> theta(0, 1);
   var phi = 2;
@@ -217,9 +241,8 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
   stan::math::recover_memory();
 
   vector<int> y2{};
-  Matrix<var, Dynamic, Dynamic> x2(0, 2);
-  Matrix<var, Dynamic, 1> beta2(2, 1);
-  beta2 << 0.3, 2;
+  matrix_v x2 = Matrix<double, Dynamic, Dynamic>(0, 2);
+  vector_v beta2 = beta_val;
   var alpha2 = 0.3;
   var phi2 = 2;
   var lp2
@@ -227,18 +250,22 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
   lp2.grad();
   EXPECT_FLOAT_EQ(lp_val, lp2.val());
   for (size_t i = 0; i < 2; i++) {
-    EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+    EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
   }
   EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
   EXPECT_FLOAT_EQ(phi_adj, phi2.adj());
 }
 
-TEST(ProbDistributionsNegBinomial2LogGLM,
+TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
      glm_matches_neg_binomial_2_log_vars_zero_attributes) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   vector<int> y{1, 0, 1};
   Matrix<var, Dynamic, Dynamic> x(3, 0);
   Matrix<var, Dynamic, 1> beta(0, 1);
@@ -257,8 +284,8 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
   stan::math::recover_memory();
 
   vector<int> y2{1, 0, 1};
-  Matrix<var, Dynamic, Dynamic> x2(3, 0);
-  Matrix<var, Dynamic, 1> beta2(0, 1);
+  matrix_v x2 = Matrix<double, Dynamic, Dynamic>(3, 0);
+  vector_v beta2 = Matrix<double, Dynamic, 1>(0, 1);
   var alpha2 = 0.3;
   var phi2 = 2;
   var lp2
@@ -271,12 +298,16 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TEST(ProbDistributionsNegBinomial2LogGLM,
+TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
      glm_matches_neg_binomial_2_log_vars_rand) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   for (size_t ii = 0; ii < 200; ii++) {
     vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
@@ -311,8 +342,8 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
     double phi_adj = phi.adj();
 
     stan::math::recover_memory();
-    Matrix<var, Dynamic, 1> beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
+    vector_v beta2 = betareal;
+    matrix_v x2 = xreal;
     var alpha2 = alphareal[0];
     var phi2 = phireal;
     var lp2
@@ -320,13 +351,13 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
     lp2.grad();
     EXPECT_FLOAT_EQ(lp_val, lp2.val());
     for (size_t i = 0; i < 2; i++) {
-      EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+      EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
     }
     EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
     EXPECT_FLOAT_EQ(phi_adj, phi2.adj());
     for (size_t j = 0; j < 3; j++) {
       for (size_t i = 0; i < 2; i++) {
-        EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
+        EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
       }
     }
   }
@@ -334,12 +365,16 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, in case beta is a scalar.
-TEST(ProbDistributionsNegBinomial2LogGLM,
+TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
      glm_matches_neg_binomial_2_log_vars_rand_scal_beta) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   for (size_t ii = 0; ii < 42; ii++) {
     vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
@@ -372,7 +407,7 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
     stan::math::recover_memory();
 
     var beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
+    matrix_v x2 = xreal;
     var alpha2 = alphareal[0];
     var phi2 = phireal;
     var lp2
@@ -383,19 +418,23 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
     EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
     EXPECT_FLOAT_EQ(phi_adj, phi2.adj());
     for (size_t j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(x_adj(j, 0), x2(j, 0).adj());
+      EXPECT_FLOAT_EQ(x_adj(j, 0), x2.adj()(j, 0));
     }
   }
 }
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TEST(ProbDistributionsNegBinomial2LogGLM,
+TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
      glm_matches_neg_binomial_2_log_varying_intercept) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   for (size_t ii = 0; ii < 200; ii++) {
     vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
@@ -436,34 +475,38 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
     }
 
     stan::math::recover_memory();
-    Matrix<var, Dynamic, 1> beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
-    Matrix<var, Dynamic, 1> alpha2 = alphareal;
-    Matrix<var, Dynamic, 1> phi2 = phireal;
+    vector_v beta2 = betareal;
+    matrix_v x2 = xreal;
+    vector_v alpha2 = alphareal;
+    vector_v phi2 = phireal;
     var lp2
         = stan::math::neg_binomial_2_log_glm_lpmf(y, x2, alpha2, beta2, phi2);
     lp2.grad();
     EXPECT_FLOAT_EQ(lp_val, lp2.val());
     for (size_t i = 0; i < 2; i++) {
-      EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+      EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
     }
     for (size_t j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(phi_adj[j], phi2[j].adj());
-      EXPECT_FLOAT_EQ(alpha_adj[j], alpha2[j].adj());
+      EXPECT_FLOAT_EQ(phi_adj[j], phi2.adj()[j]);
+      EXPECT_FLOAT_EQ(alpha_adj[j], alpha2.adj()[j]);
       for (size_t i = 0; i < 2; i++) {
-        EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
+        EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
       }
     }
   }
 }
 
 //  We check that we can instantiate all different interface types.
-TEST(ProbDistributionsNegBinomial2LogGLM,
+TYPED_TEST(ProbDistributionsNegBinomial2LogGLM,
      glm_matches_neg_binomial_2_log_interface_types) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double value = 0;
   double value2 = 0;
 
@@ -487,14 +530,10 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
 
   var v = 1.0;
   std::vector<var> vv = {{1.0, 2.0}};
-  Eigen::Matrix<var, -1, 1> evv(2);
-  Eigen::Matrix<var, 1, -1> rvv(2);
-  Eigen::Matrix<var, -1, -1> m1v(1, 1);
-  m1v << 1.0;
-  Eigen::Matrix<var, -1, -1> mv(2, 2);
-  evv << 1.0, 2.0;
-  rvv << 1.0, 2.0;
-  mv << 1.0, 2.0, 3.0, 4.0;
+  vector_v evv = ev;
+  row_vector_v rvv = rv;
+  matrix_v m1v = m1;
+  matrix_v mv = m;
 
   value2 += stan::math::neg_binomial_2_log_glm_lpmf(i, m1v, v, v, v).val();
   value2 += stan::math::neg_binomial_2_log_glm_lpmf(vi, mv, vv, vv, vv).val();
@@ -513,6 +552,7 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+
   int N = 3;
   int M = 2;
   int W = 4;

--- a/test/unit/math/rev/prob/normal_id_glm_lpdf_test.cpp
+++ b/test/unit/math/rev/prob/normal_id_glm_lpdf_test.cpp
@@ -61,7 +61,8 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_doubles_rand) {
 }
 
 template <class T>
-class ProbDistributionsNormalIdGLM : public stan::math::test::VarMatrixTypedTests<T> {};
+class ProbDistributionsNormalIdGLM
+    : public stan::math::test::VarMatrixTypedTests<T> {};
 // For testing var_value<Matrix> and Matrix<var>
 TYPED_TEST_SUITE(ProbDistributionsNormalIdGLM, stan::math::test::VarMatImpls);
 
@@ -253,7 +254,8 @@ TYPED_TEST(ProbDistributionsNormalIdGLM, broadcast_y) {
   EXPECT_DOUBLE_EQ(sigma1.adj(), sigma2.adj());
 }
 
-TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_zero_instances) {
+TYPED_TEST(ProbDistributionsNormalIdGLM,
+           glm_matches_normal_id_vars_zero_instances) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -304,7 +306,8 @@ TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_zero_instanc
   EXPECT_FLOAT_EQ(sigma_adj, sigma2.adj());
 }
 
-TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_zero_attributes) {
+TYPED_TEST(ProbDistributionsNormalIdGLM,
+           glm_matches_normal_id_vars_zero_attributes) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -426,7 +429,8 @@ TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand) {
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, in case beta is a scalar.
-TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand_scal_beta) {
+TYPED_TEST(ProbDistributionsNormalIdGLM,
+           glm_matches_normal_id_vars_rand_scal_beta) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -486,7 +490,8 @@ TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand_scal_be
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_varying_intercept) {
+TYPED_TEST(ProbDistributionsNormalIdGLM,
+           glm_matches_normal_id_varying_intercept) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -557,78 +562,79 @@ TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_varying_intercept
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
 TYPED_TEST(ProbDistributionsNormalIdGLM,
-     glm_matches_normal_id_varying_intercept_and_scale) {
-       using Eigen::Dynamic;
-       using Eigen::Matrix;
-       using stan::math::var;
-       using matrix_v = typename TypeParam::matrix_v;
-       using vector_v = typename TypeParam::vector_v;
-       using row_vector_v = typename TypeParam::row_vector_v;
+           glm_matches_normal_id_varying_intercept_and_scale) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::var;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
 
-       for (size_t ii = 0; ii < 42; ii++) {
-         Matrix<double, Dynamic, 1> yreal = Matrix<double, Dynamic, 1>::Random(3, 1);
-         Matrix<double, Dynamic, Dynamic> xreal
-             = Matrix<double, Dynamic, Dynamic>::Random(3, 2);
-         Matrix<double, Dynamic, 1> betareal
-             = Matrix<double, Dynamic, Dynamic>::Random(2, 1);
-         Matrix<double, Dynamic, 1> alphareal
-             = Matrix<double, Dynamic, 1>::Random(3, 1);
-         Matrix<double, Dynamic, 1> phireal
-             = Matrix<double, Dynamic, Dynamic>::Random(3, 1)
-               + Matrix<double, Dynamic, 1>::Ones(3, 1);
-         Matrix<var, Dynamic, 1> y = yreal;
-         Matrix<var, Dynamic, 1> beta = betareal;
-         Matrix<var, Dynamic, 1> theta(3, 1);
-         Matrix<var, Dynamic, Dynamic> x = xreal;
-         Matrix<var, Dynamic, 1> alpha = alphareal;
-         Matrix<var, Dynamic, 1> phi = phireal;
-         theta = (x * beta) + alpha;
-         var lp = stan::math::normal_lpdf(y, theta, phi);
-         lp.grad();
+  for (size_t ii = 0; ii < 42; ii++) {
+    Matrix<double, Dynamic, 1> yreal = Matrix<double, Dynamic, 1>::Random(3, 1);
+    Matrix<double, Dynamic, Dynamic> xreal
+        = Matrix<double, Dynamic, Dynamic>::Random(3, 2);
+    Matrix<double, Dynamic, 1> betareal
+        = Matrix<double, Dynamic, Dynamic>::Random(2, 1);
+    Matrix<double, Dynamic, 1> alphareal
+        = Matrix<double, Dynamic, 1>::Random(3, 1);
+    Matrix<double, Dynamic, 1> phireal
+        = Matrix<double, Dynamic, Dynamic>::Random(3, 1)
+          + Matrix<double, Dynamic, 1>::Ones(3, 1);
+    Matrix<var, Dynamic, 1> y = yreal;
+    Matrix<var, Dynamic, 1> beta = betareal;
+    Matrix<var, Dynamic, 1> theta(3, 1);
+    Matrix<var, Dynamic, Dynamic> x = xreal;
+    Matrix<var, Dynamic, 1> alpha = alphareal;
+    Matrix<var, Dynamic, 1> phi = phireal;
+    theta = (x * beta) + alpha;
+    var lp = stan::math::normal_lpdf(y, theta, phi);
+    lp.grad();
 
-         double lp_val = lp.val();
-         Matrix<double, Dynamic, 1> alpha_adj(3, 1);
-         Matrix<double, Dynamic, Dynamic> x_adj(3, 2);
-         Matrix<double, Dynamic, 1> beta_adj(2, 1);
-         Matrix<double, Dynamic, 1> phi_adj(3, 1);
-         Matrix<double, Dynamic, 1> y_adj(3, 1);
-         for (size_t i = 0; i < 2; i++) {
-           beta_adj[i] = beta[i].adj();
-           for (size_t j = 0; j < 3; j++) {
-             x_adj(j, i) = x(j, i).adj();
-           }
-         }
-         for (size_t j = 0; j < 3; j++) {
-           alpha_adj[j] = alpha[j].adj();
-           phi_adj[j] = phi[j].adj();
-           y_adj[j] = y[j].adj();
-         }
+    double lp_val = lp.val();
+    Matrix<double, Dynamic, 1> alpha_adj(3, 1);
+    Matrix<double, Dynamic, Dynamic> x_adj(3, 2);
+    Matrix<double, Dynamic, 1> beta_adj(2, 1);
+    Matrix<double, Dynamic, 1> phi_adj(3, 1);
+    Matrix<double, Dynamic, 1> y_adj(3, 1);
+    for (size_t i = 0; i < 2; i++) {
+      beta_adj[i] = beta[i].adj();
+      for (size_t j = 0; j < 3; j++) {
+        x_adj(j, i) = x(j, i).adj();
+      }
+    }
+    for (size_t j = 0; j < 3; j++) {
+      alpha_adj[j] = alpha[j].adj();
+      phi_adj[j] = phi[j].adj();
+      y_adj[j] = y[j].adj();
+    }
 
-         stan::math::recover_memory();
-         vector_v y2 = yreal;
-         vector_v beta2 = betareal;
-         matrix_v x2 = xreal;
-         vector_v alpha2 = alphareal;
-         vector_v phi2 = phireal;
-         var lp2 = stan::math::normal_id_glm_lpdf(y2, x2, alpha2, beta2, phi2);
-         lp2.grad();
-         EXPECT_FLOAT_EQ(lp_val, lp2.val());
-         for (size_t i = 0; i < 2; i++) {
-           EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
-         }
-         for (size_t j = 0; j < 3; j++) {
-           EXPECT_FLOAT_EQ(alpha_adj[j], alpha2.adj()[j]);
-           EXPECT_FLOAT_EQ(y_adj[j], y2.adj()[j]);
-           EXPECT_FLOAT_EQ(phi_adj[j], phi2.adj()[j]);
-           for (size_t i = 0; i < 2; i++) {
-             EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
-           }
-         }
-       }
+    stan::math::recover_memory();
+    vector_v y2 = yreal;
+    vector_v beta2 = betareal;
+    matrix_v x2 = xreal;
+    vector_v alpha2 = alphareal;
+    vector_v phi2 = phireal;
+    var lp2 = stan::math::normal_id_glm_lpdf(y2, x2, alpha2, beta2, phi2);
+    lp2.grad();
+    EXPECT_FLOAT_EQ(lp_val, lp2.val());
+    for (size_t i = 0; i < 2; i++) {
+      EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
+    }
+    for (size_t j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(alpha_adj[j], alpha2.adj()[j]);
+      EXPECT_FLOAT_EQ(y_adj[j], y2.adj()[j]);
+      EXPECT_FLOAT_EQ(phi_adj[j], phi2.adj()[j]);
+      for (size_t i = 0; i < 2; i++) {
+        EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
+      }
+    }
+  }
 }
 
 //  We check that we can instantiate all different interface types.
-TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_interface_types) {
+TYPED_TEST(ProbDistributionsNormalIdGLM,
+           glm_matches_normal_id_interface_types) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;

--- a/test/unit/math/rev/prob/normal_id_glm_lpdf_test.cpp
+++ b/test/unit/math/rev/prob/normal_id_glm_lpdf_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev.hpp>
 #include <stan/math/prim.hpp>
+#include <test/unit/math/rev/util.hpp>
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>
@@ -58,12 +59,21 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_doubles_rand) {
         (stan::math::normal_id_glm_lpdf<true>(y, x, alpha, beta, phi[0])));
   }
 }
+
+template <class T>
+class ProbDistributionsNormalIdGLM : public stan::math::test::VarMatrixTypedTests<T> {};
+// For testing var_value<Matrix> and Matrix<var>
+TYPED_TEST_SUITE(ProbDistributionsNormalIdGLM, stan::math::test::VarMatImpls);
+
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars) {
+TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   Matrix<var, Dynamic, 1> y(3, 1);
   y << 14, 32, 21;
   Matrix<var, Dynamic, Dynamic> x(3, 2);
@@ -93,37 +103,42 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars) {
   for (size_t j = 0; j < 3; j++) {
     y_adj[j] = y[j].adj();
   }
-
   stan::math::recover_memory();
-
-  Matrix<var, Dynamic, 1> y2(3, 1);
-  y2 << 14, 32, 21;
-  Matrix<var, Dynamic, Dynamic> x2(3, 2);
-  x2 << -12, 46, -42, 24, 25, 27;
-  Matrix<var, Dynamic, 1> beta2(2, 1);
-  beta2 << 0.3, 2;
+  Matrix<double, Dynamic, 1> y2_val(3, 1);
+  y2_val << 14, 32, 21;
+  vector_v y2 = y2_val;
+  Matrix<double, Dynamic, Dynamic> x2_val(3, 2);
+  x2_val << -12, 46, -42, 24, 25, 27;
+  matrix_v x2 = x2_val;
+  Matrix<double, Dynamic, 1> beta2_val(2, 1);
+  beta2_val << 0.3, 2;
+  vector_v beta2 = beta2_val;
   var alpha2 = 0.3;
   var sigma2 = 10;
   var lp2 = stan::math::normal_id_glm_lpdf(y2, x2, alpha2, beta2, sigma2);
   lp2.grad();
   EXPECT_FLOAT_EQ(lp_val, lp2.val());
   for (size_t i = 0; i < 2; i++) {
-    EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+    EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
   }
   EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
   EXPECT_FLOAT_EQ(sigma_adj, sigma2.adj());
   for (size_t j = 0; j < 3; j++) {
-    EXPECT_FLOAT_EQ(y_adj[j], y2[j].adj());
+    EXPECT_FLOAT_EQ(y_adj[j], y2.adj()[j]);
     for (size_t i = 0; i < 2; i++) {
-      EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
+      EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
     }
   }
 }
 
-TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_simple) {
+TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_simple) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double eps = 1e-9;
   Matrix<double, Dynamic, 1> y(3, 1);
   y << 14, 32, 21;
@@ -131,8 +146,8 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_simple) {
   x << -12, 46, -42, 24, 25, 27;
   Matrix<double, Dynamic, 1> beta(2, 1);
   beta << 0.3, 2;
-  Matrix<var, Dynamic, 1> beta1 = beta;
-  Matrix<var, Dynamic, 1> beta2 = beta;
+  vector_v beta1 = beta;
+  vector_v beta2 = beta;
   var alpha1 = 0.3;
   var alpha2 = 0.3;
   double sigma = 10;
@@ -146,27 +161,31 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_simple) {
   (lp1 + lp2).grad();
 
   for (int i = 0; i < 2; i++) {
-    EXPECT_NEAR(beta1[i].adj(), beta2[i].adj(), eps);
+    EXPECT_NEAR(beta1.adj()[i], beta2.adj()[i], eps);
   }
   EXPECT_NEAR(alpha1.adj(), alpha2.adj(), eps);
 }
 
-TEST(ProbDistributionsNormalIdGLM, broadcast_x) {
+TYPED_TEST(ProbDistributionsNormalIdGLM, broadcast_x) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   Matrix<double, Dynamic, 1> y(3, 1);
   y << 14, 32, 21;
-  Matrix<var, Dynamic, 1> y1 = y;
-  Matrix<var, Dynamic, 1> y2 = y;
+  vector_v y1 = y;
+  vector_v y2 = y;
   Matrix<double, 1, Dynamic> x(1, 2);
   x << -12, 46;
-  Matrix<var, 1, Dynamic> x1 = x;
-  Matrix<var, Dynamic, Dynamic> x_mat = x.replicate(3, 1);
+  row_vector_v x1 = x;
+  matrix_v x_mat = x.replicate(3, 1);
   Matrix<double, Dynamic, 1> beta(2, 1);
   beta << 0.3, 2;
-  Matrix<var, Dynamic, 1> beta1 = beta;
-  Matrix<var, Dynamic, 1> beta2 = beta;
+  vector_v beta1 = beta;
+  vector_v beta2 = beta;
   var alpha1 = 0.3;
   var alpha2 = 0.3;
   var sigma1 = 10;
@@ -180,32 +199,36 @@ TEST(ProbDistributionsNormalIdGLM, broadcast_x) {
   (lp1 + lp2).grad();
 
   for (int i = 0; i < 3; i++) {
-    EXPECT_DOUBLE_EQ(y1[i].adj(), y1[i].adj());
+    EXPECT_DOUBLE_EQ(y1.adj()[i], y2.adj()[i]);
   }
 
   for (int i = 0; i < 2; i++) {
-    EXPECT_DOUBLE_EQ(x1[i].adj(), x_mat.col(i).adj().sum());
-    EXPECT_DOUBLE_EQ(beta1[i].adj(), beta2[i].adj());
+    EXPECT_DOUBLE_EQ(x1.adj()[i], x_mat.col(i).adj().sum());
+    EXPECT_DOUBLE_EQ(beta1.adj()[i], beta2.adj()[i]);
   }
   EXPECT_DOUBLE_EQ(alpha1.adj(), alpha2.adj());
   EXPECT_DOUBLE_EQ(sigma1.adj(), sigma2.adj());
 }
 
-TEST(ProbDistributionsNormalIdGLM, broadcast_y) {
+TYPED_TEST(ProbDistributionsNormalIdGLM, broadcast_y) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double y = 13;
   var y1 = y;
-  Matrix<var, Dynamic, 1> y_vec = Matrix<double, Dynamic, 1>::Constant(3, 1, y);
+  vector_v y_vec = Matrix<double, Dynamic, 1>::Constant(3, 1, y);
   Matrix<double, Dynamic, Dynamic> x(3, 2);
   x << -12, 46, -42, 24, 25, 27;
-  Matrix<var, Dynamic, Dynamic> x1 = x;
-  Matrix<var, Dynamic, Dynamic> x2 = x;
-  Matrix<double, Dynamic, 1> beta(2, 1);
+  matrix_v x1 = x;
+  matrix_v x2 = x;
+  Eigen::VectorXd beta(2, 1);
   beta << 0.3, 2;
-  Matrix<var, Dynamic, 1> beta1 = beta;
-  Matrix<var, Dynamic, 1> beta2 = beta;
+  vector_v beta1 = beta;
+  vector_v beta2 = beta;
   var alpha1 = 0.3;
   var alpha2 = 0.3;
   var sigma1 = 10;
@@ -222,25 +245,33 @@ TEST(ProbDistributionsNormalIdGLM, broadcast_y) {
 
   for (int i = 0; i < 2; i++) {
     for (int j = 0; j < 2; j++) {
-      EXPECT_DOUBLE_EQ(x1(j, i).adj(), x2(j, i).adj());
+      EXPECT_DOUBLE_EQ(x1.adj()(j, i), x2.adj()(j, i));
     }
-    EXPECT_DOUBLE_EQ(beta1[i].adj(), beta2[i].adj());
+    EXPECT_DOUBLE_EQ(beta1.adj()[i], beta2.adj()[i]);
   }
   EXPECT_DOUBLE_EQ(alpha1.adj(), alpha2.adj());
   EXPECT_DOUBLE_EQ(sigma1.adj(), sigma2.adj());
 }
 
-TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_zero_instances) {
+TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_zero_instances) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
-  Matrix<var, Dynamic, 1> y(0, 1);
-  Matrix<var, Dynamic, Dynamic> x(0, 2);
-  Matrix<var, Dynamic, 1> beta(2, 1);
-  beta << 0.3, 2;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
+  Matrix<double, Dynamic, 1> y_val(0, 1);
+  vector_v y = y_val;
+  Matrix<double, Dynamic, Dynamic> x_val(0, 2);
+  matrix_v x = x_val;
+  Matrix<double, Dynamic, 1> beta_val(2, 1);
+  beta_val << 0.3, 2;
+  vector_v beta = beta_val;
   var alpha = 0.3;
   var sigma = 10;
-  Matrix<var, Dynamic, 1> theta(0, 1);
+  Matrix<double, Dynamic, 1> theta_val(0, 1);
+  vector_v theta = theta_val;
   var lp = stan::math::normal_lpdf(y, theta, sigma);
   lp.grad();
 
@@ -248,41 +279,50 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_zero_instances) {
   double alpha_adj = alpha.adj();
   Matrix<double, Dynamic, 1> beta_adj(2, 1);
   for (size_t i = 0; i < 2; i++) {
-    beta_adj[i] = beta[i].adj();
+    beta_adj[i] = beta.adj()[i];
   }
   double sigma_adj = sigma.adj();
 
   stan::math::recover_memory();
 
-  Matrix<var, Dynamic, 1> y2(0, 1);
-  Matrix<var, Dynamic, Dynamic> x2(0, 2);
-  Matrix<var, Dynamic, 1> beta2(2, 1);
-  beta2 << 0.3, 2;
+  Matrix<double, Dynamic, 1> y2_val(0, 1);
+  vector_v y2 = y2_val;
+  Matrix<double, Dynamic, Dynamic> x2_val(0, 2);
+  matrix_v x2 = x2_val;
+  Matrix<double, Dynamic, 1> beta2_val(2, 1);
+  beta2_val << 0.3, 2;
+  vector_v beta2 = beta2_val;
   var alpha2 = 0.3;
   var sigma2 = 10;
   var lp2 = stan::math::normal_id_glm_lpdf(y2, x2, alpha2, beta2, sigma2);
   lp2.grad();
   EXPECT_FLOAT_EQ(lp_val, lp2.val());
   for (size_t i = 0; i < 2; i++) {
-    EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+    EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
   }
   EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
   EXPECT_FLOAT_EQ(sigma_adj, sigma2.adj());
 }
 
-TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_zero_attributes) {
+TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_zero_attributes) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
-  Matrix<var, Dynamic, 1> y(3, 1);
-  y << 14, 32, 21;
-  Matrix<var, Dynamic, Dynamic> x(3, 0);
-  Matrix<var, Dynamic, 1> beta(0, 1);
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
+  Matrix<double, Dynamic, 1> y_val(3, 1);
+  y_val << 14, 32, 21;
+  vector_v y = y_val;
+  Matrix<double, Dynamic, Dynamic> x_val(3, 0);
+  matrix_v x = x_val;
+  Matrix<double, Dynamic, 1> beta_val(0, 1);
+  vector_v beta = beta_val;
   var alpha = 0.3;
   var sigma = 10;
-  Matrix<var, Dynamic, 1> alphavec = alpha * Matrix<double, 3, 1>::Ones();
-  Matrix<var, Dynamic, 1> theta(3, 1);
-  theta = x * beta + alphavec;
+  vector_v alphavec = stan::math::rep_vector<vector_v>(alpha, 3);
+  vector_v theta = x * beta + alphavec;
   var lp = stan::math::normal_lpdf(y, theta, sigma);
   lp.grad();
 
@@ -291,15 +331,18 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_zero_attributes) {
   Matrix<double, Dynamic, 1> y_adj(3, 1);
   double sigma_adj = sigma.adj();
   for (size_t j = 0; j < 3; j++) {
-    y_adj[j] = y[j].adj();
+    y_adj[j] = y.adj()[j];
   }
 
   stan::math::recover_memory();
 
-  Matrix<var, Dynamic, 1> y2(3, 1);
-  y2 << 14, 32, 21;
-  Matrix<var, Dynamic, Dynamic> x2(3, 0);
-  Matrix<var, Dynamic, 1> beta2(0, 1);
+  Matrix<double, Dynamic, 1> y2_val(3, 1);
+  y2_val << 14, 32, 21;
+  vector_v y2 = y2_val;
+  Matrix<double, Dynamic, Dynamic> x2_val(3, 0);
+  matrix_v x2 = x2_val;
+  Matrix<double, Dynamic, 1> beta2_val(0, 1);
+  vector_v beta2 = beta2_val;
   var alpha2 = 0.3;
   var sigma2 = 10;
   var lp2 = stan::math::normal_id_glm_lpdf(y2, x2, alpha2, beta2, sigma2);
@@ -308,16 +351,20 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_zero_attributes) {
   EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
   EXPECT_FLOAT_EQ(sigma_adj, sigma2.adj());
   for (size_t j = 0; j < 3; j++) {
-    EXPECT_FLOAT_EQ(y_adj[j], y2[j].adj());
+    EXPECT_FLOAT_EQ(y_adj[j], y2.adj()[j]);
   }
 }
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand) {
+TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   for (size_t ii = 0; ii < 42; ii++) {
     Matrix<double, Dynamic, 1> yreal = Matrix<double, Dynamic, 1>::Random(3, 1);
     Matrix<double, Dynamic, Dynamic> xreal
@@ -355,23 +402,23 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand) {
 
     stan::math::recover_memory();
 
-    Matrix<var, Dynamic, 1> y2 = yreal;
-    Matrix<var, Dynamic, 1> beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
+    vector_v y2 = yreal;
+    vector_v beta2 = betareal;
+    matrix_v x2 = xreal;
     var alpha2 = alphareal[0];
     var phi2 = phireal;
     var lp2 = stan::math::normal_id_glm_lpdf(y2, x2, alpha2, beta2, phi2);
     lp2.grad();
     EXPECT_FLOAT_EQ(lp_val, lp2.val());
     for (size_t i = 0; i < 2; i++) {
-      EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+      EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
     }
     EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
     EXPECT_FLOAT_EQ(phi_adj, phi2.adj());
     for (size_t j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(y_adj[j], y2[j].adj());
+      EXPECT_FLOAT_EQ(y_adj[j], y2.adj()[j]);
       for (size_t i = 0; i < 2; i++) {
-        EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
+        EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
       }
     }
   }
@@ -379,10 +426,14 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand) {
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, in case beta is a scalar.
-TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand_scal_beta) {
+TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand_scal_beta) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   for (size_t ii = 0; ii < 42; ii++) {
     Matrix<double, Dynamic, 1> yreal = Matrix<double, Dynamic, 1>::Random(3, 1);
     Matrix<double, Dynamic, Dynamic> xreal
@@ -415,10 +466,9 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand_scal_beta) {
     }
 
     stan::math::recover_memory();
-
-    Matrix<var, Dynamic, 1> y2 = yreal;
+    vector_v y2 = yreal;
     var beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
+    matrix_v x2 = xreal;
     var alpha2 = alphareal[0];
     var phi2 = phireal;
     var lp2 = stan::math::normal_id_glm_lpdf(y2, x2, alpha2, beta2, phi2);
@@ -428,18 +478,22 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand_scal_beta) {
     EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
     EXPECT_FLOAT_EQ(phi_adj, phi2.adj());
     for (size_t j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(y_adj[j], y2[j].adj());
-      EXPECT_FLOAT_EQ(x_adj(j, 0), x2(j, 0).adj());
+      EXPECT_FLOAT_EQ(y_adj[j], y2.adj()[j]);
+      EXPECT_FLOAT_EQ(x_adj(j, 0), x2.adj()(j, 0));
     }
   }
 }
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_varying_intercept) {
+TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_varying_intercept) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   for (size_t ii = 0; ii < 42; ii++) {
     Matrix<double, Dynamic, 1> yreal = Matrix<double, Dynamic, 1>::Random(3, 1);
     Matrix<double, Dynamic, Dynamic> xreal
@@ -478,23 +532,23 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_varying_intercept) {
 
     stan::math::recover_memory();
 
-    Matrix<var, Dynamic, 1> y2 = yreal;
-    Matrix<var, Dynamic, 1> beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
-    Matrix<var, Dynamic, 1> alpha2 = alphareal;
+    vector_v y2 = yreal;
+    vector_v beta2 = betareal;
+    matrix_v x2 = xreal;
+    vector_v alpha2 = alphareal;
     var phi2 = phireal;
     var lp2 = stan::math::normal_id_glm_lpdf(y2, x2, alpha2, beta2, phi2);
     lp2.grad();
     EXPECT_FLOAT_EQ(lp_val, lp2.val());
     EXPECT_FLOAT_EQ(phi_adj, phi2.adj());
     for (size_t i = 0; i < 2; i++) {
-      EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+      EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
     }
     for (size_t j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(alpha_adj[j], alpha2[j].adj());
-      EXPECT_FLOAT_EQ(y_adj[j], y2[j].adj());
+      EXPECT_FLOAT_EQ(alpha_adj[j], alpha2.adj()[j]);
+      EXPECT_FLOAT_EQ(y_adj[j], y2.adj()[j]);
       for (size_t i = 0; i < 2; i++) {
-        EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
+        EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
       }
     }
   }
@@ -502,79 +556,86 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_varying_intercept) {
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TEST(ProbDistributionsNormalIdGLM,
+TYPED_TEST(ProbDistributionsNormalIdGLM,
      glm_matches_normal_id_varying_intercept_and_scale) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using stan::math::var;
-  for (size_t ii = 0; ii < 42; ii++) {
-    Matrix<double, Dynamic, 1> yreal = Matrix<double, Dynamic, 1>::Random(3, 1);
-    Matrix<double, Dynamic, Dynamic> xreal
-        = Matrix<double, Dynamic, Dynamic>::Random(3, 2);
-    Matrix<double, Dynamic, 1> betareal
-        = Matrix<double, Dynamic, Dynamic>::Random(2, 1);
-    Matrix<double, Dynamic, 1> alphareal
-        = Matrix<double, Dynamic, 1>::Random(3, 1);
-    Matrix<double, Dynamic, 1> phireal
-        = Matrix<double, Dynamic, Dynamic>::Random(3, 1)
-          + Matrix<double, Dynamic, 1>::Ones(3, 1);
-    Matrix<var, Dynamic, 1> y = yreal;
-    Matrix<var, Dynamic, 1> beta = betareal;
-    Matrix<var, Dynamic, 1> theta(3, 1);
-    Matrix<var, Dynamic, Dynamic> x = xreal;
-    Matrix<var, Dynamic, 1> alpha = alphareal;
-    Matrix<var, Dynamic, 1> phi = phireal;
-    theta = (x * beta) + alpha;
-    var lp = stan::math::normal_lpdf(y, theta, phi);
-    lp.grad();
+       using Eigen::Dynamic;
+       using Eigen::Matrix;
+       using stan::math::var;
+       using matrix_v = typename TypeParam::matrix_v;
+       using vector_v = typename TypeParam::vector_v;
+       using row_vector_v = typename TypeParam::row_vector_v;
 
-    double lp_val = lp.val();
-    Matrix<double, Dynamic, 1> alpha_adj(3, 1);
-    Matrix<double, Dynamic, Dynamic> x_adj(3, 2);
-    Matrix<double, Dynamic, 1> beta_adj(2, 1);
-    Matrix<double, Dynamic, 1> phi_adj(3, 1);
-    Matrix<double, Dynamic, 1> y_adj(3, 1);
-    for (size_t i = 0; i < 2; i++) {
-      beta_adj[i] = beta[i].adj();
-      for (size_t j = 0; j < 3; j++) {
-        x_adj(j, i) = x(j, i).adj();
-      }
-    }
-    for (size_t j = 0; j < 3; j++) {
-      alpha_adj[j] = alpha[j].adj();
-      phi_adj[j] = phi[j].adj();
-      y_adj[j] = y[j].adj();
-    }
+       for (size_t ii = 0; ii < 42; ii++) {
+         Matrix<double, Dynamic, 1> yreal = Matrix<double, Dynamic, 1>::Random(3, 1);
+         Matrix<double, Dynamic, Dynamic> xreal
+             = Matrix<double, Dynamic, Dynamic>::Random(3, 2);
+         Matrix<double, Dynamic, 1> betareal
+             = Matrix<double, Dynamic, Dynamic>::Random(2, 1);
+         Matrix<double, Dynamic, 1> alphareal
+             = Matrix<double, Dynamic, 1>::Random(3, 1);
+         Matrix<double, Dynamic, 1> phireal
+             = Matrix<double, Dynamic, Dynamic>::Random(3, 1)
+               + Matrix<double, Dynamic, 1>::Ones(3, 1);
+         Matrix<var, Dynamic, 1> y = yreal;
+         Matrix<var, Dynamic, 1> beta = betareal;
+         Matrix<var, Dynamic, 1> theta(3, 1);
+         Matrix<var, Dynamic, Dynamic> x = xreal;
+         Matrix<var, Dynamic, 1> alpha = alphareal;
+         Matrix<var, Dynamic, 1> phi = phireal;
+         theta = (x * beta) + alpha;
+         var lp = stan::math::normal_lpdf(y, theta, phi);
+         lp.grad();
 
-    stan::math::recover_memory();
+         double lp_val = lp.val();
+         Matrix<double, Dynamic, 1> alpha_adj(3, 1);
+         Matrix<double, Dynamic, Dynamic> x_adj(3, 2);
+         Matrix<double, Dynamic, 1> beta_adj(2, 1);
+         Matrix<double, Dynamic, 1> phi_adj(3, 1);
+         Matrix<double, Dynamic, 1> y_adj(3, 1);
+         for (size_t i = 0; i < 2; i++) {
+           beta_adj[i] = beta[i].adj();
+           for (size_t j = 0; j < 3; j++) {
+             x_adj(j, i) = x(j, i).adj();
+           }
+         }
+         for (size_t j = 0; j < 3; j++) {
+           alpha_adj[j] = alpha[j].adj();
+           phi_adj[j] = phi[j].adj();
+           y_adj[j] = y[j].adj();
+         }
 
-    Matrix<var, Dynamic, 1> y2 = yreal;
-    Matrix<var, Dynamic, 1> beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
-    Matrix<var, Dynamic, 1> alpha2 = alphareal;
-    Matrix<var, Dynamic, 1> phi2 = phireal;
-    var lp2 = stan::math::normal_id_glm_lpdf(y2, x2, alpha2, beta2, phi2);
-    lp2.grad();
-    EXPECT_FLOAT_EQ(lp_val, lp2.val());
-    for (size_t i = 0; i < 2; i++) {
-      EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
-    }
-    for (size_t j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(alpha_adj[j], alpha2[j].adj());
-      EXPECT_FLOAT_EQ(y_adj[j], y2[j].adj());
-      EXPECT_FLOAT_EQ(phi_adj[j], phi2[j].adj());
-      for (size_t i = 0; i < 2; i++) {
-        EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
-      }
-    }
-  }
+         stan::math::recover_memory();
+         vector_v y2 = yreal;
+         vector_v beta2 = betareal;
+         matrix_v x2 = xreal;
+         vector_v alpha2 = alphareal;
+         vector_v phi2 = phireal;
+         var lp2 = stan::math::normal_id_glm_lpdf(y2, x2, alpha2, beta2, phi2);
+         lp2.grad();
+         EXPECT_FLOAT_EQ(lp_val, lp2.val());
+         for (size_t i = 0; i < 2; i++) {
+           EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
+         }
+         for (size_t j = 0; j < 3; j++) {
+           EXPECT_FLOAT_EQ(alpha_adj[j], alpha2.adj()[j]);
+           EXPECT_FLOAT_EQ(y_adj[j], y2.adj()[j]);
+           EXPECT_FLOAT_EQ(phi_adj[j], phi2.adj()[j]);
+           for (size_t i = 0; i < 2; i++) {
+             EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
+           }
+         }
+       }
 }
 
 //  We check that we can instantiate all different interface types.
-TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_interface_types) {
+TYPED_TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_interface_types) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double value = 0;
   double value2 = 0;
 
@@ -596,14 +657,19 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_interface_types) {
 
   var v = 1.0;
   std::vector<var> vv = {{1.0, 2.0}};
-  Eigen::Matrix<var, -1, 1> evv(2);
-  Eigen::Matrix<var, 1, -1> rvv(2);
-  Eigen::Matrix<var, -1, -1> m1v(1, 1);
-  m1v << 1.0;
-  Eigen::Matrix<var, -1, -1> mv(2, 2);
-  evv << 1.0, 2.0;
-  rvv << 1.0, 2.0;
-  mv << 1.0, 2.0, 3.0, 4.0;
+
+  Eigen::Matrix<double, -1, 1> evv_val(2);
+  evv_val << 1.0, 2.0;
+  vector_v evv = evv_val;
+  Eigen::Matrix<double, 1, -1> rvv_val(2);
+  rvv_val << 1.0, 2.0;
+  row_vector_v rvv = rvv_val;
+  Eigen::Matrix<double, -1, -1> m1v_val(1, 1);
+  m1v_val << 1.0;
+  matrix_v m1v = m1v_val;
+  Eigen::Matrix<double, -1, -1> mv_val(2, 2);
+  mv_val << 1.0, 2.0, 3.0, 4.0;
+  matrix_v mv = mv_val;
 
   value2 += stan::math::normal_id_glm_lpdf(v, m1v, v, v, v).val();
   value2 += stan::math::normal_id_glm_lpdf(vv, mv, vv, vv, vv).val();

--- a/test/unit/math/rev/prob/ordered_logistic_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/ordered_logistic_glm_lpmf_test.cpp
@@ -6,8 +6,7 @@
 
 template <bool propto, typename T_x, typename T_beta, typename T_cuts>
 stan::return_type_t<T_x, T_beta, T_cuts> ordered_logistic_glm_simple_lpmf(
-    const std::vector<int>& y,
-    T_x&& x, T_beta&& beta, T_cuts&& cuts) {
+    const std::vector<int>& y, T_x&& x, T_beta&& beta, T_cuts&& cuts) {
   using stan::math::as_column_vector_or_scalar;
   auto&& beta_col = as_column_vector_or_scalar(beta);
   auto location = stan::math::multiply(x, beta_col);
@@ -58,12 +57,14 @@ TEST(ProbDistributionsOrderedLogisticGLM,
 }
 
 template <class T>
-class ProbDistributionsOrderedLogisticGLM : public stan::math::test::VarMatrixTypedTests<T> {};
+class ProbDistributionsOrderedLogisticGLM
+    : public stan::math::test::VarMatrixTypedTests<T> {};
 
-TYPED_TEST_SUITE(ProbDistributionsOrderedLogisticGLM, stan::math::test::VarMatImpls);
+TYPED_TEST_SUITE(ProbDistributionsOrderedLogisticGLM,
+                 stan::math::test::VarMatImpls);
 
-
-TYPED_TEST(ProbDistributionsOrderedLogisticGLM, glm_matches_ordered_logistic_vars) {
+TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
+           glm_matches_ordered_logistic_vars) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -114,7 +115,7 @@ TYPED_TEST(ProbDistributionsOrderedLogisticGLM, glm_matches_ordered_logistic_var
 }
 
 TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
-     glm_matches_ordered_logistic_vars_broadcast_y) {
+           glm_matches_ordered_logistic_vars_broadcast_y) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -171,7 +172,7 @@ TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
 }
 
 TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
-     glm_matches_ordered_logistic_vars_broadcast_x) {
+           glm_matches_ordered_logistic_vars_broadcast_x) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -224,7 +225,7 @@ TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
 }
 
 TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
-     glm_matches_ordered_logistic_single_instance) {
+           glm_matches_ordered_logistic_single_instance) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -273,7 +274,7 @@ TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
 }
 
 TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
-     glm_matches_ordered_logistic_zero_instances) {
+           glm_matches_ordered_logistic_zero_instances) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -317,7 +318,7 @@ TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
 }
 
 TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
-     glm_matches_ordered_logistic_zero_attributes) {
+           glm_matches_ordered_logistic_zero_attributes) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -356,7 +357,7 @@ TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
 }
 
 TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
-     glm_matches_ordered_logistic_single_class) {
+           glm_matches_ordered_logistic_single_class) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -405,7 +406,7 @@ TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
 }
 
 TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
-     glm_matches_ordered_logistic_vars_big) {
+           glm_matches_ordered_logistic_vars_big) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;

--- a/test/unit/math/rev/prob/ordered_logistic_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/ordered_logistic_glm_lpmf_test.cpp
@@ -1,21 +1,16 @@
 #include <stan/math.hpp>
-#include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <test/unit/math/rev/util.hpp>
+#include <gtest/gtest.h>
 #include <vector>
 
 template <bool propto, typename T_x, typename T_beta, typename T_cuts>
 stan::return_type_t<T_x, T_beta, T_cuts> ordered_logistic_glm_simple_lpmf(
     const std::vector<int>& y,
-    const Eigen::Matrix<T_x, Eigen::Dynamic, Eigen::Dynamic>& x,
-    const T_beta& beta, const T_cuts& cuts) {
-  using T_x_beta = stan::return_type_t<T_x, T_beta>;
+    T_x&& x, T_beta&& beta, T_cuts&& cuts) {
   using stan::math::as_column_vector_or_scalar;
-
-  auto& beta_col = as_column_vector_or_scalar(beta);
-
-  Eigen::Matrix<T_x_beta, Eigen::Dynamic, 1> location
-      = x.template cast<T_x_beta>() * beta_col.template cast<T_x_beta>();
-
+  auto&& beta_col = as_column_vector_or_scalar(beta);
+  auto location = stan::math::multiply(x, beta_col);
   return stan::math::ordered_logistic_lpmf<propto>(y, location, cuts);
 }
 
@@ -62,7 +57,13 @@ TEST(ProbDistributionsOrderedLogisticGLM,
   }
 }
 
-TEST(ProbDistributionsOrderedLogisticGLM, glm_matches_ordered_logistic_vars) {
+template <class T>
+class ProbDistributionsOrderedLogisticGLM : public stan::math::test::VarMatrixTypedTests<T> {};
+
+TYPED_TEST_SUITE(ProbDistributionsOrderedLogisticGLM, stan::math::test::VarMatImpls);
+
+
+TYPED_TEST(ProbDistributionsOrderedLogisticGLM, glm_matches_ordered_logistic_vars) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -70,20 +71,30 @@ TEST(ProbDistributionsOrderedLogisticGLM, glm_matches_ordered_logistic_vars) {
   using Eigen::VectorXd;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double eps = 1e-13;
   int N = 5;
   int M = 2;
   int C = 3;
   vector<int> y{1, 1, 2, 4, 4};
-  Matrix<var, Dynamic, 1> cuts1(C), cuts2(C);
-  cuts1 << 0.9, 1.1, 7;
-  cuts2 << 0.9, 1.1, 7;
-  Matrix<var, Dynamic, 1> beta1(M), beta2(M);
-  beta1 << 1.1, 0.4;
-  beta2 << 1.1, 0.4;
-  Matrix<var, Dynamic, Dynamic> x1(N, M), x2(N, M);
-  x1 << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
-  x2 << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
+  Matrix<double, Dynamic, 1> cuts1_val(C), cuts2_val(C);
+  cuts1_val << 0.9, 1.1, 7;
+  cuts2_val << 0.9, 1.1, 7;
+  vector_v cuts1 = cuts1_val;
+  vector_v cuts2 = cuts2_val;
+  Matrix<double, Dynamic, 1> beta1_val(M), beta2_val(M);
+  beta1_val << 1.1, 0.4;
+  beta2_val << 1.1, 0.4;
+  vector_v beta1 = beta1_val;
+  vector_v beta2 = beta2_val;
+  Matrix<double, Dynamic, Dynamic> x1_val(N, M), x2_val(N, M);
+  x1_val << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
+  x2_val << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
+  matrix_v x1 = x1_val;
+  matrix_v x2 = x2_val;
   var res1 = stan::math::ordered_logistic_glm_lpmf(y, x1, beta1, cuts1);
   var res2 = ordered_logistic_glm_simple_lpmf<false>(y, x2, beta2, cuts2);
   (res1 + res2).grad();
@@ -91,18 +102,18 @@ TEST(ProbDistributionsOrderedLogisticGLM, glm_matches_ordered_logistic_vars) {
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < M; i++) {
     for (int j = 0; j < N; j++) {
-      EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+      EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
     }
   }
   for (int i = 0; i < M; i++) {
-    EXPECT_NEAR(beta1[i].adj(), beta2[i].adj(), eps);
+    EXPECT_NEAR(beta1.adj()[i], beta2.adj()[i], eps);
   }
   for (int i = 0; i < C; i++) {
-    EXPECT_NEAR(cuts1[i].adj(), cuts2[i].adj(), eps);
+    EXPECT_NEAR(cuts1.adj()[i], cuts2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsOrderedLogisticGLM,
+TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
      glm_matches_ordered_logistic_vars_broadcast_y) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -111,19 +122,29 @@ TEST(ProbDistributionsOrderedLogisticGLM,
   using Eigen::VectorXd;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double eps = 1e-13;
   int N = 5;
   int M = 2;
   int C = 3;
-  Matrix<var, Dynamic, 1> cuts1(C), cuts2(C);
-  cuts1 << 0.9, 1.1, 7;
-  cuts2 << 0.9, 1.1, 7;
-  Matrix<var, Dynamic, 1> beta1(M), beta2(M);
-  beta1 << 1.1, 0.4;
-  beta2 << 1.1, 0.4;
-  Matrix<var, Dynamic, Dynamic> x1(N, M), x2(N, M);
-  x1 << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
-  x2 << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
+  Matrix<double, Dynamic, 1> cuts1_val(C), cuts2_val(C);
+  cuts1_val << 0.9, 1.1, 7;
+  cuts2_val << 0.9, 1.1, 7;
+  vector_v cuts1 = cuts1_val;
+  vector_v cuts2 = cuts2_val;
+  Matrix<double, Dynamic, 1> beta1_val(M), beta2_val(M);
+  beta1_val << 1.1, 0.4;
+  beta2_val << 1.1, 0.4;
+  vector_v beta1 = beta1_val;
+  vector_v beta2 = beta2_val;
+  Matrix<double, Dynamic, Dynamic> x1_val(N, M), x2_val(N, M);
+  x1_val << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
+  x2_val << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
+  matrix_v x1 = x1_val;
+  matrix_v x2 = x2_val;
 
   for (int y_scal = 1; y_scal <= C; y_scal++) {
     vector<int> y(N, y_scal);
@@ -136,20 +157,20 @@ TEST(ProbDistributionsOrderedLogisticGLM,
     EXPECT_NEAR(res1.val(), res2.val(), eps);
     for (int i = 0; i < M; i++) {
       for (int j = 0; j < N; j++) {
-        x_adj(j, i) = x2(j, i).adj();
-        EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+        x_adj(j, i) = x2.adj()(j, i);
+        EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
       }
     }
     for (int i = 0; i < M; i++) {
-      EXPECT_NEAR(beta1[i].adj(), beta2[i].adj(), eps);
+      EXPECT_NEAR(beta1.adj()[i], beta2.adj()[i], eps);
     }
     for (int i = 0; i < C; i++) {
-      EXPECT_NEAR(cuts1[i].adj(), cuts2[i].adj(), eps);
+      EXPECT_NEAR(cuts1.adj()[i], cuts2.adj()[i], eps);
     }
   }
 }
 
-TEST(ProbDistributionsOrderedLogisticGLM,
+TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
      glm_matches_ordered_logistic_vars_broadcast_x) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -158,21 +179,29 @@ TEST(ProbDistributionsOrderedLogisticGLM,
   using Eigen::VectorXd;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double eps = 1e-13;
   int N = 5;
   int M = 2;
   int C = 3;
   vector<int> y{1, 1, 2, 4, 4};
-  Matrix<var, Dynamic, 1> cuts1(C), cuts2(C);
-  cuts1 << 0.9, 1.1, 7;
-  cuts2 << 0.9, 1.1, 7;
-  Matrix<var, Dynamic, 1> beta1(M), beta2(M);
-  beta1 << 1.1, 0.4;
-  beta2 << 1.1, 0.4;
+  Matrix<double, Dynamic, 1> cuts1_val(C), cuts2_val(C);
+  cuts1_val << 0.9, 1.1, 7;
+  cuts2_val << 0.9, 1.1, 7;
+  vector_v cuts1 = cuts1_val;
+  vector_v cuts2 = cuts2_val;
+  Matrix<double, Dynamic, 1> beta1_val(M), beta2_val(M);
+  beta1_val << 1.1, 0.4;
+  beta2_val << 1.1, 0.4;
+  vector_v beta1 = beta1_val;
+  vector_v beta2 = beta2_val;
   RowVectorXd x_double(M);
   x_double << 1, 2;
-  Matrix<var, 1, Dynamic> x_row = x_double;
-  Matrix<var, Dynamic, Dynamic> x = x_double.replicate(N, 1);
+  row_vector_v x_row = x_double;
+  matrix_v x = x_double.replicate(N, 1);
 
   var res1 = ordered_logistic_glm_lpmf(y, x_row, beta1, cuts1);
   var res2 = ordered_logistic_glm_lpmf(y, x, beta2, cuts2);
@@ -182,19 +211,19 @@ TEST(ProbDistributionsOrderedLogisticGLM,
   for (int i = 0; i < M; i++) {
     double x_sum = 0;
     for (int j = 0; j < N; j++) {
-      x_sum += x(j, i).adj();
+      x_sum += x.adj()(j, i);
     }
-    EXPECT_NEAR(x_row[i].adj(), x_sum, eps);
+    EXPECT_NEAR(x_row.adj()[i], x_sum, eps);
   }
   for (int i = 0; i < M; i++) {
-    EXPECT_NEAR(beta1[i].adj(), beta2[i].adj(), eps);
+    EXPECT_NEAR(beta1.adj()[i], beta2.adj()[i], eps);
   }
   for (int i = 0; i < C; i++) {
-    EXPECT_NEAR(cuts1[i].adj(), cuts2[i].adj(), eps);
+    EXPECT_NEAR(cuts1.adj()[i], cuts2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsOrderedLogisticGLM,
+TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
      glm_matches_ordered_logistic_single_instance) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -203,37 +232,47 @@ TEST(ProbDistributionsOrderedLogisticGLM,
   using Eigen::VectorXd;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double eps = 1e-13;
   int N = 1;
   int M = 2;
   int C = 3;
   vector<int> y{1};
-  Matrix<var, Dynamic, 1> cuts1(C), cuts2(C);
-  cuts1 << 0.9, 1.1, 7;
-  cuts2 << 0.9, 1.1, 7;
-  Matrix<var, Dynamic, 1> beta1(M), beta2(M);
-  beta1 << 1.1, 0.4;
-  beta2 << 1.1, 0.4;
-  Matrix<var, Dynamic, Dynamic> x1(N, M), x2(N, M);
-  x1 << 1, 2;
-  x2 << 1, 2;
+  Matrix<double, Dynamic, 1> cuts1_val(C), cuts2_val(C);
+  cuts1_val << 0.9, 1.1, 7;
+  cuts2_val << 0.9, 1.1, 7;
+  vector_v cuts1 = cuts1_val;
+  vector_v cuts2 = cuts2_val;
+  Matrix<double, Dynamic, 1> beta1_val(M), beta2_val(M);
+  beta1_val << 1.1, 0.4;
+  beta2_val << 1.1, 0.4;
+  vector_v beta1 = beta1_val;
+  vector_v beta2 = beta2_val;
+  Matrix<double, Dynamic, Dynamic> x1_val(N, M), x2_val(N, M);
+  x1_val << 1, 2;
+  x2_val << 1, 2;
+  matrix_v x1 = x1_val;
+  matrix_v x2 = x2_val;
   var res1 = ordered_logistic_glm_lpmf(y, x1, beta1, cuts1);
   var res2 = ordered_logistic_glm_simple_lpmf<false>(y, x2, beta2, cuts2);
   (res1 + res2).grad();
 
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < M; i++) {
-    EXPECT_NEAR(x1(0, i).adj(), x2(0, i).adj(), eps);
+    EXPECT_NEAR(x1.adj()(0, i), x2.adj()(0, i), eps);
   }
   for (int i = 0; i < M; i++) {
-    EXPECT_NEAR(beta1[i].adj(), beta2[i].adj(), eps);
+    EXPECT_NEAR(beta1.adj()[i], beta2.adj()[i], eps);
   }
   for (int i = 0; i < C; i++) {
-    EXPECT_NEAR(cuts1[i].adj(), cuts2[i].adj(), eps);
+    EXPECT_NEAR(cuts1.adj()[i], cuts2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsOrderedLogisticGLM,
+TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
      glm_matches_ordered_logistic_zero_instances) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -242,32 +281,42 @@ TEST(ProbDistributionsOrderedLogisticGLM,
   using Eigen::VectorXd;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double eps = 1e-13;
   int N = 0;
   int M = 2;
   int C = 3;
   vector<int> y{};
-  Matrix<var, Dynamic, 1> cuts1(C), cuts2(C);
-  cuts1 << 0.9, 1.1, 7;
-  cuts2 << 0.9, 1.1, 7;
-  Matrix<var, Dynamic, 1> beta1(M), beta2(M);
-  beta1 << 1.1, 0.4;
-  beta2 << 1.1, 0.4;
-  Matrix<var, Dynamic, Dynamic> x1(N, M), x2(N, M);
+  Matrix<double, Dynamic, 1> cuts1_val(C), cuts2_val(C);
+  cuts1_val << 0.9, 1.1, 7;
+  cuts2_val << 0.9, 1.1, 7;
+  vector_v cuts1 = cuts1_val;
+  vector_v cuts2 = cuts2_val;
+  Matrix<double, Dynamic, 1> beta1_val(M), beta2_val(M);
+  beta1_val << 1.1, 0.4;
+  beta2_val << 1.1, 0.4;
+  vector_v beta1 = beta1_val;
+  vector_v beta2 = beta2_val;
+  Matrix<double, Dynamic, Dynamic> x1_val(N, M), x2_val(N, M);
+  matrix_v x1 = x1_val;
+  matrix_v x2 = x2_val;
   var res1 = ordered_logistic_glm_lpmf(y, x1, beta1, cuts1);
   var res2 = ordered_logistic_glm_simple_lpmf<false>(y, x2, beta2, cuts2);
   (res1 + res2).grad();
 
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < M; i++) {
-    EXPECT_NEAR(beta1[i].adj(), beta2[i].adj(), eps);
+    EXPECT_NEAR(beta1.adj()[i], beta2.adj()[i], eps);
   }
   for (int i = 0; i < C; i++) {
-    EXPECT_NEAR(cuts1[i].adj(), cuts2[i].adj(), eps);
+    EXPECT_NEAR(cuts1.adj()[i], cuts2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsOrderedLogisticGLM,
+TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
      glm_matches_ordered_logistic_zero_attributes) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -276,27 +325,37 @@ TEST(ProbDistributionsOrderedLogisticGLM,
   using Eigen::VectorXd;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double eps = 1e-13;
   int N = 5;
   int M = 0;
   int C = 3;
   vector<int> y{1, 1, 2, 4, 4};
-  Matrix<var, Dynamic, 1> cuts1(C), cuts2(C);
-  cuts1 << 0.9, 1.1, 7;
-  cuts2 << 0.9, 1.1, 7;
-  Matrix<var, Dynamic, 1> beta1(M), beta2(M);
-  Matrix<var, Dynamic, Dynamic> x1(N, M), x2(N, M);
+  Matrix<double, Dynamic, 1> cuts1_val(C), cuts2_val(C);
+  cuts1_val << 0.9, 1.1, 7;
+  cuts2_val << 0.9, 1.1, 7;
+  vector_v cuts1 = cuts1_val;
+  vector_v cuts2 = cuts2_val;
+  Matrix<double, Dynamic, 1> beta1_val(M), beta2_val(M);
+  vector_v beta1 = beta1_val;
+  vector_v beta2 = beta2_val;
+  Matrix<double, Dynamic, Dynamic> x1_val(N, M), x2_val(N, M);
+  matrix_v x1 = x1_val;
+  matrix_v x2 = x2_val;
   var res1 = ordered_logistic_glm_lpmf(y, x1, beta1, cuts1);
   var res2 = ordered_logistic_glm_simple_lpmf<false>(y, x2, beta2, cuts2);
   (res1 + res2).grad();
 
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < C; i++) {
-    EXPECT_NEAR(cuts1[i].adj(), cuts2[i].adj(), eps);
+    EXPECT_NEAR(cuts1.adj()[i], cuts2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsOrderedLogisticGLM,
+TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
      glm_matches_ordered_logistic_single_class) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -305,20 +364,30 @@ TEST(ProbDistributionsOrderedLogisticGLM,
   using Eigen::VectorXd;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double eps = 1e-13;
   int N = 5;
   int M = 2;
   int C = 1;
   vector<int> y{1, 1, 1, 1, 1};
-  Matrix<var, Dynamic, 1> cuts1(C), cuts2(C);
-  cuts1 << 0.9;
-  cuts2 << 0.9;
-  Matrix<var, Dynamic, 1> beta1(M), beta2(M);
-  beta1 << 1.1, 0.4;
-  beta2 << 1.1, 0.4;
-  Matrix<var, Dynamic, Dynamic> x1(N, M), x2(N, M);
-  x1 << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
-  x2 << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
+  Matrix<double, Dynamic, 1> cuts1_val(C), cuts2_val(C);
+  cuts1_val << 0.9;
+  cuts2_val << 0.9;
+  vector_v cuts1 = cuts1_val;
+  vector_v cuts2 = cuts2_val;
+  Matrix<double, Dynamic, 1> beta1_val(M), beta2_val(M);
+  beta1_val << 1.1, 0.4;
+  beta2_val << 1.1, 0.4;
+  vector_v beta1 = beta1_val;
+  vector_v beta2 = beta2_val;
+  Matrix<double, Dynamic, Dynamic> x1_val(N, M), x2_val(N, M);
+  x1_val << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
+  x2_val << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
+  matrix_v x1 = x1_val;
+  matrix_v x2 = x2_val;
   var res1 = ordered_logistic_glm_lpmf(y, x1, beta1, cuts1);
   var res2 = ordered_logistic_glm_simple_lpmf<false>(y, x2, beta2, cuts2);
   (res1 + res2).grad();
@@ -326,16 +395,16 @@ TEST(ProbDistributionsOrderedLogisticGLM,
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < M; i++) {
     for (int j = 0; j < N; j++) {
-      EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+      EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
     }
   }
   for (int i = 0; i < M; i++) {
-    EXPECT_NEAR(beta1[i].adj(), beta2[i].adj(), eps);
+    EXPECT_NEAR(beta1.adj()[i], beta2.adj()[i], eps);
   }
-  EXPECT_NEAR(cuts1[0].adj(), cuts2[0].adj(), eps);
+  EXPECT_NEAR(cuts1.adj()[0], cuts2.adj()[0], eps);
 }
 
-TEST(ProbDistributionsOrderedLogisticGLM,
+TYPED_TEST(ProbDistributionsOrderedLogisticGLM,
      glm_matches_ordered_logistic_vars_big) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -344,6 +413,10 @@ TEST(ProbDistributionsOrderedLogisticGLM,
   using Eigen::VectorXd;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double eps = 1e-7;
   int N = 155;
   int M = 15;
@@ -356,11 +429,11 @@ TEST(ProbDistributionsOrderedLogisticGLM,
   for (int i = 1; i < C; i++) {
     cuts_double[i] += cuts_double[i - 1];
   }
-  Matrix<var, Dynamic, 1> cuts1 = cuts_double, cuts2 = cuts_double;
+  vector_v cuts1 = cuts_double, cuts2 = cuts_double;
   VectorXd beta_double = VectorXd::Random(M);
-  Matrix<var, Dynamic, 1> beta1 = beta_double, beta2 = beta_double;
+  vector_v beta1 = beta_double, beta2 = beta_double;
   MatrixXd x_double = MatrixXd::Random(N, M);
-  Matrix<var, Dynamic, Dynamic> x1 = x_double, x2 = x_double;
+  matrix_v x1 = x_double, x2 = x_double;
   var res1 = ordered_logistic_glm_lpmf(y, x1, beta1, cuts1);
   var res2 = ordered_logistic_glm_simple_lpmf<false>(y, x2, beta2, cuts2);
   (res1 + res2).grad();
@@ -370,19 +443,19 @@ TEST(ProbDistributionsOrderedLogisticGLM,
   EXPECT_NEAR(res1.val(), res2.val(), eps);
   for (int i = 0; i < M; i++) {
     for (int j = 0; j < N; j++) {
-      x_adj(j, i) = x2(j, i).adj();
-      EXPECT_NEAR(x1(j, i).adj(), x2(j, i).adj(), eps);
+      x_adj(j, i) = x2.adj()(j, i);
+      EXPECT_NEAR(x1.adj()(j, i), x2.adj()(j, i), eps);
     }
   }
   for (int i = 0; i < M; i++) {
-    EXPECT_NEAR(beta1[i].adj(), beta2[i].adj(), eps);
+    EXPECT_NEAR(beta1.adj()[i], beta2.adj()[i], eps);
   }
   for (int i = 0; i < C; i++) {
-    EXPECT_NEAR(cuts1[i].adj(), cuts2[i].adj(), eps);
+    EXPECT_NEAR(cuts1.adj()[i], cuts2.adj()[i], eps);
   }
 }
 
-TEST(ProbDistributionsOrderedLogisticGLM, glm_interfaces) {
+TYPED_TEST(ProbDistributionsOrderedLogisticGLM, glm_interfaces) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
@@ -390,6 +463,10 @@ TEST(ProbDistributionsOrderedLogisticGLM, glm_interfaces) {
   using Eigen::VectorXd;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   int N = 5;
   int M = 2;
   int C = 3;
@@ -397,16 +474,16 @@ TEST(ProbDistributionsOrderedLogisticGLM, glm_interfaces) {
   int y_scal = 1;
   VectorXd cuts_double(C);
   cuts_double << 0.9, 1.1, 7;
-  Matrix<var, Dynamic, 1> cuts_var = cuts_double;
+  vector_v cuts_var = cuts_double;
   VectorXd beta_double(M);
   beta_double << 1.1, 0.4;
-  Matrix<var, Dynamic, 1> beta_var = beta_double;
+  vector_v beta_var = beta_double;
   Matrix<double, Dynamic, Dynamic> x_double(N, M);
   x_double << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0;
-  Matrix<var, Dynamic, Dynamic> x_var = x_double;
+  matrix_v x_var = x_double;
   Matrix<double, 1, Dynamic> x_row_double(M);
   x_row_double << 1, 2;
-  Matrix<var, 1, Dynamic> x_row_var = x_row_double;
+  row_vector_v x_row_var = x_row_double;
 
   EXPECT_NO_THROW(stan::math::ordered_logistic_glm_lpmf(
       y, x_double, beta_double, cuts_double));

--- a/test/unit/math/rev/prob/poisson_log_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/poisson_log_glm_lpmf_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev.hpp>
 #include <stan/math/prim.hpp>
+#include <test/unit/math/rev/util.hpp>
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>
@@ -53,18 +54,30 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_doubles_rand) {
         (stan::math::poisson_log_glm_lpmf<true>(y, x, alpha, beta)));
   }
 }
+
+template <class T>
+class ProbDistributionsPoissonLogGLM : public stan::math::test::VarMatrixTypedTests<T> {};
+
+TYPED_TEST_SUITE(ProbDistributionsPoissonLogGLM, stan::math::test::VarMatImpls);
+
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars) {
+TYPED_TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   vector<int> y{14, 2, 5};
-  Matrix<var, Dynamic, Dynamic> x(3, 2);
-  x << -12, 46, -42, 24, 25, 27;
-  Matrix<var, Dynamic, 1> beta(2, 1);
-  beta << 0.3, 2;
+  Matrix<double, Dynamic, Dynamic> x_val(3, 2);
+  x_val << -12, 46, -42, 24, 25, 27;
+  Matrix<var, Dynamic, Dynamic> x = x_val;
+  Matrix<double, Dynamic, 1> beta_val(2, 1);
+  beta_val << 0.3, 2;
+  Matrix<var, Dynamic, 1> beta = beta_val;
   var alpha = 0.3;
   Matrix<var, Dynamic, 1> alphavec = alpha * Matrix<double, 3, 1>::Ones();
   Matrix<var, Dynamic, 1> theta(3, 1);
@@ -86,37 +99,39 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars) {
   stan::math::recover_memory();
 
   vector<int> y2{14, 2, 5};
-  Matrix<var, Dynamic, Dynamic> x2(3, 2);
-  x2 << -12, 46, -42, 24, 25, 27;
-  Matrix<var, Dynamic, 1> beta2(2, 1);
-  beta2 << 0.3, 2;
+  matrix_v x2 = x_val;
+  vector_v beta2 = beta_val;
   var alpha2 = 0.3;
   var lp2 = stan::math::poisson_log_glm_lpmf(y2, x2, alpha2, beta2);
   lp2.grad();
   EXPECT_FLOAT_EQ(lp_val, lp2.val());
   EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
   for (size_t i = 0; i < 2; i++) {
-    EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+    EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
     for (size_t j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
+      EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
     }
   }
 }
 
-TEST(ProbDistributionsPoissonLogGLM, broadcast_x) {
+TYPED_TEST(ProbDistributionsPoissonLogGLM, broadcast_x) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   vector<int> y{1, 0, 5};
   Matrix<double, 1, Dynamic> x(1, 2);
   x << -12, 46;
-  Matrix<var, 1, Dynamic> x1 = x;
-  Matrix<var, Dynamic, Dynamic> x_mat = x.replicate(3, 1);
+  row_vector_v x1 = x;
+  matrix_v x_mat = x.replicate(3, 1);
   Matrix<double, Dynamic, 1> beta(2, 1);
   beta << 0.3, 2;
-  Matrix<var, Dynamic, 1> beta1 = beta;
-  Matrix<var, Dynamic, 1> beta2 = beta;
+  vector_v beta1 = beta;
+  vector_v beta2 = beta;
   var alpha1 = 0.3;
   var alpha2 = 0.3;
 
@@ -128,27 +143,30 @@ TEST(ProbDistributionsPoissonLogGLM, broadcast_x) {
   (lp1 + lp2).grad();
 
   for (int i = 0; i < 2; i++) {
-    EXPECT_DOUBLE_EQ(x1[i].adj(), x_mat.col(i).adj().sum());
-    EXPECT_DOUBLE_EQ(beta1[i].adj(), beta2[i].adj());
+    EXPECT_DOUBLE_EQ(x1.adj()[i], x_mat.col(i).adj().sum());
+    EXPECT_DOUBLE_EQ(beta1.adj()[i], beta2.adj()[i]);
   }
   EXPECT_DOUBLE_EQ(alpha1.adj(), alpha2.adj());
 }
 
-TEST(ProbDistributionsPoissonLogGLM, broadcast_y) {
+TYPED_TEST(ProbDistributionsPoissonLogGLM, broadcast_y) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   int y = 13;
   Matrix<int, Dynamic, 1> y_vec = Matrix<int, Dynamic, 1>::Constant(3, 1, y);
   Matrix<double, Dynamic, Dynamic> x(3, 2);
   x << -12, 46, -42, 24, 25, 27;
-  Matrix<var, Dynamic, Dynamic> x1 = x;
-  Matrix<var, Dynamic, Dynamic> x2 = x;
+  matrix_v x1 = x;
+  matrix_v x2 = x;
   Matrix<double, Dynamic, 1> beta(2, 1);
   beta << 0.3, 2;
-  Matrix<var, Dynamic, 1> beta1 = beta;
-  Matrix<var, Dynamic, 1> beta2 = beta;
+  vector_v beta1 = beta;
+  vector_v beta2 = beta;
   var alpha1 = 0.3;
   var alpha2 = 0.3;
 
@@ -161,19 +179,22 @@ TEST(ProbDistributionsPoissonLogGLM, broadcast_y) {
 
   for (int i = 0; i < 2; i++) {
     for (int j = 0; j < 2; j++) {
-      EXPECT_DOUBLE_EQ(x1(j, i).adj(), x2(j, i).adj());
+      EXPECT_DOUBLE_EQ(x1.adj()(j, i), x2.adj()(j, i));
     }
-    EXPECT_DOUBLE_EQ(beta1[i].adj(), beta2[i].adj());
+    EXPECT_DOUBLE_EQ(beta1.adj()[i], beta2.adj()[i]);
   }
   EXPECT_DOUBLE_EQ(alpha1.adj(), alpha2.adj());
 }
 
-TEST(ProbDistributionsPoissonLogGLM,
+TYPED_TEST(ProbDistributionsPoissonLogGLM,
      glm_matches_poisson_log_vars_zero_instances) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   vector<int> y{};
   Matrix<var, Dynamic, Dynamic> x(0, 2);
   Matrix<var, Dynamic, 1> beta(2, 1);
@@ -193,25 +214,27 @@ TEST(ProbDistributionsPoissonLogGLM,
   stan::math::recover_memory();
 
   vector<int> y2{};
-  Matrix<var, Dynamic, Dynamic> x2(0, 2);
-  Matrix<var, Dynamic, 1> beta2(2, 1);
-  beta2 << 0.3, 2;
+  matrix_v x2 = x.val();
+  vector_v beta2 = beta.val();
   var alpha2 = 0.3;
   var lp2 = stan::math::poisson_log_glm_lpmf(y2, x2, alpha2, beta2);
   lp2.grad();
   EXPECT_FLOAT_EQ(lp_val, lp2.val());
   EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
   for (size_t i = 0; i < 2; i++) {
-    EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+    EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
   }
 }
 
-TEST(ProbDistributionsPoissonLogGLM,
+TYPED_TEST(ProbDistributionsPoissonLogGLM,
      glm_matches_poisson_log_vars_zero_attributes) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   vector<int> y{14, 2, 5};
   Matrix<var, Dynamic, Dynamic> x(3, 0);
   Matrix<var, Dynamic, 1> beta(0, 1);
@@ -228,8 +251,8 @@ TEST(ProbDistributionsPoissonLogGLM,
   stan::math::recover_memory();
 
   vector<int> y2{14, 2, 5};
-  Matrix<var, Dynamic, Dynamic> x2(3, 0);
-  Matrix<var, Dynamic, 1> beta2(0, 1);
+  matrix_v x2 = Matrix<double, Dynamic, Dynamic>(3, 0);
+  vector_v beta2 = Matrix<double, Dynamic, 1>(0, 1);
   var alpha2 = 0.3;
   var lp2 = stan::math::poisson_log_glm_lpmf(y2, x2, alpha2, beta2);
   lp2.grad();
@@ -239,11 +262,14 @@ TEST(ProbDistributionsPoissonLogGLM,
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
-TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars_rand) {
+TYPED_TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars_rand) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
   for (size_t ii = 0; ii < 200; ii++) {
     vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
@@ -276,17 +302,17 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars_rand) {
 
     stan::math::recover_memory();
 
-    Matrix<var, Dynamic, 1> beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
+    vector_v beta2 = betareal;
+    matrix_v x2 = xreal;
     var alpha2 = alphareal[0];
     var lp2 = stan::math::poisson_log_glm_lpmf(y, x2, alpha2, beta2);
     lp2.grad();
     EXPECT_FLOAT_EQ(lp_val, lp2.val());
     EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
     for (size_t i = 0; i < 2; i++) {
-      EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+      EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
       for (size_t j = 0; j < 3; j++) {
-        EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
+        EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
       }
     }
   }
@@ -294,12 +320,16 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars_rand) {
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, in case beta is a scalar.
-TEST(ProbDistributionsPoissonLogGLM,
+TYPED_TEST(ProbDistributionsPoissonLogGLM,
      glm_matches_poisson_log_vars_rand_scal_beta) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   for (size_t ii = 0; ii < 42; ii++) {
     vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
@@ -329,7 +359,7 @@ TEST(ProbDistributionsPoissonLogGLM,
     stan::math::recover_memory();
 
     var beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
+    matrix_v x2 = xreal;
     var alpha2 = alphareal[0];
     var lp2 = stan::math::poisson_log_glm_lpmf(y, x2, alpha2, beta2);
     lp2.grad();
@@ -337,18 +367,22 @@ TEST(ProbDistributionsPoissonLogGLM,
     EXPECT_FLOAT_EQ(beta_adj, beta2.adj());
     EXPECT_FLOAT_EQ(alpha_adj, alpha2.adj());
     for (size_t j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(x_adj(j, 0), x2(j, 0).adj());
+      EXPECT_FLOAT_EQ(x_adj(j, 0), x2.adj()(j, 0));
     }
   }
 }
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, for the GLM with varying intercept.
-TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_varying_intercept) {
+TYPED_TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_varying_intercept) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   for (size_t ii = 0; ii < 42; ii++) {
     vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
@@ -386,32 +420,36 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_varying_intercept) {
 
     stan::math::recover_memory();
 
-    Matrix<var, Dynamic, 1> beta2 = betareal;
-    Matrix<var, Dynamic, Dynamic> x2 = xreal;
-    Matrix<var, Dynamic, 1> alpha2 = alphareal;
+    vector_v beta2 = betareal;
+    matrix_v x2 = xreal;
+    vector_v alpha2 = alphareal;
 
     var lp2 = stan::math::poisson_log_glm_lpmf(y, x2, alpha2, beta2);
     lp2.grad();
 
     EXPECT_FLOAT_EQ(lp_val, lp2.val());
     for (size_t i = 0; i < 2; i++) {
-      EXPECT_FLOAT_EQ(beta_adj[i], beta2[i].adj());
+      EXPECT_FLOAT_EQ(beta_adj[i], beta2.adj()[i]);
       for (size_t j = 0; j < 3; j++) {
-        EXPECT_FLOAT_EQ(x_adj(j, i), x2(j, i).adj());
+        EXPECT_FLOAT_EQ(x_adj(j, i), x2.adj()(j, i));
       }
     }
     for (size_t j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(alpha_adj[j], alpha2[j].adj());
+      EXPECT_FLOAT_EQ(alpha_adj[j], alpha2.adj()[j]);
     }
   }
 }
 
 //  We check that we can instantiate all different interface types.
-TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_interface_types) {
+TYPED_TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_interface_types) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
   using std::vector;
+  using matrix_v = typename TypeParam::matrix_v;
+  using vector_v = typename TypeParam::vector_v;
+  using row_vector_v = typename TypeParam::row_vector_v;
+
   double value = 0;
   double value2 = 0;
 
@@ -420,12 +458,12 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_interface_types) {
   double d = 1.0;
   std::vector<double> vd = {{1.0, 2.0}};
   Eigen::VectorXd ev(2);
+  ev << 1.0, 2.0;
   Eigen::RowVectorXd rv(2);
+  rv << 1.0, 2.0;
   Eigen::MatrixXd m1(1, 1);
   m1 << 1.0;
   Eigen::MatrixXd m(2, 2);
-  ev << 1.0, 2.0;
-  rv << 1.0, 2.0;
   m << 1.0, 2.0, 3.0, 4.0;
 
   value += stan::math::poisson_log_glm_lpmf(i, m1, d, d);
@@ -435,14 +473,10 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_interface_types) {
 
   var v = 1.0;
   std::vector<var> vv = {{1.0, 2.0}};
-  Eigen::Matrix<var, -1, 1> evv(2);
-  Eigen::Matrix<var, 1, -1> rvv(2);
-  Eigen::Matrix<var, -1, -1> m1v(1, 1);
-  m1v << 1.0;
-  Eigen::Matrix<var, -1, -1> mv(2, 2);
-  evv << 1.0, 2.0;
-  rvv << 1.0, 2.0;
-  mv << 1.0, 2.0, 3.0, 4.0;
+  vector_v evv = ev;
+  row_vector_v rvv = rv;
+  matrix_v m1v = m1;
+  matrix_v mv = m;
 
   value2 += stan::math::poisson_log_glm_lpmf(i, m1v, v, v).val();
   value2 += stan::math::poisson_log_glm_lpmf(vi, mv, vv, vv).val();

--- a/test/unit/math/rev/prob/poisson_log_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/poisson_log_glm_lpmf_test.cpp
@@ -56,7 +56,8 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_doubles_rand) {
 }
 
 template <class T>
-class ProbDistributionsPoissonLogGLM : public stan::math::test::VarMatrixTypedTests<T> {};
+class ProbDistributionsPoissonLogGLM
+    : public stan::math::test::VarMatrixTypedTests<T> {};
 
 TYPED_TEST_SUITE(ProbDistributionsPoissonLogGLM, stan::math::test::VarMatImpls);
 
@@ -187,7 +188,7 @@ TYPED_TEST(ProbDistributionsPoissonLogGLM, broadcast_y) {
 }
 
 TYPED_TEST(ProbDistributionsPoissonLogGLM,
-     glm_matches_poisson_log_vars_zero_instances) {
+           glm_matches_poisson_log_vars_zero_instances) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -227,7 +228,7 @@ TYPED_TEST(ProbDistributionsPoissonLogGLM,
 }
 
 TYPED_TEST(ProbDistributionsPoissonLogGLM,
-     glm_matches_poisson_log_vars_zero_attributes) {
+           glm_matches_poisson_log_vars_zero_attributes) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -321,7 +322,7 @@ TYPED_TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars_rand) {
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, in case beta is a scalar.
 TYPED_TEST(ProbDistributionsPoissonLogGLM,
-     glm_matches_poisson_log_vars_rand_scal_beta) {
+           glm_matches_poisson_log_vars_rand_scal_beta) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -374,7 +375,8 @@ TYPED_TEST(ProbDistributionsPoissonLogGLM,
 
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, for the GLM with varying intercept.
-TYPED_TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_varying_intercept) {
+TYPED_TEST(ProbDistributionsPoissonLogGLM,
+           glm_matches_poisson_varying_intercept) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -441,7 +443,8 @@ TYPED_TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_varying_intercept
 }
 
 //  We check that we can instantiate all different interface types.
-TYPED_TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_interface_types) {
+TYPED_TEST(ProbDistributionsPoissonLogGLM,
+           glm_matches_poisson_log_interface_types) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;

--- a/test/unit/math/rev/util.hpp
+++ b/test/unit/math/rev/util.hpp
@@ -5,6 +5,42 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+namespace stan {
+  namespace math {
+    namespace test {
+      template <bool UseVarMat>
+      using cond_var_matrix_t = std::conditional_t<UseVarMat,
+       stan::math::var_value<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>, Eigen::Matrix<stan::math::var, Eigen::Dynamic, Eigen::Dynamic>>;
+      template <bool UseVarMat>
+      using cond_var_vector_t = std::conditional_t<UseVarMat,
+        stan::math::var_value<Eigen::Matrix<double, Eigen::Dynamic, 1>>, Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>>;
+      template <bool UseVarMat>
+      using cond_var_row_vector_t = std::conditional_t<UseVarMat,
+        stan::math::var_value<Eigen::Matrix<double, 1, Eigen::Dynamic>>, Eigen::Matrix<stan::math::var, 1, Eigen::Dynamic>>;
+
+        template <bool UseVarMat>
+        struct var_matrix_types {
+          using matrix_v = stan::math::test::cond_var_matrix_t<UseVarMat>;
+          using row_vector_v = stan::math::test::cond_var_row_vector_t<UseVarMat>;
+          using vector_v = stan::math::test::cond_var_vector_t<UseVarMat>;
+        };
+
+        template <class T>
+        class VarMatrixTypedTests : public testing::Test {
+        public:
+          using matrix_v = typename T::matrix_v;
+          using row_vector_v = typename T::row_vector_v;
+          using vector_v = typename T::vector_v;
+          virtual ~VarMatrixTypedTests() {
+            stan::math::recover_memory();
+          }
+
+        };
+        using VarMatImpls = testing::Types<stan::math::test::var_matrix_types<false>, stan::math::test::var_matrix_types<true>>;
+    }
+  }
+}
+
 namespace test {
 
 void check_varis_on_stack(const stan::math::var& x) {

--- a/test/unit/math/rev/util.hpp
+++ b/test/unit/math/rev/util.hpp
@@ -6,40 +6,43 @@
 #include <vector>
 
 namespace stan {
-  namespace math {
-    namespace test {
-      template <bool UseVarMat>
-      using cond_var_matrix_t = std::conditional_t<UseVarMat,
-       stan::math::var_value<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>, Eigen::Matrix<stan::math::var, Eigen::Dynamic, Eigen::Dynamic>>;
-      template <bool UseVarMat>
-      using cond_var_vector_t = std::conditional_t<UseVarMat,
-        stan::math::var_value<Eigen::Matrix<double, Eigen::Dynamic, 1>>, Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>>;
-      template <bool UseVarMat>
-      using cond_var_row_vector_t = std::conditional_t<UseVarMat,
-        stan::math::var_value<Eigen::Matrix<double, 1, Eigen::Dynamic>>, Eigen::Matrix<stan::math::var, 1, Eigen::Dynamic>>;
+namespace math {
+namespace test {
+template <bool UseVarMat>
+using cond_var_matrix_t = std::conditional_t<
+    UseVarMat,
+    stan::math::var_value<
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>,
+    Eigen::Matrix<stan::math::var, Eigen::Dynamic, Eigen::Dynamic>>;
+template <bool UseVarMat>
+using cond_var_vector_t = std::conditional_t<
+    UseVarMat, stan::math::var_value<Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>>;
+template <bool UseVarMat>
+using cond_var_row_vector_t = std::conditional_t<
+    UseVarMat, stan::math::var_value<Eigen::Matrix<double, 1, Eigen::Dynamic>>,
+    Eigen::Matrix<stan::math::var, 1, Eigen::Dynamic>>;
 
-        template <bool UseVarMat>
-        struct var_matrix_types {
-          using matrix_v = stan::math::test::cond_var_matrix_t<UseVarMat>;
-          using row_vector_v = stan::math::test::cond_var_row_vector_t<UseVarMat>;
-          using vector_v = stan::math::test::cond_var_vector_t<UseVarMat>;
-        };
+template <bool UseVarMat>
+struct var_matrix_types {
+  using matrix_v = stan::math::test::cond_var_matrix_t<UseVarMat>;
+  using row_vector_v = stan::math::test::cond_var_row_vector_t<UseVarMat>;
+  using vector_v = stan::math::test::cond_var_vector_t<UseVarMat>;
+};
 
-        template <class T>
-        class VarMatrixTypedTests : public testing::Test {
-        public:
-          using matrix_v = typename T::matrix_v;
-          using row_vector_v = typename T::row_vector_v;
-          using vector_v = typename T::vector_v;
-          virtual ~VarMatrixTypedTests() {
-            stan::math::recover_memory();
-          }
-
-        };
-        using VarMatImpls = testing::Types<stan::math::test::var_matrix_types<false>, stan::math::test::var_matrix_types<true>>;
-    }
-  }
-}
+template <class T>
+class VarMatrixTypedTests : public testing::Test {
+ public:
+  using matrix_v = typename T::matrix_v;
+  using row_vector_v = typename T::row_vector_v;
+  using vector_v = typename T::vector_v;
+  virtual ~VarMatrixTypedTests() { stan::math::recover_memory(); }
+};
+using VarMatImpls = testing::Types<stan::math::test::var_matrix_types<false>,
+                                   stan::math::test::var_matrix_types<true>>;
+}  // namespace test
+}  // namespace math
+}  // namespace stan
 
 namespace test {
 


### PR DESCRIPTION
## Summary

Updates the glm functions and their tests to use `var<Matrix>` types. This also has a small bugfix for assigning row vectors to `var<Vector>` types. 99% of the PR here is actually just updating the glm tests to use `TYPED_TESTS()` for checking both normal matrices and var matrices.

## Tests

The glm tests have all been modified to be a `TYPED_TEST_SUITE()` with each test using `TYPED_TEST()` instead of just `TEST()` so that it will check if the functions work for both `Eigen::Matrix<var>` and `var_value<Eigen::Matrix<double>>` types.

## Side Effects

Nope

## Release notes

Have glm functions work for the new matrix type

## Checklist

- [x] Math issue #1805 

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
