### PR TITLE
add loglogistic_log

### DIFF
--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -176,6 +176,7 @@
 #include <stan/math/prim/prob/logistic_lpdf.hpp>
 #include <stan/math/prim/prob/logistic_rng.hpp>
 #include <stan/math/prim/prob/loglogistic_cdf.hpp>
+#include <stan/math/prim/prob/loglogistic_log.hpp>
 #include <stan/math/prim/prob/loglogistic_lpdf.hpp>
 #include <stan/math/prim/prob/loglogistic_rng.hpp>
 #include <stan/math/prim/prob/lognormal_ccdf_log.hpp>

--- a/stan/math/prim/prob/loglogistic_log.hpp
+++ b/stan/math/prim/prob/loglogistic_log.hpp
@@ -25,7 +25,7 @@ namespace math {
 template <bool propto, typename T_y, typename T_scale, typename T_shape,
           require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
               T_y, T_scale, T_shape>* = nullptr>
-return_type_t<T_y, T_scale, T_shape> loglogistic_lpdf(const T_y& y,
+return_type_t<T_y, T_scale, T_shape> loglogistic_log(const T_y& y,
                                                       const T_scale& alpha,
                                                       const T_shape& beta) {
   return loglogistic_lpdf<propto, T_y, T_scale, T_shape>(y, alpha, beta);
@@ -35,7 +35,7 @@ return_type_t<T_y, T_scale, T_shape> loglogistic_lpdf(const T_y& y,
  * @deprecated use <code>loglogistic_lpdf</code>
  */
 template <typename T_y, typename T_scale, typename T_shape>
-inline return_type_t<T_y, T_scale, T_shape> loglogistic_lpdf(
+inline return_type_t<T_y, T_scale, T_shape> loglogistic_log(
     const T_y& y, const T_scale& alpha, const T_shape& beta) {
   return loglogistic_lpdf<false>(y, alpha, beta);
 }

--- a/stan/math/prim/prob/loglogistic_log.hpp
+++ b/stan/math/prim/prob/loglogistic_log.hpp
@@ -1,0 +1,45 @@
+#ifndef STAN_MATH_PRIM_PROB_LOGLOGISTIC_LOG_HPP
+#define STAN_MATH_PRIM_PROB_LOGLOGISTIC_LOG_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/as_column_vector_or_scalar.hpp>
+#include <stan/math/prim/fun/as_array_or_scalar.hpp>
+#include <stan/math/prim/fun/as_value_column_array_or_scalar.hpp>
+#include <stan/math/prim/fun/exp.hpp>
+#include <stan/math/prim/fun/log.hpp>
+#include <stan/math/prim/fun/max_size.hpp>
+#include <stan/math/prim/fun/size.hpp>
+#include <stan/math/prim/fun/size_zero.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/** \ingroup prob_dists
+ * @deprecated use <code>loglogistic_lpdf</code>
+ */
+template <bool propto, typename T_y, typename T_scale, typename T_shape,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_scale, T_shape>* = nullptr>
+return_type_t<T_y, T_scale, T_shape> loglogistic_lpdf(const T_y& y,
+                                                      const T_scale& alpha,
+                                                      const T_shape& beta) {
+  return loglogistic_lpdf<propto, T_y, T_scale, T_shape>(y, alpha, beta);
+}
+
+/** \ingroup prob_dists
+ * @deprecated use <code>loglogistic_lpdf</code>
+ */
+template <typename T_y, typename T_scale, typename T_shape>
+inline return_type_t<T_y, T_scale, T_shape> loglogistic_lpdf(
+    const T_y& y, const T_scale& alpha, const T_shape& beta) {
+  return loglogistic_lpdf<false>(y, alpha, beta);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/prob/loglogistic_log.hpp
+++ b/stan/math/prim/prob/loglogistic_log.hpp
@@ -14,8 +14,8 @@ template <bool propto, typename T_y, typename T_scale, typename T_shape,
           require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
               T_y, T_scale, T_shape>* = nullptr>
 return_type_t<T_y, T_scale, T_shape> loglogistic_log(const T_y& y,
-                                                      const T_scale& alpha,
-                                                      const T_shape& beta) {
+                                                     const T_scale& alpha,
+                                                     const T_shape& beta) {
   return loglogistic_lpdf<propto, T_y, T_scale, T_shape>(y, alpha, beta);
 }
 

--- a/stan/math/prim/prob/loglogistic_log.hpp
+++ b/stan/math/prim/prob/loglogistic_log.hpp
@@ -2,19 +2,7 @@
 #define STAN_MATH_PRIM_PROB_LOGLOGISTIC_LOG_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/err.hpp>
-#include <stan/math/prim/fun/as_column_vector_or_scalar.hpp>
-#include <stan/math/prim/fun/as_array_or_scalar.hpp>
-#include <stan/math/prim/fun/as_value_column_array_or_scalar.hpp>
-#include <stan/math/prim/fun/exp.hpp>
-#include <stan/math/prim/fun/log.hpp>
-#include <stan/math/prim/fun/max_size.hpp>
-#include <stan/math/prim/fun/size.hpp>
-#include <stan/math/prim/fun/size_zero.hpp>
-#include <stan/math/prim/fun/to_ref.hpp>
-#include <stan/math/prim/fun/value_of.hpp>
-#include <stan/math/prim/functor/operands_and_partials.hpp>
-#include <cmath>
+#include <stan/math/prim/prob/loglogistic_lpdf.hpp>
 
 namespace stan {
 namespace math {


### PR DESCRIPTION
## Summary

Adds loglogistic_log (the deprecated suffix) as calls to loglogistic_lpdf so we can expose loglogistic distribution in https://github.com/stan-dev/stanc3/pull/1094

## Tests

/

## Side Effects

/

## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

