### PR TITLE
Fix for to_matrix(row_vector) and to_matrix(vector)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -260,9 +260,9 @@ pipeline {
                 sh """
                     export TBB_INC=\$(pwd)/lib/tbb_2020.3/include
                     export TBB_LIB=\$(pwd)/lib/tbb
+		    echo TBB_INTERFACE_NEW=true > make/local
                 """
-	            sh "echo CXX=${CLANG_CXX} >> make/local"
-                sh "echo CXXFLAGS += -fsanitize=address >> make/local"
+	        sh "echo CXXFLAGS += -fsanitize=address >> make/local"
                 script {
                     if (isUnix()) {
                         runTests("test/unit/math/test_ad_test.cpp", false)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -260,7 +260,6 @@ pipeline {
                 sh """
                     export TBB_INC=\$(pwd)/lib/tbb_2020.3/include
                     export TBB_LIB=\$(pwd)/lib/tbb
-                    echo TBB_INTERFACE_NEW=true > make/local
                 """
 	            sh "echo CXX=${CLANG_CXX} >> make/local"
                 sh "echo CXXFLAGS += -fsanitize=address >> make/local"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -260,9 +260,9 @@ pipeline {
 	            sh "echo CXXFLAGS += -fsanitize=address >> make/local"
                 script {
                     if (isUnix()) {
-                        runTests("test/unit/math/test_ad_test.cpp", false)
+                        runTests("test/unit", false)
                     } else {
-                        runTestsWin("test/unit/math/test_ad_test.cpp", true)
+                        runTestsWin("test/unit", true)
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -243,11 +243,7 @@ pipeline {
         }
 
         stage('Full Unit Tests') {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                }
+            agent {  label 'gg-linux'  }
             }
             when {
                 expression {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,7 +262,8 @@ pipeline {
                     export TBB_LIB=\$(pwd)/lib/tbb
                     echo TBB_INTERFACE_NEW=true > make/local
                 """
-	            sh "echo CXXFLAGS += -fsanitize=address >> make/local"
+	            sh "echo CXX=${CLANG_CXX} >> make/local"
+                sh "echo CXXFLAGS += -fsanitize=address >> make/local"
                 script {
                     if (isUnix()) {
                         runTests("test/unit/math/test_ad_test.cpp", false)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,7 +244,6 @@ pipeline {
 
         stage('Full Unit Tests') {
             agent {  label 'gg-linux'  }
-            }
             when {
                 expression {
                     !skipRemainingStages
@@ -253,12 +252,12 @@ pipeline {
             steps {
                 unstash 'MathSetup'
                 // Set Stan local compiler flags to use the new TBB interface
-                sh """
-                    export TBB_INC=\$(pwd)/lib/tbb_2020.3/include
-                    export TBB_LIB=\$(pwd)/lib/tbb
-		    echo TBB_INTERFACE_NEW=true > make/local
-                """
-	        sh "echo CXXFLAGS += -fsanitize=address >> make/local"
+                // sh """
+                //     export TBB_INC=\$(pwd)/lib/tbb_2020.3/include
+                //     export TBB_LIB=\$(pwd)/lib/tbb
+                //     echo TBB_INTERFACE_NEW=true > make/local
+                // """
+	            sh "echo CXXFLAGS += -fsanitize=address >> make/local"
                 script {
                     if (isUnix()) {
                         runTests("test/unit/math/test_ad_test.cpp", false)

--- a/stan/math/prim/fun/to_matrix.hpp
+++ b/stan/math/prim/fun/to_matrix.hpp
@@ -34,10 +34,11 @@ inline EigMat to_matrix(EigMat&& x) {
  * @return the matrix representation of the input
  */
 template <typename EigMat, require_eigen_vector_t<EigMat>* = nullptr>
-inline Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> to_matrix(
-    const EigMat& matrix) {
+inline Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> 
+  to_matrix(const EigMat& matrix) {
   using T = value_type_t<EigMat>;
-  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> res(matrix.rows(), matrix.cols());
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> 
+      res(matrix.rows(), matrix.cols());
   Eigen::Map<
       Eigen::Matrix<T, EigMat::RowsAtCompileTime, EigMat::ColsAtCompileTime>>
       res_map(res.data(), matrix.rows(), matrix.cols());

--- a/stan/math/prim/fun/to_matrix.hpp
+++ b/stan/math/prim/fun/to_matrix.hpp
@@ -35,7 +35,9 @@ inline EigMat to_matrix(EigMat&& x) {
  */
 template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
 inline auto to_matrix(EigVec&& matrix) {
-  return Eigen::Matrix<value_type_t<EigVec>, Eigen::Dynamic, Eigen::Dynamic>(std::forward<EigVec>(matrix));
+  return Eigen::Matrix<
+          value_type_t<EigVec>,
+          Eigen::Dynamic, Eigen::Dynamic>(std::forward<EigVec>(matrix));
 }
 
 /**

--- a/stan/math/prim/fun/to_matrix.hpp
+++ b/stan/math/prim/fun/to_matrix.hpp
@@ -18,7 +18,7 @@ namespace math {
  * @param x matrix
  * @return the matrix representation of the input
  */
-template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
+template <typename EigMat, require_eigen_dense_dynamic_t<EigMat>* = nullptr>
 inline EigMat to_matrix(EigMat&& x) {
   return std::forward<EigMat>(x);
 }
@@ -33,17 +33,9 @@ inline EigMat to_matrix(EigMat&& x) {
  * @param x input vector/row vector
  * @return the matrix representation of the input
  */
-template <typename EigMat, require_eigen_vector_t<EigMat>* = nullptr>
-inline Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>
-  to_matrix(const EigMat& matrix) {
-  using T = value_type_t<EigMat>;
-  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
-      res(matrix.rows(), matrix.cols());
-  Eigen::Map<
-      Eigen::Matrix<T, EigMat::RowsAtCompileTime, EigMat::ColsAtCompileTime>>
-      res_map(res.data(), matrix.rows(), matrix.cols());
-  res_map = matrix;
-  return res;
+template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
+inline auto to_matrix(EigVec&& matrix) {
+  return Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>(std::forward<EigVec>(matrix));
 }
 
 /**

--- a/stan/math/prim/fun/to_matrix.hpp
+++ b/stan/math/prim/fun/to_matrix.hpp
@@ -11,18 +11,38 @@ namespace math {
 
 /**
  * Returns a matrix with dynamic dimensions constructed from an
- * Eigen matrix which is either a row vector, column vector,
- * or matrix.
- * The runtime dimensions will be the same as the input.
+ * Eigen matrix.
  *
  * @tparam EigMat type of the matrix
  *
  * @param x matrix
  * @return the matrix representation of the input
  */
-template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline EigMat to_matrix(EigMat&& x) {
   return std::forward<EigMat>(x);
+}
+
+/**
+ * Returns a matrix with dynamic dimensions constructed from an
+ * Eigen row or column vector.
+ * The runtime dimensions will be the same as the input.
+ *
+ * @tparam EigMat type of the vector/row vector
+ *
+ * @param x input vector/row vector
+ * @return the matrix representation of the input
+ */
+template <typename EigMat, require_eigen_vector_t<EigMat>* = nullptr>
+inline Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> to_matrix(
+    const EigMat& matrix) {
+  using T = value_type_t<EigMat>;
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> res(matrix.rows(), matrix.cols());
+  Eigen::Map<
+      Eigen::Matrix<T, EigMat::RowsAtCompileTime, EigMat::ColsAtCompileTime>>
+      res_map(res.data(), matrix.rows(), matrix.cols());
+  res_map = matrix;
+  return res;
 }
 
 /**

--- a/stan/math/prim/fun/to_matrix.hpp
+++ b/stan/math/prim/fun/to_matrix.hpp
@@ -35,7 +35,7 @@ inline EigMat to_matrix(EigMat&& x) {
  */
 template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
 inline auto to_matrix(EigVec&& matrix) {
-  return Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>(std::forward<EigVec>(matrix));
+  return Eigen::Matrix<value_type_t<EigVec>, Eigen::Dynamic, Eigen::Dynamic>(std::forward<EigVec>(matrix));
 }
 
 /**

--- a/stan/math/prim/fun/to_matrix.hpp
+++ b/stan/math/prim/fun/to_matrix.hpp
@@ -34,10 +34,10 @@ inline EigMat to_matrix(EigMat&& x) {
  * @return the matrix representation of the input
  */
 template <typename EigMat, require_eigen_vector_t<EigMat>* = nullptr>
-inline Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> 
+inline Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>
   to_matrix(const EigMat& matrix) {
   using T = value_type_t<EigMat>;
-  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> 
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
       res(matrix.rows(), matrix.cols());
   Eigen::Map<
       Eigen::Matrix<T, EigMat::RowsAtCompileTime, EigMat::ColsAtCompileTime>>


### PR DESCRIPTION
## Summary

Fixes #2669 by fixing `to_matrix(row_vector)` and `to_matrix(vector)`, which were previously just forwarded. This bug surfaces if to_matrix() is used in a call to a UDF.

## Tests

/

## Side Effects

/

## Release notes

Fixed a bug with `to_matrix(row_vector)` and `to_matrix(vector)`.

## Checklist

- [x] Math issue #2669 

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
