### PR TITLE
adds cumulative_sum for the new matrix type

### DIFF
--- a/stan/math/prim/fun/cumulative_sum.hpp
+++ b/stan/math/prim/fun/cumulative_sum.hpp
@@ -45,7 +45,8 @@ inline std::vector<T> cumulative_sum(const std::vector<T>& x) {
  * @param m Vector of values.
  * @return Cumulative sum of values.
  */
-template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
+template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr,
+ require_not_st_var<EigVec>* = nullptr>
 inline auto cumulative_sum(const EigVec& m) {
   using T_scalar = value_type_t<EigVec>;
   Eigen::Matrix<T_scalar, EigVec::RowsAtCompileTime, EigVec::ColsAtCompileTime>
@@ -53,9 +54,11 @@ inline auto cumulative_sum(const EigVec& m) {
   if (m.size() == 0) {
     return result;
   }
-  const Eigen::Ref<const plain_type_t<EigVec>>& m_ref = m;
-  std::partial_sum(m_ref.data(), m_ref.data() + m_ref.size(), result.data(),
-                   std::plus<T_scalar>());
+  const auto& m_ref = to_ref(m);
+  result.coeffRef(0) = m_ref.coeff(0);
+  for (Eigen::Index i = 1; i < m_ref.size(); ++i) {
+    result.coeffRef(i) = m_ref.coeff(i) + result.coeffRef(i - 1);
+  }
   return result;
 }
 

--- a/stan/math/prim/fun/cumulative_sum.hpp
+++ b/stan/math/prim/fun/cumulative_sum.hpp
@@ -46,7 +46,7 @@ inline std::vector<T> cumulative_sum(const std::vector<T>& x) {
  * @return Cumulative sum of values.
  */
 template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr,
- require_not_st_var<EigVec>* = nullptr>
+          require_not_st_var<EigVec>* = nullptr>
 inline auto cumulative_sum(const EigVec& m) {
   using T_scalar = value_type_t<EigVec>;
   Eigen::Matrix<T_scalar, EigVec::RowsAtCompileTime, EigVec::ColsAtCompileTime>

--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -30,6 +30,7 @@
 #include <stan/math/rev/fun/cholesky_decompose.hpp>
 #include <stan/math/rev/fun/cholesky_corr_constrain.hpp>
 #include <stan/math/rev/fun/cholesky_factor_constrain.hpp>
+#include <stan/math/rev/fun/cumulative_sum.hpp>
 #include <stan/math/rev/fun/columns_dot_product.hpp>
 #include <stan/math/rev/fun/columns_dot_self.hpp>
 #include <stan/math/rev/fun/conj.hpp>

--- a/stan/math/rev/fun/cumulative_sum.hpp
+++ b/stan/math/rev/fun/cumulative_sum.hpp
@@ -11,7 +11,6 @@
 namespace stan {
 namespace math {
 
-
 /**
  * Return the cumulative sum of the specified vector.
  *
@@ -29,21 +28,20 @@ namespace math {
  */
 template <typename EigVec, require_rev_vector_t<EigVec>* = nullptr>
 inline auto cumulative_sum(const EigVec& x) {
-   arena_t<EigVec> x_arena(x);
-   using return_t
-       = return_var_matrix_t<EigVec>;
-   arena_t<return_t> res = cumulative_sum(x_arena.val()).eval();
-   if (unlikely(x.size() == 0)) {
-     return return_t(res);
-   }
-   reverse_pass_callback([x_arena, res]() mutable {
-     for (Eigen::Index i = x_arena.size() - 1; i > 0; --i) {
-       x_arena.adj().coeffRef(i) += res.adj().coeffRef(i);
-       res.adj().coeffRef(i - 1) += res.adj().coeffRef(i);
-     }
-     x_arena.adj().coeffRef(0) += res.adj().coeffRef(0);
-   });
-   return return_t(res);
+  arena_t<EigVec> x_arena(x);
+  using return_t = return_var_matrix_t<EigVec>;
+  arena_t<return_t> res = cumulative_sum(x_arena.val()).eval();
+  if (unlikely(x.size() == 0)) {
+    return return_t(res);
+  }
+  reverse_pass_callback([x_arena, res]() mutable {
+    for (Eigen::Index i = x_arena.size() - 1; i > 0; --i) {
+      x_arena.adj().coeffRef(i) += res.adj().coeffRef(i);
+      res.adj().coeffRef(i - 1) += res.adj().coeffRef(i);
+    }
+    x_arena.adj().coeffRef(0) += res.adj().coeffRef(0);
+  });
+  return return_t(res);
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/cumulative_sum.hpp
+++ b/stan/math/rev/fun/cumulative_sum.hpp
@@ -1,0 +1,52 @@
+#ifndef STAN_MATH_REV_FUN_CUMULATIVE_SUM_HPP
+#define STAN_MATH_REV_FUN_CUMULATIVE_SUM_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/prim/fun/cumulative_sum.hpp>
+#include <vector>
+#include <numeric>
+#include <functional>
+
+namespace stan {
+namespace math {
+
+
+/**
+ * Return the cumulative sum of the specified vector.
+ *
+ * The cumulative sum is of the same type as the input and
+ * has values defined by
+ *
+ * \code x(0), x(1) + x(2), ..., x(1) + , ..., + x(x.size()-1) @endcode
+ *
+ * @tparam EigVec type derived from `Eigen::EigenBase` or a `var_value<T>` with
+ *  `T` deriving from `Eigen::EigenBase` with one compile time dimension
+ *   equal to 1
+ *
+ * @param m Vector of values.
+ * @return Cumulative sum of values.
+ */
+template <typename EigVec, require_rev_vector_t<EigVec>* = nullptr>
+inline auto cumulative_sum(const EigVec& x) {
+   arena_t<EigVec> x_arena(x);
+   using return_t
+       = return_var_matrix_t<EigVec>;
+   arena_t<return_t> res = cumulative_sum(x_arena.val()).eval();
+   if (unlikely(x.size() == 0)) {
+     return return_t(res);
+   }
+   reverse_pass_callback([x_arena, res]() mutable {
+     for (Eigen::Index i = x_arena.size() - 1; i > 0; --i) {
+       x_arena.adj().coeffRef(i) += res.adj().coeffRef(i);
+       res.adj().coeffRef(i - 1) += res.adj().coeffRef(i);
+     }
+     x_arena.adj().coeffRef(0) += res.adj().coeffRef(0);
+   });
+   return return_t(res);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/test/unit/math/mix/fun/cumulative_sum_test.cpp
+++ b/test/unit/math/mix/fun/cumulative_sum_test.cpp
@@ -7,7 +7,9 @@ void expect_cumulative_sum(std::vector<double>& x) {
   Eigen::RowVectorXd rv = Eigen::Map<Eigen::RowVectorXd>(x.data(), x.size());
   stan::test::expect_ad(f, x);
   stan::test::expect_ad(f, v);
+  stan::test::expect_ad_matvar(f, v);
   stan::test::expect_ad(f, rv);
+  stan::test::expect_ad_matvar(f, rv);
 }
 
 TEST(MathMixMatFun, cumulativeSum) {


### PR DESCRIPTION

## Summary

Adds a `cumulative_sum` that accept a `var<Matrix>` type

## Tests

Tests added to the mix tests using the `expect_ad` framework.

```cpp
./runTests.py ./test/unit/math/mix/fun/cumulative_sum_test.cpp
```

## Side Effects

Nope!

## Release notes

Adds a `cumulative_sum` that accept a `var<Matrix>` type

## Checklist

- [x] Math issue #1805 

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
