### PR TITLE
fix template error for matrix fma

### DIFF
--- a/stan/math/rev/fun/fma.hpp
+++ b/stan/math/rev/fun/fma.hpp
@@ -81,8 +81,7 @@ inline var fma(const var& x, const var& y, Tc&& z) {
  * @param z Summand.
  * @return Product of the multiplicands plus the summand, ($a * $b) + $c.
  */
-template <typename Tb,
-          require_arithmetic_t<Tb>* = nullptr>
+template <typename Tb, require_arithmetic_t<Tb>* = nullptr>
 inline var fma(const var& x, Tb&& y, const var& z) {
   return make_callback_var(fma(x.val(), y, z.val()), [x, y, z](auto& vi) {
     x.adj() += vi.adj() * y;

--- a/stan/math/rev/fun/fma.hpp
+++ b/stan/math/rev/fun/fma.hpp
@@ -81,10 +81,9 @@ inline var fma(const var& x, const var& y, Tc&& z) {
  * @param z Summand.
  * @return Product of the multiplicands plus the summand, ($a * $b) + $c.
  */
-template <typename Ta, typename Tb, typename Tc,
-          require_arithmetic_t<Tb>* = nullptr,
-          require_all_var_t<Ta, Tc>* = nullptr>
-inline var fma(Ta&& x, Tb&& y, Tc&& z) {
+template <typename Tb,
+          require_arithmetic_t<Tb>* = nullptr>
+inline var fma(const var& x, Tb&& y, const var& z) {
   return make_callback_var(fma(x.val(), y, z.val()), [x, y, z](auto& vi) {
     x.adj() += vi.adj() * y;
     z.adj() += vi.adj();

--- a/test/unit/math/mix/fun/fma_2_test.cpp
+++ b/test/unit/math/mix/fun/fma_2_test.cpp
@@ -5,9 +5,11 @@ TEST(mathMixScalFun, fma_vector) {
   auto f = [](const auto& x1, const auto& x2, const auto& x3) {
     auto ret = stan::math::fma(x1, x2, x3).eval();
     using ret_t = std::decay_t<decltype(ret)>;
-    constexpr bool is_correct_return_type = stan::is_var_matrix<ret_t>::value
-     || stan::is_eigen_dense_base<ret_t>::value;
-    static_assert(is_correct_return_type, "Matrix type was supposed to be returned.");
+    constexpr bool is_correct_return_type
+        = stan::is_var_matrix<ret_t>::value
+          || stan::is_eigen_dense_base<ret_t>::value;
+    static_assert(is_correct_return_type,
+                  "Matrix type was supposed to be returned.");
     return ret;
   };
 

--- a/test/unit/math/mix/fun/fma_2_test.cpp
+++ b/test/unit/math/mix/fun/fma_2_test.cpp
@@ -3,7 +3,12 @@
 
 TEST(mathMixScalFun, fma_vector) {
   auto f = [](const auto& x1, const auto& x2, const auto& x3) {
-    return stan::math::fma(x1, x2, x3);
+    auto ret = stan::math::fma(x1, x2, x3).eval();
+    using ret_t = std::decay_t<decltype(ret)>;
+    constexpr bool is_correct_return_type = stan::is_var_matrix<ret_t>::value
+     || stan::is_eigen_dense_base<ret_t>::value;
+    static_assert(is_correct_return_type, "Matrix type was supposed to be returned.");
+    return ret;
   };
 
   double xd = 1.0;

--- a/test/unit/math/mix/fun/fma_3_test.cpp
+++ b/test/unit/math/mix/fun/fma_3_test.cpp
@@ -5,9 +5,11 @@ TEST(mathMixScalFun, fma_row_vector) {
   auto f = [](const auto& x1, const auto& x2, const auto& x3) {
     auto ret = stan::math::fma(x1, x2, x3).eval();
     using ret_t = std::decay_t<decltype(ret)>;
-    constexpr bool is_correct_return_type = stan::is_var_matrix<ret_t>::value
-     || stan::is_eigen_dense_base<ret_t>::value;
-    static_assert(is_correct_return_type, "Matrix type was supposed to be returned.");
+    constexpr bool is_correct_return_type
+        = stan::is_var_matrix<ret_t>::value
+          || stan::is_eigen_dense_base<ret_t>::value;
+    static_assert(is_correct_return_type,
+                  "Matrix type was supposed to be returned.");
     return ret;
   };
 

--- a/test/unit/math/mix/fun/fma_3_test.cpp
+++ b/test/unit/math/mix/fun/fma_3_test.cpp
@@ -3,7 +3,12 @@
 
 TEST(mathMixScalFun, fma_row_vector) {
   auto f = [](const auto& x1, const auto& x2, const auto& x3) {
-    return stan::math::fma(x1, x2, x3);
+    auto ret = stan::math::fma(x1, x2, x3).eval();
+    using ret_t = std::decay_t<decltype(ret)>;
+    constexpr bool is_correct_return_type = stan::is_var_matrix<ret_t>::value
+     || stan::is_eigen_dense_base<ret_t>::value;
+    static_assert(is_correct_return_type, "Matrix type was supposed to be returned.");
+    return ret;
   };
 
   double xd = 1.0;

--- a/test/unit/math/mix/fun/fma_4_test.cpp
+++ b/test/unit/math/mix/fun/fma_4_test.cpp
@@ -3,7 +3,12 @@
 
 TEST(mathMixScalFun, fma_matrix) {
   auto f = [](const auto& x1, const auto& x2, const auto& x3) {
-    return stan::math::fma(x1, x2, x3).eval();
+    auto ret = stan::math::fma(x1, x2, x3).eval();
+    using ret_t = std::decay_t<decltype(ret)>;
+    constexpr bool is_correct_return_type = stan::is_var_matrix<ret_t>::value
+     || stan::is_eigen_dense_base<ret_t>::value;
+    static_assert(is_correct_return_type, "Matrix type was supposed to be returned.");
+    return ret;
   };
 
   double xd = 1.0;

--- a/test/unit/math/mix/fun/fma_4_test.cpp
+++ b/test/unit/math/mix/fun/fma_4_test.cpp
@@ -5,9 +5,11 @@ TEST(mathMixScalFun, fma_matrix) {
   auto f = [](const auto& x1, const auto& x2, const auto& x3) {
     auto ret = stan::math::fma(x1, x2, x3).eval();
     using ret_t = std::decay_t<decltype(ret)>;
-    constexpr bool is_correct_return_type = stan::is_var_matrix<ret_t>::value
-     || stan::is_eigen_dense_base<ret_t>::value;
-    static_assert(is_correct_return_type, "Matrix type was supposed to be returned.");
+    constexpr bool is_correct_return_type
+        = stan::is_var_matrix<ret_t>::value
+          || stan::is_eigen_dense_base<ret_t>::value;
+    static_assert(is_correct_return_type,
+                  "Matrix type was supposed to be returned.");
     return ret;
   };
 


### PR DESCRIPTION


## Summary

Bug fix for https://github.com/stan-dev/stanc3/issues/1150 where fma would choose the wrong template because one was too broad.

## Tests

static assert added to scalar/matrix combinations of fma in tests to make sure correct return type is given.

## Side Effects

Nope

## Release notes

Replace this text with a short note on what will change if this pull request is merged in which case this will be included in the release notes.

## Checklist

- [x] Math issue [stanc issue](https://github.com/stan-dev/stanc3/issues/1150)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
