### PR TITLE
Adds operator= for varmat types when compile time rows/cols differ

### DIFF
--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -1024,7 +1024,9 @@ class var_value<T, internal::require_matrix_var_value<T>> {
             require_all_plain_type_t<T, S>* = nullptr,
             require_not_same_t<plain_type_t<T>, plain_type_t<S>>* = nullptr>
   inline var_value<T>& operator=(const var_value<S>& other) {
-    static_assert(EIGEN_PREDICATE_SAME_MATRIX_SIZE(T, S), "You mixed matrices of different sizes that are not assignable.");
+    static_assert(
+        EIGEN_PREDICATE_SAME_MATRIX_SIZE(T, S),
+        "You mixed matrices of different sizes that are not assignable.");
     vi_ = new vari_type(other.vi_);
     return *this;
   }

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -1004,9 +1004,28 @@ class var_value<T, internal::require_matrix_var_value<T>> {
    * @return this
    */
   template <typename S, require_assignable_t<value_type, S>* = nullptr,
-            require_all_plain_type_t<T, S>* = nullptr>
+            require_all_plain_type_t<T, S>* = nullptr,
+            require_same_t<plain_type_t<T>, plain_type_t<S>>* = nullptr>
   inline var_value<T>& operator=(const var_value<S>& other) {
     vi_ = other.vi_;
+    return *this;
+  }
+
+  /**
+   * Assignment of one plain type to another when one sides compile time columns
+   * differ from the other.
+   * @tparam S A type inheriting from `Eigen::DenseBase` that has a differing
+   *  number of compile time rows or columns, but is assignable to
+   *  `this`'s underlying Eigen type.
+   * @param other the value to assign
+   * @return this
+   */
+  template <typename S, require_assignable_t<value_type, S>* = nullptr,
+            require_all_plain_type_t<T, S>* = nullptr,
+            require_not_same_t<plain_type_t<T>, plain_type_t<S>>* = nullptr>
+  inline var_value<T>& operator=(const var_value<S>& other) {
+    static_assert(EIGEN_PREDICATE_SAME_MATRIX_SIZE(T, S), "You mixed matrices of different sizes that are not assignable.");
+    vi_ = new vari_type(other.vi_);
     return *this;
   }
 

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -736,11 +736,11 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
     }
   }
 
-protected:
+ protected:
   template <typename S, require_not_same_t<T, S>* = nullptr>
   vari_value(const vari_value<S>* x) : val_(x->val_), adj_(x->adj_) {}
-public:
 
+ public:
   /**
    * Return a constant reference to the value of this vari.
    *

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -738,7 +738,7 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
 
  protected:
   template <typename S, require_not_same_t<T, S>* = nullptr>
-  vari_value(const vari_value<S>* x) : val_(x->val_), adj_(x->adj_) {}
+  explicit vari_value(const vari_value<S>* x) : val_(x->val_), adj_(x->adj_) {}
 
  public:
   /**

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -736,6 +736,11 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
     }
   }
 
+protected:
+  template <typename S, require_not_same_t<T, S>* = nullptr>
+  vari_value(const vari_value<S>* x) : val_(x->val_), adj_(x->adj_) {}
+public:
+
   /**
    * Return a constant reference to the value of this vari.
    *

--- a/test/unit/math/rev/core/var_test.cpp
+++ b/test/unit/math/rev/core/var_test.cpp
@@ -899,3 +899,20 @@ TEST_F(AgradRev, grad) {
   EXPECT_FLOAT_EQ(11.0, a.adj());
   EXPECT_FLOAT_EQ(5.0, b.adj());
 }
+
+TEST_F(AgradRev, matrix_compile_time_conversions) {
+  using stan::math::var_value;
+  Eigen::VectorXd colvec_vals = Eigen::VectorXd::Random(5);
+  Eigen::RowVectorXd rowvec_vals = Eigen::VectorXd::Random(5);
+  Eigen::Matrix<double, 1, 1> x11_vals = Eigen::Matrix<double, 1, 1>::Random(1, 1);
+  var_value<Eigen::Matrix<double, -1, 1>> colvec = colvec_vals;
+  var_value<Eigen::Matrix<double, 1, -1>> rowvec = rowvec_vals;
+  colvec = rowvec;
+  EXPECT_MATRIX_FLOAT_EQ(colvec.val().transpose(), rowvec.val());
+  var_value<Eigen::Matrix<double, 1, 1>> x11 = x11_vals;
+  colvec = x11;
+  rowvec = x11;
+  EXPECT_MATRIX_FLOAT_EQ(colvec.val(), rowvec.val());
+  EXPECT_MATRIX_FLOAT_EQ(x11.val(), rowvec.val());
+
+}

--- a/test/unit/math/rev/core/var_test.cpp
+++ b/test/unit/math/rev/core/var_test.cpp
@@ -904,7 +904,8 @@ TEST_F(AgradRev, matrix_compile_time_conversions) {
   using stan::math::var_value;
   Eigen::VectorXd colvec_vals = Eigen::VectorXd::Random(5);
   Eigen::RowVectorXd rowvec_vals = Eigen::VectorXd::Random(5);
-  Eigen::Matrix<double, 1, 1> x11_vals = Eigen::Matrix<double, 1, 1>::Random(1, 1);
+  Eigen::Matrix<double, 1, 1> x11_vals
+      = Eigen::Matrix<double, 1, 1>::Random(1, 1);
   var_value<Eigen::Matrix<double, -1, 1>> colvec = colvec_vals;
   var_value<Eigen::Matrix<double, 1, -1>> rowvec = rowvec_vals;
   colvec = rowvec;
@@ -914,5 +915,4 @@ TEST_F(AgradRev, matrix_compile_time_conversions) {
   rowvec = x11;
   EXPECT_MATRIX_FLOAT_EQ(colvec.val(), rowvec.val());
   EXPECT_MATRIX_FLOAT_EQ(x11.val(), rowvec.val());
-
 }


### PR DESCRIPTION

## Summary

This fixes a bug found in https://github.com/stan-dev/stanc3/issues/1150 where we could not do assignment of  `var<Matrix<RowsAtCompileTime, ColsAtCompileTime>`'s when their compile time rows and columns differed. This fixes that by adding a new `operator=` to `var_value` such that when the inner matrices differ in compile time rows/cols it can correctly assigns them if able.

## Tests

Test added to `var_test` to check that matrices of different compile time sizes that eigen can assign to / from are also assignable with `var<Matrix>` types.

## Side Effects

Nope

## Release notes

Fix bug that does now allow for `var<Matrix>` types with different compile time rows/cols to be assigned to one another.

## Checklist

- [x] ~Math~ stanc issue https://github.com/stan-dev/stanc3/issues/1150

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
