### PR TITLE
Add complex types to signature expression tests

### DIFF
--- a/stan/math/prim/fun/sum.hpp
+++ b/stan/math/prim/fun/sum.hpp
@@ -47,6 +47,19 @@ inline value_type_t<T> sum(const T& m) {
   return m.sum();
 }
 
+/**
+ * Returns the sum of the coefficients of the specified
+ * Eigen Matrix, Array or expression of complex type.
+ *
+ * @tparam T Type of argument
+ * @param m argument
+ * @return Sum of coefficients of argument.
+ */
+template <typename T, require_eigen_vt<is_complex, T>* = nullptr>
+inline value_type_t<T> sum(const T& m) {
+  return m.sum();
+}
+
 }  // namespace math
 }  // namespace stan
 

--- a/test/code_generator.py
+++ b/test/code_generator.py
@@ -4,10 +4,12 @@ import os
 import statement_types
 from sig_utils import parse_array, non_differentiable_args, special_arg_values
 
+
 class CodeGenerator:
     """
     This class generates C++ to test Stan functions
     """
+
     def __init__(self):
         self.name_counter = 0
         self.code_list = []
@@ -19,13 +21,15 @@ class CodeGenerator:
         :param statement: An object of type statement_types.CppStatement
         """
         if not isinstance(statement, statement_types.CppStatement):
-            raise TypeError("Argument to FunctionGenerator._add_statement must be an instance of an object that inherits from CppStatement")
+            raise TypeError(
+                "Argument to FunctionGenerator._add_statement must be an instance of an object that inherits from CppStatement"
+            )
 
         self.code_list.append(statement)
         return statement
 
     def _get_next_name_suffix(self):
-        """Get the next available """
+        """Get the next available"""
         self.name_counter += 1
         return repr(self.name_counter - 1)
 
@@ -43,14 +47,18 @@ class CodeGenerator:
         :param size: Size of matrix-like arguments. This is not used for array arguments (which will effectively all be size 1)
         """
         arg_list = []
-        for n, (overload, stan_arg) in enumerate(zip(arg_overloads, signature_parser.stan_args)):
+        for n, (overload, stan_arg) in enumerate(
+            zip(arg_overloads, signature_parser.stan_args)
+        ):
             suffix = self._get_next_name_suffix()
 
             number_nested_arrays, inner_type = parse_array(stan_arg)
 
             # Check if argument is differentiable
-            if inner_type == "int" or n in non_differentiable_args.get(signature_parser.function_name, []):
-                  overload = "Prim"
+            if inner_type == "int" or n in non_differentiable_args.get(
+                signature_parser.function_name, []
+            ):
+                overload = "Prim"
 
             # By default the variable value is None and a default will be substituted
             value = None
@@ -68,28 +76,57 @@ class CodeGenerator:
             # The first case here is used for the array initializers in sig_utils.special_arg_values
             # Everything else uses the second case
             if number_nested_arrays > 0 and isinstance(value, collections.Iterable):
-                arg = statement_types.ArrayVariable(overload, "array" + suffix, number_nested_arrays, inner_type, size = 1, value = value)
+                arg = statement_types.ArrayVariable(
+                    overload,
+                    "array" + suffix,
+                    number_nested_arrays,
+                    inner_type,
+                    size=1,
+                    value=value,
+                )
             else:
                 if inner_type == "int":
                     arg = statement_types.IntVariable("int" + suffix, value)
                 elif inner_type == "real":
                     arg = statement_types.RealVariable(overload, "real" + suffix, value)
                 elif inner_type == "complex":
-                    arg = statement_types.ComplexVariable(overload, "complex" + suffix, value)
-                elif inner_type in ("vector", "row_vector", "matrix", "complex_vector", "complex_row_vector", "complex_matrix"):
-                    arg = statement_types.MatrixVariable(overload, "matrix" + suffix, inner_type, size, value)
+                    arg = statement_types.ComplexVariable(
+                        overload, "complex" + suffix, value
+                    )
+                elif inner_type in (
+                    "vector",
+                    "row_vector",
+                    "matrix",
+                    "complex_vector",
+                    "complex_row_vector",
+                    "complex_matrix",
+                ):
+                    arg = statement_types.MatrixVariable(
+                        overload, "matrix" + suffix, inner_type, size, value
+                    )
                 elif inner_type == "rng":
                     arg = statement_types.RngVariable("rng" + suffix)
                 elif inner_type == "ostream_ptr":
                     arg = statement_types.OStreamVariable("ostream" + suffix)
                 elif inner_type == "scalar_return_type":
-                    arg = statement_types.ReturnTypeTVariable("ret_type" + suffix, *arg_list)
+                    arg = statement_types.ReturnTypeTVariable(
+                        "ret_type" + suffix, *arg_list
+                    )
                 elif inner_type == "simplex":
-                    arg = statement_types.SimplexVariable(overload, "simplex" + suffix, size, value)
+                    arg = statement_types.SimplexVariable(
+                        overload, "simplex" + suffix, size, value
+                    )
                 elif inner_type == "positive_definite_matrix":
-                    arg = statement_types.PositiveDefiniteMatrixVariable(overload, "positive_definite_matrix" + suffix, size, value)
-                elif inner_type == "(vector, vector, data array[] real, data array[] int) => vector":
-                    arg = statement_types.AlgebraSolverFunctorVariable("functor" + suffix)
+                    arg = statement_types.PositiveDefiniteMatrixVariable(
+                        overload, "positive_definite_matrix" + suffix, size, value
+                    )
+                elif (
+                    inner_type
+                    == "(vector, vector, data array[] real, data array[] int) => vector"
+                ):
+                    arg = statement_types.AlgebraSolverFunctorVariable(
+                        "functor" + suffix
+                    )
                 elif inner_type == "(real, vector, ostream_ptr, vector) => vector":
                     arg = statement_types.OdeFunctorVariable("functor" + suffix)
                 else:
@@ -97,12 +134,23 @@ class CodeGenerator:
 
                 if number_nested_arrays > 0:
                     self._add_statement(arg)
-                    arg = statement_types.ArrayVariable(overload, "array" + suffix, number_nested_arrays, inner_type, size = 1, value = arg)
+                    arg = statement_types.ArrayVariable(
+                        overload,
+                        "array" + suffix,
+                        number_nested_arrays,
+                        inner_type,
+                        size=1,
+                        value=arg,
+                    )
 
             arg_list.append(self._add_statement(arg))
 
         if signature_parser.is_rng():
-            arg_list.append(self._add_statement(statement_types.RngVariable("rng" + self._get_next_name_suffix())))
+            arg_list.append(
+                self._add_statement(
+                    statement_types.RngVariable("rng" + self._get_next_name_suffix())
+                )
+            )
 
         return arg_list
 
@@ -113,15 +161,26 @@ class CodeGenerator:
         :param arg1: First argument
         :param arg1: Second argument
         """
-        return self._add_statement(statement_types.FunctionCall("stan::math::add", "sum_of_sums" + self._get_next_name_suffix(), arg1, arg2))
+        return self._add_statement(
+            statement_types.FunctionCall(
+                "stan::math::add",
+                "sum_of_sums" + self._get_next_name_suffix(),
+                arg1,
+                arg2,
+            )
+        )
 
-    def convert_to_expression(self, arg, size = None):
+    def convert_to_expression(self, arg, size=None):
         """
         Generate code to convert arg to an expression type of given size. If size is None, use the argument size
 
         :param arg: Argument to convert to expression
         """
-        return self._add_statement(statement_types.ExpressionVariable(arg.name + "_expr" + self._get_next_name_suffix(), arg, size))
+        return self._add_statement(
+            statement_types.ExpressionVariable(
+                arg.name + "_expr" + self._get_next_name_suffix(), arg, size
+            )
+        )
 
     def expect_adj_eq(self, arg1, arg2):
         """
@@ -130,7 +189,9 @@ class CodeGenerator:
         :param arg1: First argument
         :param arg2: Second argument
         """
-        return self._add_statement(statement_types.FunctionCall("stan::test::expect_adj_eq", None, arg1, arg2))
+        return self._add_statement(
+            statement_types.FunctionCall("stan::test::expect_adj_eq", None, arg1, arg2)
+        )
 
     def expect_eq(self, arg1, arg2):
         """
@@ -139,7 +200,9 @@ class CodeGenerator:
         :param arg1: First argument
         :param arg2: Second argument
         """
-        return self._add_statement(statement_types.FunctionCall("EXPECT_STAN_EQ", None, arg1, arg2))
+        return self._add_statement(
+            statement_types.FunctionCall("EXPECT_STAN_EQ", None, arg1, arg2)
+        )
 
     def expect_leq_one(self, arg):
         """
@@ -147,8 +210,12 @@ class CodeGenerator:
 
         :param arg: Argument to check
         """
-        one = self._add_statement(statement_types.IntVariable("int" + self._get_next_name_suffix(), 1))
-        return self._add_statement(statement_types.FunctionCall("EXPECT_LE", None, arg, one))
+        one = self._add_statement(
+            statement_types.IntVariable("int" + self._get_next_name_suffix(), 1)
+        )
+        return self._add_statement(
+            statement_types.FunctionCall("EXPECT_LE", None, arg, one)
+        )
 
     def function_call_assign(self, cpp_function_name, *args):
         """
@@ -157,7 +224,11 @@ class CodeGenerator:
         :param cpp_function_name: c++ function name to call
         :param args: list of arguments to pass to function
         """
-        return self._add_statement(statement_types.FunctionCall(cpp_function_name, "result" + self._get_next_name_suffix(), *args))
+        return self._add_statement(
+            statement_types.FunctionCall(
+                cpp_function_name, "result" + self._get_next_name_suffix(), *args
+            )
+        )
 
     def grad(self, arg):
         """
@@ -165,11 +236,15 @@ class CodeGenerator:
 
         :param arg: Argument to call grad on
         """
-        return self._add_statement(statement_types.FunctionCall("stan::test::grad", None, arg))
+        return self._add_statement(
+            statement_types.FunctionCall("stan::test::grad", None, arg)
+        )
 
     def recover_memory(self):
         """Generate code to call stan::math::recover_memory()"""
-        return self._add_statement(statement_types.FunctionCall("stan::math::recover_memory", None))
+        return self._add_statement(
+            statement_types.FunctionCall("stan::math::recover_memory", None)
+        )
 
     def recursive_sum(self, arg):
         """
@@ -177,7 +252,13 @@ class CodeGenerator:
 
         :param arg: Argument to sum
         """
-        return self._add_statement(statement_types.FunctionCall("stan::test::recursive_sum", "summed_result" + self._get_next_name_suffix(), arg))
+        return self._add_statement(
+            statement_types.FunctionCall(
+                "stan::test::recursive_sum",
+                "summed_result" + self._get_next_name_suffix(),
+                arg,
+            )
+        )
 
     def to_var_value(self, arg):
         """
@@ -185,4 +266,10 @@ class CodeGenerator:
 
         :param arg: Argument to convert to varmat
         """
-        return self._add_statement(statement_types.FunctionCall("stan::math::to_var_value", arg.name + "_varmat" + self._get_next_name_suffix(), arg))
+        return self._add_statement(
+            statement_types.FunctionCall(
+                "stan::math::to_var_value",
+                arg.name + "_varmat" + self._get_next_name_suffix(),
+                arg,
+            )
+        )

--- a/test/code_generator.py
+++ b/test/code_generator.py
@@ -15,7 +15,7 @@ class CodeGenerator:
     def _add_statement(self, statement):
         """
         Add a statement to the code generator
-        
+
         :param statement: An object of type statement_types.CppStatement
         """
         if not isinstance(statement, statement_types.CppStatement):
@@ -74,7 +74,9 @@ class CodeGenerator:
                     arg = statement_types.IntVariable("int" + suffix, value)
                 elif inner_type == "real":
                     arg = statement_types.RealVariable(overload, "real" + suffix, value)
-                elif inner_type in ("vector", "row_vector", "matrix"):
+                elif inner_type == "complex":
+                    arg = statement_types.ComplexVariable(overload, "complex" + suffix, value)
+                elif inner_type in ("vector", "row_vector", "matrix", "complex_vector", "complex_row_vector", "complex_matrix"):
                     arg = statement_types.MatrixVariable(overload, "matrix" + suffix, inner_type, size, value)
                 elif inner_type == "rng":
                     arg = statement_types.RngVariable("rng" + suffix)
@@ -107,24 +109,24 @@ class CodeGenerator:
     def add(self, arg1, arg2):
         """
         Generate code for arg1 + arg2
-        
+
         :param arg1: First argument
         :param arg1: Second argument
         """
         return self._add_statement(statement_types.FunctionCall("stan::math::add", "sum_of_sums" + self._get_next_name_suffix(), arg1, arg2))
-    
+
     def convert_to_expression(self, arg, size = None):
         """
         Generate code to convert arg to an expression type of given size. If size is None, use the argument size
-        
+
         :param arg: Argument to convert to expression
         """
         return self._add_statement(statement_types.ExpressionVariable(arg.name + "_expr" + self._get_next_name_suffix(), arg, size))
-    
+
     def expect_adj_eq(self, arg1, arg2):
         """
         Generate code that checks that the adjoints of arg1 and arg2 are equal
-        
+
         :param arg1: First argument
         :param arg2: Second argument
         """
@@ -133,25 +135,25 @@ class CodeGenerator:
     def expect_eq(self, arg1, arg2):
         """
         Generate code that checks that values of arg1 and arg2 are equal
-        
+
         :param arg1: First argument
         :param arg2: Second argument
         """
         return self._add_statement(statement_types.FunctionCall("EXPECT_STAN_EQ", None, arg1, arg2))
-    
+
     def expect_leq_one(self, arg):
         """
         Generate code to check that arg is less than or equal to one
-        
+
         :param arg: Argument to check
         """
         one = self._add_statement(statement_types.IntVariable("int" + self._get_next_name_suffix(), 1))
         return self._add_statement(statement_types.FunctionCall("EXPECT_LE", None, arg, one))
-    
+
     def function_call_assign(self, cpp_function_name, *args):
         """
         Generate code to call the c++ function given by cpp_function_name with given args and assign the result to another variable
-        
+
         :param cpp_function_name: c++ function name to call
         :param args: list of arguments to pass to function
         """
@@ -160,11 +162,11 @@ class CodeGenerator:
     def grad(self, arg):
         """
         Generate code to call stan::test::grad(arg) (equivalent of arg.grad())
-        
+
         :param arg: Argument to call grad on
         """
         return self._add_statement(statement_types.FunctionCall("stan::test::grad", None, arg))
-    
+
     def recover_memory(self):
         """Generate code to call stan::math::recover_memory()"""
         return self._add_statement(statement_types.FunctionCall("stan::math::recover_memory", None))
@@ -172,15 +174,15 @@ class CodeGenerator:
     def recursive_sum(self, arg):
         """
         Generate code that repeatedly sums arg until all that is left is a scalar
-        
+
         :param arg: Argument to sum
         """
         return self._add_statement(statement_types.FunctionCall("stan::test::recursive_sum", "summed_result" + self._get_next_name_suffix(), arg))
-    
+
     def to_var_value(self, arg):
         """
         Generate code to convert arg to a varmat
-        
+
         :param arg: Argument to convert to varmat
         """
         return self._add_statement(statement_types.FunctionCall("stan::math::to_var_value", arg.name + "_varmat" + self._get_next_name_suffix(), arg))

--- a/test/expressions/expression_test_helpers.hpp
+++ b/test/expressions/expression_test_helpers.hpp
@@ -25,7 +25,7 @@ auto recursive_sum(const T& a) {
 
 template <typename T>
 auto recursive_sum(const std::vector<T>& a) {
-  scalar_type_t<T> res = recursive_sum(a[0]);
+  auto res = recursive_sum(a[0]);
   for (int i = 0; i < a.size(); i++) {
     res += recursive_sum(a[i]);
   }
@@ -40,6 +40,12 @@ template <typename T, require_floating_point_t<T>* = nullptr>
 T make_arg(double value = 0.4, int size = 1) {
   return value;
 }
+
+template <typename T, require_complex_t<T>* = nullptr>
+T make_arg(std::complex<double> value = 0.4, int size = 1) {
+  return value;
+}
+
 template <typename T, require_var_t<T>* = nullptr>
 T make_arg(T value = 0.4, int size = 1) {
   return value;
@@ -64,6 +70,7 @@ T make_arg(T_scalar value = 0.4, int size = 1) {
   T res = T::Constant(size, make_arg<value_type_t<T>>(value));
   return res;
 }
+
 template <typename T, typename T_scalar = double,
           require_std_vector_t<T>* = nullptr>
 T make_arg(T_scalar value = 0.4, int size = 1) {
@@ -109,6 +116,23 @@ template <typename T, require_arithmetic_t<T>* = nullptr>
 void expect_eq(math::fvar<T> a, math::fvar<T> b, const char* msg) {
   expect_eq(a.val(), b.val(), msg);
   expect_eq(a.d(), b.d(), msg);
+}
+
+template <typename T, require_arithmetic_t<T>* = nullptr>
+void expect_eq(std::complex<T> a, std::complex<T> b, const char* msg) {
+  expect_eq(a.real(), b.real(), msg);
+  expect_eq(a.imag(), b.imag(), msg);
+}
+
+void expect_eq(std::complex<math::var> a, std::complex<math::var> b, const char* msg) {
+  expect_eq(a.real(), b.real(), msg);
+  expect_eq(a.imag(), b.imag(), msg);
+}
+
+template <typename T, require_arithmetic_t<T>* = nullptr>
+void expect_eq(std::complex<math::fvar<T>> a, std::complex<math::fvar<T>> b, const char* msg) {
+  expect_eq(a.real(), b.real(), msg);
+  expect_eq(a.imag(), b.imag(), msg);
 }
 
 template <typename T1, typename T2, require_all_eigen_t<T1, T2>* = nullptr,
@@ -165,6 +189,8 @@ void expect_adj_eq(const std::vector<T>& a, const std::vector<T>& b,
 }
 
 void grad(stan::math::var& a) { a.grad(); }
+void grad(std::complex<stan::math::var>& a) { a.real().grad(); a.imag().grad(); }
+
 
 #define TO_STRING_(x) #x
 #define TO_STRING(x) TO_STRING_(x)

--- a/test/expressions/expression_test_helpers.hpp
+++ b/test/expressions/expression_test_helpers.hpp
@@ -124,13 +124,15 @@ void expect_eq(std::complex<T> a, std::complex<T> b, const char* msg) {
   expect_eq(a.imag(), b.imag(), msg);
 }
 
-void expect_eq(std::complex<math::var> a, std::complex<math::var> b, const char* msg) {
+void expect_eq(std::complex<math::var> a, std::complex<math::var> b,
+               const char* msg) {
   expect_eq(a.real(), b.real(), msg);
   expect_eq(a.imag(), b.imag(), msg);
 }
 
 template <typename T, require_arithmetic_t<T>* = nullptr>
-void expect_eq(std::complex<math::fvar<T>> a, std::complex<math::fvar<T>> b, const char* msg) {
+void expect_eq(std::complex<math::fvar<T>> a, std::complex<math::fvar<T>> b,
+               const char* msg) {
   expect_eq(a.real(), b.real(), msg);
   expect_eq(a.imag(), b.imag(), msg);
 }
@@ -189,8 +191,10 @@ void expect_adj_eq(const std::vector<T>& a, const std::vector<T>& b,
 }
 
 void grad(stan::math::var& a) { a.grad(); }
-void grad(std::complex<stan::math::var>& a) { a.real().grad(); a.imag().grad(); }
-
+void grad(std::complex<stan::math::var>& a) {
+  a.real().grad();
+  a.imag().grad();
+}
 
 #define TO_STRING_(x) #x
 #define TO_STRING(x) TO_STRING_(x)

--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -17,6 +17,7 @@ arg_types = {
     "array[] int": "std::vector<int>",
     "array[,] int": "std::vector<std::vector<int>>",
     "real": "SCALAR",
+    "complex":"std::complex<SCALAR>",
     "array[] real": "std::vector<SCALAR>",
     "array[,] real": "std::vector<std::vector<SCALAR>>",
     "vector": "Eigen::Matrix<SCALAR, Eigen::Dynamic, 1>",
@@ -24,6 +25,11 @@ arg_types = {
     "row_vector": "Eigen::Matrix<SCALAR, 1, Eigen::Dynamic>",
     "array[] row_vector": "std::vector<Eigen::Matrix<SCALAR, 1, Eigen::Dynamic>>",
     "matrix": "Eigen::Matrix<SCALAR, Eigen::Dynamic, Eigen::Dynamic>",
+    "complex_vector": "Eigen::Matrix<std::complex<SCALAR>, Eigen::Dynamic, 1>",
+    "array[] complex_vector": "std::vector<Eigen::Matrix<std::complex<SCALAR>, Eigen::Dynamic, 1>>",
+    "complex_row_vector": "Eigen::Matrix<std::complex<SCALAR>, 1, Eigen::Dynamic>",
+    "array[] complex_row_vector": "std::vector<Eigen::Matrix<std::complex<SCALAR>, 1, Eigen::Dynamic>>",
+    "complex_matrix": "Eigen::Matrix<std::complex<SCALAR>, Eigen::Dynamic, Eigen::Dynamic>",
 }
 
 scalar_stan_types = ("int", "real", "rng", "ostream_ptr")

--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -17,7 +17,7 @@ arg_types = {
     "array[] int": "std::vector<int>",
     "array[,] int": "std::vector<std::vector<int>>",
     "real": "SCALAR",
-    "complex":"std::complex<SCALAR>",
+    "complex": "std::complex<SCALAR>",
     "array[] real": "std::vector<SCALAR>",
     "array[,] real": "std::vector<std::vector<SCALAR>>",
     "vector": "Eigen::Matrix<SCALAR, Eigen::Dynamic, 1>",
@@ -34,6 +34,7 @@ arg_types = {
 
 scalar_stan_types = ("int", "real", "rng", "ostream_ptr")
 
+
 def parse_array(stan_arg):
     """
     parses stan array type
@@ -44,6 +45,7 @@ def parse_array(stan_arg):
         commas, inner_type = stan_arg.lstrip("array[").split("]")
         return len(commas) + 1, inner_type.strip()
     return 0, stan_arg.strip()
+
 
 def get_cpp_type(stan_type):
     """
@@ -63,8 +65,8 @@ pos_definite = "positive_definite_matrix"
 scalar_return_type = "scalar_return_type"
 
 make_special_arg_values = {
-    simplex : "make_simplex",
-    pos_definite : "make_pos_definite_matrix"
+    simplex: "make_simplex",
+    pos_definite: "make_pos_definite_matrix",
 }
 
 # list of function arguments that need special scalar values.
@@ -116,18 +118,18 @@ special_arg_values = {
     "pareto_type_2_cdf": [1.5, 0.7, None, None],
     "pareto_type_2_cdf_log": [1.5, 0.7, None, None],
     "pareto_type_2_lcdf": [1.5, 0.7, None, None],
-    "positive_ordered_constrain" : [None, scalar_return_type],
+    "positive_ordered_constrain": [None, scalar_return_type],
     "positive_ordered_free": [1.0],
-    "ordered_constrain" : [None, scalar_return_type],
+    "ordered_constrain": [None, scalar_return_type],
     "ordered_free": [1.0],
-    "simplex_constrain" : [None, scalar_return_type],
+    "simplex_constrain": [None, scalar_return_type],
     "simplex_free": [simplex],
     "student_t_cdf": [0.8, None, 0.4, None],
     "student_t_cdf_log": [0.8, None, 0.4, None],
     "student_t_ccdf_log": [0.8, None, 0.4, None],
     "student_t_lccdf": [0.8, None, 0.4, None],
     "student_t_lcdf": [0.8, None, 0.4, None],
-    "unit_vector_constrain" : [None, scalar_return_type],
+    "unit_vector_constrain": [None, scalar_return_type],
     "unit_vector_free": [simplex],
     "uniform_cdf": [None, 0.2, 0.9],
     "uniform_ccdf_log": [None, 0.2, 0.9],
@@ -178,7 +180,7 @@ no_fwd_overload = [
     "ode_bdf_tol",
     "ode_rk45",
     "ode_rk45_tol",
-    "quantile"
+    "quantile",
 ]
 
 internal_signatures = [
@@ -286,7 +288,11 @@ def parse_signature(signature):
     function_name, rest = rest.split("(", 1)
     args = re.findall(r"(?:[(][^()]+[)][^,()]+)|(?:[^,()]+(?:,*[]][^,()]+)?)", rest)
     #  regex parts:        ^^^^^^functor^^^^^^     ^^^^any other arg^^^^^^^
-    args = [i.lstrip("data").strip() if "data" in i else i.strip() for i in args if i.strip()]
+    args = [
+        i.lstrip("data").strip() if "data" in i else i.strip()
+        for i in args
+        if i.strip()
+    ]
     return return_type.strip(), function_name.strip(), args
 
 
@@ -310,6 +316,7 @@ def handle_function_list(functions_input):
             function_names.append(f)
     return function_names, function_signatures
 
+
 def reference_vector_argument(arg):
     """
     Determines a reference argument, so as not to duplicate arrays of reals, vectors and row vectors,
@@ -320,6 +327,7 @@ def reference_vector_argument(arg):
     if arg in ("array[] real", "row_vector"):
         return "vector"
     return arg
+
 
 overload_scalar = {
     "Prim": "double",

--- a/test/signature_parser.py
+++ b/test/signature_parser.py
@@ -1,13 +1,17 @@
 from sig_utils import parse_signature, no_fwd_overload, no_rev_overload, ignored
 
+
 class SignatureParser:
     """
     SignatureParser parses Stanc3 function signatures and returns helpful information about them
 
     :param signature: stanc3 function signature string
     """
+
     def __init__(self, signature):
-        self.return_type, self.function_name, self.stan_args = parse_signature(signature)
+        self.return_type, self.function_name, self.stan_args = parse_signature(
+            signature
+        )
 
     def number_arguments(self):
         """Get the number of arguments in this signature"""
@@ -39,7 +43,18 @@ class SignatureParser:
 
     def has_eigen_compatible_arg(self):
         """Return true if any argument is vector-like (can be an Eigen c++ type)"""
-        return any(arg in ("matrix", "vector", "row_vector", "complex_vector", "complex_row_vector", "complex_matrix") for arg in self.stan_args)
+        return any(
+            arg
+            in (
+                "matrix",
+                "vector",
+                "row_vector",
+                "complex_vector",
+                "complex_row_vector",
+                "complex_matrix",
+            )
+            for arg in self.stan_args
+        )
 
     def returns_int(self):
         """Return true if the function returns an int"""

--- a/test/signature_parser.py
+++ b/test/signature_parser.py
@@ -8,7 +8,7 @@ class SignatureParser:
     """
     def __init__(self, signature):
         self.return_type, self.function_name, self.stan_args = parse_signature(signature)
-    
+
     def number_arguments(self):
         """Get the number of arguments in this signature"""
         return len(self.stan_args)
@@ -16,7 +16,7 @@ class SignatureParser:
     def is_ode(self):
         """Return true if this signature is an ODE function"""
         return self.function_name.startswith("ode")
-    
+
     def is_high_order(self):
         """Return true if this signature is a higher order function"""
         return any("=>" in arg for arg in self.stan_args)
@@ -24,7 +24,7 @@ class SignatureParser:
     def is_rng(self):
         """Return true if this signature is a random number generator"""
         return self.function_name.endswith("_rng")
-    
+
     def is_fwd_compatible(self):
         """Return true if this signature should compatible with forward mode autodiff"""
         return not (self.function_name in no_fwd_overload or self.is_rng())
@@ -39,7 +39,7 @@ class SignatureParser:
 
     def has_eigen_compatible_arg(self):
         """Return true if any argument is vector-like (can be an Eigen c++ type)"""
-        return any(arg in ("matrix", "vector", "row_vector") for arg in self.stan_args)
+        return any(arg in ("matrix", "vector", "row_vector", "complex_vector", "complex_row_vector", "complex_matrix") for arg in self.stan_args)
 
     def returns_int(self):
         """Return true if the function returns an int"""

--- a/test/statement_types.py
+++ b/test/statement_types.py
@@ -11,7 +11,7 @@ class CppStatement:
     def is_reverse_mode(self):
         """By default, a statement is not reverse mode"""
         return False
-    
+
     def is_eigen_compatible(self):
         """By default, a statement is not matrix-like"""
         return False
@@ -29,7 +29,7 @@ class IntVariable(CppStatement):
     def __init__(self, name, value = None):
         """
         Initialize matrix
-        
+
         :param overload: Type of overload as string (Prim/Fwd/Rev/etc.)
         :param name: C++ name of variable
         :param value: Scalar value to initialize matrix with
@@ -49,7 +49,7 @@ class RealVariable(CppStatement):
     def __init__(self, overload, name, value = None):
         """
         Initialize matrix
-        
+
         :param overload: Type of overload as string (Prim/Fwd/Rev/etc.)
         :param name: C++ name of variable
         :param value: Scalar value to initialize matrix with
@@ -60,23 +60,50 @@ class RealVariable(CppStatement):
             self.value = 0.4
         else:
             self.value = value
-    
+
     def is_reverse_mode(self):
         """Return true if the overload is reverse mode"""
         return self.overload.startswith("Rev")
-    
+
     def cpp(self):
         """Generate c++"""
         scalar = overload_scalar[self.overload]
 
         return "{type} {name} = {value};".format(type = scalar, name = self.name, value = self.value)
 
+class ComplexVariable(CppStatement):
+    """Represents a scalar, real variable"""
+    def __init__(self, overload, name, value = None):
+        """
+        Initialize matrix
+
+        :param overload: Type of overload as string (Prim/Fwd/Rev/etc.)
+        :param name: C++ name of variable
+        :param value: Scalar value to initialize matrix with
+        """
+        self.overload = overload
+        self.name = name
+        if value is None:
+            self.value = "stan::math::to_complex(0.4,0.4)"
+        else:
+            self.value = value
+
+    def is_reverse_mode(self):
+        """Return true if the overload is reverse mode"""
+        return self.overload.startswith("Rev")
+
+    def cpp(self):
+        """Generate c++"""
+        scalar = overload_scalar[self.overload]
+
+        return "std::complex<{type}> {name} = {value};".format(type = scalar, name = self.name, value = self.value)
+
 class MatrixVariable(CppStatement):
     """Represents a matrix variable"""
     def __init__(self, overload, name, stan_arg, size, value = None):
         """
         Initialize matrix
-        
+
         :param overload: Type of overload as string (Prim/Fwd/Rev/etc.)
         :param name: C++ name of variable
         :param stan_arg: Stanc3 type string
@@ -87,12 +114,12 @@ class MatrixVariable(CppStatement):
         self.name = name
         self.stan_arg = stan_arg
         self.size = size
-        
+
         if value is None:
             self.value = 0.4
         else:
             self.value = value
-    
+
     def is_reverse_mode(self):
         """Return true if the overload is reverse mode"""
         return self.overload.startswith("Rev")
@@ -100,11 +127,11 @@ class MatrixVariable(CppStatement):
     def is_eigen_compatible(self):
         """Return true (this is a matrix like variable)"""
         return True
-    
+
     def is_varmat_compatible(self):
         """Return true (matrix-like types are varmat compatible)"""
         return True
-    
+
     def cpp(self):
         """Generate C++"""
         scalar = overload_scalar[self.overload]
@@ -118,7 +145,7 @@ class SimplexVariable(CppStatement):
     def __init__(self, overload, name, size, value = None):
         """
         Initialize simplex
-        
+
         :param overload: Type of overload as string (Prim/Fwd/Rev/etc.)
         :param name: C++ name of variable
         :param size: Number of simplex elements
@@ -133,7 +160,7 @@ class SimplexVariable(CppStatement):
             self.value = 0.4
         else:
             self.value = value
-    
+
     def is_reverse_mode(self):
         """Return true if the overload is reverse mode"""
         return self.overload.startswith("Rev")
@@ -141,11 +168,11 @@ class SimplexVariable(CppStatement):
     def is_eigen_compatible(self):
         """Return true (simplices are vectors)"""
         return True
-    
+
     def is_varmat_compatible(self):
         """Return true (vectors are varmat compatible)"""
         return True
-    
+
     def cpp(self):
         """Generate C++"""
         scalar = overload_scalar[self.overload]
@@ -159,7 +186,7 @@ class PositiveDefiniteMatrixVariable(CppStatement):
     def __init__(self, overload, name, size, value = None):
         """
         Initialize positive definite matrix
-        
+
         :param overload: Type of overload as string (Prim/Fwd/Rev/etc.)
         :param name: C++ name of variable
         :param size: Number of rows/columns of positive definite matrix
@@ -174,7 +201,7 @@ class PositiveDefiniteMatrixVariable(CppStatement):
             self.value = 0.4
         else:
             self.value = value
-    
+
     def is_reverse_mode(self):
         """Return true if the overload is reverse mode"""
         return self.overload.startswith("Rev")
@@ -182,11 +209,11 @@ class PositiveDefiniteMatrixVariable(CppStatement):
     def is_eigen_compatible(self):
         """Return true (positive definite matrices are matrices)"""
         return True
-    
+
     def is_varmat_compatible(self):
         """Return true (positive definite matrices are varmat compatible)"""
         return True
-    
+
     def cpp(self):
         """Generate C++"""
         scalar = overload_scalar[self.overload]
@@ -200,12 +227,12 @@ class AlgebraSolverFunctorVariable(CppStatement):
     def __init__(self, name):
         """
         Initialize functor for algebra solver
-        
+
         :param overload: Type of overload as string (Prim/Fwd/Rev/etc.)
         :param name: C++ name of variable
         """
         self.name = name
-    
+
     def cpp(self):
         """Generate C++"""
         return "stan::test::simple_eq_functor {name};".format(name = self.name)
@@ -215,12 +242,12 @@ class OdeFunctorVariable(CppStatement):
     def __init__(self, name):
         """
         Initialize functor for ode function
-        
+
         :param overload: Type of overload as string (Prim/Fwd/Rev/etc.)
         :param name: C++ name of variable
         """
         self.name = name
-    
+
     def cpp(self):
         """Generate C++"""
         return "stan::test::test_functor {name};".format(name = self.name)
@@ -230,7 +257,7 @@ class ReturnTypeTVariable(CppStatement):
     def __init__(self, name, *args):
         """
         Initialize a scalar return type variable with type computed from the given args
-        
+
         :param name: C++ name of variable
         :param args: Args from which to compute the return type
         """
@@ -238,11 +265,11 @@ class ReturnTypeTVariable(CppStatement):
         arg_names = ["decltype({name})".format(name = arg.name) for arg in args]
         self.type_str = "stan::return_type_t<{names}>".format(names = ','.join(arg_names))
         self._is_reverse_mode = any(arg.is_reverse_mode() for arg in args)
-    
+
     def is_reverse_mode(self):
         """Return true if any of the arguments are reverse mode"""
         return self._is_reverse_mode
-    
+
     def cpp(self):
         """Generate C++"""
         return "{type} {name} = 0;".format(type = self.type_str, name = self.name)
@@ -252,11 +279,11 @@ class RngVariable(CppStatement):
     def __init__(self, name):
         """
         Initialize an rng object
-        
+
         :param name: C++ name of variable
         """
         self.name = name
-    
+
     def cpp(self):
         """Generate C++"""
         return "std::minstd_rand {name};".format(name = self.name)
@@ -266,11 +293,11 @@ class OStreamVariable(CppStatement):
     def __init__(self, name):
         """
         Initialize an ostream pointer
-        
+
         :param name: C++ name of variable
         """
         self.name = name
-    
+
     def cpp(self):
         """Generate C++"""
         return "std::ostream* {name} = &std::cout;".format(name = self.name)
@@ -280,7 +307,7 @@ class ArrayVariable(CppStatement):
     def __init__(self, overload, name, number_nested_arrays, inner_type, size, value):
         """
         Initialize an array
-        
+
         :param overload: Type of overload as string (Prim/Fwd/Rev/etc.)
         :param name: C++ name of variable
         :param number_nested_arrays: Number of array dimensions
@@ -294,7 +321,7 @@ class ArrayVariable(CppStatement):
         self.inner_type = inner_type
         self.value = value
         self.size = size
-    
+
     def is_reverse_mode(self):
         """
         If the underlying value is a CppStatement, return the reverse-mode-ness of that underlying variable
@@ -312,7 +339,7 @@ class ArrayVariable(CppStatement):
             return self.value.is_varmat_compatible()
         else:
             return False
-    
+
     def cpp(self):
         """Generate C++"""
         if isinstance(self.value, CppStatement):
@@ -339,7 +366,7 @@ class FunctionCall(CppStatement):
     def __init__(self, function_name, name, *args):
         """
         Represents a function call and optional assignment of the result to a variable
-        
+
         :param function_name: C++ name of function
         :param name: C++ name of variable, None if result is not saved
         :param args: Args to pass to function call
@@ -376,7 +403,7 @@ class ExpressionVariable(CppStatement):
     def __init__(self, name, arg, size = None):
         """
         Initialize Eigen expression variable
-        
+
         :param name: C++ name of variable
         :param arg: Variable from which to form the expression
         :param size: Length of vector expression or rows/columns of matrix expression, if None use arg.size
@@ -391,7 +418,7 @@ class ExpressionVariable(CppStatement):
         self._is_reverse_mode = arg.is_reverse_mode()
         self._arg_stan_arg = arg.stan_arg
         self._arg_name = arg.name
-    
+
     def is_reverse_mode(self):
         """Return true if the base argument was reverse mode"""
         return self._is_reverse_mode
@@ -399,7 +426,7 @@ class ExpressionVariable(CppStatement):
     def is_eigen_compatible(self):
         """Return true (expressions are Eigen types)"""
         return True
-    
+
     def is_expression(self):
         """Return true (this is an expression)"""
         return True
@@ -415,9 +442,9 @@ class ExpressionVariable(CppStatement):
             "stan::test::counterOp<{scalar}> {counter_op_name}(&{counter});".format(scalar = scalar, counter_op_name = counter_op_name, counter = self.counter.name) + os.linesep
         )
 
-        if self._arg_stan_arg == "matrix":
+        if self._arg_stan_arg in ("matrix", 'complex_matrix'):
             return code + "auto {name} = {arg}.block(0,0,{size},{size}).unaryExpr({counter_op});".format(name = self.name, arg = self._arg_name, size = self.size, counter_op = counter_op_name)
-        elif self._arg_stan_arg in ("vector", "row_vector"):
+        elif self._arg_stan_arg in ("vector", "row_vector", "complex_vector", "complex_row_vector"):
             return code + "auto {name} = {arg}.segment(0,{size}).unaryExpr({counter_op});".format(name = self.name, arg = self._arg_name, size = self.size, counter_op = counter_op_name)
         else:
             raise Exception("Can't make an expression out of a " + self.arg.stan_arg)

--- a/test/statement_types.py
+++ b/test/statement_types.py
@@ -493,12 +493,17 @@ class ExpressionVariable(CppStatement):
 
         scalar = overload_scalar[self._arg_overload]
         counter_op_name = "{name}_counter_op".format(name=self.name)
+        value_type = (
+            "std::complex<" + scalar + ">"
+            if "complex_" in self._arg_stan_arg
+            else scalar
+        )
 
         code = (
             self.counter.cpp()
             + os.linesep
-            + "stan::test::counterOp<{scalar}> {counter_op_name}(&{counter});".format(
-                scalar=scalar,
+            + "stan::test::counterOp<{value_type}> {counter_op_name}(&{counter});".format(
+                value_type=value_type,
                 counter_op_name=counter_op_name,
                 counter=self.counter.name,
             )

--- a/test/statement_types.py
+++ b/test/statement_types.py
@@ -3,8 +3,10 @@ import os
 
 from sig_utils import overload_scalar, get_cpp_type, arg_types
 
+
 class CppStatement:
     """Base class for all statements. Implements some default checks. Should not be used directly"""
+
     def __init__(self):
         raise Exception("CppStatement should never be instantiated directly")
 
@@ -24,9 +26,11 @@ class CppStatement:
         """By default, a statement is not an expression"""
         return False
 
+
 class IntVariable(CppStatement):
     """Represents an integer variable"""
-    def __init__(self, name, value = None):
+
+    def __init__(self, name, value=None):
         """
         Initialize matrix
 
@@ -42,11 +46,13 @@ class IntVariable(CppStatement):
 
     def cpp(self):
         """Generate C++"""
-        return "int {name} = {value};".format(name = self.name, value = self.value)
+        return "int {name} = {value};".format(name=self.name, value=self.value)
+
 
 class RealVariable(CppStatement):
     """Represents a scalar, real variable"""
-    def __init__(self, overload, name, value = None):
+
+    def __init__(self, overload, name, value=None):
         """
         Initialize matrix
 
@@ -69,11 +75,15 @@ class RealVariable(CppStatement):
         """Generate c++"""
         scalar = overload_scalar[self.overload]
 
-        return "{type} {name} = {value};".format(type = scalar, name = self.name, value = self.value)
+        return "{type} {name} = {value};".format(
+            type=scalar, name=self.name, value=self.value
+        )
+
 
 class ComplexVariable(CppStatement):
     """Represents a scalar, real variable"""
-    def __init__(self, overload, name, value = None):
+
+    def __init__(self, overload, name, value=None):
         """
         Initialize matrix
 
@@ -96,11 +106,15 @@ class ComplexVariable(CppStatement):
         """Generate c++"""
         scalar = overload_scalar[self.overload]
 
-        return "std::complex<{type}> {name} = {value};".format(type = scalar, name = self.name, value = self.value)
+        return "std::complex<{type}> {name} = {value};".format(
+            type=scalar, name=self.name, value=self.value
+        )
+
 
 class MatrixVariable(CppStatement):
     """Represents a matrix variable"""
-    def __init__(self, overload, name, stan_arg, size, value = None):
+
+    def __init__(self, overload, name, stan_arg, size, value=None):
         """
         Initialize matrix
 
@@ -138,11 +152,15 @@ class MatrixVariable(CppStatement):
         cpp_arg_template = get_cpp_type(self.stan_arg)
         arg_type = cpp_arg_template.replace("SCALAR", scalar)
 
-        return "auto {name} = stan::test::make_arg<{type}>({value}, {size});".format(name = self.name, type = arg_type, value = self.value, size = self.size)
+        return "auto {name} = stan::test::make_arg<{type}>({value}, {size});".format(
+            name=self.name, type=arg_type, value=self.value, size=self.size
+        )
+
 
 class SimplexVariable(CppStatement):
     """Represents a simplex variable"""
-    def __init__(self, overload, name, size, value = None):
+
+    def __init__(self, overload, name, size, value=None):
         """
         Initialize simplex
 
@@ -179,11 +197,17 @@ class SimplexVariable(CppStatement):
         cpp_arg_template = get_cpp_type(self.stan_arg)
         arg_type = cpp_arg_template.replace("SCALAR", scalar)
 
-        return "auto {name} = stan::test::make_simplex<{type}>({value}, {size});".format(name = self.name, type = arg_type, value = self.value, size = self.size)
+        return (
+            "auto {name} = stan::test::make_simplex<{type}>({value}, {size});".format(
+                name=self.name, type=arg_type, value=self.value, size=self.size
+            )
+        )
+
 
 class PositiveDefiniteMatrixVariable(CppStatement):
     """Represents a positive definite matrix variable"""
-    def __init__(self, overload, name, size, value = None):
+
+    def __init__(self, overload, name, size, value=None):
         """
         Initialize positive definite matrix
 
@@ -220,10 +244,14 @@ class PositiveDefiniteMatrixVariable(CppStatement):
         cpp_arg_template = get_cpp_type(self.stan_arg)
         arg_type = cpp_arg_template.replace("SCALAR", scalar)
 
-        return "auto {name} = stan::test::make_pos_definite_matrix<{type}>({value}, {size});".format(name = self.name, type = arg_type, value = self.value, size = self.size)
+        return "auto {name} = stan::test::make_pos_definite_matrix<{type}>({value}, {size});".format(
+            name=self.name, type=arg_type, value=self.value, size=self.size
+        )
+
 
 class AlgebraSolverFunctorVariable(CppStatement):
     """Represents a functor variable that is compatible with Stan's algebra solver"""
+
     def __init__(self, name):
         """
         Initialize functor for algebra solver
@@ -235,10 +263,12 @@ class AlgebraSolverFunctorVariable(CppStatement):
 
     def cpp(self):
         """Generate C++"""
-        return "stan::test::simple_eq_functor {name};".format(name = self.name)
+        return "stan::test::simple_eq_functor {name};".format(name=self.name)
+
 
 class OdeFunctorVariable(CppStatement):
     """Represents a functor variable that is compatible with Stan's variadic ode solvers"""
+
     def __init__(self, name):
         """
         Initialize functor for ode function
@@ -250,10 +280,12 @@ class OdeFunctorVariable(CppStatement):
 
     def cpp(self):
         """Generate C++"""
-        return "stan::test::test_functor {name};".format(name = self.name)
+        return "stan::test::test_functor {name};".format(name=self.name)
+
 
 class ReturnTypeTVariable(CppStatement):
     """Represents a scalar variable with type computed from the types of all the input arguments and stan::return_type_t"""
+
     def __init__(self, name, *args):
         """
         Initialize a scalar return type variable with type computed from the given args
@@ -262,8 +294,8 @@ class ReturnTypeTVariable(CppStatement):
         :param args: Args from which to compute the return type
         """
         self.name = name
-        arg_names = ["decltype({name})".format(name = arg.name) for arg in args]
-        self.type_str = "stan::return_type_t<{names}>".format(names = ','.join(arg_names))
+        arg_names = ["decltype({name})".format(name=arg.name) for arg in args]
+        self.type_str = "stan::return_type_t<{names}>".format(names=",".join(arg_names))
         self._is_reverse_mode = any(arg.is_reverse_mode() for arg in args)
 
     def is_reverse_mode(self):
@@ -272,10 +304,12 @@ class ReturnTypeTVariable(CppStatement):
 
     def cpp(self):
         """Generate C++"""
-        return "{type} {name} = 0;".format(type = self.type_str, name = self.name)
+        return "{type} {name} = 0;".format(type=self.type_str, name=self.name)
+
 
 class RngVariable(CppStatement):
     """Represents a random number generator"""
+
     def __init__(self, name):
         """
         Initialize an rng object
@@ -286,10 +320,12 @@ class RngVariable(CppStatement):
 
     def cpp(self):
         """Generate C++"""
-        return "std::minstd_rand {name};".format(name = self.name)
+        return "std::minstd_rand {name};".format(name=self.name)
+
 
 class OStreamVariable(CppStatement):
     """Represents an ostream pointer"""
+
     def __init__(self, name):
         """
         Initialize an ostream pointer
@@ -300,10 +336,12 @@ class OStreamVariable(CppStatement):
 
     def cpp(self):
         """Generate C++"""
-        return "std::ostream* {name} = &std::cout;".format(name = self.name)
+        return "std::ostream* {name} = &std::cout;".format(name=self.name)
+
 
 class ArrayVariable(CppStatement):
     """Represents an array variable"""
+
     def __init__(self, overload, name, number_nested_arrays, inner_type, size, value):
         """
         Initialize an array
@@ -343,26 +381,37 @@ class ArrayVariable(CppStatement):
     def cpp(self):
         """Generate C++"""
         if isinstance(self.value, CppStatement):
-            lhs_string = "decltype({name})".format(name = self.value.name)
+            lhs_string = "decltype({name})".format(name=self.value.name)
             rhs_string = self.value.name
             for n in range(self.number_nested_arrays):
                 lhs_string = "std::vector<" + lhs_string + ">"
                 rhs_string = "{" + ",".join([rhs_string] * self.size) + "}"
 
-            return "{lhs_string} {name} = {rhs_string};".format(lhs_string = lhs_string, name = self.name, rhs_string = rhs_string)
+            return "{lhs_string} {name} = {rhs_string};".format(
+                lhs_string=lhs_string, name=self.name, rhs_string=rhs_string
+            )
         else:
             # For when self.value is an initializer list
             if self.number_nested_arrays == 1:
                 scalar = overload_scalar[self.overload]
-                lhs_string = "std::vector<{type}>".format(type = arg_types[self.inner_type].replace("SCALAR", scalar))
+                lhs_string = "std::vector<{type}>".format(
+                    type=arg_types[self.inner_type].replace("SCALAR", scalar)
+                )
 
                 value_string = ",".join([repr(value) for value in self.value])
-                return "{lhs_string} {name} = {{{value}}};".format(lhs_string = lhs_string, name = self.name, value = value_string)
+                return "{lhs_string} {name} = {{{value}}};".format(
+                    lhs_string=lhs_string, name=self.name, value=value_string
+                )
             else:
-                raise NotImplementedError("Array initializers are not implemented for number_nested_arrays = " + repr(self.number_nested_arrays))
+                raise NotImplementedError(
+                    "Array initializers are not implemented for number_nested_arrays = "
+                    + repr(self.number_nested_arrays)
+                )
+
 
 class FunctionCall(CppStatement):
     """Represents a function call and optional assignment"""
+
     def __init__(self, function_name, name, *args):
         """
         Represents a function call and optional assignment of the result to a variable
@@ -373,8 +422,10 @@ class FunctionCall(CppStatement):
         """
         self.function_name = function_name
         self.name = name
-        self.arg_str = ','.join(arg.name for arg in args)
-        self._is_reverse_mode = any(arg.is_reverse_mode() for arg in args) and self.name is not None
+        self.arg_str = ",".join(arg.name for arg in args)
+        self._is_reverse_mode = (
+            any(arg.is_reverse_mode() for arg in args) and self.name is not None
+        )
 
     def is_reverse_mode(self):
         """
@@ -394,13 +445,19 @@ class FunctionCall(CppStatement):
     def cpp(self):
         """Generate C++"""
         if self.name:
-            return "auto {name} = stan::math::eval({function_name}({arg_str}));".format(name = self.name, function_name = self.function_name, arg_str = self.arg_str)
+            return "auto {name} = stan::math::eval({function_name}({arg_str}));".format(
+                name=self.name, function_name=self.function_name, arg_str=self.arg_str
+            )
         else:
-            return "{function_name}({arg_str});".format(function_name = self.function_name, arg_str = self.arg_str)
+            return "{function_name}({arg_str});".format(
+                function_name=self.function_name, arg_str=self.arg_str
+            )
+
 
 class ExpressionVariable(CppStatement):
     """Represents an Eigen expression"""
-    def __init__(self, name, arg, size = None):
+
+    def __init__(self, name, arg, size=None):
         """
         Initialize Eigen expression variable
 
@@ -409,7 +466,7 @@ class ExpressionVariable(CppStatement):
         :param size: Length of vector expression or rows/columns of matrix expression, if None use arg.size
         """
         self.name = name
-        self.counter = IntVariable("{name}_counter".format(name = self.name), 0)
+        self.counter = IntVariable("{name}_counter".format(name=self.name), 0)
         if not size:
             self.size = arg.size
         else:
@@ -435,16 +492,37 @@ class ExpressionVariable(CppStatement):
         """Generate C++"""
 
         scalar = overload_scalar[self._arg_overload]
-        counter_op_name = "{name}_counter_op".format(name = self.name)
+        counter_op_name = "{name}_counter_op".format(name=self.name)
 
         code = (
-            self.counter.cpp() + os.linesep +
-            "stan::test::counterOp<{scalar}> {counter_op_name}(&{counter});".format(scalar = scalar, counter_op_name = counter_op_name, counter = self.counter.name) + os.linesep
+            self.counter.cpp()
+            + os.linesep
+            + "stan::test::counterOp<{scalar}> {counter_op_name}(&{counter});".format(
+                scalar=scalar,
+                counter_op_name=counter_op_name,
+                counter=self.counter.name,
+            )
+            + os.linesep
         )
 
-        if self._arg_stan_arg in ("matrix", 'complex_matrix'):
-            return code + "auto {name} = {arg}.block(0,0,{size},{size}).unaryExpr({counter_op});".format(name = self.name, arg = self._arg_name, size = self.size, counter_op = counter_op_name)
-        elif self._arg_stan_arg in ("vector", "row_vector", "complex_vector", "complex_row_vector"):
-            return code + "auto {name} = {arg}.segment(0,{size}).unaryExpr({counter_op});".format(name = self.name, arg = self._arg_name, size = self.size, counter_op = counter_op_name)
+        if self._arg_stan_arg in ("matrix", "complex_matrix"):
+            return code + "auto {name} = {arg}.block(0,0,{size},{size}).unaryExpr({counter_op});".format(
+                name=self.name,
+                arg=self._arg_name,
+                size=self.size,
+                counter_op=counter_op_name,
+            )
+        elif self._arg_stan_arg in (
+            "vector",
+            "row_vector",
+            "complex_vector",
+            "complex_row_vector",
+        ):
+            return code + "auto {name} = {arg}.segment(0,{size}).unaryExpr({counter_op});".format(
+                name=self.name,
+                arg=self._arg_name,
+                size=self.size,
+                counter_op=counter_op_name,
+            )
         else:
             raise Exception("Can't make an expression out of a " + self.arg.stan_arg)


### PR DESCRIPTION
Closes #2676 

## Summary

This adds `complex`, `complex_matrix`, `complex_vector`, and `complex_row_vector` to the types automatically tested by the expression tests based on stanc3's signatures.

## Checklist

- [x] Math issue #2676

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
