### PR TITLE
adds is_vt_complex and is_not_vt_complex type traits

### DIFF
--- a/stan/math/prim/meta/is_complex.hpp
+++ b/stan/math/prim/meta/is_complex.hpp
@@ -80,7 +80,8 @@ struct is_vt_complex : is_complex<value_type_t<std::decay_t<T>>> {};
  * @ingroup type_trait
  */
 template <typename T>
-struct is_vt_not_complex : bool_constant<!is_complex<value_type_t<std::decay_t<T>>>::value> {};
+struct is_vt_not_complex
+    : bool_constant<!is_complex<value_type_t<std::decay_t<T>>>::value> {};
 
 }  // namespace stan
 

--- a/stan/math/prim/meta/is_complex.hpp
+++ b/stan/math/prim/meta/is_complex.hpp
@@ -58,6 +58,30 @@ struct scalar_type<T, std::enable_if_t<is_complex<T>::value>> {
 STAN_ADD_REQUIRE_UNARY(complex, is_complex, require_stan_scalar_complex);
 STAN_ADD_REQUIRE_UNARY_INNER(complex, is_complex, require_stan_scalar_complex);
 
+/**
+ * If the `value_type` of the type `T` is of type
+ *  `std::complex` or a cv-qualified version thereof, provides the
+ * member constant `value` equal `true`; for any other type the value is
+ * `false`.
+ *
+ * @tparam T type to check
+ * @ingroup type_trait
+ */
+template <typename T>
+struct is_vt_complex : is_complex<value_type_t<std::decay_t<T>>> {};
+
+/**
+ * If the `value_type` of the type `T` is not of type
+ * `std::complex` or a cv-qualified version thereof, provides the
+ * member constant `value` equal `true`; for any other type the value is
+ * `false`.
+ *
+ * @tparam T type to check
+ * @ingroup type_trait
+ */
+template <typename T>
+struct is_vt_not_complex : bool_constant<!is_complex<value_type_t<std::decay_t<T>>>::value> {};
+
 }  // namespace stan
 
 #endif

--- a/test/unit/math/mix/meta/is_complex_test.cpp
+++ b/test/unit/math/mix/meta/is_complex_test.cpp
@@ -35,3 +35,87 @@ TEST(stanMathMix, isComplex) {
   expect_is_complex<false, double>();
   expect_is_complex<false, std::string>();
 }
+
+template <bool expected, typename T>
+void expect_is_vt_complex() {
+  EXPECT_EQ(expected, stan::is_vt_complex<T>::value);
+}
+
+template <typename T>
+void test_is_vt_complex() {
+  using complex_std_vec = std::vector<std::complex<T>>;
+  using complex_eigen_vec = Eigen::Matrix<std::complex<T>, -1, 1>;
+  expect_is_vt_complex<true, complex_std_vec>();
+  expect_is_vt_complex<true, const complex_std_vec>();
+  expect_is_vt_complex<true, complex_std_vec&>();
+  expect_is_vt_complex<true, const complex_std_vec&>();
+  expect_is_vt_complex<false, complex_std_vec*>();
+  expect_is_vt_complex<false, const complex_std_vec*>();
+
+  expect_is_vt_complex<true, complex_eigen_vec>();
+  expect_is_vt_complex<true, const complex_eigen_vec>();
+  expect_is_vt_complex<true, complex_eigen_vec&>();
+  expect_is_vt_complex<true, const complex_eigen_vec&>();
+  expect_is_vt_complex<false, complex_eigen_vec*>();
+  expect_is_vt_complex<false, const complex_eigen_vec*>();
+
+}
+
+TEST(stanMathMix, is_vt_Complex) {
+  using stan::math::fvar;
+  using stan::math::var;
+  test_is_vt_complex<double>();
+  test_is_vt_complex<var>();
+  test_is_vt_complex<fvar<double>>();
+  test_is_vt_complex<fvar<fvar<double>>>();
+  test_is_vt_complex<fvar<var>>();
+  test_is_vt_complex<fvar<fvar<var>>>();
+
+  expect_is_vt_complex<false, std::vector<bool>>();
+  expect_is_vt_complex<false, std::vector<int>>();
+  expect_is_vt_complex<false, std::vector<size_t>>();
+  expect_is_vt_complex<false, std::vector<double>>();
+  expect_is_vt_complex<false, std::vector<std::string>>();
+}
+
+template <bool expected, typename T>
+void expect_is_vt_not_complex() {
+  EXPECT_EQ(expected, stan::is_vt_not_complex<T>::value);
+}
+
+template <typename T>
+void test_is_vt_not_complex() {
+  using complex_std_vec = std::vector<std::complex<T>>;
+  using complex_eigen_vec = Eigen::Matrix<std::complex<T>, -1, 1>;
+  expect_is_vt_not_complex<!true, complex_std_vec>();
+  expect_is_vt_not_complex<!true, const complex_std_vec>();
+  expect_is_vt_not_complex<!true, complex_std_vec&>();
+  expect_is_vt_not_complex<!true, const complex_std_vec&>();
+  expect_is_vt_not_complex<!false, complex_std_vec*>();
+  expect_is_vt_not_complex<!false, const complex_std_vec*>();
+
+  expect_is_vt_not_complex<!true, complex_eigen_vec>();
+  expect_is_vt_not_complex<!true, const complex_eigen_vec>();
+  expect_is_vt_not_complex<!true, complex_eigen_vec&>();
+  expect_is_vt_not_complex<!true, const complex_eigen_vec&>();
+  expect_is_vt_not_complex<!false, complex_eigen_vec*>();
+  expect_is_vt_not_complex<!false, const complex_eigen_vec*>();
+
+}
+
+TEST(stanMathMix, is_vt_not_Complex) {
+  using stan::math::fvar;
+  using stan::math::var;
+  test_is_vt_not_complex<double>();
+  test_is_vt_not_complex<var>();
+  test_is_vt_not_complex<fvar<double>>();
+  test_is_vt_not_complex<fvar<fvar<double>>>();
+  test_is_vt_not_complex<fvar<var>>();
+  test_is_vt_not_complex<fvar<fvar<var>>>();
+
+  expect_is_vt_not_complex<!false, std::vector<bool>>();
+  expect_is_vt_not_complex<!false, std::vector<int>>();
+  expect_is_vt_not_complex<!false, std::vector<size_t>>();
+  expect_is_vt_not_complex<!false, std::vector<double>>();
+  expect_is_vt_not_complex<!false, std::vector<std::string>>();
+}

--- a/test/unit/math/mix/meta/is_complex_test.cpp
+++ b/test/unit/math/mix/meta/is_complex_test.cpp
@@ -58,7 +58,6 @@ void test_is_vt_complex() {
   expect_is_vt_complex<true, const complex_eigen_vec&>();
   expect_is_vt_complex<false, complex_eigen_vec*>();
   expect_is_vt_complex<false, const complex_eigen_vec*>();
-
 }
 
 TEST(stanMathMix, is_vt_Complex) {
@@ -100,7 +99,6 @@ void test_is_vt_not_complex() {
   expect_is_vt_not_complex<!true, const complex_eigen_vec&>();
   expect_is_vt_not_complex<!false, complex_eigen_vec*>();
   expect_is_vt_not_complex<!false, const complex_eigen_vec*>();
-
 }
 
 TEST(stanMathMix, is_vt_not_Complex) {


### PR DESCRIPTION

## Summary

Adds two type traits `is_vt_complex` and `is_vt_not_complex` that checks whether the value type of a type `T` is complex or not. This will mostly be used in the stanc compiler when generating C++ functions from user defined functions.

## Tests

Tests added to test both traits can be run with 

```
./runTests.py test/unit/math/mix/meta/is_complex_test.cpp
```

## Side Effects

Nope

## Release notes

Adds type traits for detecting whether a type has a value type that is complex

## Checklist

- [ ] Math issue 

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
