### PR TITLE
adds vectorized versions of get_real and get_imag

### DIFF
--- a/stan/math/prim/fun/get_imag.hpp
+++ b/stan/math/prim/fun/get_imag.hpp
@@ -15,8 +15,36 @@ namespace math {
  * @return imaginary component of argument
  */
 template <typename T>
-T get_imag(const std::complex<T>& z) {
+inline T get_imag(const std::complex<T>& z) {
   return z.imag();
+}
+
+/**
+ * Return the real component of the complex argument.
+ *
+ * @tparam Eig A type derived from `Eigen::EigenBase`
+ * @param[in] z complex value whose real component is extracted
+ * @return real component of argument
+ */
+template <typename Eig, require_eigen_vt<is_complex, Eig>* = nullptr>
+inline auto get_imag(const Eig& z) {
+  return z.imag();
+}
+
+/**
+ * Return the real component of the complex argument.
+ *
+ * @tparam StdVec A `std::vector` type with complex scalar type
+ * @param[in] z complex value whose real component is extracted
+ * @return real component of argument
+ */
+template <typename StdVec, require_std_vector_st<is_complex, StdVec>* = nullptr>
+inline auto get_imag(const StdVec& z) {
+  promote_scalar_t<base_type_t<StdVec>, StdVec> result(z.size());
+  std::transform(z.begin(), z.end(), result.begin(), [](auto&& x) {
+    return get_imag(x);
+  });
+  return result;
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/get_imag.hpp
+++ b/stan/math/prim/fun/get_imag.hpp
@@ -41,9 +41,8 @@ inline auto get_imag(const Eig& z) {
 template <typename StdVec, require_std_vector_st<is_complex, StdVec>* = nullptr>
 inline auto get_imag(const StdVec& z) {
   promote_scalar_t<base_type_t<StdVec>, StdVec> result(z.size());
-  std::transform(z.begin(), z.end(), result.begin(), [](auto&& x) {
-    return get_imag(x);
-  });
+  std::transform(z.begin(), z.end(), result.begin(),
+                 [](auto&& x) { return get_imag(x); });
   return result;
 }
 

--- a/stan/math/prim/fun/get_real.hpp
+++ b/stan/math/prim/fun/get_real.hpp
@@ -15,9 +15,39 @@ namespace math {
  * @return real component of argument
  */
 template <typename T>
-T get_real(const std::complex<T>& z) {
+inline T get_real(const std::complex<T>& z) {
   return z.real();
 }
+
+/**
+ * Return the real component of the complex argument.
+ *
+ * @tparam Eig A type derived from `Eigen::EigenBase`
+ * @param[in] z complex value whose real component is extracted
+ * @return real component of argument
+ */
+template <typename Eig, require_eigen_vt<is_complex, Eig>* = nullptr>
+inline auto get_real(const Eig& z) {
+  return z.real();
+}
+
+/**
+ * Return the real component of the complex argument.
+ *
+ * @tparam StdVec A `std::vector` type with complex scalar type
+ * @param[in] z complex value whose real component is extracted
+ * @return real component of argument
+ */
+template <typename StdVec, require_std_vector_st<is_complex, StdVec>* = nullptr>
+inline auto get_real(const StdVec& z) {
+  promote_scalar_t<base_type_t<StdVec>, StdVec> result(z.size());
+  std::transform(z.begin(), z.end(), result.begin(), [](auto&& x) {
+    return get_real(x);
+  });
+  return result;
+}
+
+
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/get_real.hpp
+++ b/stan/math/prim/fun/get_real.hpp
@@ -41,13 +41,10 @@ inline auto get_real(const Eig& z) {
 template <typename StdVec, require_std_vector_st<is_complex, StdVec>* = nullptr>
 inline auto get_real(const StdVec& z) {
   promote_scalar_t<base_type_t<StdVec>, StdVec> result(z.size());
-  std::transform(z.begin(), z.end(), result.begin(), [](auto&& x) {
-    return get_real(x);
-  });
+  std::transform(z.begin(), z.end(), result.begin(),
+                 [](auto&& x) { return get_real(x); });
   return result;
 }
-
-
 
 }  // namespace math
 }  // namespace stan

--- a/test/unit/math/mix/fun/get_imag_test.cpp
+++ b/test/unit/math/mix/fun/get_imag_test.cpp
@@ -12,7 +12,8 @@ void test_vectorized_get_imag() {
   using matrix_t = Eigen::Matrix<T, -1, -1>;
   using complex_matrix = Eigen::Matrix<complex_t, -1, -1>;
   complex_matrix A(2, 2);
-  A << complex_t(T(0), T(1)), complex_t(T(2), T(3)), complex_t(T(4), T(5)), complex_t(T(6), T(7));
+  A << complex_t(T(0), T(1)), complex_t(T(2), T(3)), complex_t(T(4), T(5)),
+      complex_t(T(6), T(7));
   matrix_t values = A.imag();
   matrix_t A_imag = stan::math::get_imag(A);
   EXPECT_MATRIX_EQ(A_imag, values);
@@ -22,7 +23,8 @@ void test_vectorized_get_imag() {
     EXPECT_MATRIX_EQ(a_imag, values);
   }
   std::vector<std::vector<complex_matrix>> A_vec_vec{A_vec, A_vec, A_vec};
-  std::vector<std::vector<matrix_t>> A_vec_vec_imag = stan::math::get_imag(A_vec_vec);
+  std::vector<std::vector<matrix_t>> A_vec_vec_imag
+      = stan::math::get_imag(A_vec_vec);
   for (auto&& a_vec_imag : A_vec_vec_imag) {
     for (auto&& a_imag : a_vec_imag) {
       EXPECT_MATRIX_EQ(a_imag, values);
@@ -34,5 +36,6 @@ TEST(mathMixMatFun, get_imag_vectorized) {
   test_vectorized_get_imag<stan::math::var>();
   test_vectorized_get_imag<stan::math::fvar<double>>();
   test_vectorized_get_imag<stan::math::fvar<stan::math::var>>();
-  test_vectorized_get_imag<stan::math::fvar<stan::math::fvar<stan::math::var>>>();
+  test_vectorized_get_imag<
+      stan::math::fvar<stan::math::fvar<stan::math::var>>>();
 }

--- a/test/unit/math/mix/fun/get_imag_test.cpp
+++ b/test/unit/math/mix/fun/get_imag_test.cpp
@@ -5,3 +5,34 @@ TEST(mathMixMatFun, get_imag) {
   auto f = [](const auto& z) { return stan::math::get_imag(z); };
   stan::test::expect_complex_common(f);
 }
+
+template <typename T>
+void test_vectorized_get_imag() {
+  using complex_t = std::complex<T>;
+  using matrix_t = Eigen::Matrix<T, -1, -1>;
+  using complex_matrix = Eigen::Matrix<complex_t, -1, -1>;
+  complex_matrix A(2, 2);
+  A << complex_t(T(0), T(1)), complex_t(T(2), T(3)), complex_t(T(4), T(5)), complex_t(T(6), T(7));
+  matrix_t values = A.imag();
+  matrix_t A_imag = stan::math::get_imag(A);
+  EXPECT_MATRIX_EQ(A_imag, values);
+  std::vector<complex_matrix> A_vec{A, A, A};
+  std::vector<matrix_t> A_vec_imag = stan::math::get_imag(A_vec);
+  for (auto&& a_imag : A_vec_imag) {
+    EXPECT_MATRIX_EQ(a_imag, values);
+  }
+  std::vector<std::vector<complex_matrix>> A_vec_vec{A_vec, A_vec, A_vec};
+  std::vector<std::vector<matrix_t>> A_vec_vec_imag = stan::math::get_imag(A_vec_vec);
+  for (auto&& a_vec_imag : A_vec_vec_imag) {
+    for (auto&& a_imag : a_vec_imag) {
+      EXPECT_MATRIX_EQ(a_imag, values);
+    }
+  }
+}
+TEST(mathMixMatFun, get_imag_vectorized) {
+  test_vectorized_get_imag<double>();
+  test_vectorized_get_imag<stan::math::var>();
+  test_vectorized_get_imag<stan::math::fvar<double>>();
+  test_vectorized_get_imag<stan::math::fvar<stan::math::var>>();
+  test_vectorized_get_imag<stan::math::fvar<stan::math::fvar<stan::math::var>>>();
+}

--- a/test/unit/math/mix/fun/get_real_test.cpp
+++ b/test/unit/math/mix/fun/get_real_test.cpp
@@ -12,7 +12,8 @@ void test_vectorized_get_real() {
   using matrix_t = Eigen::Matrix<T, -1, -1>;
   using complex_matrix = Eigen::Matrix<complex_t, -1, -1>;
   complex_matrix A(2, 2);
-  A << complex_t(T(0), T(1)), complex_t(T(2), T(3)), complex_t(T(4), T(5)), complex_t(T(6), T(7));
+  A << complex_t(T(0), T(1)), complex_t(T(2), T(3)), complex_t(T(4), T(5)),
+      complex_t(T(6), T(7));
   matrix_t values = A.real();
   matrix_t A_imag = stan::math::get_real(A);
   EXPECT_MATRIX_EQ(A_imag, values);
@@ -22,7 +23,8 @@ void test_vectorized_get_real() {
     EXPECT_MATRIX_EQ(a_imag, values);
   }
   std::vector<std::vector<complex_matrix>> A_vec_vec{A_vec, A_vec, A_vec};
-  std::vector<std::vector<matrix_t>> A_vec_vec_imag = stan::math::get_real(A_vec_vec);
+  std::vector<std::vector<matrix_t>> A_vec_vec_imag
+      = stan::math::get_real(A_vec_vec);
   for (auto&& a_vec_imag : A_vec_vec_imag) {
     for (auto&& a_imag : a_vec_imag) {
       EXPECT_MATRIX_EQ(a_imag, values);
@@ -34,5 +36,6 @@ TEST(mathMixMatFun, get_real_vectorized) {
   test_vectorized_get_real<stan::math::var>();
   test_vectorized_get_real<stan::math::fvar<double>>();
   test_vectorized_get_real<stan::math::fvar<stan::math::var>>();
-  test_vectorized_get_real<stan::math::fvar<stan::math::fvar<stan::math::var>>>();
+  test_vectorized_get_real<
+      stan::math::fvar<stan::math::fvar<stan::math::var>>>();
 }

--- a/test/unit/math/mix/fun/get_real_test.cpp
+++ b/test/unit/math/mix/fun/get_real_test.cpp
@@ -5,3 +5,34 @@ TEST(mathMixMatFun, get_real) {
   auto f = [](const auto& z) { return stan::math::get_real(z); };
   stan::test::expect_complex_common(f);
 }
+
+template <typename T>
+void test_vectorized_get_real() {
+  using complex_t = std::complex<T>;
+  using matrix_t = Eigen::Matrix<T, -1, -1>;
+  using complex_matrix = Eigen::Matrix<complex_t, -1, -1>;
+  complex_matrix A(2, 2);
+  A << complex_t(T(0), T(1)), complex_t(T(2), T(3)), complex_t(T(4), T(5)), complex_t(T(6), T(7));
+  matrix_t values = A.real();
+  matrix_t A_imag = stan::math::get_real(A);
+  EXPECT_MATRIX_EQ(A_imag, values);
+  std::vector<complex_matrix> A_vec{A, A, A};
+  std::vector<matrix_t> A_vec_imag = stan::math::get_real(A_vec);
+  for (auto&& a_imag : A_vec_imag) {
+    EXPECT_MATRIX_EQ(a_imag, values);
+  }
+  std::vector<std::vector<complex_matrix>> A_vec_vec{A_vec, A_vec, A_vec};
+  std::vector<std::vector<matrix_t>> A_vec_vec_imag = stan::math::get_real(A_vec_vec);
+  for (auto&& a_vec_imag : A_vec_vec_imag) {
+    for (auto&& a_imag : a_vec_imag) {
+      EXPECT_MATRIX_EQ(a_imag, values);
+    }
+  }
+}
+TEST(mathMixMatFun, get_real_vectorized) {
+  test_vectorized_get_real<double>();
+  test_vectorized_get_real<stan::math::var>();
+  test_vectorized_get_real<stan::math::fvar<double>>();
+  test_vectorized_get_real<stan::math::fvar<stan::math::var>>();
+  test_vectorized_get_real<stan::math::fvar<stan::math::fvar<stan::math::var>>>();
+}


### PR DESCRIPTION
## Summary

Fixes #2675 by adding vectorized versions of `get_real` and `get_imag`

## Tests

```
./runTests.py -j3 test/unit/math/mix/fun/get_real_test.cpp test/unit/math/mix/fun/get_imag_test.cpp
```

## Side Effects

Nope

## Release notes

adds vectorized versions of get_real and get_imag

## Checklist

- [x] Math issue #2675

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
