### PR TITLE
Enable address sanitizer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -247,6 +247,7 @@ pipeline {
                 docker {
                     image 'stanorg/ci:gpu'
                     label 'linux'
+                    args '--cap-add SYS_PTRACE'
                 }
             }
             when {
@@ -256,7 +257,7 @@ pipeline {
             }
             steps {
                 unstash 'MathSetup'
-	            // sh "echo CXXFLAGS += -fsanitize=address >> make/local"
+	            sh "echo CXXFLAGS += -fsanitize=address >> make/local"
                 script {
                     if (isUnix()) {
                         runTests("test/unit", false)


### PR DESCRIPTION
## Summary

Enable address sanitizer and fix it when running inside Docker in Flatiron CI.

## Tests

## Side Effects

No

## Release notes

Enable address sanitizer and fix it when running inside Docker in Flatiron CI.

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
