### PR TITLE
Make `arena_allocator` usable for all std containers.

### DIFF
--- a/stan/math/rev/core/arena_allocator.hpp
+++ b/stan/math/rev/core/arena_allocator.hpp
@@ -10,10 +10,14 @@ namespace math {
  * std library compatible allocator that uses AD stack.
  * @tparam T type of scalar
  *
- * @warning The type T needs to be either trivially destructible or the dynamic allocations needs to be managed by the arena_allocator.
+ * @warning The type T needs to be either trivially destructible or the dynamic
+allocations needs to be managed by the arena_allocator.
  * For example this works: @code{.cpp}
-using my_matrix = std::vector<std::vector<double, stan::math::arena_allocator<double>>, stan::math::arena_allocator<std::vector<double, stan::math::arena_allocator<double>>>>;@endcode
- * 
+using my_matrix = std::vector<std::vector<double,
+stan::math::arena_allocator<double>>,
+stan::math::arena_allocator<std::vector<double,
+stan::math::arena_allocator<double>>>>;@endcode
+ *
  */
 template <typename T>
 struct arena_allocator {

--- a/stan/math/rev/core/arena_allocator.hpp
+++ b/stan/math/rev/core/arena_allocator.hpp
@@ -14,6 +14,13 @@ template <typename T>
 struct arena_allocator {
   using value_type = T;
 
+  arena_allocator() = default;
+
+  arena_allocator(const arena_allocator& rhs) = default;
+
+  template <class U>
+  arena_allocator(const arena_allocator<U>& rhs) {}
+
   /**
    * Allocates space for `n` items of type `T`.
    *

--- a/stan/math/rev/core/arena_allocator.hpp
+++ b/stan/math/rev/core/arena_allocator.hpp
@@ -9,6 +9,11 @@ namespace math {
 /**
  * std library compatible allocator that uses AD stack.
  * @tparam T type of scalar
+ *
+ * @warning The type T needs to be either trivially destructible or the dynamic allocations needs to be managed by the arena_allocator.
+ * For example this works: @code{.cpp}
+using my_matrix = std::vector<std::vector<double, stan::math::arena_allocator<double>>, stan::math::arena_allocator<std::vector<double, stan::math::arena_allocator<double>>>>;@endcode
+ * 
  */
 template <typename T>
 struct arena_allocator {

--- a/test/unit/math/rev/core/arena_allocator_test.cpp
+++ b/test/unit/math/rev/core/arena_allocator_test.cpp
@@ -30,6 +30,24 @@ void arena_allocator_test() {
       stan::math::ChainableStack::instance_->memalloc_.in_stack(v3.data()));
   EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(
       v3.data() + v3.size()));
+
+  std::unordered_map<int, int, std::hash<int>, std::equal_to<int>,
+                     stan::math::arena_allocator<std::pair<const int, int>>>
+      m;
+  m.insert(std::make_pair(3, 5));
+  m.insert(std::make_pair(4, 6));
+  for (auto it = m.begin(); it != m.end(); ++it) {
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
+  }
+
+  std::set<int, std::less<int>, stan::math::arena_allocator<int>> s;
+  s.insert(3);
+  s.insert(5);
+  for (auto it = m.begin(); it != m.end(); ++it) {
+    EXPECT_TRUE(
+	stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
+  }
 }
 
 TEST(AgradRev, arena_allocator_test) {

--- a/test/unit/math/rev/core/arena_allocator_test.cpp
+++ b/test/unit/math/rev/core/arena_allocator_test.cpp
@@ -1,6 +1,13 @@
 #include <stan/math/rev/core.hpp>
 #include <gtest/gtest.h>
 #include <vector>
+#include <deque>
+#include <list>
+#include <forward_list>
+#include <set>
+#include <unordered_set>
+#include <map>
+#include <unordered_map>
 
 void arena_allocator_test() {
   std::vector<int, stan::math::arena_allocator<int>> v;
@@ -31,7 +38,59 @@ void arena_allocator_test() {
   EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(
       v3.data() + v3.size()));
 
-  std::unordered_map<int, int, std::hash<int>, std::equal_to<int>,
+  std::deque<int, stan::math::arena_allocator<int>> d(4, 1);
+  for (auto it = d.begin(); it != d.end(); ++it) {
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
+  }
+
+  std::list<int, stan::math::arena_allocator<int>> l(4, 1);
+  for (auto it = l.begin(); it != l.end(); ++it) {
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
+  }
+
+  std::forward_list<int, stan::math::arena_allocator<int>> fl(4, 1);
+  for (auto it = fl.begin(); it != fl.end(); ++it) {
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
+  }
+
+  std::set<int, std::less<int>, stan::math::arena_allocator<int>> s;
+  s.insert(3);
+  s.insert(5);
+  for (auto it = s.begin(); it != s.end(); ++it) {
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
+  }
+
+  std::multiset<int, std::less<int>, stan::math::arena_allocator<int>> ms;
+  ms.insert(3);
+  ms.insert(5);
+  ms.insert(5);
+  for (auto it = ms.begin(); it != ms.end(); ++it) {
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
+  }
+
+  std::unordered_set<int, std::hash<int>, std::equal_to<int>, stan::math::arena_allocator<int>> u_s;
+  u_s.insert(3);
+  u_s.insert(5);
+  for (auto it = u_s.begin(); it != u_s.end(); ++it) {
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
+  }
+
+  std::unordered_multiset<int, std::hash<int>, std::equal_to<int>, stan::math::arena_allocator<int>> u_ms;
+  u_ms.insert(3);
+  u_ms.insert(5);
+  u_ms.insert(5);
+  for (auto it = u_ms.begin(); it != u_ms.end(); ++it) {
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
+  }
+
+  std::map<int, int, std::less<int>,
                      stan::math::arena_allocator<std::pair<const int, int>>>
       m;
   m.insert(std::make_pair(3, 5));
@@ -41,10 +100,34 @@ void arena_allocator_test() {
         stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
   }
 
-  std::set<int, std::less<int>, stan::math::arena_allocator<int>> s;
-  s.insert(3);
-  s.insert(5);
-  for (auto it = m.begin(); it != m.end(); ++it) {
+  std::multimap<int, int, std::less<int>,
+                     stan::math::arena_allocator<std::pair<const int, int>>>
+      mm;
+  mm.insert(std::make_pair(3, 5));
+  mm.insert(std::make_pair(4, 6));
+  mm.insert(std::make_pair(4, 8));
+  for (auto it = mm.begin(); it != mm.end(); ++it) {
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
+  }
+
+  std::unordered_map<int, int, std::hash<int>, std::equal_to<int>,
+                     stan::math::arena_allocator<std::pair<const int, int>>>
+      u_m;
+  u_m.insert(std::make_pair(3, 5));
+  u_m.insert(std::make_pair(4, 6));
+  for (auto it = u_m.begin(); it != u_m.end(); ++it) {
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
+  }
+
+  std::unordered_multimap<int, int, std::hash<int>, std::equal_to<int>,
+                     stan::math::arena_allocator<std::pair<const int, int>>>
+      u_mm;
+  u_mm.insert(std::make_pair(3, 5));
+  u_mm.insert(std::make_pair(4, 6));
+  u_mm.insert(std::make_pair(4, 8));
+  for (auto it = u_mm.begin(); it != u_mm.end(); ++it) {
     EXPECT_TRUE(
         stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
   }

--- a/test/unit/math/rev/core/arena_allocator_test.cpp
+++ b/test/unit/math/rev/core/arena_allocator_test.cpp
@@ -73,7 +73,9 @@ void arena_allocator_test() {
         stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
   }
 
-  std::unordered_set<int, std::hash<int>, std::equal_to<int>, stan::math::arena_allocator<int>> u_s;
+  std::unordered_set<int, std::hash<int>, std::equal_to<int>,
+                     stan::math::arena_allocator<int>>
+      u_s;
   u_s.insert(3);
   u_s.insert(5);
   for (auto it = u_s.begin(); it != u_s.end(); ++it) {
@@ -81,7 +83,9 @@ void arena_allocator_test() {
         stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
   }
 
-  std::unordered_multiset<int, std::hash<int>, std::equal_to<int>, stan::math::arena_allocator<int>> u_ms;
+  std::unordered_multiset<int, std::hash<int>, std::equal_to<int>,
+                          stan::math::arena_allocator<int>>
+      u_ms;
   u_ms.insert(3);
   u_ms.insert(5);
   u_ms.insert(5);
@@ -91,7 +95,7 @@ void arena_allocator_test() {
   }
 
   std::map<int, int, std::less<int>,
-                     stan::math::arena_allocator<std::pair<const int, int>>>
+           stan::math::arena_allocator<std::pair<const int, int>>>
       m;
   m.insert(std::make_pair(3, 5));
   m.insert(std::make_pair(4, 6));
@@ -101,7 +105,7 @@ void arena_allocator_test() {
   }
 
   std::multimap<int, int, std::less<int>,
-                     stan::math::arena_allocator<std::pair<const int, int>>>
+                stan::math::arena_allocator<std::pair<const int, int>>>
       mm;
   mm.insert(std::make_pair(3, 5));
   mm.insert(std::make_pair(4, 6));
@@ -121,8 +125,9 @@ void arena_allocator_test() {
         stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
   }
 
-  std::unordered_multimap<int, int, std::hash<int>, std::equal_to<int>,
-                     stan::math::arena_allocator<std::pair<const int, int>>>
+  std::unordered_multimap<
+      int, int, std::hash<int>, std::equal_to<int>,
+      stan::math::arena_allocator<std::pair<const int, int>>>
       u_mm;
   u_mm.insert(std::make_pair(3, 5));
   u_mm.insert(std::make_pair(4, 6));

--- a/test/unit/math/rev/core/arena_allocator_test.cpp
+++ b/test/unit/math/rev/core/arena_allocator_test.cpp
@@ -46,7 +46,7 @@ void arena_allocator_test() {
   s.insert(5);
   for (auto it = m.begin(); it != m.end(); ++it) {
     EXPECT_TRUE(
-	stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*it)));
   }
 }
 


### PR DESCRIPTION
## Summary

The `arena_allocator` got  a new constructor to make it usable as a drop-in replacement for `std::allocator` in all std containers.

The additional constructor has the signature
```
  template <class U>
  arena_allocator(const arena_allocator<U>& rhs);
``` 
and the body is trivial because `arena_allocator` is a stateless wrapper class.

## Tests

Additional tests are added for the containers `std::unordered_map` and `std::set` in use with the `arena_allocator`.

These tests would have been failed before this PR.

## Side Effects

No.

## Release notes

Make `arena_allocator` usable for all std containers.

## Checklist

- [x] #2683 Math issue 
- [x] Copyright holder: Matthias Peschke

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
