### PR TITLE
add wishart_cholesky

### DIFF
--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -364,6 +364,7 @@
 #include <stan/math/prim/prob/wiener_log.hpp>
 #include <stan/math/prim/prob/wiener_lpdf.hpp>
 #include <stan/math/prim/prob/wishart_cholesky_lpdf.hpp>
+#include <stan/math/prim/prob/wishart_cholesky_rng.hpp>
 #include <stan/math/prim/prob/wishart_log.hpp>
 #include <stan/math/prim/prob/wishart_lpdf.hpp>
 #include <stan/math/prim/prob/wishart_rng.hpp>

--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -363,6 +363,7 @@
 #include <stan/math/prim/prob/weibull_rng.hpp>
 #include <stan/math/prim/prob/wiener_log.hpp>
 #include <stan/math/prim/prob/wiener_lpdf.hpp>
+#include <stan/math/prim/prob/wishart_cholesky_lpdf.hpp>
 #include <stan/math/prim/prob/wishart_log.hpp>
 #include <stan/math/prim/prob/wishart_lpdf.hpp>
 #include <stan/math/prim/prob/wishart_rng.hpp>

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -12,12 +12,12 @@ namespace stan {
 namespace math {
 
 /** \ingroup multivar_dists
- * The log of the Wishart density for the given Cholesky factor, degrees of
- freedom,
- * and scale Cholesky factor matrix.
+ * Return the natural logarithm of the unnormalized Wishart density of the specified
+ * lower-triangular Cholesky factor variate, positive degrees of freedom, and lower-triangular
+ * Cholesky factor of the scale matrix.
  *
- * The scale matrix, LS, must be a lower Cholesky factor.
- * Dimension, k, is implicit.
+ * The scale matrix, L_S, must be a lower Cholesky factor
+ * dimension, k, is implicit
  * nu must be greater than k-1
  *
  * The change of variables from the input positive-definite matrix to
@@ -25,40 +25,40 @@ namespace math {
  * Muirhead, R. J. (2005).
  * Aspects of Multivariate Statistical Theory. Wiley-Interscience.
 
- * @tparam T_y type of matrix
- * @tparam T_dof type of degrees of freedom
- * @tparam T_scale type of scale
- * @param LY A lower triangular Cholesky factor covariance matrix.
- * @param nu The degrees of freedom.
- * @param LS The Cholesky factor of the scale matrix.
- * @return The log of the Wishart density at LY given nu and LS.
+ * @tparam T_y Cholesky factor matrix
+ * @tparam T_dof scalar degrees of freedom
+ * @tparam T_scale Cholesky factor matrix
+ * @param L_Y lower triangular Cholesky factor of the inverse covariance matrix
+ * @param nu scalar degrees of freedom
+ * @param L_S lower triangular Cholesky factor of the scale matrix
+ * @return natural logarithm of the Wishart density at L_Y given nu and L_S
  * @throw std::domain_error if nu is not greater than k-1
- * @throw std::domain_error if LS is not a valid Cholesky factor.
+ * @throw std::domain_error if L_S is not a valid Cholesky factor
  */
 template <bool propto, typename T_y, typename T_dof, typename T_scale,
           require_stan_scalar_t<T_dof>* = nullptr,
           require_all_matrix_t<T_y, T_scale>* = nullptr>
-return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& LY,
+return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& L_Y,
                                                          const T_dof& nu,
-                                                         const T_scale& LS) {
+                                                         const T_scale& L_S) {
   using Eigen::Dynamic;
   using Eigen::Lower;
   using Eigen::Matrix;
-  using T_LY_ref = ref_type_t<T_y>;
+  using T_L_Y_ref = ref_type_t<T_y>;
   using T_nu_ref = ref_type_t<T_dof>;
-  using T_LS_ref = ref_type_t<T_scale>;
+  using T_L_S_ref = ref_type_t<T_scale>;
   static const char* function = "wishart_cholesky_lpdf";
-  Eigen::Index k = LY.rows();
-  check_size_match(function, "Rows of random variable", LY.rows(),
-                   "columns of scale parameter", LS.rows());
+  Eigen::Index k = L_Y.rows();
+  check_size_match(function, "Rows of random variable", L_Y.rows(),
+                   "columns of scale parameter", L_S.rows());
 
-  T_LY_ref LY_ref = LY;
+  T_L_Y_ref L_Y_ref = L_Y;
   T_nu_ref nu_ref = nu;
-  T_LS_ref LS_ref = LS;
+  T_L_S_ref L_S_ref = L_S;
 
   check_greater(function, "Degrees of freedom parameter", nu_ref, k - 1);
-  check_cholesky_factor(function, "random variable", LY_ref);
-  check_cholesky_factor(function, "scale parameter", LS_ref);
+  check_cholesky_factor(function, "random variable", L_Y_ref);
+  check_cholesky_factor(function, "scale parameter", L_S_ref);
 
   return_type_t<T_y, T_dof, T_scale> lp(0.0);
 
@@ -71,12 +71,11 @@ return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& LY,
   }
 
   if (include_summand<propto, T_dof, T_scale, T_y>::value) {
-    auto LSinvLY = mdivide_left_tri<Eigen::Lower>(LS_ref, LY_ref);
-
+    auto L_SinvL_Y = mdivide_left_tri<Eigen::Lower>(L_S_ref, L_Y_ref);
     for (int i = 0; i < k; i++) {
-      lp -= 0.5 * dot_self(LSinvLY.row(i).head(i + 1))
-            + nu_ref * log(LS_ref.coeff(i, i))
-            - (nu_ref - i - 1) * log(LY_ref.coeff(i, i));
+      lp -= 0.5 * dot_self(L_SinvL_Y.row(i).head(i + 1))
+            + nu_ref * log(L_S_ref.coeff(i, i))
+            - (nu_ref - i - 1) * log(L_Y_ref.coeff(i, i));
     }
   }
 
@@ -85,8 +84,8 @@ return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& LY,
 
 template <typename T_y, typename T_dof, typename T_scale>
 inline return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(
-    const T_y& LW, const T_dof& nu, const T_scale& LS) {
-  return wishart_cholesky_lpdf<false>(LW, nu, LS);
+    const T_y& LW, const T_dof& nu, const T_scale& L_S) {
+  return wishart_cholesky_lpdf<false>(LW, nu, L_S);
 }
 
 }  // namespace math

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -64,7 +64,7 @@ return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& L_Y,
 
   return_type_t<T_y, T_dof, T_scale> lp(0.0);
 
- if (include_summand<propto, T_dof, T_scale, T_y>::value) {
+  if (include_summand<propto, T_dof, T_scale, T_y>::value) {
     auto L_SinvL_Y = mdivide_left_tri<Eigen::Lower>(L_S_ref, L_Y_ref);
     return_type_t<T_y, T_dof, T_scale> dot_LSinvLY(0.0);
 

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -1,0 +1,95 @@
+#ifndef STAN_MATH_PRIM_PROB_WISHART_CHOLESKY_LPDF_HPP
+#define STAN_MATH_PRIM_PROB_WISHART_CHOLESKY_LPDF_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/LDLT_factor.hpp>
+#include <stan/math/prim/fun/dot_self.hpp>
+#include <stan/math/prim/fun/lmgamma.hpp>
+#include <stan/math/prim/fun/trace.hpp>
+#include <stan/math/prim/fun/log_determinant_ldlt.hpp>
+#include <stan/math/prim/fun/mdivide_left_ldlt.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup multivar_dists
+ * The log of the Wishart density for the given Cholesky factor, degrees of freedom,
+ * and scale Cholesky factor matrix.
+ *
+ * The scale matrix, LS, must be a lower Cholesky factor.
+ * Dimension, k, is implicit.
+ * nu must be greater than k-1
+ *
+ * The change of variables from the input positive-definite matrix to
+ * the Cholesky factor is given in Theorem 2.1.9 in 
+ * Muirhead, R. J. (2005). 
+ * Aspects of Multivariate Statistical Theory. Wiley-Interscience. 
+
+ * @tparam T_y type of matrix
+ * @tparam T_dof type of degrees of freedom
+ * @tparam T_scale type of scale
+ * @param LY A lower triangular Cholesky factor covariance matrix
+ * @param nu Degrees of freedom
+ * @param LS The Cholesky factor of the scale matrix
+ * @return The log of the Wishart density at LY given nu and LS.
+ * @throw std::domain_error if nu is not greater than k-1
+ * @throw std::domain_error if S is not square, not symmetric, or not
+ * semi-positive definite.
+ */
+template <bool propto, typename T_y, typename T_dof, typename T_scale,
+          require_stan_scalar_t<T_dof>* = nullptr,
+          require_all_matrix_t<T_y, T_scale>* = nullptr>
+return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& LY, const T_dof& nu,
+                                                const T_scale& LS) {
+  using Eigen::Dynamic;
+  using Eigen::Lower;
+  using Eigen::Matrix;
+  using T_LY_ref = ref_type_t<T_y>;
+  using T_nu_ref = ref_type_t<T_dof>;
+  using T_LS_ref = ref_type_t<T_scale>;
+  static const char* function = "wishart_cholesky_lpdf";
+  Eigen::Index k = LY.rows();
+  check_size_match(function, "Rows of random variable", LY.rows(),
+                   "columns of scale parameter", LS.rows());
+
+  T_LY_ref LY_ref = LY;
+  T_nu_ref nu_ref = nu;
+  T_LS_ref LS_ref = LS;
+
+  check_greater(function, "Degrees of freedom parameter", nu_ref, k - 1);
+  check_cholesky_factor(function, "random variable", LY_ref);
+  check_cholesky_factor(function, "scale parameter", LS_ref);
+
+  return_type_t<T_y, T_dof, T_scale> lp(0.0);
+
+  if (include_summand<propto, T_dof>::value) {
+     lp += k * LOG_TWO * (1 - 0.5 * nu_ref);
+  }
+
+  if (include_summand<propto, T_dof>::value) {
+    lp -= lmgamma(k, 0.5 * nu_ref);
+  }
+
+  if (include_summand<propto, T_dof, T_scale, T_y>::value) {
+    auto LSinvLY = mdivide_left_tri<Eigen::Lower>(LS_ref, LY_ref);
+  
+    for (int i = 0; i < k; i++) {
+       lp -= 0.5 * dot_self(LSinvLY.row(i).head(i + 1)) + nu_ref * log(LS_ref.coeff(i, i)) - (nu_ref - i - 1) * log(LY_ref.coeff(i, i));
+    }
+  }
+
+  return lp;
+}
+
+template <typename T_y, typename T_dof, typename T_scale>
+inline return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& LW,
+                                                       const T_dof& nu,
+                                                       const T_scale& LS) {
+  return wishart_cholesky_lpdf<false>(LW, nu, LS);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -80,9 +80,9 @@ return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& L_Y,
       dot_LSinvLY += dot_self(L_SinvL_Y.row(i).head(i + 1));
       linspaced_rv(i) = nu_minus_1 - i;
     }
-    lp += -0.5 * dot_LSinvLY 
-          + dot_product(linspaced_rv, log(L_Y_ref.diagonal())) 
-           - nu_ref * sum(log(L_S_ref.diagonal()));
+    lp += -0.5 * dot_LSinvLY
+          + dot_product(linspaced_rv, log(L_Y_ref.diagonal()))
+          - nu_ref * sum(log(L_S_ref.diagonal()));
   }
   return lp;
 }

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -28,13 +28,12 @@ namespace math {
  * @tparam T_y type of matrix
  * @tparam T_dof type of degrees of freedom
  * @tparam T_scale type of scale
- * @param LY A lower triangular Cholesky factor covariance matrix
- * @param nu Degrees of freedom
- * @param LS The Cholesky factor of the scale matrix
+ * @param LY A lower triangular Cholesky factor covariance matrix.
+ * @param nu The degrees of freedom.
+ * @param LS The Cholesky factor of the scale matrix.
  * @return The log of the Wishart density at LY given nu and LS.
  * @throw std::domain_error if nu is not greater than k-1
- * @throw std::domain_error if S is not square, not symmetric, or not
- * semi-positive definite.
+ * @throw std::domain_error if LS is not a valid Cholesky factor.
  */
 template <bool propto, typename T_y, typename T_dof, typename T_scale,
           require_stan_scalar_t<T_dof>* = nullptr,

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -10,7 +10,6 @@
 
 namespace stan {
 namespace math {
-
 /** \ingroup multivar_dists
  * Return the natural logarithm of the unnormalized Wishart density of the
  specified
@@ -18,7 +17,7 @@ namespace math {
  lower-triangular
  * Cholesky factor of the scale matrix.
  *
- * The scale matrix, L_S, must be a lower Cholesky factor
+ * The scale matrix, `L_S`, must be a lower Cholesky factor
  * dimension, k, is implicit
  * nu must be greater than k-1
  *
@@ -43,9 +42,7 @@ template <bool propto, typename T_y, typename T_dof, typename T_scale,
 return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& L_Y,
                                                          const T_dof& nu,
                                                          const T_scale& L_S) {
-  using Eigen::Dynamic;
   using Eigen::Lower;
-  using Eigen::Matrix;
   using T_L_Y_ref = ref_type_t<T_y>;
   using T_nu_ref = ref_type_t<T_dof>;
   using T_L_S_ref = ref_type_t<T_scale>;
@@ -59,31 +56,30 @@ return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& L_Y,
   T_L_S_ref L_S_ref = L_S;
 
   check_greater(function, "Degrees of freedom parameter", nu_ref, k - 1);
-  check_positive(function, "Cholesky Random variable", L_Y_ref.diagonal());
+  check_positive(function, "Cholesky random variable", L_Y_ref.diagonal());
   check_positive(function, "columns of Cholesky Random variable",
                  L_Y_ref.cols());
-  check_positive(function, "Cholesky Scale matrix", L_S_ref.diagonal());
-  check_positive(function, "columns of Cholesky Scale matrix", L_S_ref.cols());
+  check_positive(function, "Cholesky scale matrix", L_S_ref.diagonal());
+  check_positive(function, "columns of Cholesky scale matrix", L_S_ref.cols());
 
   return_type_t<T_y, T_dof, T_scale> lp(0.0);
 
+ if (include_summand<propto, T_dof, T_scale, T_y>::value) {
+    auto L_SinvL_Y = mdivide_left_tri<Eigen::Lower>(L_S_ref, L_Y_ref);
+    return_type_t<T_y, T_dof, T_scale> dot_LSinvLY(0.0);
+
+    for (int i = 0; i < k; i++) {
+      dot_LSinvLY += dot_self(L_SinvL_Y.row(i).head(i + 1));
+      lp += (nu_ref - i - 1) * log(L_Y_ref.coeff(i, i));
+    }
+    lp += -0.5 * dot_LSinvLY;
+    lp += -1. * nu_ref * sum(log(L_S_ref.diagonal()));
+  }
+
   if (include_summand<propto, T_dof>::value) {
     lp += k * LOG_TWO * (1 - 0.5 * nu_ref);
+    lp += -lmgamma(k, 0.5 * nu_ref);
   }
-
-  if (include_summand<propto, T_dof>::value) {
-    lp -= lmgamma(k, 0.5 * nu_ref);
-  }
-
-  if (include_summand<propto, T_dof, T_scale, T_y>::value) {
-    auto L_SinvL_Y = mdivide_left_tri<Eigen::Lower>(L_S_ref, L_Y_ref);
-    for (int i = 0; i < k; i++) {
-      lp -= 0.5 * dot_self(L_SinvL_Y.row(i).head(i + 1))
-            + nu_ref * log(L_S_ref.coeff(i, i))
-            - (nu_ref - i - 1) * log(L_Y_ref.coeff(i, i));
-    }
-  }
-
   return lp;
 }
 

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -59,8 +59,10 @@ return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& L_Y,
   T_L_S_ref L_S_ref = L_S;
 
   check_greater(function, "Degrees of freedom parameter", nu_ref, k - 1);
-  check_cholesky_factor(function, "random variable", L_Y_ref);
-  check_cholesky_factor(function, "scale parameter", L_S_ref);
+  check_positive(function, "Cholesky Random variable", L_Y_ref.diagonal());
+  check_positive(function, "columns of Cholesky Random variable", L_Y_ref.cols());
+  check_positive(function, "Cholesky Scale matrix", L_S_ref.diagonal());
+  check_positive(function, "columns of Cholesky Scale matrix", L_S_ref.cols());
 
   return_type_t<T_y, T_dof, T_scale> lp(0.0);
 

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -3,12 +3,9 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
-#include <stan/math/prim/fun/LDLT_factor.hpp>
 #include <stan/math/prim/fun/dot_self.hpp>
 #include <stan/math/prim/fun/lmgamma.hpp>
-#include <stan/math/prim/fun/trace.hpp>
-#include <stan/math/prim/fun/log_determinant_ldlt.hpp>
-#include <stan/math/prim/fun/mdivide_left_ldlt.hpp>
+#include <stan/math/prim/fun/mdivide_left_tri.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 
 namespace stan {

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -60,7 +60,8 @@ return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& L_Y,
 
   check_greater(function, "Degrees of freedom parameter", nu_ref, k - 1);
   check_positive(function, "Cholesky Random variable", L_Y_ref.diagonal());
-  check_positive(function, "columns of Cholesky Random variable", L_Y_ref.cols());
+  check_positive(function, "columns of Cholesky Random variable",
+                 L_Y_ref.cols());
   check_positive(function, "Cholesky Scale matrix", L_S_ref.diagonal());
   check_positive(function, "columns of Cholesky Scale matrix", L_S_ref.cols());
 

--- a/stan/math/prim/prob/wishart_cholesky_rng.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_rng.hpp
@@ -1,0 +1,35 @@
+#ifndef STAN_MATH_PRIM_PROB_WISHART_CHOLESKY_RNG_HPP
+#define STAN_MATH_PRIM_PROB_WISHART_CHOLESKY_RNG_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/crossprod.hpp>
+#include <stan/math/prim/prob/chi_square_rng.hpp>
+#include <stan/math/prim/prob/normal_rng.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+template <class RNG>
+inline Eigen::MatrixXd wishart_cholesky_rng(double nu, const Eigen::MatrixXd& L,
+                                            RNG& rng) {
+  using Eigen::MatrixXd;
+  static const char* function = "wishart_cholesky_rng";
+  index_type_t<MatrixXd> k = L.rows();
+  check_greater(function, "degrees of freedom > dims - 1", nu, k - 1);
+  check_cholesky_factor(function, "scale parameter", L);
+
+  MatrixXd B = MatrixXd::Zero(k, k);
+  for (int j = 0; j < k; ++j) {
+    for (int i = 0; i < j; ++i) {
+      B(i, j) = normal_rng(0, 1, rng);
+    }
+    B(j, j) = std::sqrt(chi_square_rng(nu - j, rng));
+  }
+  return L.template triangularView<Eigen::Lower>() * B.transpose();
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/prob/wishart_cholesky_rng.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_rng.hpp
@@ -20,8 +20,8 @@ namespace math {
  * @tparam RNG Random number generator type
  * @param[in] nu scalar degrees of freedom
  * @param[in] L_S lower Cholesky factor of the scale matrix
- * @param[in, out] rng Random-number generator
- * @return Random lower Cholesky factor drawn from the given inverse Wishart
+ * @param[in, out] rng random-number generator
+ * @return random lower Cholesky factor drawn from the given inverse Wishart
  * distribution
  * @throw std::domain_error if the scale matrix is not a Cholesky factor
  * @throw std::domain_error if the degrees of freedom is greater than k - 1
@@ -35,7 +35,8 @@ inline Eigen::MatrixXd wishart_cholesky_rng(double nu,
   static const char* function = "wishart_cholesky_rng";
   index_type_t<MatrixXd> k = L_S.rows();
   check_greater(function, "degrees of freedom > dims - 1", nu, k - 1);
-  check_cholesky_factor(function, "scale parameter", L_S);
+  check_positive(function, "Cholesky Scale matrix", L_S.diagonal());
+  check_positive(function, "columns of Cholesky Scale matrix", L_S.cols());
 
   MatrixXd B = MatrixXd::Zero(k, k);
   for (int j = 0; j < k; ++j) {

--- a/stan/math/prim/prob/wishart_cholesky_rng.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_rng.hpp
@@ -17,7 +17,7 @@ namespace math {
  * with the specified degrees of freedom
  * using the specified random number generator.
  *
- * @tparam RNG Random number generator type
+ * @tparam RNG random number generator type
  * @param[in] nu scalar degrees of freedom
  * @param[in] L_S lower Cholesky factor of the scale matrix
  * @param[in, out] rng random-number generator

--- a/stan/math/prim/prob/wishart_cholesky_rng.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_rng.hpp
@@ -11,14 +11,30 @@
 namespace stan {
 namespace math {
 
+/** \ingroup multivar_dists
+ * Return a random Cholesky factor of the inverse covariance matrix
+ * of the specified dimensionality drawn from the Wishart distribution 
+ * with the specified degrees of freedom
+ * using the specified random number generator.
+ *
+ * @tparam RNG Random number generator type
+ * @param[in] nu scalar degrees of freedom
+ * @param[in] L_S lower Cholesky factor of the scale matrix
+ * @param[in, out] rng Random-number generator
+ * @return Random lower Cholesky factor drawn from the given inverse Wishart
+ * distribution
+ * @throw std::domain_error if the scale matrix is not a Cholesky factor
+ * @throw std::domain_error if the degrees of freedom is greater than k - 1
+ * where k is the dimension of L_S
+ */
 template <class RNG>
-inline Eigen::MatrixXd wishart_cholesky_rng(double nu, const Eigen::MatrixXd& L,
+inline Eigen::MatrixXd wishart_cholesky_rng(double nu, const Eigen::MatrixXd& L_S,
                                             RNG& rng) {
   using Eigen::MatrixXd;
   static const char* function = "wishart_cholesky_rng";
-  index_type_t<MatrixXd> k = L.rows();
+  index_type_t<MatrixXd> k = L_S.rows();
   check_greater(function, "degrees of freedom > dims - 1", nu, k - 1);
-  check_cholesky_factor(function, "scale parameter", L);
+  check_cholesky_factor(function, "scale parameter", L_S);
 
   MatrixXd B = MatrixXd::Zero(k, k);
   for (int j = 0; j < k; ++j) {
@@ -27,7 +43,7 @@ inline Eigen::MatrixXd wishart_cholesky_rng(double nu, const Eigen::MatrixXd& L,
     }
     B(j, j) = std::sqrt(chi_square_rng(nu - j, rng));
   }
-  return L.template triangularView<Eigen::Lower>() * B.transpose();
+  return L_S.template triangularView<Eigen::Lower>() * B.transpose();
 }
 
 }  // namespace math

--- a/test/unit/math/mix/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/mix/prob/wishart_cholesky_test.cpp
@@ -59,9 +59,10 @@ TEST(ProbDistributionsWishartCholesky, fvar_var) {
   // computed with MCMCpack in R
   double lp = -13.95961162478571360 + 4.04590909757044237;
 
-  EXPECT_NEAR(lp, stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S).val_.val(), 1e-9);
-  EXPECT_NEAR(2.3751897169452936, stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S).d_.val(),
+  EXPECT_NEAR(lp, stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S).val_.val(),
               1e-9);
+  EXPECT_NEAR(2.3751897169452936,
+              stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S).d_.val(), 1e-9);
 
   stan::math::recover_memory();
 }
@@ -84,14 +85,17 @@ TEST(ProbDistributionsWishartCholesky, fvar_fvar_var) {
     L_Y(i).d_ = 1.0;
     L_S(i).d_ = 1.0;
   }
-   unsigned int dof = 3;
+  unsigned int dof = 3;
   // log absolute determinant of the change of variables from Y -> LL'
   // see Theorem 2.1.9 in Muirhead, Aspects of Multivariate Statistical Theory
   // computed with MCMCpack in R
   double lp = -13.95961162478571360 + 4.04590909757044237;
 
-  EXPECT_NEAR(lp, stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S).val_.val_.val(), 1e-6);
-  EXPECT_NEAR(2.3751897169452936, stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S).d_.val_.val(),
+  EXPECT_NEAR(lp,
+              stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S).val_.val_.val(),
+              1e-6);
+  EXPECT_NEAR(2.3751897169452936,
+              stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S).d_.val_.val(),
               1e-6);
 
   stan::math::recover_memory();

--- a/test/unit/math/mix/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/mix/prob/wishart_cholesky_test.cpp
@@ -1,0 +1,98 @@
+#include <test/unit/math/test_ad.hpp>
+
+TEST(ProbDistributionsWishartCholesky, matvar) {
+  auto f = [](const auto& L_Y, const auto& dof, const auto& L_S) {
+    return stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S);
+  };
+
+  double dof = 3.4;
+  Eigen::MatrixXd L_Y11(1, 1);
+  L_Y11 << 1;
+  Eigen::MatrixXd L_S11(1, 1);
+  L_S11 << 1;
+  stan::test::expect_ad(f, L_Y11, dof, L_S11);
+  stan::test::expect_ad_matvar(f, L_Y11, dof, L_S11);
+
+  Eigen::MatrixXd L_Y00(0, 0);
+  Eigen::MatrixXd L_S00(0, 0);
+  stan::test::expect_ad(f, L_Y00, dof, L_S00);
+  stan::test::expect_ad_matvar(f, L_Y00, dof, L_S00);
+
+  Eigen::MatrixXd y22(2, 2);
+  y22 << 1.0, 0.1, 0.1, 1.5;
+  Eigen::MatrixXd L_Y22 = y22.llt().matrixL();
+  Eigen::MatrixXd Sigma22(2, 2);
+  Sigma22 << 1.5, 0.5, 0.5, 1.1;
+  Eigen::MatrixXd L_S22 = Sigma22.llt().matrixL();
+  stan::test::expect_ad(f, L_Y22, dof, L_S22);
+  stan::test::expect_ad_matvar(f, L_Y22, dof, L_S22);
+
+  // Error sizes
+  stan::test::expect_ad(f, L_Y00, dof, L_S11);
+  stan::test::expect_ad(f, L_Y11, dof, L_S00);
+  stan::test::expect_ad_matvar(f, L_Y00, dof, L_S11);
+  stan::test::expect_ad_matvar(f, L_Y11, dof, L_S00);
+}
+
+TEST(ProbDistributionsWishartCholesky, fvar_var) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::fvar;
+  using stan::math::var;
+  Matrix<fvar<var>, Dynamic, Dynamic> Sigma(2, 2);
+  Sigma << 1.848220, 1.899623, 1.899623, 12.751941;
+
+  Matrix<fvar<var>, Dynamic, Dynamic> Y(2, 2);
+  Y << 2.011108, -11.20661, -11.20661, 112.94139;
+
+  auto L_Y = stan::math::cholesky_decompose(Y);
+  auto L_S = stan::math::cholesky_decompose(Sigma);
+
+  for (int i = 0; i < 4; i++) {
+    L_Y(i).d_ = 1.0;
+    L_S(i).d_ = 1.0;
+  }
+
+  unsigned int dof = 3;
+  // log absolute determinant of the change of variables from Y -> LL'
+  // see Theorem 2.1.9 in Muirhead, Aspects of Multivariate Statistical Theory
+  // computed with MCMCpack in R
+  double lp = -13.95961162478571360 + 4.04590909757044237;
+
+  EXPECT_NEAR(lp, stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S).val_.val(), 1e-9);
+  EXPECT_NEAR(2.3751897169452936, stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S).d_.val(),
+              1e-9);
+
+  stan::math::recover_memory();
+}
+
+TEST(ProbDistributionsWishartCholesky, fvar_fvar_var) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::fvar;
+  using stan::math::var;
+  Matrix<fvar<fvar<var> >, Dynamic, Dynamic> Sigma(2, 2);
+  Sigma << 1.848220, 1.899623, 1.899623, 12.751941;
+
+  Matrix<fvar<fvar<var> >, Dynamic, Dynamic> Y(2, 2);
+  Y << 2.011108, -11.206611, -11.206611, 112.94139;
+
+  auto L_Y = stan::math::cholesky_decompose(Y);
+  auto L_S = stan::math::cholesky_decompose(Sigma);
+
+  for (int i = 0; i < 4; i++) {
+    L_Y(i).d_ = 1.0;
+    L_S(i).d_ = 1.0;
+  }
+   unsigned int dof = 3;
+  // log absolute determinant of the change of variables from Y -> LL'
+  // see Theorem 2.1.9 in Muirhead, Aspects of Multivariate Statistical Theory
+  // computed with MCMCpack in R
+  double lp = -13.95961162478571360 + 4.04590909757044237;
+
+  EXPECT_NEAR(lp, stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S).val_.val_.val(), 1e-6);
+  EXPECT_NEAR(2.3751897169452936, stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S).d_.val_.val(),
+              1e-6);
+
+  stan::math::recover_memory();
+}

--- a/test/unit/math/prim/prob/wishart_cholesky_rng_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_rng_test.cpp
@@ -49,23 +49,6 @@ TEST(ProbDistributionsWishartCholesky, rng_pos_def) {
                std::domain_error);
 }
 
-TEST(ProbDistributionsWishartCholesky, cholesky_factor_check) {
-  using Eigen::MatrixXd;
-  using stan::math::identity_matrix;
-  using stan::math::wishart_cholesky_rng;
-  using stan::test::unit::expect_symmetric;
-  using stan::test::unit::spd_rng;
-
-  boost::random::mt19937 rng;
-
-  for (int k = 1; k < 20; ++k)
-    for (double nu = k - 0.9; nu < k + 10; ++nu)
-      for (int n = 0; n < 10; ++n)
-        expect_symmetric(
-            stan::math::multiply_lower_tri_self_transpose(wishart_cholesky_rng(
-                nu, stan::math::cholesky_decompose(spd_rng(k, rng)), rng)));
-}
-
 TEST(ProbDistributionsWishartCholesky, marginalTwoChiSquareGoodnessFitTest) {
   using boost::math::chi_squared;
   using boost::math::digamma;

--- a/test/unit/math/prim/prob/wishart_cholesky_rng_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_rng_test.cpp
@@ -1,0 +1,137 @@
+#include <stan/math/prim.hpp>
+#include <test/unit/math/prim/util.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/math/distributions/chi_squared.hpp>
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <vector>
+
+TEST(ProbDistributionsWishartCholesky, rng) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using Eigen::MatrixXd;
+
+  using stan::math::wishart_cholesky_rng;
+
+  boost::random::mt19937 rng;
+
+  MatrixXd omega(3, 4);
+  EXPECT_THROW(wishart_cholesky_rng(3.0, omega, rng), std::domain_error);
+
+  MatrixXd sigma(3, 3);
+  sigma << 9.0, -3.0, 0.0, -3.0, 4.0, 1.0, 0.0, 1.0, 3.0;
+
+  Matrix<double, Dynamic, Dynamic> LS = sigma.llt().matrixL();
+
+  EXPECT_NO_THROW(wishart_cholesky_rng(3.0, LS, rng));
+  EXPECT_THROW(wishart_cholesky_rng(2, LS, rng), std::domain_error);
+  EXPECT_THROW(wishart_cholesky_rng(-1, LS, rng), std::domain_error);
+  LS(2, 2) = -1.0;
+  EXPECT_THROW(wishart_cholesky_rng(3.0, LS, rng), std::domain_error);
+}
+
+TEST(ProbDistributionsWishartCholesky, rng_pos_def) {
+  using Eigen::MatrixXd;
+  using stan::math::wishart_cholesky_rng;
+
+  boost::random::mt19937 rng;
+
+  MatrixXd Sigma(2, 2);
+  MatrixXd Sigma_non_pos_def(2, 2);
+
+  Sigma << 1, 0, 0, 1;
+  Sigma_non_pos_def << -1, 0, 0, 1;
+
+  unsigned int dof = 5;
+
+  EXPECT_NO_THROW(wishart_cholesky_rng(dof, Sigma, rng));
+  EXPECT_THROW(wishart_cholesky_rng(dof, Sigma_non_pos_def, rng),
+               std::domain_error);
+}
+
+TEST(ProbDistributionsWishartCholesky, cholesky_factor_check) {
+  using Eigen::MatrixXd;
+  using stan::math::identity_matrix;
+  using stan::math::wishart_cholesky_rng;
+  using stan::test::unit::expect_symmetric;
+  using stan::test::unit::spd_rng;
+
+  boost::random::mt19937 rng;
+
+  for (int k = 1; k < 20; ++k)
+    for (double nu = k - 0.9; nu < k + 10; ++nu)
+      for (int n = 0; n < 10; ++n)
+        expect_symmetric(
+            stan::math::multiply_lower_tri_self_transpose(wishart_cholesky_rng(
+                nu, stan::math::cholesky_decompose(spd_rng(k, rng)), rng)));
+}
+
+TEST(ProbDistributionsWishartCholesky, marginalTwoChiSquareGoodnessFitTest) {
+  using boost::math::chi_squared;
+  using boost::math::digamma;
+  using Eigen::MatrixXd;
+  using stan::math::determinant;
+  using stan::math::wishart_cholesky_rng;
+  using std::log;
+
+  boost::random::mt19937 rng;
+  MatrixXd sigma(3, 3);
+  sigma << 9.0, -3.0, 2.0, -3.0, 4.0, 0.0, 2.0, 0.0, 3.0;
+  int N = 10000;
+
+  double avg = 0;
+  double expect = sigma.rows() * log(2.0) + log(determinant(sigma))
+                  + digamma(5.0 / 2.0) + digamma(4.0 / 2.0)
+                  + digamma(3.0 / 2.0);
+
+  MatrixXd a(sigma.rows(), sigma.rows());
+  for (int count = 0; count < N; ++count) {
+    a = wishart_cholesky_rng(5.0, stan::math::cholesky_decompose(sigma), rng);
+    avg += stan::math::sum(stan::math::log(a.diagonal()));
+  }
+  avg /= N;
+  double chi = (expect - avg) * (expect - avg) / expect;
+  chi_squared mydist(1);
+  EXPECT_TRUE(chi < quantile(complement(mydist, 1e-6)));
+}
+
+TEST(ProbDistributionsWishartCholesky, SpecialRNGTest) {
+  // For any vector C != 0
+  // (C' * W * C) / (C' * S * C)
+  // must be chi-square distributed with df = k
+  // which has mean = k and variance = 2k
+
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using Eigen::MatrixXd;
+  using Eigen::VectorXd;
+  using stan::math::multiply_lower_tri_self_transpose;
+  using stan::math::wishart_cholesky_rng;
+
+  boost::random::mt19937 rng(1234);
+
+  MatrixXd sigma(3, 3);
+
+  sigma << 9.0, 2.0, 2.0, 2.0, 4.0, 1.0, 2.0, 1.0, 3.0;
+
+  Matrix<double, Dynamic, Dynamic> LS = sigma.llt().matrixL();
+
+  VectorXd C(3);
+  C << 2, 1, 3;
+
+  size_t N = 1e4;
+  int k = 20;
+  // tolerance for variance
+  double tol = 0.2;
+  std::vector<double> acum;
+  acum.reserve(N);
+  for (size_t i = 0; i < N; i++)
+    acum.push_back(
+        (C.transpose()
+         * multiply_lower_tri_self_transpose(wishart_cholesky_rng(k, LS, rng))
+         * C)(0)
+        / (C.transpose() * sigma * C)(0));
+
+  EXPECT_NEAR(1, stan::math::mean(acum) / k, tol * tol);
+  EXPECT_NEAR(1, stan::math::variance(acum) / (2 * k), tol);
+}

--- a/test/unit/math/prim/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_test.cpp
@@ -1,0 +1,192 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/math/special_functions/digamma.hpp>
+#include <boost/math/distributions.hpp>
+
+TEST(ProbDistributionsWishart, wishart_symmetry) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+
+  using Eigen::MatrixXd;
+  using stan::math::wishart_cholesky_lpdf;
+
+  MatrixXd Sigma(4, 4);
+  MatrixXd Y(4, 4);
+
+  Y << 7.988168, -9.555605, -14.47483, 4.395895, -9.555605, 44.750570,
+      49.215769, -15.454186, -14.474830, 49.215769, 60.08987, -20.48108,
+      4.395895, -15.454186, -20.48108, 7.885833;
+
+  Sigma << 2.9983662, 0.2898776, -2.650523, 0.1055911, 0.2898776, 11.4803610,
+      7.1579931, -3.1129955, -2.650523, 7.1579931, 11.676181, -3.586685,
+      0.1055911, -3.1129955, -3.586685, 1.4482736;
+
+  unsigned int dof = 5;
+
+  Matrix<double, Dynamic, Dynamic> LY = Y.llt().matrixL();
+  Matrix<double, Dynamic, Dynamic> LS = Sigma.llt().matrixL();
+
+  EXPECT_NO_THROW(wishart_cholesky_lpdf(LY, dof, LS));
+}
+
+TEST(ProbDistributionsWishart, wishart_pos_def) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+
+  using Eigen::MatrixXd;
+  using stan::math::wishart_cholesky_lpdf;
+
+  MatrixXd Sigma(2, 2);
+  MatrixXd Sigma_non_pos_def(2, 2);
+  MatrixXd Y(2, 2);
+  MatrixXd Y_non_pos_def(2, 2);
+
+  Sigma << 1, 0, 0, 1;
+  Sigma_non_pos_def << -1, 0, 0, 1;
+  Y << 1, 0, 0, 1;
+  Y_non_pos_def << -1, 0, 0, 1;
+
+  unsigned int dof = 5;
+
+  EXPECT_NO_THROW(wishart_cholesky_lpdf(Y, dof, Sigma));
+  EXPECT_THROW(wishart_cholesky_lpdf(Y_non_pos_def, dof, Sigma), std::domain_error);
+  EXPECT_THROW(wishart_cholesky_lpdf(Y, dof, Sigma_non_pos_def), std::domain_error);
+}
+
+TEST(ProbDistributionsWishart, 2x2) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  Matrix<double, Dynamic, Dynamic> Sigma(2, 2);
+  Sigma << 1.848220, 1.899623, 1.899623, 12.751941;
+
+  Matrix<double, Dynamic, Dynamic> Y(2, 2);
+  Y << 2.011108, -11.206611, -11.206611, 112.94139;
+
+  Matrix<double, Dynamic, Dynamic> LY = Y.llt().matrixL();
+  Matrix<double, Dynamic, Dynamic> LS = Sigma.llt().matrixL();
+
+  unsigned int dof = 3;
+  // log absolute determinant of the change of variables from Y -> LL'
+  // see Theorem 2.1.9 in Muirhead, Aspects of Multivariate Statistical Theory
+  double log_jac = 2 * stan::math::LOG_TWO;
+  
+  for (int i = 0; i < 2; i++) {
+    log_jac  += (2 - i) * log(LY(i, i));  
+}
+  
+  // computed with MCMCpack in R
+  double lp = log(8.658e-07) + log_jac;
+
+  EXPECT_NEAR(lp, stan::math::wishart_cholesky_lpdf(LY, dof, LS), 0.01);
+}
+TEST(ProbDistributionsWishart, 4x4) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  Matrix<double, Dynamic, Dynamic> Y(4, 4);
+  Y << 7.988168, -9.555605, -14.47483, 4.395895, -9.555605, 44.750570, 49.21577,
+      -18.454186, -14.474830, 49.21577, 60.08987, -21.48108, 4.395895,
+      -18.454186, -21.48108, 7.885833;
+
+  Matrix<double, Dynamic, Dynamic> Sigma(4, 4);
+  Sigma << 2.9983662, 0.2898776, -2.650523, 0.1055911, 0.2898776, 11.4803610,
+      7.1579931, -3.1129955, -2.650523, 7.1579931, 11.676181, -3.5866852,
+      0.1055911, -3.1129955, -3.5866852, 1.4482736;
+
+  Matrix<double, Dynamic, Dynamic> LY = Y.llt().matrixL();
+  Matrix<double, Dynamic, Dynamic> LS = Sigma.llt().matrixL();
+
+  unsigned int dof = 4;
+  double log_jac = 4 * stan::math::LOG_TWO;
+  unsigned int n = 4;
+  for (int i = 0; i < n; i++) {
+    log_jac  += (n - i) * log(LY(i, i));  
+    }
+  
+  double log_p = log(8.034197e-10) + log_jac;
+  EXPECT_NEAR(log_p, stan::math::wishart_cholesky_lpdf(LY, dof, LS), 0.01);
+
+  dof = 5;
+
+  log_p = log(1.517951e-10) + log_jac;
+  EXPECT_NEAR(log_p, stan::math::wishart_cholesky_lpdf(LY, dof, LS), 0.01);
+}
+
+TEST(ProbDistributionsWishart, 2x2Propto) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  Matrix<double, Dynamic, Dynamic> Sigma(2, 2);
+  Sigma << 1.848220, 1.899623, 1.899623, 12.751941;
+
+  Matrix<double, Dynamic, Dynamic> Y(2, 2);
+  Y << 2.011108, -11.206611, -11.206611, 112.94139;
+
+  Matrix<double, Dynamic, Dynamic> LY = Y.llt().matrixL();
+  Matrix<double, Dynamic, Dynamic> LS = Sigma.llt().matrixL();
+
+  unsigned int dof = 3;
+
+  EXPECT_FLOAT_EQ(0.0, stan::math::wishart_cholesky_lpdf<true>(LY, dof, LS));
+}
+
+TEST(ProbDistributionsWishart, 4x4Propto) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  Matrix<double, Dynamic, Dynamic> Y(4, 4);
+  Y << 7.988168, -9.555605, -14.47483, 4.395895, -9.555605, 44.750570,
+      49.215769, -18.454186, -14.474830, 49.215769, 60.08987, -21.48108,
+      4.395895, -18.454186, -21.48108, 7.885833;
+
+  Matrix<double, Dynamic, Dynamic> Sigma(4, 4);
+  Sigma << 2.9983662, 0.2898776, -2.650523, 0.1055911, 0.2898776, 11.4803610,
+      7.1579931, -3.1129955, -2.650523, 7.1579931, 11.676181, -3.5866852,
+      0.1055911, -3.1129955, -3.5866852, 1.4482736;
+
+  Matrix<double, Dynamic, Dynamic> LY = Y.llt().matrixL();
+  Matrix<double, Dynamic, Dynamic> LS = Sigma.llt().matrixL();
+
+  double dof = 4;
+  EXPECT_FLOAT_EQ(0.0, stan::math::wishart_cholesky_lpdf<true>(LY, dof, LS));
+
+  dof = 5;
+  EXPECT_FLOAT_EQ(0.0, stan::math::wishart_cholesky_lpdf<true>(LY, dof, LS));
+}
+
+TEST(ProbDistributionsWishart, error) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::wishart_cholesky_lpdf;
+  Matrix<double, Dynamic, Dynamic> Sigma;
+  Matrix<double, Dynamic, Dynamic> Y;
+  double nu;
+
+  Sigma.resize(1, 1);
+  Y.resize(1, 1);
+  Sigma.setIdentity();
+  Y.setIdentity();
+  nu = 1;
+  EXPECT_NO_THROW(wishart_cholesky_lpdf(Y, nu, Sigma));
+
+  nu = 5;
+  Sigma.resize(2, 1);
+  EXPECT_THROW(wishart_cholesky_lpdf(Y, nu, Sigma), std::invalid_argument);
+
+  nu = 5;
+  Sigma.resize(2, 2);
+  Y.resize(2, 1);
+  EXPECT_THROW(wishart_cholesky_lpdf(Y, nu, Sigma), std::domain_error);
+
+  nu = 5;
+  Sigma.resize(2, 2);
+  Y.resize(3, 3);
+  EXPECT_THROW(wishart_cholesky_lpdf(Y, nu, Sigma), std::invalid_argument);
+
+  Sigma.resize(3, 3);
+  Sigma.setIdentity();
+  Y.resize(3, 3);
+  Y.setIdentity();
+  nu = 3;
+  EXPECT_NO_THROW(wishart_cholesky_lpdf(Y, nu, Sigma));
+  nu = 2;
+  EXPECT_THROW(wishart_cholesky_lpdf(Y, nu, Sigma), std::domain_error);
+}

--- a/test/unit/math/prim/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_test.cpp
@@ -4,7 +4,7 @@
 #include <boost/math/special_functions/digamma.hpp>
 #include <boost/math/distributions.hpp>
 
-TEST(ProbDistributionsWishart, wishart_symmetry) {
+TEST(ProbDistributionsWishartCholesky, wishart_symmetry) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
 
@@ -30,7 +30,7 @@ TEST(ProbDistributionsWishart, wishart_symmetry) {
   EXPECT_NO_THROW(wishart_cholesky_lpdf(LY, dof, LS));
 }
 
-TEST(ProbDistributionsWishart, wishart_pos_def) {
+TEST(ProbDistributionsWishartCholesky, wishart_pos_def) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
 
@@ -56,7 +56,7 @@ TEST(ProbDistributionsWishart, wishart_pos_def) {
                std::domain_error);
 }
 
-TEST(ProbDistributionsWishart, 2x2) {
+TEST(ProbDistributionsWishartCholesky, 2x2) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   Matrix<double, Dynamic, Dynamic> Sigma(2, 2);
@@ -82,7 +82,8 @@ TEST(ProbDistributionsWishart, 2x2) {
 
   EXPECT_NEAR(lp, stan::math::wishart_cholesky_lpdf(LY, dof, LS), 0.01);
 }
-TEST(ProbDistributionsWishart, 4x4) {
+
+TEST(ProbDistributionsWishartCholesky, 4x4) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   Matrix<double, Dynamic, Dynamic> Y(4, 4);
@@ -114,7 +115,7 @@ TEST(ProbDistributionsWishart, 4x4) {
   EXPECT_NEAR(log_p, stan::math::wishart_cholesky_lpdf(LY, dof, LS), 0.01);
 }
 
-TEST(ProbDistributionsWishart, 2x2Propto) {
+TEST(ProbDistributionsWishartCholesky, 2x2Propto) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   Matrix<double, Dynamic, Dynamic> Sigma(2, 2);
@@ -131,7 +132,7 @@ TEST(ProbDistributionsWishart, 2x2Propto) {
   EXPECT_FLOAT_EQ(0.0, stan::math::wishart_cholesky_lpdf<true>(LY, dof, LS));
 }
 
-TEST(ProbDistributionsWishart, 4x4Propto) {
+TEST(ProbDistributionsWishartCholesky, 4x4Propto) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   Matrix<double, Dynamic, Dynamic> Y(4, 4);
@@ -154,7 +155,7 @@ TEST(ProbDistributionsWishart, 4x4Propto) {
   EXPECT_FLOAT_EQ(0.0, stan::math::wishart_cholesky_lpdf<true>(LY, dof, LS));
 }
 
-TEST(ProbDistributionsWishart, error) {
+TEST(ProbDistributionsWishartCholesky, error) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::wishart_cholesky_lpdf;

--- a/test/unit/math/prim/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_test.cpp
@@ -82,7 +82,7 @@ TEST(ProbDistributionsWishartCholesky, dof_0) {
   MatrixXd L_S = Sigma.llt().matrixL();
 
   unsigned int dof = std::numeric_limits<double>::quiet_NaN();
-  EXPECT_THROW(stan::math::wishart_cholesky_lpdf(Y, dof, Sigma),
+  EXPECT_THROW(stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S),
                std::domain_error);
 }
 

--- a/test/unit/math/prim/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_test.cpp
@@ -120,7 +120,6 @@ TEST(ProbDistributionsWishartCholesky, 2x2) {
   for (int i = 0; i < 2; i++) {
     log_jac += (2 - i) * log(L_Y(i, i));
   }
-
   // computed with MCMCpack in R
   double lp = -13.9596117200 + log_jac;
 

--- a/test/unit/math/rev/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/rev/prob/wishart_cholesky_test.cpp
@@ -1,0 +1,135 @@
+#include <stan/math/rev.hpp>
+#include <test/unit/math/rev/util.hpp>
+#include <test/unit/math/rev/prob/expect_eq_diffs.hpp>
+#include <gtest/gtest.h>
+#include <string>
+
+template <typename T_y, typename T_dof, typename T_scale>
+void expect_propto_wishart_cholesky_lpdf(T_y L_Y1, T_dof nu1, T_scale L_S1, T_y L_Y2, T_dof nu2,
+                               T_scale L_S2, std::string message) {
+  expect_eq_diffs(stan::math::wishart_cholesky_lpdf<false>(L_Y1, nu1, L_S1),
+                  stan::math::wishart_cholesky_lpdf<false>(L_Y2, nu2, L_S2),
+                  stan::math::wishart_cholesky_lpdf<true>(L_Y1, nu1, L_S1),
+                  stan::math::wishart_cholesky_lpdf<true>(L_Y2, nu2, L_S2), message);
+}
+
+using Eigen::Dynamic;
+using Eigen::Matrix;
+
+class AgradDistributionsWishartCholesky : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    Eigen::MatrixXd Y1(2, 2);
+    Eigen::MatrixXd Y2(2, 2);
+    Y1 << 2.011108, -11.20661, -11.20661, 112.94139;
+    Y2 << 13.4, 12.2, 12.2, 11.5;
+
+    L_Y1 = Y1.llt().matrixL();
+    L_Y2 = Y2.llt().matrixL();
+
+    nu1 = 3;
+    nu2 = 5.3;
+
+    Eigen::MatrixXd S1(2, 2);
+    Eigen::MatrixXd S2(2, 2);
+    S1 << 1.848220, 1.899623, 1.899623, 12.751941;
+    S2 << 3.0, 1.4, 1.4, 7.0;
+    
+    L_S1 = S1.llt().matrixL();
+    L_S2 = S2.llt().matrixL();
+
+  }
+  Eigen::MatrixXd L_Y1;
+  Eigen::MatrixXd L_Y2;
+  double nu1;
+  double nu2;
+  Eigen::MatrixXd L_S1;
+  Eigen::MatrixXd L_S2;
+};
+
+TEST_F(AgradDistributionsWishartCholesky, Propto) {
+  using stan::math::to_var;
+  expect_propto_wishart_cholesky_lpdf(to_var(L_Y1), to_var(nu1), to_var(L_S1), to_var(L_Y2),
+                            to_var(nu2), to_var(L_S2), "var: L_Y, nu, and L_S");
+
+  stan::math::recover_memory();
+}
+TEST_F(AgradDistributionsWishartCholesky, ProptoY) {
+  using stan::math::to_var;
+  expect_propto_wishart_cholesky_lpdf(to_var(L_Y1), nu1, L_S1, to_var(L_Y2), nu1, L_S1, "var: L_Y");
+
+  stan::math::recover_memory();
+}
+TEST_F(AgradDistributionsWishartCholesky, ProptoYNu) {
+  using stan::math::to_var;
+  expect_propto_wishart_cholesky_lpdf(to_var(L_Y1), to_var(nu1), L_S1, to_var(L_Y2),
+                            to_var(nu2), L_S1, "var: L_y and nu");
+
+  stan::math::recover_memory();
+}
+TEST_F(AgradDistributionsWishartCholesky, ProptoYLSigma) {
+  using stan::math::to_var;
+  expect_propto_wishart_cholesky_lpdf(to_var(L_Y1), nu1, to_var(L_S1), to_var(L_Y2), nu1,
+                            to_var(L_S2), "var: L_Y and L_S");
+
+  stan::math::recover_memory();
+}
+TEST_F(AgradDistributionsWishartCholesky, ProptoNu) {
+  using stan::math::to_var;
+  expect_propto_wishart_cholesky_lpdf(L_Y1, to_var(nu1), L_S1, L_Y1, to_var(nu2), L_S1,
+                            "var: nu");
+
+  stan::math::recover_memory();
+}
+TEST_F(AgradDistributionsWishartCholesky, ProptoNuL_S) {
+  using stan::math::to_var;
+  expect_propto_wishart_cholesky_lpdf(L_Y1, to_var(nu1), to_var(L_S1), L_Y1, to_var(nu2),
+                            to_var(L_S2), "var: nu and sigma");
+
+  stan::math::recover_memory();
+}
+TEST_F(AgradDistributionsWishartCholesky, ProptoL_S) {
+  using stan::math::to_var;
+  expect_propto_wishart_cholesky_lpdf(L_Y1, nu1, to_var(L_S1), L_Y1, nu1, to_var(L_S2),
+                            "var: L_S");
+
+  stan::math::recover_memory();
+}
+
+TEST(WishartCholesky, check_varis_on_stack) {
+  using stan::math::to_var;
+  Eigen::MatrixXd Y(2, 2);
+  Y << 2.011108, -11.20661, -11.20661, 112.94139;
+  Eigen::MatrixXd L_Y = Y.llt().matrixL();
+  double nu = 3;
+
+  Eigen::MatrixXd S(2, 2);
+  S << 1.848220, 1.899623, 1.899623, 12.751941;
+  Eigen::MatrixXd L_S = S.llt().matrixL();
+
+  test::check_varis_on_stack(
+      stan::math::wishart_cholesky_lpdf<false>(to_var(L_Y), to_var(nu), to_var(L_S)));
+  test::check_varis_on_stack(
+      stan::math::wishart_cholesky_lpdf<false>(to_var(L_Y), to_var(nu), L_S));
+  test::check_varis_on_stack(
+      stan::math::wishart_cholesky_lpdf<false>(to_var(L_Y), nu, to_var(L_S)));
+  test::check_varis_on_stack(stan::math::wishart_cholesky_lpdf<false>(to_var(L_Y), nu, L_S));
+  test::check_varis_on_stack(
+      stan::math::wishart_cholesky_lpdf<false>(L_Y, to_var(nu), to_var(L_S)));
+  test::check_varis_on_stack(stan::math::wishart_cholesky_lpdf<false>(L_Y, to_var(nu), L_S));
+  test::check_varis_on_stack(stan::math::wishart_cholesky_lpdf<false>(L_Y, nu, to_var(L_S)));
+
+  test::check_varis_on_stack(
+      stan::math::wishart_cholesky_lpdf<true>(to_var(L_Y), to_var(nu), to_var(L_S)));
+  test::check_varis_on_stack(
+      stan::math::wishart_cholesky_lpdf<true>(to_var(L_Y), to_var(nu), L_S));
+  test::check_varis_on_stack(
+      stan::math::wishart_cholesky_lpdf<true>(to_var(L_Y), nu, to_var(L_S)));
+  test::check_varis_on_stack(stan::math::wishart_cholesky_lpdf<true>(to_var(L_Y), nu, L_S));
+  test::check_varis_on_stack(
+      stan::math::wishart_cholesky_lpdf<true>(L_Y, to_var(nu), to_var(L_S)));
+  test::check_varis_on_stack(stan::math::wishart_cholesky_lpdf<true>(L_Y, to_var(nu), L_S));
+  test::check_varis_on_stack(stan::math::wishart_cholesky_lpdf<true>(L_Y, nu, to_var(L_S)));
+
+  stan::math::recover_memory();
+}


### PR DESCRIPTION
## Summary

Adds the `wishart_cholesky_lpdf()` and `wishart_cholesky_rng()` functions.

## Tests

The tests use the `wishart_lpdf` tests but add log absolute Jacobian correction for the change of variables from the input X to the Cholesky factor L.

## Release notes

The `wishart_cholesky_lpdf` is the Cholesky parameterization of the Wishart distribution of both the input matrix and the scale matrix.

## Checklist

- [x] Math issue #2705 

- [x] Copyright holder: Sean Pinkney

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
