### PR TITLE
Added check for multivariate student t rng function

### DIFF
--- a/stan/math/prim/prob/multi_student_t_rng.hpp
+++ b/stan/math/prim/prob/multi_student_t_rng.hpp
@@ -60,6 +60,9 @@ multi_student_t_rng(
                      size_mu);
   }
 
+  check_size_match(function, "Size of random variable", size_mu,
+                   "rows of scale parameter", S.rows());
+
   for (size_t i = 0; i < N; i++) {
     check_finite(function, "Location parameter", mu_vec[i]);
   }

--- a/test/unit/math/prim/prob/multi_student_t_test.cpp
+++ b/test/unit/math/prim/prob/multi_student_t_test.cpp
@@ -264,6 +264,25 @@ TEST(ProbDistributionsMultiStudentT, ErrorSize3) {
   EXPECT_THROW(multi_student_t_rng(nu, mu, Sigma, rng), std::invalid_argument);
 }
 
+TEST(ProbDistributionsMultiStudentT, ErrorSizeSigma) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::multi_student_t_lpdf;
+  using stan::math::multi_student_t_rng;
+  using std::vector;
+  boost::random::mt19937 rng;
+  Matrix<double, Dynamic, 1> y(3, 1);
+  y << 2.0, -2.0, 11.0;
+  Matrix<double, Dynamic, 1> mu(3, 1);
+  mu << 1.0, -1.0, 3.0;
+  Matrix<double, Dynamic, Dynamic> Sigma(2, 2);
+  Sigma << 1.0, 0.0, 0.0, 1.0;
+  double nu = 4.0;
+
+  EXPECT_THROW(multi_student_t_lpdf(y, nu, mu, Sigma), std::invalid_argument);
+  EXPECT_THROW(multi_student_t_rng(nu, mu, Sigma, rng), std::invalid_argument);
+}
+
 TEST(ProbDistributionsMultiStudentT, ProptoAllDoublesZero) {
   using Eigen::Dynamic;
   using Eigen::Matrix;


### PR DESCRIPTION
## Summary

There was no check for consistent sizes of the location vector and the scale matrix in the multivariate student T rng function. If a user passed in different sized containers they would trigger a cryptic Eigen error. This now shows that the error is related to a mismatch in the sizes.

## Tests

Added a check and a new test for this.

## Release notes

Added a check for consistent container sizes in the multivariate student t rng function.

## Checklist

- [x] Copyright holder: Sean Pinkney

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
