### PR TITLE
Remove Rtools35 in Windows GHA tests - switch to Rtools40

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Windows RTools 3.5
+name: Windows Rtools40
 
 on:
   pull_request:
@@ -31,7 +31,7 @@ jobs:
       with:
         r-version: 4.1.3
     
-    - name: Set path for RTools 4.0
+    - name: Set path for Rtools40
       if: runner.os == 'Windows'
       run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Install mingw32-make and check toolchain path
@@ -78,7 +78,7 @@ jobs:
       with:
         r-version: 4.1.3
     
-    - name: Set path for RTools 4.0
+    - name: Set path for Rtools40
       if: runner.os == 'Windows'
       run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Install mingw32-make and check toolchain path
@@ -129,7 +129,7 @@ jobs:
       with:
         r-version: 4.1.3
     
-    - name: Set path for RTools 4.0
+    - name: Set path for Rtools40
       if: runner.os == 'Windows'
       run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Install mingw32-make and check toolchain path
@@ -147,10 +147,7 @@ jobs:
       run: mingw32-make -f make/standalone math-libs
     - name: Add TBB to PATH
       shell: powershell
-      run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-    - name: Disable running fwd/mix tests
-      shell: powershell
-      run: echo "CXXFLAGS+= -DSTAN_MATH_TESTS_REV_ONLY" | Out-File -Append -FilePath make/local -Encoding utf8      
+      run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8  
     - name: Run mix/fun unit tests
       shell: powershell
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,21 +27,23 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '2.x'
-    - name: Download RTools
-      run: Invoke-WebRequest -Uri https://cran.rstudio.com/bin/windows/Rtools/Rtools35.exe -OutFile ./R35.exe
-    - name: Install RTools
-      shell: powershell
-      run: Start-Process -FilePath ./R35.exe -ArgumentList /VERYSILENT -NoNewWindow -Wait
-    - name: PATH Setup
-      shell: powershell
-      run: echo "C:/Rtools/bin;C:/Rtools/mingw_64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-    - name: Print g++ & make version and path
-      shell: powershell
+    - uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: 4.1.3
+    
+    - name: Set path for RTools 4.0
+      if: runner.os == 'Windows'
+      run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Install mingw32-make and check toolchain path
+      if: runner.os == 'Windows'
       run: |
+        pacman -Syu mingw-w64-x86_64-make --noconfirm
         g++ --version
         Get-Command g++ | Select-Object -ExpandProperty Definition
         mingw32-make --version
         Get-Command mingw32-make | Select-Object -ExpandProperty Definition
+      shell: powershell
+
     - name: Build Math libs
       shell: powershell
       run: mingw32-make -f make/standalone math-libs
@@ -72,21 +74,23 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '2.x'
-    - name: Download RTools
-      run: Invoke-WebRequest -Uri https://cran.rstudio.com/bin/windows/Rtools/Rtools35.exe -OutFile ./R35.exe
-    - name: Install RTools
-      shell: powershell
-      run: Start-Process -FilePath ./R35.exe -ArgumentList /VERYSILENT -NoNewWindow -Wait
-    - name: PATH Setup
-      shell: powershell
-      run: echo "C:/Rtools/bin;C:/Rtools/mingw_64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-    - name: Print g++ & make version and path
-      shell: powershell
+    - uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: 4.1.3
+    
+    - name: Set path for RTools 4.0
+      if: runner.os == 'Windows'
+      run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Install mingw32-make and check toolchain path
+      if: runner.os == 'Windows'
       run: |
+        pacman -Syu mingw-w64-x86_64-make --noconfirm
         g++ --version
         Get-Command g++ | Select-Object -ExpandProperty Definition
         mingw32-make --version
         Get-Command mingw32-make | Select-Object -ExpandProperty Definition
+      shell: powershell
+
     - name: Build Math libs
       shell: powershell
       run: mingw32-make -f make/standalone math-libs
@@ -121,21 +125,23 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '2.x'
-    - name: Download RTools
-      run: Invoke-WebRequest -Uri https://cran.rstudio.com/bin/windows/Rtools/Rtools35.exe -OutFile ./R35.exe
-    - name: Install RTools
-      shell: powershell
-      run: Start-Process -FilePath ./R35.exe -ArgumentList /VERYSILENT -NoNewWindow -Wait
-    - name: PATH Setup
-      shell: powershell
-      run: echo "C:/Rtools/bin;C:/Rtools/mingw_64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-    - name: Print g++ & make version and path
-      shell: powershell
+    - uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: 4.1.3
+    
+    - name: Set path for RTools 4.0
+      if: runner.os == 'Windows'
+      run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Install mingw32-make and check toolchain path
+      if: runner.os == 'Windows'
       run: |
+        pacman -Syu mingw-w64-x86_64-make --noconfirm
         g++ --version
         Get-Command g++ | Select-Object -ExpandProperty Definition
         mingw32-make --version
         Get-Command mingw32-make | Select-Object -ExpandProperty Definition
+      shell: powershell
+
     - name: Build Math libs
       shell: powershell
       run: mingw32-make -f make/standalone math-libs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -471,26 +471,6 @@ pipeline {
                     }
                     post { always { retry(3) { deleteDir() } } }
                 }
-
-                stage('Windows Headers & Unit') {
-                    agent { label 'windows' }
-                    when {
-                        allOf {
-                            anyOf {
-                                branch 'develop'
-                                branch 'master'
-                                expression { params.run_win_tests }
-                            }
-                            expression {
-                                !skipRemainingStages
-                            }
-                        }
-                    }
-                    steps {
-                        unstash 'MathSetup'
-                        runTestsWin("test/unit", true, false)
-                    }
-                }
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,6 @@ pipeline {
         string(defaultValue: '', name: 'cmdstan_pr', description: 'PR to test CmdStan upstream against e.g. PR-630')
         string(defaultValue: '', name: 'stan_pr', description: 'PR to test Stan upstream against e.g. PR-630')
         booleanParam(defaultValue: false, name: 'withRowVector', description: 'Run additional distribution tests on RowVectors (takes 5x as long)')
-        booleanParam(defaultValue: false, name: 'run_win_tests', description: 'Run full unit tests on Windows.')
     }
     options {
         skipDefaultCheckout()


### PR DESCRIPTION
## Summary

As the title says, this switches to Rtools40 for Windows testing. Rtools35 has been obsolete for some time and is no longer supported.

## Tests

/

## Side Effects

/

## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
