### PR TITLE
rewrite log_determinant_spd rev using arena 

### DIFF
--- a/stan/math/rev/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/fun/log_determinant_spd.hpp
@@ -29,7 +29,7 @@ inline var log_determinant_spd(const T& M) {
 
   arena_t<T> arena_M = M;
   matrix_d M_d = arena_M.val();
-  auto M_ldlt = M_d.ldlt().eval();
+  auto M_ldlt = M_d.ldlt();
   if (M_ldlt.info() != Eigen::Success) {
     constexpr double y = 0;
     throw_domain_error("log_determinant_spd", "matrix argument", y,

--- a/stan/math/rev/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/fun/log_determinant_spd.hpp
@@ -22,7 +22,7 @@ namespace math {
  */
 template <typename T, require_rev_matrix_t<T>* = nullptr>
 inline var log_determinant_spd(const T& M) {
-  if (m.size() == 0) {
+  if (M.size() == 0) {
     return var(0.0);
   }
   check_symmetric("log_determinant", "M", M);

--- a/stan/math/rev/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/fun/log_determinant_spd.hpp
@@ -29,7 +29,7 @@ inline var log_determinant_spd(const T& M) {
 
   arena_t<T> arena_M = M;
   matrix_d M_d = arena_M.val();
-  auto M_ldlt = M_d.ldlt();
+  auto M_ldlt = M_d.ldlt().eval();
   if (M_ldlt.info() != Eigen::Success) {
     constexpr double y = 0;
     throw_domain_error("log_determinant_spd", "matrix argument", y,

--- a/stan/math/rev/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/fun/log_determinant_spd.hpp
@@ -16,91 +16,43 @@ namespace math {
 /**
  * Returns the log det of a symmetric, positive-definite matrix
  *
- * @tparam EigMat Type of the matrix
+ * @tparam T Type is an Eigen Matrix
  * @param m a symmetric, positive-definite matrix
  * @return The log determinant of the specified matrix
  */
-template <typename EigMat, require_eigen_vt<is_var, EigMat>* = nullptr>
-inline var log_determinant_spd(const EigMat& m) {
-  if (m.size() == 0) {
-    return 0;
-  }
-
-  matrix_d m_d = m.val();
-  check_symmetric("log_determinant_spd", "m", m_d);
-
-  Eigen::LDLT<matrix_d> ldlt(m_d);
-  if (ldlt.info() != Eigen::Success) {
-    double y = 0;
-    throw_domain_error("log_determinant_spd", "matrix argument", y,
-                       "failed LDLT factorization");
-  }
-
-  // compute the inverse of A (needed for the derivative)
-  m_d.setIdentity(m.rows(), m.cols());
-  ldlt.solveInPlace(m_d);
-
-  if (ldlt.isNegative() || (ldlt.vectorD().array() <= 1e-16).any()) {
-    double y = 0;
-    throw_domain_error("log_determinant_spd", "matrix argument", y,
-                       "matrix is negative definite");
-  }
-
-  double val = sum(log(ldlt.vectorD()));
-
-  check_finite("log_determinant_spd",
-               "log determininant of the matrix argument", val);
-
-  vari** operands
-      = ChainableStack::instance_->memalloc_.alloc_array<vari*>(m.size());
-  Eigen::Map<matrix_vi>(operands, m.rows(), m.cols()) = m.vi();
-
-  double* gradients
-      = ChainableStack::instance_->memalloc_.alloc_array<double>(m.size());
-  Eigen::Map<matrix_d>(gradients, m.rows(), m.cols()) = m_d;
-
-  return var(
-      new precomputed_gradients_vari(val, m.size(), operands, gradients));
-}
-
-/**
- * Returns the log det of a symmetric, positive-definite matrix
- *
- * @tparam EigMat Type of the matrix
- * @param m a symmetric, positive-definite matrix
- * @return The log determinant of the specified matrix
- */
-template <typename T, require_var_matrix_t<T>* = nullptr>
+template <typename T, require_rev_matrix_t<T>* = nullptr>
 inline var log_determinant_spd(const T& m) {
-  check_square("log_determinant_spd", "m", m);
-
   if (m.size() == 0) {
     return var(0.0);
   }
+  check_symmetric("log_determinant", "m", m);
 
-  check_symmetric("log_determinant_spd", "m", m.val());
-
-  auto ldlt = m.val().ldlt();
-  if (ldlt.info() != Eigen::Success) {
+  matrix_d m_d = m.val();
+  arena_t<T> arena_m = m;
+  auto m_ldlt = arena_m.val().ldlt();
+  if (m_ldlt.info() != Eigen::Success) {
     double y = 0;
     throw_domain_error("log_determinant_spd", "matrix argument", y,
                        "failed LDLT factorization");
   }
 
-  if (ldlt.isNegative() || (ldlt.vectorD().array() <= 1e-16).any()) {
+    // compute the inverse of A (needed for the derivative)
+  m_d.setIdentity(m.rows(), m.cols());
+
+  auto arena_m_inv_transpose = to_arena(m_ldlt.solve(m_d).transpose());
+
+   if (m_ldlt.isNegative() || (m_ldlt.vectorD().array() <= 1e-16).any()) {
     double y = 0;
     throw_domain_error("log_determinant_spd", "matrix argument", y,
                        "matrix is negative definite");
   }
 
-  arena_t<Eigen::MatrixXd> arena_m_inv_transpose
-      = Eigen::MatrixXd::Identity(m.rows(), m.cols());
-  ldlt.solveInPlace(arena_m_inv_transpose);
+  var log_det = sum(log(m_ldlt.vectorD()));
 
-  return make_callback_var(sum(log(ldlt.vectorD())),
-                           [m, arena_m_inv_transpose](const auto& res) mutable {
-                             m.adj() += res.adj() * arena_m_inv_transpose;
-                           });
+  reverse_pass_callback([arena_m, log_det, arena_m_inv_transpose]() mutable {
+    arena_m.adj() += log_det.adj() * arena_m_inv_transpose;
+  });
+  return log_det;
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/fun/log_determinant_spd.hpp
@@ -36,12 +36,12 @@ inline var log_determinant_spd(const T& m) {
                        "failed LDLT factorization");
   }
 
-    // compute the inverse of A (needed for the derivative)
+  // compute the inverse of A (needed for the derivative)
   m_d.setIdentity(m.rows(), m.cols());
 
   auto arena_m_inv_transpose = to_arena(m_ldlt.solve(m_d).transpose());
 
-   if (m_ldlt.isNegative() || (m_ldlt.vectorD().array() <= 1e-16).any()) {
+  if (m_ldlt.isNegative() || (m_ldlt.vectorD().array() <= 1e-16).any()) {
     double y = 0;
     throw_domain_error("log_determinant_spd", "matrix argument", y,
                        "matrix is negative definite");


### PR DESCRIPTION
## Summary

Updates the `log_determinant_spd` function using the arena syntax.

## Tests

No new tests. 

## Side Effects

None

## Release notes



## Checklist

- [x] Math issue #2718

- [x] Copyright holder: Sean Pinkney

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
