### PR TITLE
Disable jumbo test build for mix/

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -289,7 +289,7 @@ pipeline {
                         unstash 'MathSetup'
                         sh "echo CXXFLAGS += -fsanitize=address >> make/local"
                         script {
-                            runTests("test/unit/math/mix", true)
+                            runTests("test/unit/math/mix", false)
                         }
                     }
                     post { always { retry(3) { deleteDir() } } }


### PR DESCRIPTION
## Summary

The PR title says it all. I am guessing the jumbo build are the cause for the recent occasional test errors  (the test fail during compilation sporadically with an error that is completely unrelated to the PRs). My current guess is they started occurring after we enabled jumbo build back. 

This will probably cause the tests to run a bit longer - but rather they run longer and not fail sporadically.

## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

