### PR TITLE
Adjust signatures of eigenvalues and eigenvectors to accept expressions

### DIFF
--- a/stan/math/prim/fun/eigenvalues.hpp
+++ b/stan/math/prim/fun/eigenvalues.hpp
@@ -7,13 +7,12 @@
 namespace stan {
 namespace math {
 
-template <typename T>
-Eigen::Matrix<std::complex<T>, -1, 1> eigenvalues(
-    const Eigen::Matrix<T, -1, -1>& m) {
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
+inline auto eigenvalues(const EigMat& m) {
   check_nonzero_size("eigenvalues", "m", m);
   check_square("eigenvalues", "m", m);
 
-  Eigen::EigenSolver<Eigen::Matrix<T, -1, -1>> solver(m);
+  Eigen::EigenSolver<plain_type_t<EigMat>> solver(m);
   return solver.eigenvalues();
 }
 

--- a/stan/math/prim/fun/eigenvalues.hpp
+++ b/stan/math/prim/fun/eigenvalues.hpp
@@ -9,10 +9,12 @@ namespace math {
 
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto eigenvalues(const EigMat& m) {
-  check_nonzero_size("eigenvalues", "m", m);
-  check_square("eigenvalues", "m", m);
+  using PlainMat = plain_type_t<EigMat>;
+  const PlainMat& m_eval = m;
+  check_nonzero_size("eigenvalues", "m", m_eval);
+  check_square("eigenvalues", "m", m_eval);
 
-  Eigen::EigenSolver<plain_type_t<EigMat>> solver(m);
+  Eigen::EigenSolver<PlainMat> solver(m_eval);
   return solver.eigenvalues();
 }
 

--- a/stan/math/prim/fun/eigenvectors.hpp
+++ b/stan/math/prim/fun/eigenvectors.hpp
@@ -7,13 +7,12 @@
 namespace stan {
 namespace math {
 
-template <typename T>
-Eigen::Matrix<std::complex<T>, -1, -1> eigenvectors(
-    const Eigen::Matrix<T, -1, -1>& m) {
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
+inline auto eigenvectors(const EigMat& m) {
   check_nonzero_size("eigenvectors", "m", m);
   check_square("eigenvectors", "m", m);
 
-  Eigen::EigenSolver<Eigen::Matrix<T, -1, -1>> solver(m);
+  Eigen::EigenSolver<plain_type_t<EigMat>> solver(m);
   return solver.eigenvectors();
 }
 

--- a/stan/math/prim/fun/eigenvectors.hpp
+++ b/stan/math/prim/fun/eigenvectors.hpp
@@ -9,10 +9,12 @@ namespace math {
 
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto eigenvectors(const EigMat& m) {
-  check_nonzero_size("eigenvectors", "m", m);
-  check_square("eigenvectors", "m", m);
+  using PlainMat = plain_type_t<EigMat>;
+  const PlainMat& m_eval = m;
+  check_nonzero_size("eigenvectors", "m", m_eval);
+  check_square("eigenvectors", "m", m_eval);
 
-  Eigen::EigenSolver<plain_type_t<EigMat>> solver(m);
+  Eigen::EigenSolver<PlainMat> solver(m_eval);
   return solver.eigenvectors();
 }
 

--- a/test/statement_types.py
+++ b/test/statement_types.py
@@ -130,7 +130,10 @@ class MatrixVariable(CppStatement):
         self.size = size
 
         if value is None:
-            self.value = 0.4
+            if 'complex' in stan_arg:
+                self.value = "stan::math::to_complex(0.4,0.4)"
+            else:
+                self.value = 0.4
         else:
             self.value = value
 


### PR DESCRIPTION
## Summary

This adjusts the signatures of the `eigenvalues` and `eigenvectors` functions to accept eigen expressions as input. This will allow them to be exposed in the Stan language: https://github.com/stan-dev/stanc3/pull/1192

## Tests

Existing tests for functionality remain in place. Additional expression tests will be automatically run when exposed in the compiler, I've run them locally for now.

## Side Effects

None

## Release notes

Updated the signatures of `eigenvalues` and `eigenvectors` to use our pseudo-concept require templates. 

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder:  Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
