### PR TITLE
Add check that L_Y is a squared matrix in wishart_cholesky_lpdf

### DIFF
--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -54,6 +54,8 @@ return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& L_Y,
                    "columns of scale parameter", L_S.rows());
   check_size_match(function, "Rows of random variable", L_Y.rows(),
                    "columns of random variable", L_Y.cols());
+  check_size_match(function, "Rows of scale parameter", L_S.rows(),
+                   "columns of scale parameter", L_S.cols());
   T_L_Y_ref L_Y_ref = L_Y;
   T_nu_ref nu_ref = nu;
   T_L_S_ref L_S_ref = L_S;

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -52,7 +52,8 @@ return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& L_Y,
   Eigen::Index k = L_Y.rows();
   check_size_match(function, "Rows of random variable", L_Y.rows(),
                    "columns of scale parameter", L_S.rows());
-
+  check_size_match(function, "Rows of random variable", L_Y.rows(),
+                   "columns of random variable", L_Y.cols());
   T_L_Y_ref L_Y_ref = L_Y;
   T_nu_ref nu_ref = nu;
   T_L_S_ref L_S_ref = L_S;

--- a/test/unit/math/prim/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_test.cpp
@@ -216,7 +216,7 @@ TEST(ProbDistributionsWishartCholesky, error) {
   nu = 5;
   MatrixXd Y(2, 1);
   EXPECT_THROW(wishart_cholesky_lpdf(Y, nu, MatrixXd::Identity(2, 2)),
-               std::domain_error);
+               std::invalid_argument);
 
   nu = 5;
   EXPECT_THROW(wishart_cholesky_lpdf(MatrixXd::Identity(3, 3), nu,


### PR DESCRIPTION
## Summary

No issue for this PR - this is to fix develop that is failing: https://jenkins.flatironinstitute.org/blue/organizations/jenkins/Stan%2FMath/detail/develop/38/pipeline

Its failing because a test was expecting a std::domain_error but on clang the following does not trigger that: 
```
wishart_cholesky_test: lib/eigen_3.3.9/Eigen/src/Core/Block.h:147: Eigen::Block<Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1>, 1, -1, false>, 1, -1, false>::Block(XprType &, Eigen::Index, Eigen::Index, Eigen::Index, Eigen::Index) [XprType = Eigen::Block<Eigen::Matrix<double, -1, -1, 0, -1, -1>, 1, -1, false>, BlockRows = 1, BlockCols = -1, InnerPanel = false]: Assertion `startRow >= 0 && blockRows >= 0 && startRow <= xpr.rows() - blockRows && startCol >= 0 && blockCols >= 0 && startCol <= xpr.cols() - blockCols' failed.
```
The fix is to check that `L_Y` matrix is square.

In the PR tests we run with g++ while on merge to develop test we also test the full unit tests with clang, which is why we only saw that after merge.

## Tests

/

## Side Effects

/


## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
