### PR TITLE
Add complex overloads for eigendecomposition functions

### DIFF
--- a/stan/math/prim/core/operator_division.hpp
+++ b/stan/math/prim/core/operator_division.hpp
@@ -18,7 +18,7 @@ namespace internal {
  * @param[in] rhs second argument
  * @return quotient of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_not_eigen_t<U, V>* = nullptr>
 inline complex_return_t<U, V> complex_divide(const U& lhs, const V& rhs) {
   complex_return_t<U, V> y(lhs);
   y /= rhs;
@@ -35,7 +35,8 @@ inline complex_return_t<U, V> complex_divide(const U& lhs, const V& rhs) {
  * @param y second argument
  * @return quotient of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V,
+          require_all_var_or_arithmetic_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator/(const std::complex<U>& x,
                                         const std::complex<V>& y) {
   return internal::complex_divide(x, y);
@@ -50,7 +51,7 @@ inline complex_return_t<U, V> operator/(const std::complex<U>& x,
  * @param y second argument
  * @return quotient of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_not_eigen_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator/(const std::complex<U>& x, const V& y) {
   return internal::complex_divide(x, y);
 }
@@ -64,7 +65,7 @@ inline complex_return_t<U, V> operator/(const std::complex<U>& x, const V& y) {
  * @param y second argument
  * @return quotient of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_not_eigen_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator/(const U& x, const std::complex<V>& y) {
   return internal::complex_divide(x, y);
 }

--- a/stan/math/prim/core/operator_division.hpp
+++ b/stan/math/prim/core/operator_division.hpp
@@ -35,8 +35,7 @@ inline complex_return_t<U, V> complex_divide(const U& lhs, const V& rhs) {
  * @param y second argument
  * @return quotient of the arguments
  */
-template <typename U, typename V,
-          require_all_var_or_arithmetic_t<U, V>* = nullptr>
+template <typename U, typename V, require_all_not_eigen_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator/(const std::complex<U>& x,
                                         const std::complex<V>& y) {
   return internal::complex_divide(x, y);

--- a/stan/math/prim/fun/eigenvalues.hpp
+++ b/stan/math/prim/fun/eigenvalues.hpp
@@ -7,14 +7,27 @@
 namespace stan {
 namespace math {
 
-template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
+          require_not_vt_complex<EigMat>* = nullptr>
 inline auto eigenvalues(const EigMat& m) {
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
   check_nonzero_size("eigenvalues", "m", m_eval);
   check_square("eigenvalues", "m", m_eval);
 
-  Eigen::EigenSolver<PlainMat> solver(m_eval);
+  Eigen::EigenSolver<PlainMat> solver(m_eval, false);
+  return solver.eigenvalues();
+}
+
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
+          require_vt_complex<EigMat>* = nullptr>
+Eigen::Matrix<scalar_type_t<EigMat>, -1, -1> eigenvalues(const EigMat& m) {
+  using PlainMat = Eigen::Matrix<scalar_type_t<EigMat>, -1, -1>;
+  const PlainMat& m_eval = m;
+  check_nonzero_size("eigenvalues", "m", m_eval);
+  check_square("eigenvalues", "m", m_eval);
+
+  Eigen::ComplexEigenSolver<PlainMat> solver(m_eval, false);
   return solver.eigenvalues();
 }
 

--- a/stan/math/prim/fun/eigenvectors.hpp
+++ b/stan/math/prim/fun/eigenvectors.hpp
@@ -7,7 +7,8 @@
 namespace stan {
 namespace math {
 
-template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
+          require_not_vt_complex<EigMat>* = nullptr>
 inline auto eigenvectors(const EigMat& m) {
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
@@ -15,6 +16,18 @@ inline auto eigenvectors(const EigMat& m) {
   check_square("eigenvectors", "m", m_eval);
 
   Eigen::EigenSolver<PlainMat> solver(m_eval);
+  return solver.eigenvectors();
+}
+
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
+          require_vt_complex<EigMat>* = nullptr>
+Eigen::Matrix<scalar_type_t<EigMat>, -1, -1> eigenvectors(const EigMat& m) {
+  using PlainMat = Eigen::Matrix<scalar_type_t<EigMat>, -1, -1>;
+  const PlainMat& m_eval = m;
+  check_nonzero_size("eigenvectors", "m", m_eval);
+  check_square("eigenvectors", "m", m_eval);
+
+  Eigen::ComplexEigenSolver<PlainMat> solver(m_eval);
   return solver.eigenvectors();
 }
 

--- a/test/unit/math/mix/fun/eigenvalues_test.cpp
+++ b/test/unit/math/mix/fun/eigenvalues_test.cpp
@@ -2,13 +2,14 @@
 #include <stdexcept>
 
 TEST(mathMixFun, eigenvalues) {
+  stan::test::ad_tolerances tols = stan::test::reverse_only_ad_tolerances();
   auto f = [](const auto& x) {
     using stan::math::eigenvalues;
     return eigenvalues(x);
   };
   for (const auto& x : stan::test::square_test_matrices(0, 2)) {
-    stan::test::expect_ad(f, x);
-    stan::test::expect_ad(f, Eigen::MatrixXcd(x));
+    stan::test::expect_ad(tols,f, x);
+    stan::test::expect_ad(tols,f, Eigen::MatrixXcd(x));
   }
 
   Eigen::MatrixXd a32(3, 2);

--- a/test/unit/math/mix/fun/eigenvalues_test.cpp
+++ b/test/unit/math/mix/fun/eigenvalues_test.cpp
@@ -2,14 +2,13 @@
 #include <stdexcept>
 
 TEST(mathMixFun, eigenvalues) {
-  stan::test::ad_tolerances tols = stan::test::reverse_only_ad_tolerances();
   auto f = [](const auto& x) {
     using stan::math::eigenvalues;
     return eigenvalues(x);
   };
   for (const auto& x : stan::test::square_test_matrices(0, 2)) {
-    stan::test::expect_ad(tols,f, x);
-    stan::test::expect_ad(tols,f, Eigen::MatrixXcd(x));
+    stan::test::expect_ad(f, x);
+    stan::test::expect_ad(f, Eigen::MatrixXcd(x));
   }
 
   Eigen::MatrixXd a32(3, 2);

--- a/test/unit/math/mix/fun/eigenvalues_test.cpp
+++ b/test/unit/math/mix/fun/eigenvalues_test.cpp
@@ -8,11 +8,14 @@ TEST(mathMixFun, eigenvalues) {
   };
   for (const auto& x : stan::test::square_test_matrices(0, 2)) {
     stan::test::expect_ad(f, x);
+    stan::test::expect_ad(f, Eigen::MatrixXcd(x));
+
   }
 
   Eigen::MatrixXd a32(3, 2);
   a32 << 3, -5, 7, -7.2, 9.1, -6.3;
   EXPECT_THROW(f(a32), std::invalid_argument);
+  EXPECT_THROW(f(Eigen::MatrixXcd(a32)), std::invalid_argument);
 }
 
 // see eigenvectors_test.cpp for test of eigenvectors() and eigenvalues()

--- a/test/unit/math/mix/fun/eigenvalues_test.cpp
+++ b/test/unit/math/mix/fun/eigenvalues_test.cpp
@@ -9,7 +9,6 @@ TEST(mathMixFun, eigenvalues) {
   for (const auto& x : stan::test::square_test_matrices(0, 2)) {
     stan::test::expect_ad(f, x);
     stan::test::expect_ad(f, Eigen::MatrixXcd(x));
-
   }
 
   Eigen::MatrixXd a32(3, 2);

--- a/test/unit/math/mix/fun/eigenvectors_test.cpp
+++ b/test/unit/math/mix/fun/eigenvectors_test.cpp
@@ -8,11 +8,13 @@ TEST(mathMixFun, eigenvectors) {
   };
   for (const auto& x : stan::test::square_test_matrices(0, 2)) {
     stan::test::expect_ad(f, x);
+    stan::test::expect_ad(f, Eigen::MatrixXcd(x));
   }
 
   Eigen::MatrixXd a32(3, 2);
   a32 << 3, -5, 7, -7.2, 9.1, -6.3;
   EXPECT_THROW(f(a32), std::invalid_argument);
+  EXPECT_THROW(f(Eigen::MatrixXcd(a32)), std::invalid_argument);
 }
 
 template <typename T>


### PR DESCRIPTION
## Summary

This adds wrappers around Eigen's [ComplexEigenSolver](https://eigen.tuxfamily.org/dox/classEigen_1_1ComplexEigenSolver.html) class to add `eigenvalues` and `eigenvectors` functions defined over complex matrices.

There are two oddities here. The first is that Eigen internally uses `operator/`, and our overloads were not guarded enough to prevent them from being used on eigen objects. The second is it seems like (at least) the Hessian tests are failing. 


## Tests

Existing tests were updated to also test complex matrices.

## Side Effects

None

## Release notes

Added eigenvalues and eigenvectors overloads which accept matrices with complex values.

## Checklist

- [x] Copyright holder: Simons Foundation

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
