### PR TITLE
fix apply_scalar_unary and abs so that abs(complex<T>) return T

### DIFF
--- a/stan/math/mix.hpp
+++ b/stan/math/mix.hpp
@@ -5,14 +5,14 @@
 #include <stan/math/mix/fun.hpp>
 #include <stan/math/mix/functor.hpp>
 
-#ifdef STAN_OPENCL
-#include <stan/math/opencl/rev.hpp>
-#endif
-
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/fwd/meta.hpp>
 #include <stan/math/fwd/fun.hpp>
 #include <stan/math/fwd/functor.hpp>
+
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#endif
 
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/meta.hpp>

--- a/stan/math/prim/fun/Phi.hpp
+++ b/stan/math/prim/fun/Phi.hpp
@@ -51,7 +51,7 @@ inline double Phi(double x) {
  */
 struct Phi_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return Phi(x);
   }
 };

--- a/stan/math/prim/fun/Phi_approx.hpp
+++ b/stan/math/prim/fun/Phi_approx.hpp
@@ -47,7 +47,7 @@ struct Phi_approx_fun {
    * @return approximate value of Phi applied to argument
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return Phi_approx(x);
   }
 };

--- a/stan/math/prim/fun/abs.hpp
+++ b/stan/math/prim/fun/abs.hpp
@@ -49,7 +49,7 @@ inline auto abs(T x) {
  */
 struct abs_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return abs(x);
   }
 };

--- a/stan/math/prim/fun/acos.hpp
+++ b/stan/math/prim/fun/acos.hpp
@@ -27,7 +27,7 @@ namespace math {
  */
 struct acos_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::acos;
     return acos(x);
   }

--- a/stan/math/prim/fun/acosh.hpp
+++ b/stan/math/prim/fun/acosh.hpp
@@ -68,7 +68,7 @@ struct acosh_fun {
    * @return Inverse hyperbolic cosine of the argument.
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return acosh(x);
   }
 };

--- a/stan/math/prim/fun/asin.hpp
+++ b/stan/math/prim/fun/asin.hpp
@@ -25,7 +25,7 @@ namespace math {
  */
 struct asin_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::asin;
     return asin(x);
   }

--- a/stan/math/prim/fun/asinh.hpp
+++ b/stan/math/prim/fun/asinh.hpp
@@ -29,7 +29,7 @@ namespace math {
  */
 struct asinh_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::asinh;
     return asinh(x);
   }

--- a/stan/math/prim/fun/atan.hpp
+++ b/stan/math/prim/fun/atan.hpp
@@ -23,7 +23,7 @@ namespace math {
  */
 struct atan_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::atan;
     return atan(x);
   }

--- a/stan/math/prim/fun/atanh.hpp
+++ b/stan/math/prim/fun/atanh.hpp
@@ -57,7 +57,7 @@ struct atanh_fun {
    * @return Inverse hyperbolic tangent of the argument.
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return atanh(x);
   }
 };

--- a/stan/math/prim/fun/cbrt.hpp
+++ b/stan/math/prim/fun/cbrt.hpp
@@ -17,7 +17,7 @@ namespace math {
  */
 struct cbrt_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::cbrt;
     return cbrt(x);
   }

--- a/stan/math/prim/fun/ceil.hpp
+++ b/stan/math/prim/fun/ceil.hpp
@@ -19,7 +19,7 @@ namespace math {
  */
 struct ceil_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::ceil;
     return ceil(x);
   }

--- a/stan/math/prim/fun/cos.hpp
+++ b/stan/math/prim/fun/cos.hpp
@@ -22,7 +22,7 @@ namespace math {
  */
 struct cos_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::cos;
     return cos(x);
   }

--- a/stan/math/prim/fun/cosh.hpp
+++ b/stan/math/prim/fun/cosh.hpp
@@ -21,7 +21,7 @@ namespace math {
  */
 struct cosh_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::cosh;
     return cosh(x);
   }

--- a/stan/math/prim/fun/digamma.hpp
+++ b/stan/math/prim/fun/digamma.hpp
@@ -58,7 +58,7 @@ inline double digamma(double x) {
  */
 struct digamma_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return digamma(x);
   }
 };

--- a/stan/math/prim/fun/erf.hpp
+++ b/stan/math/prim/fun/erf.hpp
@@ -17,7 +17,7 @@ namespace math {
  */
 struct erf_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::erf;
     return erf(x);
   }

--- a/stan/math/prim/fun/erfc.hpp
+++ b/stan/math/prim/fun/erfc.hpp
@@ -18,7 +18,7 @@ namespace math {
  */
 struct erfc_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::erfc;
     return erfc(x);
   }

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -24,7 +24,7 @@ struct exp_fun {
    * @return Exponential of argument.
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::exp;
     return exp(x);
   }

--- a/stan/math/prim/fun/exp2.hpp
+++ b/stan/math/prim/fun/exp2.hpp
@@ -20,7 +20,7 @@ struct exp2_fun {
    * @return Base two exponent of the argument.
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::exp2;
     return exp2(x);
   }

--- a/stan/math/prim/fun/expm1.hpp
+++ b/stan/math/prim/fun/expm1.hpp
@@ -17,7 +17,7 @@ namespace math {
  */
 struct expm1_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::expm1;
     return expm1(x);
   }

--- a/stan/math/prim/fun/fabs.hpp
+++ b/stan/math/prim/fun/fabs.hpp
@@ -11,12 +11,12 @@ namespace stan {
 namespace math {
 
 template <typename T, require_arithmetic_t<T>* = nullptr>
-auto fabs(T x) {
+inline auto fabs(T x) {
   return std::abs(x);
 }
 
 template <typename T, require_complex_t<T>* = nullptr>
-auto fabs(T x) {
+inline auto fabs(T x) {
   return hypot(x.real(), x.imag());
 }
 
@@ -29,7 +29,7 @@ auto fabs(T x) {
  */
 struct fabs_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return fabs(x);
   }
 };

--- a/stan/math/prim/fun/floor.hpp
+++ b/stan/math/prim/fun/floor.hpp
@@ -19,7 +19,7 @@ namespace math {
  */
 struct floor_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::floor;
     return floor(x);
   }

--- a/stan/math/prim/fun/inv.hpp
+++ b/stan/math/prim/fun/inv.hpp
@@ -18,7 +18,7 @@ namespace math {
  */
 struct inv_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return 1.0 / x;
   }
 };

--- a/stan/math/prim/fun/inv_Phi.hpp
+++ b/stan/math/prim/fun/inv_Phi.hpp
@@ -160,7 +160,7 @@ inline double inv_Phi(double p) {
  */
 struct inv_Phi_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return inv_Phi(x);
   }
 };

--- a/stan/math/prim/fun/inv_cloglog.hpp
+++ b/stan/math/prim/fun/inv_cloglog.hpp
@@ -47,7 +47,7 @@ namespace math {
  */
 inline double inv_cloglog(double x) {
   using std::exp;
-  return 1 - exp(-exp(x));
+  return 1. - exp(-exp(x));
 }
 
 /**
@@ -59,7 +59,7 @@ inline double inv_cloglog(double x) {
  */
 struct inv_cloglog_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return inv_cloglog(x);
   }
 };

--- a/stan/math/prim/fun/inv_erfc.hpp
+++ b/stan/math/prim/fun/inv_erfc.hpp
@@ -30,7 +30,7 @@ inline auto inv_erfc(const T& x) {
  */
 struct inv_erfc_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return inv_erfc(x);
   }
 };

--- a/stan/math/prim/fun/inv_logit.hpp
+++ b/stan/math/prim/fun/inv_logit.hpp
@@ -69,7 +69,7 @@ inline double inv_logit(double a) {
  */
 struct inv_logit_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return inv_logit(x);
   }
 };

--- a/stan/math/prim/fun/inv_sqrt.hpp
+++ b/stan/math/prim/fun/inv_sqrt.hpp
@@ -26,7 +26,7 @@ inline auto inv_sqrt(T x) {
  */
 struct inv_sqrt_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return inv_sqrt(x);
   }
 };

--- a/stan/math/prim/fun/lambert_w.hpp
+++ b/stan/math/prim/fun/lambert_w.hpp
@@ -48,7 +48,7 @@ namespace internal {
  */
 struct lambert_w0_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return lambert_w0(x);
   }
 };
@@ -64,7 +64,7 @@ struct lambert_w0_fun {
  */
 struct lambert_wm1_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return lambert_wm1(x);
   }
 };

--- a/stan/math/prim/fun/lgamma.hpp
+++ b/stan/math/prim/fun/lgamma.hpp
@@ -100,7 +100,7 @@ inline double lgamma(int x) {
  */
 struct lgamma_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return lgamma(x);
   }
 };

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -27,7 +27,7 @@ struct log_fun {
    * @return Natural log of x.
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::log;
     return log(x);
   }

--- a/stan/math/prim/fun/log10.hpp
+++ b/stan/math/prim/fun/log10.hpp
@@ -21,7 +21,7 @@ namespace math {
  */
 struct log10_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::log10;
     return log10(x);
   }

--- a/stan/math/prim/fun/log1m.hpp
+++ b/stan/math/prim/fun/log1m.hpp
@@ -55,7 +55,7 @@ inline double log1m(double x) {
  */
 struct log1m_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return log1m(x);
   }
 };

--- a/stan/math/prim/fun/log1m_exp.hpp
+++ b/stan/math/prim/fun/log1m_exp.hpp
@@ -65,7 +65,7 @@ inline double log1m_exp(double a) {
  */
 struct log1m_exp_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return log1m_exp(x);
   }
 };

--- a/stan/math/prim/fun/log1m_inv_logit.hpp
+++ b/stan/math/prim/fun/log1m_inv_logit.hpp
@@ -65,7 +65,7 @@ struct log1m_inv_logit_fun {
    * @return natural log of one minus inverse logit of argument
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return log1m_inv_logit(x);
   }
 };

--- a/stan/math/prim/fun/log1p.hpp
+++ b/stan/math/prim/fun/log1p.hpp
@@ -61,7 +61,7 @@ struct log1p_fun {
    * @return natural log of one plus the argument
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return log1p(x);
   }
 };

--- a/stan/math/prim/fun/log1p_exp.hpp
+++ b/stan/math/prim/fun/log1p_exp.hpp
@@ -60,7 +60,7 @@ inline double log1p_exp(double a) {
  */
 struct log1p_exp_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return log1p_exp(x);
   }
 };

--- a/stan/math/prim/fun/log2.hpp
+++ b/stan/math/prim/fun/log2.hpp
@@ -14,7 +14,7 @@ namespace math {
  *
  * @return Natural logarithm of two.
  */
-inline double log2() { return LOG_TWO; }
+inline constexpr double log2() { return LOG_TWO; }
 
 /**
  * Structure to wrap `log2()` so it can be vectorized.
@@ -28,7 +28,7 @@ struct log2_fun {
    * @return base two log of the argument
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::log2;
     return log2(x);
   }

--- a/stan/math/prim/fun/log_inv_logit.hpp
+++ b/stan/math/prim/fun/log_inv_logit.hpp
@@ -63,7 +63,7 @@ struct log_inv_logit_fun {
    * @return natural log of inverse logit of argument
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return log_inv_logit(x);
   }
 };

--- a/stan/math/prim/fun/logit.hpp
+++ b/stan/math/prim/fun/logit.hpp
@@ -68,7 +68,7 @@ struct logit_fun {
    * @return log odds of the argument
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return logit(x);
   }
 };

--- a/stan/math/prim/fun/round.hpp
+++ b/stan/math/prim/fun/round.hpp
@@ -19,7 +19,7 @@ namespace math {
  */
 struct round_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::round;
     return round(x);
   }

--- a/stan/math/prim/fun/sin.hpp
+++ b/stan/math/prim/fun/sin.hpp
@@ -22,7 +22,7 @@ namespace math {
  */
 struct sin_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::sin;
     return sin(x);
   }

--- a/stan/math/prim/fun/sinh.hpp
+++ b/stan/math/prim/fun/sinh.hpp
@@ -20,7 +20,7 @@ namespace math {
  */
 struct sinh_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::sinh;
     return sinh(x);
   }

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -20,7 +20,7 @@ namespace math {
  */
 struct sqrt_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::sqrt;
     return sqrt(x);
   }

--- a/stan/math/prim/fun/square.hpp
+++ b/stan/math/prim/fun/square.hpp
@@ -34,7 +34,7 @@ inline double square(double x) { return std::pow(x, 2); }
  */
 struct square_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return square(x);
   }
 };

--- a/stan/math/prim/fun/step.hpp
+++ b/stan/math/prim/fun/step.hpp
@@ -44,7 +44,7 @@ struct step_fun {
    * @return step(y)
    */
   template <typename T>
-  static inline T fun(const T& y) {
+  static inline auto fun(const T& y) {
     return step(y);
   }
 };

--- a/stan/math/prim/fun/tan.hpp
+++ b/stan/math/prim/fun/tan.hpp
@@ -22,7 +22,7 @@ namespace math {
  */
 struct tan_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::tan;
     return tan(x);
   }

--- a/stan/math/prim/fun/tanh.hpp
+++ b/stan/math/prim/fun/tanh.hpp
@@ -22,7 +22,7 @@ namespace math {
  */
 struct tanh_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::tanh;
     return tanh(x);
   }

--- a/stan/math/prim/fun/tgamma.hpp
+++ b/stan/math/prim/fun/tgamma.hpp
@@ -33,7 +33,7 @@ inline double tgamma(double x) {
  */
 struct tgamma_fun {
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return tgamma(x);
   }
 };

--- a/stan/math/prim/fun/trigamma.hpp
+++ b/stan/math/prim/fun/trigamma.hpp
@@ -141,7 +141,7 @@ struct trigamma_fun {
    * @return trigamma applied to argument.
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     return trigamma(x);
   }
 };

--- a/stan/math/prim/fun/trunc.hpp
+++ b/stan/math/prim/fun/trunc.hpp
@@ -21,7 +21,7 @@ struct trunc_fun {
    * @return truncation of the argument
    */
   template <typename T>
-  static inline T fun(const T& x) {
+  static inline auto fun(const T& x) {
     using std::trunc;
     return trunc(x);
   }

--- a/stan/math/prim/functor/apply_scalar_unary.hpp
+++ b/stan/math/prim/functor/apply_scalar_unary.hpp
@@ -59,8 +59,9 @@ struct apply_scalar_unary<F, T, require_eigen_t<T>> {
    * by F to the specified matrix.
    */
   static inline auto apply(const T& x) {
-    return x.unaryExpr(
-        [](auto&& x) { return apply_scalar_unary<F, std::decay_t<decltype(x)>>::apply(x); });
+    return x.unaryExpr([](auto&& x) {
+      return apply_scalar_unary<F, std::decay_t<decltype(x)>>::apply(x);
+    });
   }
 
   /**
@@ -82,7 +83,7 @@ struct apply_scalar_unary<F, T, require_floating_point_t<T>> {
   /**
    * The return type, double.
    */
-   using return_t = std::decay_t<decltype(F::fun(std::declval<T>()))>;
+  using return_t = std::decay_t<decltype(F::fun(std::declval<T>()))>;
 
   /**
    * Apply the function specified by F to the specified argument.
@@ -104,7 +105,6 @@ struct apply_scalar_unary<F, T, require_floating_point_t<T>> {
  */
 template <typename F, typename T>
 struct apply_scalar_unary<F, T, require_complex_t<T>> {
-
   /**
    * Apply the function specified by F to the specified argument.
    * This is defined through a direct application of
@@ -119,7 +119,6 @@ struct apply_scalar_unary<F, T, require_complex_t<T>> {
    * The return type
    */
   using return_t = std::decay_t<decltype(F::fun(std::declval<T>()))>;
-
 };
 
 /**
@@ -176,7 +175,8 @@ struct apply_scalar_unary<F, std::vector<T>> {
    * container.
    */
   static inline auto apply(const std::vector<T>& x) {
-    //using inner_t = std::decay_t<plain_type_t<decltype(apply_scalar_unary<F, T>::apply(x[0]))>>;
+    // using inner_t = std::decay_t<plain_type_t<decltype(apply_scalar_unary<F,
+    // T>::apply(x[0]))>>;
     return_t fx(x.size());
     for (size_t i = 0; i < x.size(); ++i) {
       fx[i] = apply_scalar_unary<F, T>::apply(x[i]);

--- a/stan/math/prim/functor/apply_scalar_unary.hpp
+++ b/stan/math/prim/functor/apply_scalar_unary.hpp
@@ -140,7 +140,7 @@ struct apply_scalar_unary<F, T, require_integral_t<T>> {
    * @param x Argument scalar.
    * @return Result of applying F to the scalar.
    */
-  static inline auto apply(T x) { return F::fun(static_cast<double>(x)); }
+  static inline auto apply(T x) { return F::fun(x); }
   /**
    * The return type, double.
    */
@@ -175,8 +175,6 @@ struct apply_scalar_unary<F, std::vector<T>> {
    * container.
    */
   static inline auto apply(const std::vector<T>& x) {
-    // using inner_t = std::decay_t<plain_type_t<decltype(apply_scalar_unary<F,
-    // T>::apply(x[0]))>>;
     return_t fx(x.size());
     for (size_t i = 0; i < x.size(); ++i) {
       fx[i] = apply_scalar_unary<F, T>::apply(x[i]);

--- a/test/unit/math/mix/fun/abs_test.cpp
+++ b/test/unit/math/mix/fun/abs_test.cpp
@@ -18,8 +18,17 @@ TEST(mixFun, absBasics) {
   std::vector<int> v = abs(u);
 }
 
+template <typename T1, typename T2>
+using is_complex_and_base_ret = stan::bool_constant<
+(!stan::is_complex<stan::scalar_type_t<std::decay_t<T1>>>::value)
+ || (stan::is_complex<stan::scalar_type_t<std::decay_t<T1>>>::value &&
+     !stan::is_complex<stan::scalar_type_t<std::decay_t<T2>>>::value)>;
 TEST(mixFun, abs) {
-  auto f = [](const auto& x) { return stan::math::abs(x); };
+  auto f = [](const auto& x) {
+    auto xx = stan::math::abs(x);
+    static_assert(is_complex_and_base_ret<decltype(x), decltype(xx)>::value, "NO!");
+    return xx;
+  };
   stan::test::expect_common_nonzero_unary(f);
   // 0 (no derivative at 0)
   stan::test::expect_value(f, 0);

--- a/test/unit/math/mix/fun/abs_test.cpp
+++ b/test/unit/math/mix/fun/abs_test.cpp
@@ -20,13 +20,14 @@ TEST(mixFun, absBasics) {
 
 template <typename T1, typename T2>
 using is_complex_and_base_ret = stan::bool_constant<
-(!stan::is_complex<stan::scalar_type_t<std::decay_t<T1>>>::value)
- || (stan::is_complex<stan::scalar_type_t<std::decay_t<T1>>>::value &&
-     !stan::is_complex<stan::scalar_type_t<std::decay_t<T2>>>::value)>;
+    (!stan::is_complex<stan::scalar_type_t<std::decay_t<T1>>>::value)
+    || (stan::is_complex<stan::scalar_type_t<std::decay_t<T1>>>::value
+        && !stan::is_complex<stan::scalar_type_t<std::decay_t<T2>>>::value)>;
 TEST(mixFun, abs) {
   auto f = [](const auto& x) {
     auto xx = stan::math::abs(x);
-    static_assert(is_complex_and_base_ret<decltype(x), decltype(xx)>::value, "if x is complex<T> the return must not be T!");
+    static_assert(is_complex_and_base_ret<decltype(x), decltype(xx)>::value,
+                  "if x is complex<T> the return must not be T!");
     return xx;
   };
   stan::test::expect_common_nonzero_unary(f);

--- a/test/unit/math/mix/fun/abs_test.cpp
+++ b/test/unit/math/mix/fun/abs_test.cpp
@@ -26,7 +26,7 @@ using is_complex_and_base_ret = stan::bool_constant<
 TEST(mixFun, abs) {
   auto f = [](const auto& x) {
     auto xx = stan::math::abs(x);
-    static_assert(is_complex_and_base_ret<decltype(x), decltype(xx)>::value, "NO!");
+    static_assert(is_complex_and_base_ret<decltype(x), decltype(xx)>::value, "if x is complex<T> the return must not be T!");
     return xx;
   };
   stan::test::expect_common_nonzero_unary(f);


### PR DESCRIPTION

## Summary

Fix for #2737 so that `abs(complex<T>)` returns the type `T` and not `complex<T>`.

@WardBrian can you try this branch out with your stanc3 branch? This should have the stuff in it to allow the full vectorization.

@bob-carpenter this does also touch `apply_scalar_unary`, do we want `abs(int)` to return `int` or `double`? Right now it returns `double` but I modified `apply_scalar_unary` to return the same type as the output of the function we pass it (so `sin(int)` would still return an `double` but `abs(int)` can return an `int`. Is that alright?



## Tests

A static assert is added to the `abs()` test to make sure that if we have `complex<T>` as the input we get back `T` as the output.

## Side Effects

The `apply_scalar_unary` change is one we should discuss to make sure it's still doing what we would like.

## Release notes

Fix #2737

## Checklist

- [x] Math issue #2737 

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
