### PR TITLE
Support norm1 and norm2 for std::vectors

### DIFF
--- a/stan/math/fwd/fun/norm1.hpp
+++ b/stan/math/fwd/fun/norm1.hpp
@@ -21,7 +21,7 @@ namespace math {
  * @return L1 norm of x.
  */
 template <typename Container,
-          require_container_st<is_fvar, Container>* = nullptr>
+          require_eigen_vector_vt<is_fvar, Container>* = nullptr>
 inline auto norm1(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [&](const auto& v) {

--- a/stan/math/fwd/fun/norm2.hpp
+++ b/stan/math/fwd/fun/norm2.hpp
@@ -19,7 +19,7 @@ namespace math {
  * @return L2 norm of x.
  */
 template <typename Container,
-          require_container_st<is_fvar, Container>* = nullptr>
+          require_eigen_vector_vt<is_fvar, Container>* = nullptr>
 inline auto norm2(const Container& x) {
   return apply_vector_unary<ref_type_t<Container>>::reduce(
       to_ref(x), [&](const auto& v) {

--- a/stan/math/prim/fun/norm1.hpp
+++ b/stan/math/prim/fun/norm1.hpp
@@ -16,11 +16,24 @@ namespace math {
  * @param v Vector.
  * @return L1 norm of v.
  */
-template <typename Container, require_st_arithmetic<Container>* = nullptr,
-          require_container_t<Container>* = nullptr>
+template <typename T, require_eigen_vector_vt<std::is_arithmetic, T>* = nullptr>
+inline double norm1(const T& v) {
+  ref_type_t<T> v_ref = v;
+  return v_ref.template lpNorm<1>();
+}
+
+/**
+ * Returns L1 norm of a vector. For vectors that equals the
+ * sum of magnitudes of its individual elements.
+ *
+ * @tparam Container type of the vector (must be derived from \c std::Vector)
+ * @param v Vector.
+ * @return L1 norm of v.
+ */
+template <typename Container, require_std_vector_t<Container>* = nullptr>
 inline auto norm1(const Container& x) {
-  return apply_vector_unary<ref_type_t<Container>>::reduce(
-      to_ref(x), [](const auto& v) { return v.template lpNorm<1>(); });
+  return apply_vector_unary<Container>::reduce(
+      x, [](const auto& v) { return norm1(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -16,11 +16,24 @@ namespace math {
  * @param v Vector.
  * @return L2 norm of v.
  */
-template <typename Container, require_st_arithmetic<Container>* = nullptr,
-          require_container_t<Container>* = nullptr>
+template <typename T, require_eigen_vector_vt<std::is_arithmetic, T>* = nullptr>
+inline double norm2(const T& v) {
+  ref_type_t<T> v_ref = v;
+  return v_ref.template lpNorm<2>();
+}
+
+/**
+ * Returns L2 norm of a vector. For vectors that equals the square-root of the
+ * sum of squares of the elements.
+ *
+ * @tparam Container type of the vector (must be derived from \c std::vector)
+ * @param v Vector.
+ * @return L2 norm of v.
+ */
+template <typename Container, require_std_vector_t<Container>* = nullptr>
 inline auto norm2(const Container& x) {
-  return apply_vector_unary<ref_type_t<Container>>::reduce(
-      to_ref(x), [](const auto& v) { return v.template lpNorm<2>(); });
+  return apply_vector_unary<Container>::reduce(
+      x, [](const auto& v) { return norm2(v); });
 }
 
 }  // namespace math

--- a/test/unit/math/mix/fun/norm1_test.cpp
+++ b/test/unit/math/mix/fun/norm1_test.cpp
@@ -19,4 +19,11 @@ TEST(MathMixMatFun, norm1) {
     stan::test::expect_ad(f, a);
     stan::test::expect_ad_matvar(f, a);
   }
+
+  std::vector<Eigen::VectorXd> vec_eig{x3, x3, x3};
+  stan::test::expect_ad(f, vec_eig);
+  stan::test::expect_ad_matvar(f, vec_eig);
+
+  std::vector<double> vec_real{1, 2, 3, 4};
+  stan::test::expect_ad(f, vec_real);
 }

--- a/test/unit/math/mix/fun/norm2_test.cpp
+++ b/test/unit/math/mix/fun/norm2_test.cpp
@@ -19,4 +19,11 @@ TEST(MathMixMatFun, norm2) {
     stan::test::expect_ad(f, a);
     stan::test::expect_ad_matvar(f, a);
   }
+
+  std::vector<Eigen::VectorXd> vec_eig{x3, x3, x3};
+  stan::test::expect_ad(f, vec_eig);
+  stan::test::expect_ad_matvar(f, vec_eig);
+
+  std::vector<double> vec_real{1, 2, 3, 4};
+  stan::test::expect_ad(f, vec_real);
 }


### PR DESCRIPTION
## Summary

This implements vectorized versions of `norm1` and `norm2` which will accept a std::vector of scalars or of eigen types. The implementation is more or less directly taken from @andrjohns comment [here](https://github.com/stan-dev/stanc3/pull/1140#issuecomment-1059917410)

## Tests

I added basic tests of `std::vector<double>` and `std::vector<Eigen::VectorXd>` in addition to the tests already present.

I've also tested the accompanying stanc3 PR by @yizhang-yiz (https://github.com/stan-dev/stanc3/pull/1140)  with this branch, [here](https://jenkins.flatironinstitute.org/blue/organizations/jenkins/Stan%2FStanc3/detail/PR-1140/29/pipeline/)

## Side Effects

This allows us to expose signatures like `norm1(array[] real) => real` in the Stan language. We could also expose deeper nested versions like `norm1(array[] vector)`.

## Release notes

`norm1` and `norm2` were extended with the `apply_vector_unary` to accept general std::vectors as well as the Eigen vectors previously supported. 

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
