### PR TITLE
Add analytic derivatives for fft, inv_fft

### DIFF
--- a/stan/math/prim/fun/fft.hpp
+++ b/stan/math/prim/fun/fft.hpp
@@ -61,7 +61,6 @@ inline Eigen::Matrix<scalar_type_t<V>, -1, 1> fft(const V& x) {
  * @param[in] y vector to inverse transform
  * @return inverse discrete Fourier transform of `y`
  */
-
 template <typename V, require_eigen_vector_vt<is_complex, V>* = nullptr,
           require_not_var_t<base_type_t<value_type_t<V>>>* = nullptr>
 inline Eigen::Matrix<scalar_type_t<V>, -1, 1> inv_fft(const V& y) {

--- a/stan/math/prim/fun/fft.hpp
+++ b/stan/math/prim/fun/fft.hpp
@@ -30,7 +30,8 @@ namespace math {
  * @param[in] x vector to transform
  * @return discrete Fourier transform of `x`
  */
-template <typename V, require_eigen_vector_vt<is_complex, V>* = nullptr>
+template <typename V, require_eigen_vector_vt<is_complex, V>* = nullptr,
+          require_not_var_t<base_type_t<value_type_t<V>>>* = nullptr>
 inline Eigen::Matrix<scalar_type_t<V>, -1, 1> fft(const V& x) {
   // copy because fft() requires Eigen::Matrix type
   Eigen::Matrix<scalar_type_t<V>, -1, 1> xv = x;
@@ -60,7 +61,9 @@ inline Eigen::Matrix<scalar_type_t<V>, -1, 1> fft(const V& x) {
  * @param[in] y vector to inverse transform
  * @return inverse discrete Fourier transform of `y`
  */
-template <typename V, require_eigen_vector_vt<is_complex, V>* = nullptr>
+
+template <typename V, require_eigen_vector_vt<is_complex, V>* = nullptr,
+          require_not_var_t<base_type_t<value_type_t<V>>>* = nullptr>
 inline Eigen::Matrix<scalar_type_t<V>, -1, 1> inv_fft(const V& y) {
   // copy because fft() requires Eigen::Matrix type
   Eigen::Matrix<scalar_type_t<V>, -1, 1> yv = y;

--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -61,6 +61,7 @@
 #include <stan/math/rev/fun/fabs.hpp>
 #include <stan/math/rev/fun/falling_factorial.hpp>
 #include <stan/math/rev/fun/fdim.hpp>
+#include <stan/math/rev/fun/fft.hpp>
 #include <stan/math/rev/fun/fill.hpp>
 #include <stan/math/rev/fun/floor.hpp>
 #include <stan/math/rev/fun/fma.hpp>

--- a/stan/math/rev/fun/fft.hpp
+++ b/stan/math/rev/fun/fft.hpp
@@ -1,0 +1,62 @@
+#ifndef STAN_MATH_REV_FUN_FFT_HPP
+#define STAN_MATH_REV_FUN_FFT_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/typedefs.hpp>
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/prim/fun/fft.hpp>
+#include <stan/math/prim/fun/to_complex.hpp>
+#include <Eigen/Dense>
+#include <complex>
+#include <type_traits>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+template <typename V, require_eigen_vector_vt<is_complex, V>* = nullptr,
+          require_var_t<base_type_t<value_type_t<V>>>* = nullptr>
+inline plain_type_t<V> fft(const V& v) {
+  if (unlikely(v.size() <= 1)) {
+    return plain_type_t<V>(v);
+  }
+
+  arena_t<V> arena_v = v;
+  arena_t<V> res = fft(to_complex(arena_v.real().val(), arena_v.imag().val()));
+
+  reverse_pass_callback([arena_v, res]() mutable {
+    // adjoint(x) += length(y) * ifft(adjoint(y))
+    auto adj_inv_fft = inv_fft(to_complex(res.real().adj(), res.imag().adj()));
+    adj_inv_fft *= res.size();
+    arena_v.real().adj() += adj_inv_fft.real();
+    arena_v.imag().adj() += adj_inv_fft.imag();
+  });
+
+  return plain_type_t<V>(res);
+}
+
+template <typename V, require_eigen_vector_vt<is_complex, V>* = nullptr,
+          require_var_t<base_type_t<value_type_t<V>>>* = nullptr>
+inline plain_type_t<V> inv_fft(const V& v) {
+  if (unlikely(v.size() <= 1)) {
+    return plain_type_t<V>(v);
+  }
+
+  arena_t<V> arena_v = v;
+  arena_t<V> res
+      = inv_fft(to_complex(arena_v.real().val(), arena_v.imag().val()));
+
+  reverse_pass_callback([arena_v, res]() mutable {
+    // adjoint(x) += (1 / length(y)) * fft(adjoint(y))
+    auto adj_fft = fft(to_complex(res.real().adj(), res.imag().adj()));
+    adj_fft /= res.size();
+
+    arena_v.real().adj() += adj_fft.real();
+    arena_v.imag().adj() += adj_fft.imag();
+  });
+  return plain_type_t<V>(res);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/fun/fft.hpp
+++ b/stan/math/rev/fun/fft.hpp
@@ -14,18 +14,40 @@
 namespace stan {
 namespace math {
 
+/**
+ * Return the discrete Fourier transform of the specified complex
+ * vector.
+ *
+ * Given an input complex vector `x[0:N-1]` of size `N`, the discrete
+ * Fourier transform computes entries of the resulting complex
+ * vector `y[0:N-1]` by
+ *
+ * ```
+ * y[n] = SUM_{i < N} x[i] * exp(-n * i * 2 * pi * sqrt(-1) / N)
+ * ```
+ *
+ * The adjoint computation is given by
+ * ```
+ * adjoint(x) += length(y) * inv_fft(adjoint(y))
+ * ```
+ *
+ * If the input is of size zero, the result is a size zero vector.
+ *
+ * @tparam V type of complex vector argument
+ * @param[in] x vector to transform
+ * @return discrete Fourier transform of `x`
+ */
 template <typename V, require_eigen_vector_vt<is_complex, V>* = nullptr,
           require_var_t<base_type_t<value_type_t<V>>>* = nullptr>
-inline plain_type_t<V> fft(const V& v) {
-  if (unlikely(v.size() <= 1)) {
-    return plain_type_t<V>(v);
+inline plain_type_t<V> fft(const V& x) {
+  if (unlikely(x.size() <= 1)) {
+    return plain_type_t<V>(x);
   }
 
-  arena_t<V> arena_v = v;
+  arena_t<V> arena_v = x;
   arena_t<V> res = fft(to_complex(arena_v.real().val(), arena_v.imag().val()));
 
   reverse_pass_callback([arena_v, res]() mutable {
-    // adjoint(x) += length(y) * ifft(adjoint(y))
     auto adj_inv_fft = inv_fft(to_complex(res.real().adj(), res.imag().adj()));
     adj_inv_fft *= res.size();
     arena_v.real().adj() += adj_inv_fft.real();
@@ -35,19 +57,43 @@ inline plain_type_t<V> fft(const V& v) {
   return plain_type_t<V>(res);
 }
 
+/**
+ * Return the inverse discrete Fourier transform of the specified
+ * complex vector.
+ *
+ * Given an input complex vector `y[0:N-1]` of size `N`, the inverse
+ * discrete Fourier transform computes entries of the resulting
+ * complex vector `x[0:N-1]` by
+ *
+ * ```
+ * x[n] = SUM_{i < N} y[i] * exp(n * i * 2 * pi * sqrt(-1) / N)
+ * ```
+ *
+ *  * The adjoint computation is given by
+ * ```
+ * adjoint(y) += (1 / length(x)) * fft(adjoint(x))
+ * ```
+ *
+ * If the input is of size zero, the result is a size zero vector.
+ * The only difference between the discrete DFT and its inverse is
+ * the sign of the exponent.
+ *
+ * @tparam V type of complex vector argument
+ * @param[in] y vector to inverse transform
+ * @return inverse discrete Fourier transform of `y`
+ */
 template <typename V, require_eigen_vector_vt<is_complex, V>* = nullptr,
           require_var_t<base_type_t<value_type_t<V>>>* = nullptr>
-inline plain_type_t<V> inv_fft(const V& v) {
-  if (unlikely(v.size() <= 1)) {
-    return plain_type_t<V>(v);
+inline plain_type_t<V> inv_fft(const V& y) {
+  if (unlikely(y.size() <= 1)) {
+    return plain_type_t<V>(y);
   }
 
-  arena_t<V> arena_v = v;
+  arena_t<V> arena_v = y;
   arena_t<V> res
       = inv_fft(to_complex(arena_v.real().val(), arena_v.imag().val()));
 
   reverse_pass_callback([arena_v, res]() mutable {
-    // adjoint(x) += (1 / length(y)) * fft(adjoint(y))
     auto adj_fft = fft(to_complex(res.real().adj(), res.imag().adj()));
     adj_fft /= res.size();
 


### PR DESCRIPTION
## Summary

Adds reverse-mode specializations to `fft` and `inv_fft`. FFT has reverse mode `adjoint(x) += length(y) * ifft(adjoint(y))`, iFFT is `adjoint(x) += (1 / length(y)) * fft(adjoint(y))`

This uses #2749. If we added #2747, the code would become slightly cleaner, but this isn't too bad.

## Tests

Existing tests in `test/unit/math/mix/fun/fft_test` pass

## Side Effects

None

## Release notes

Added reverse-mode specializations for `fft` and `inv_fft`

## Checklist

- [x] Math issue: Closes #2740 

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
