### PR TITLE
[WIP] Allow distributions to return vectors

### DIFF
--- a/stan/math/fwd/functor/operands_and_partials.hpp
+++ b/stan/math/fwd/functor/operands_and_partials.hpp
@@ -111,7 +111,8 @@ class operands_and_partials<Op1, Op2, Op3, Op4, Op5, fvar<Dx>> {
   template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
   auto build(EigVec&& value) {
     Eigen::Array<fvar<Dx>, -1, 1> ret(value.template cast<fvar<Dx>>());
-    ret.d() = (edge1_.dx_v() + edge2_.dx_v() + edge3_.dx_v() + edge4_.dx_v() + edge5_.dx_v());
+    ret.d() = (edge1_.dx_v() + edge2_.dx_v() + edge3_.dx_v() + edge4_.dx_v()
+               + edge5_.dx_v());
     return ret;
   }
 };
@@ -150,7 +151,6 @@ class ops_partials_edge<Dx, std::vector<fvar<Dx>>> {
     }
     return derivative;
   }
-
 };
 
 template <typename Dx, int R, int C>
@@ -215,7 +215,7 @@ class ops_partials_edge<Dx, std::vector<Eigen::Matrix<fvar<Dx>, R, C>>> {
   Eigen::Array<Dx, -1, 1> dx_v() {
     Eigen::Array<Dx, -1, 1> derivative(this->operands_.size());
     for (size_t i = 0; i < this->operands_.size(); ++i) {
-        derivative[i] = this->partials_vec_[i].dot(this->operands_[i].d());
+      derivative[i] = this->partials_vec_[i].dot(this->operands_[i].d());
     }
     return derivative;
   }
@@ -249,7 +249,8 @@ class ops_partials_edge<Dx, std::vector<std::vector<fvar<Dx>>>> {
     return derivative;
   }
   Eigen::Array<Dx, -1, 1> dx_v() {
-    Eigen::Array<Dx, -1, 1> derivative = Eigen::Array<Dx, -1, 1>::Zero(this->operands_.size());
+    Eigen::Array<Dx, -1, 1> derivative
+        = Eigen::Array<Dx, -1, 1>::Zero(this->operands_.size());
     for (size_t i = 0; i < this->operands_.size(); ++i) {
       for (int j = 0; j < this->operands_[i].size(); ++j) {
         derivative[i] = this->partials_vec_[i][j] * this->operands_[i][j].d_;

--- a/stan/math/prim/functor/operands_and_partials.hpp
+++ b/stan/math/prim/functor/operands_and_partials.hpp
@@ -62,6 +62,7 @@ struct ops_partials_edge<ViewElt, Op, require_st_arithmetic<Op>> {
    * expression returning zero.
    */
   static constexpr double dx() noexcept { return 0.0; }
+  static constexpr double dx_v() noexcept { return 0.0; }
   /**
    * Return the size of the operand for the edge. For doubles this is a compile
    * time expression returning zero.

--- a/stan/math/prim/functor/operands_and_partials.hpp
+++ b/stan/math/prim/functor/operands_and_partials.hpp
@@ -139,7 +139,8 @@ class operands_and_partials {
    * @param value the return value of the function we are compressing
    * @return the value with its derivative
    */
-  inline double build(double value) const noexcept { return value; }
+  template <typename T>
+  inline auto build(T&& value) const noexcept { return std::forward<T>(value); }
 
   // These will always be 0 size base template instantiations (above).
   internal::ops_partials_edge<double, std::decay_t<Op1>> edge1_;

--- a/stan/math/prim/functor/prob_reducer.hpp
+++ b/stan/math/prim/functor/prob_reducer.hpp
@@ -1,16 +1,16 @@
 #ifndef STAN_MATH_PRIM_FUNCTOR_PROB_REDUCER_HPP
 #define STAN_MATH_PRIM_FUNCTOR_PROB_REDUCER_HPP
 
-
 #include <stan/math/prim/meta.hpp>
 
 namespace stan {
 namespace math {
 
 /**
- * Used by distributions to decide whether return type shoudl be Scalar or Vector.
+ * Used by distributions to decide whether return type shoudl be Scalar or
+ * Vector.
  */
-enum class ProbReturnType {Scalar, Vector};
+enum class ProbReturnType { Scalar, Vector };
 
 /**
  * For scalars performs summations and is a no-op reducer for eigen vectors.
@@ -25,7 +25,7 @@ struct prob_reducer;
  */
 template <typename T>
 struct prob_reducer<T, require_stan_scalar_t<T>> {
-  T ret_; // Underlying return type
+  T ret_;  // Underlying return type
 
   /**
    * Construct from an Eigen type
@@ -41,9 +41,11 @@ struct prob_reducer<T, require_stan_scalar_t<T>> {
    * @tparam Tossed An integral type
    * @param x will be summed and passed into `ret_`.
    */
-  template <typename EigArr, typename Tossed, require_eigen_t<EigArr>* = nullptr,
-   require_integral_t<Tossed>* = nullptr>
-  prob_reducer(EigArr&& x, Tossed&& /* */) : ret_(sum(std::forward<EigArr>(x))) {}
+  template <typename EigArr, typename Tossed,
+            require_eigen_t<EigArr>* = nullptr,
+            require_integral_t<Tossed>* = nullptr>
+  prob_reducer(EigArr&& x, Tossed&& /* */)
+      : ret_(sum(std::forward<EigArr>(x))) {}
 
   /**
    * Construct from a scalar type.
@@ -59,7 +61,8 @@ struct prob_reducer<T, require_stan_scalar_t<T>> {
    * @tparam Tossed an integral type
    * @param x will be summed and inserted into `ret_`.
    */
-  template <typename Scalar, typename Tossed, require_stan_scalar_t<Scalar>* = nullptr>
+  template <typename Scalar, typename Tossed,
+            require_stan_scalar_t<Scalar>* = nullptr>
   prob_reducer(Scalar&& x, Tossed&& /* */) : ret_(x) {}
 
   /**
@@ -119,9 +122,7 @@ struct prob_reducer<T, require_stan_scalar_t<T>> {
   /**
    * Return the underlying scalar return type.
    */
-  inline auto ret() noexcept {
-    return ret_;
-  }
+  inline auto ret() noexcept { return ret_; }
 
   /**
    * Return a zero value, used when distribution has special cases that
@@ -132,7 +133,6 @@ struct prob_reducer<T, require_stan_scalar_t<T>> {
   static auto zero(int /* */) {
     return return_type_t<Types...>(0);
   }
-
 };
 
 template <typename T>
@@ -153,7 +153,8 @@ struct prob_reducer<T, require_eigen_t<T>> {
    * @tparam Tossed An integral type
    * @param x will be forwarded to `ret_`.
    */
-  template <typename EigArr, typename Size, require_eigen_t<EigArr>* = nullptr, require_integral_t<Size>* = nullptr>
+  template <typename EigArr, typename Size, require_eigen_t<EigArr>* = nullptr,
+            require_integral_t<Size>* = nullptr>
   prob_reducer(EigArr&& x, Size /* x */) : ret_(std::forward<EigArr>(x)) {}
 
   /**
@@ -163,8 +164,9 @@ struct prob_reducer<T, require_eigen_t<T>> {
    * @param x passed to `ret_` along with size to fill with a base value.
    * @param n The size `ret_` should be
    */
-  template <typename Scalar, typename Size, require_stan_scalar_t<Scalar>* = nullptr,
-   require_integral_t<Size>* = nullptr>
+  template <typename Scalar, typename Size,
+            require_stan_scalar_t<Scalar>* = nullptr,
+            require_integral_t<Size>* = nullptr>
   prob_reducer(Scalar constant, Size n) : ret_(T::Constant(n, constant)) {}
 
   /**
@@ -216,9 +218,7 @@ struct prob_reducer<T, require_eigen_t<T>> {
    * Return the underlying scalar return type. Passed the underlying by
    * moving it which can cause `ret_` to be uninitialized after.
    */
-  inline auto&& ret() noexcept {
-    return std::move(ret_);
-  }
+  inline auto&& ret() noexcept { return std::move(ret_); }
 
   /**
    * Return a zero value, used when distribution has special cases that
@@ -228,20 +228,23 @@ struct prob_reducer<T, require_eigen_t<T>> {
    */
   template <typename... Types>
   static auto zero(int size) {
-    return Eigen::Array<return_type_t<Types...>, -1, 1>::Constant(0, size).eval();
+    return Eigen::Array<return_type_t<Types...>, -1, 1>::Constant(0, size)
+        .eval();
   }
-
 };
 
 /**
  * Generate a reducer with correct return type.
  * @tparam ReturnType Either Scalar or Vector.
- * @tparam Types A parameter pack of types to deduce the underlying scalar type from
+ * @tparam Types A parameter pack of types to deduce the underlying scalar type
+ * from
  */
 template <ProbReturnType ReturnType, typename... Types>
-using prob_return_t = prob_reducer<std::conditional_t<ReturnType == ProbReturnType::Scalar, return_type_t<Types...>, Eigen::Array<return_type_t<Types...>, -1, 1>>>;
+using prob_return_t = prob_reducer<std::conditional_t<
+    ReturnType == ProbReturnType::Scalar, return_type_t<Types...>,
+    Eigen::Array<return_type_t<Types...>, -1, 1>>>;
 
-}
-}
+}  // namespace math
+}  // namespace stan
 
 #endif

--- a/stan/math/prim/functor/prob_reducer.hpp
+++ b/stan/math/prim/functor/prob_reducer.hpp
@@ -1,0 +1,247 @@
+#ifndef STAN_MATH_PRIM_FUNCTOR_PROB_REDUCER_HPP
+#define STAN_MATH_PRIM_FUNCTOR_PROB_REDUCER_HPP
+
+
+#include <stan/math/prim/meta.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Used by distributions to decide whether return type shoudl be Scalar or Vector.
+ */
+enum class ProbReturnType {Scalar, Vector};
+
+/**
+ * For scalars performs summations and is a no-op reducer for eigen vectors.
+ * Used in the probability distributions for scalar or vector return types.
+ */
+template <typename T, typename = void>
+struct prob_reducer;
+
+/**
+ * For scalars performs summations when given eigen types.
+ * @tparam A stan scalar type
+ */
+template <typename T>
+struct prob_reducer<T, require_stan_scalar_t<T>> {
+  T ret_; // Underlying return type
+
+  /**
+   * Construct from an Eigen type
+   * @tparam EigArr A type inheriting from `Eigen::EigenBase`
+   * @param x will be summed and passed into `ret_`.
+   */
+  template <typename EigArr, require_eigen_t<EigArr>* = nullptr>
+  prob_reducer(EigArr&& x) : ret_(sum(std::forward<EigArr>(x))) {}
+
+  /**
+   * Construct from an Eigen type while ignoring size argument passed.
+   * @tparam EigArr A type inheriting from `Eigen::EigenBase`
+   * @tparam Tossed An integral type
+   * @param x will be summed and passed into `ret_`.
+   */
+  template <typename EigArr, typename Tossed, require_eigen_t<EigArr>* = nullptr,
+   require_integral_t<Tossed>* = nullptr>
+  prob_reducer(EigArr&& x, Tossed&& /* */) : ret_(sum(std::forward<EigArr>(x))) {}
+
+  /**
+   * Construct from a scalar type.
+   * @tparam Scalar a scalar
+   * @param x passed to `ret_`.
+   */
+  template <typename Scalar, require_stan_scalar_t<Scalar>* = nullptr>
+  prob_reducer(Scalar&& x) : ret_(x) {}
+
+  /**
+   * Construct from an Eigen type while ignoring size argument passed.
+   * @tparam Scalar a scalar
+   * @tparam Tossed an integral type
+   * @param x will be summed and inserted into `ret_`.
+   */
+  template <typename Scalar, typename Tossed, require_stan_scalar_t<Scalar>* = nullptr>
+  prob_reducer(Scalar&& x, Tossed&& /* */) : ret_(x) {}
+
+  /**
+   * Perform summation and then assignment
+   * @tparam EigArr A type inheriting from `Eigen::EigenBase`
+   */
+  template <typename EigArr, require_eigen_t<EigArr>* = nullptr>
+  inline auto operator=(EigArr&& x) {
+    ret_ = sum(x);
+    return *this;
+  }
+
+  /**
+   * Assignment
+   * @tparam Scalar A scalar type
+   */
+  template <typename Scalar, require_stan_scalar_t<Scalar>* = nullptr>
+  inline auto operator=(Scalar x) {
+    ret_ = x;
+    return *this;
+  }
+
+  /**
+   * Perform summation and then `+=`
+   * @tparam EigArr A type inheriting from `Eigen::EigenBase`
+   * @param x Eigen object to be summed.
+   */
+  template <typename EigArr, require_eigen_t<EigArr>* = nullptr>
+  inline auto operator+=(EigArr&& x) {
+    ret_ += sum(x);
+    return *this;
+  }
+
+  template <typename Scalar, require_stan_scalar_t<Scalar>* = nullptr>
+  inline auto operator+=(Scalar&& x) {
+    ret_ += x;
+    return *this;
+  }
+
+  /**
+   * Perform summation and then `-=`
+   * @tparam EigArr A type inheriting from `Eigen::EigenBase`
+   * @param x Eigen object to be summed.
+   */
+  template <typename EigArr, require_eigen_t<EigArr>* = nullptr>
+  inline auto operator-=(EigArr&& x) {
+    ret_ -= sum(x);
+    return *this;
+  }
+
+  template <typename Scalar, require_stan_scalar_t<Scalar>* = nullptr>
+  inline auto operator-=(Scalar&& x) {
+    ret_ -= x;
+    return *this;
+  }
+
+  /**
+   * Return the underlying scalar return type.
+   */
+  inline auto ret() noexcept {
+    return ret_;
+  }
+
+  /**
+   * Return a zero value, used when distribution has special cases that
+   *  immedietly return zero.
+   * @tparam Types types to deduce the overall return type of the function.
+   */
+  template <typename... Types>
+  static auto zero(int /* */) {
+    return return_type_t<Types...>(0);
+  }
+
+};
+
+template <typename T>
+struct prob_reducer<T, require_eigen_t<T>> {
+  T ret_;
+
+  /**
+   * Construct from an Eigen type
+   * @tparam EigArr A type inheriting from `Eigen::EigenBase`
+   * @param x will be forwarded into `ret_`.
+   */
+  template <typename EigArr, require_eigen_t<EigArr>* = nullptr>
+  prob_reducer(EigArr&& x) : ret_(std::forward<EigArr>(x)) {}
+
+  /**
+   * Construct from an Eigen type while ignoring size argument passed.
+   * @tparam EigArr A type inheriting from `Eigen::EigenBase`
+   * @tparam Tossed An integral type
+   * @param x will be forwarded to `ret_`.
+   */
+  template <typename EigArr, typename Size, require_eigen_t<EigArr>* = nullptr, require_integral_t<Size>* = nullptr>
+  prob_reducer(EigArr&& x, Size /* x */) : ret_(std::forward<EigArr>(x)) {}
+
+  /**
+   * Construct from a scalar type.
+   * @tparam Scalar a scalar
+   * @tparam Size An integral type
+   * @param x passed to `ret_` along with size to fill with a base value.
+   * @param n The size `ret_` should be
+   */
+  template <typename Scalar, typename Size, require_stan_scalar_t<Scalar>* = nullptr,
+   require_integral_t<Size>* = nullptr>
+  prob_reducer(Scalar constant, Size n) : ret_(T::Constant(n, constant)) {}
+
+  /**
+   * assignment
+   * @tparam EigArr A type inheriting from `Eigen::EigenBase`
+   */
+  template <typename EigArr, require_eigen_t<EigArr>* = nullptr>
+  inline auto operator=(EigArr&& x) {
+    ret_ = std::forward<EigArr>(x);
+    return *this;
+  }
+
+  /**
+   * assignm scalar by propogating value over `ret_`
+   * @tparam Scalar a stan scalar
+   * @param x The value to fill `ret_` with.
+   */
+  template <typename Scalar, require_stan_scalar_t<Scalar>* = nullptr>
+  inline auto operator=(Scalar x) {
+    ret_ = Eigen::Array<value_type_t<T>, -1, 1>::Constant(x, ret_.size());
+    return *this;
+  }
+
+  template <typename EigArr, require_eigen_t<EigArr>* = nullptr>
+  inline auto operator+=(EigArr&& x) {
+    ret_ += std::forward<EigArr>(x);
+    return *this;
+  }
+
+  template <typename Scalar, require_stan_scalar_t<Scalar>* = nullptr>
+  inline auto operator+=(Scalar&& x) {
+    ret_ += x;
+    return *this;
+  }
+
+  template <typename EigArr, require_eigen_t<EigArr>* = nullptr>
+  inline auto operator-=(EigArr&& x) {
+    ret_ -= std::forward<EigArr>(x);
+    return *this;
+  }
+
+  template <typename Scalar, require_stan_scalar_t<Scalar>* = nullptr>
+  inline auto operator-=(Scalar&& x) {
+    ret_ -= x;
+    return *this;
+  }
+
+  /**
+   * Return the underlying scalar return type. Passed the underlying by
+   * moving it which can cause `ret_` to be uninitialized after.
+   */
+  inline auto&& ret() noexcept {
+    return std::move(ret_);
+  }
+
+  /**
+   * Return a zero value, used when distribution has special cases that
+   *  immedietly return zero.
+   * @tparam Types types to deduce the overall return type of the function.
+   * @param size The size of the array to return
+   */
+  template <typename... Types>
+  static auto zero(int size) {
+    return Eigen::Array<return_type_t<Types...>, -1, 1>::Constant(0, size).eval();
+  }
+
+};
+
+/**
+ * Generate a reducer with correct return type.
+ * @tparam ReturnType Either Scalar or Vector.
+ * @tparam Types A parameter pack of types to deduce the underlying scalar type from
+ */
+template <ProbReturnType ReturnType, typename... Types>
+using prob_return_t = prob_reducer<std::conditional_t<ReturnType == ProbReturnType::Scalar, return_type_t<Types...>, Eigen::Array<return_type_t<Types...>, -1, 1>>>;
+
+}
+}
+
+#endif

--- a/stan/math/prim/prob/normal_log.hpp
+++ b/stan/math/prim/prob/normal_log.hpp
@@ -29,7 +29,7 @@ namespace math {
  * @tparam T_loc Type of location parameter.
  */
 template <bool propto, typename T_y, typename T_loc, typename T_scale>
-inline return_type_t<T_y, T_loc, T_scale> normal_log(const T_y& y,
+inline auto normal_log(const T_y& y,
                                                      const T_loc& mu,
                                                      const T_scale& sigma) {
   return normal_lpdf<propto>(y, mu, sigma);
@@ -39,7 +39,7 @@ inline return_type_t<T_y, T_loc, T_scale> normal_log(const T_y& y,
  * @deprecated use <code>normal_lpdf</code>
  */
 template <typename T_y, typename T_loc, typename T_scale>
-inline return_type_t<T_y, T_loc, T_scale> normal_log(const T_y& y,
+inline auto normal_log(const T_y& y,
                                                      const T_loc& mu,
                                                      const T_scale& sigma) {
   return normal_lpdf<false>(y, mu, sigma);

--- a/stan/math/prim/prob/normal_log.hpp
+++ b/stan/math/prim/prob/normal_log.hpp
@@ -32,7 +32,7 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale>
 inline return_type_t<T_y, T_loc, T_scale> normal_log(const T_y& y,
                                                      const T_loc& mu,
                                                      const T_scale& sigma) {
-  return normal_lpdf<propto, T_y, T_loc, T_scale>(y, mu, sigma);
+  return normal_lpdf<propto>(y, mu, sigma);
 }
 
 /** \ingroup prob_dists
@@ -42,7 +42,7 @@ template <typename T_y, typename T_loc, typename T_scale>
 inline return_type_t<T_y, T_loc, T_scale> normal_log(const T_y& y,
                                                      const T_loc& mu,
                                                      const T_scale& sigma) {
-  return normal_lpdf<T_y, T_loc, T_scale>(y, mu, sigma);
+  return normal_lpdf<false>(y, mu, sigma);
 }
 
 }  // namespace math

--- a/stan/math/prim/prob/normal_lpdf.hpp
+++ b/stan/math/prim/prob/normal_lpdf.hpp
@@ -39,12 +39,11 @@ namespace math {
  * @return The log of the product of the densities.
  * @throw std::domain_error if the scale is not positive.
  */
-template <bool propto, ProbReturnType RetType = ProbReturnType::Scalar, typename T_y, typename T_loc, typename T_scale,
+template <bool propto, ProbReturnType RetType = ProbReturnType::Scalar,
+          typename T_y, typename T_loc, typename T_scale,
           require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
               T_y, T_loc, T_scale>* = nullptr>
-inline auto normal_lpdf(const T_y& y,
-                                                      const T_loc& mu,
-                                                      const T_scale& sigma) {
+inline auto normal_lpdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
   using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
   using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
@@ -116,9 +115,7 @@ inline auto normal_lpdf(const T_y& y,
 }
 
 template <typename T_y, typename T_loc, typename T_scale>
-inline auto normal_lpdf(const T_y& y,
-                                                      const T_loc& mu,
-                                                      const T_scale& sigma) {
+inline auto normal_lpdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
   return normal_lpdf<false>(y, mu, sigma);
 }
 

--- a/stan/math/rev/functor/operands_and_partials.hpp
+++ b/stan/math/rev/functor/operands_and_partials.hpp
@@ -48,12 +48,25 @@ inline void update_adjoints(var_value<T1>& x, const T2& y, const vari& z) {
   x.adj() += z.adj() * y;
 }
 
+template <typename T1, typename T2,
+          require_all_kernel_expressions_and_none_scalar_t<T1, T2>* = nullptr>
+inline void update_adjoints(var_value<T1>& x, const T2& y, const var& z) {
+  x.adj() += z.adj() * y;
+}
+
 template <typename Scalar1, typename Scalar2, require_var_t<Scalar1>* = nullptr,
           require_not_var_matrix_t<Scalar1>* = nullptr,
           require_arithmetic_t<Scalar2>* = nullptr>
 inline void update_adjoints(Scalar1 x, Scalar2 y, const vari& z) noexcept {
   x.adj() += z.adj() * y;
 }
+template <typename Scalar1, typename Scalar2, require_var_t<Scalar1>* = nullptr,
+          require_not_var_matrix_t<Scalar1>* = nullptr,
+          require_arithmetic_t<Scalar2>* = nullptr>
+inline void update_adjoints(Scalar1 x, Scalar2 y, const var& z) noexcept {
+  x.adj() += z.adj() * y;
+}
+
 template <typename Matrix1, typename Matrix2,
           require_rev_matrix_t<Matrix1>* = nullptr,
           require_st_arithmetic<Matrix2>* = nullptr>
@@ -61,14 +74,34 @@ inline void update_adjoints(Matrix1& x, const Matrix2& y, const vari& z) {
   x.adj().array() += z.adj() * y.array();
 }
 
+template <typename Matrix1, typename Matrix2,
+          require_rev_matrix_t<Matrix1>* = nullptr,
+          require_st_arithmetic<Matrix2>* = nullptr>
+inline void update_adjoints(Matrix1& x, const Matrix2& y, const var& z) {
+  x.adj().array() += z.adj() * y.array();
+}
+
 template <typename Arith, typename Alt, require_st_arithmetic<Arith>* = nullptr>
 inline constexpr void update_adjoints(Arith&& /* x */, Alt&& /* y */,
                                       const vari& /* z */) noexcept {}
+
+template <typename Arith, typename Alt, require_st_arithmetic<Arith>* = nullptr>
+inline constexpr void update_adjoints(Arith&& /* x */, Alt&& /* y */,
+                                      const var& /* z */) noexcept {}
 
 template <typename StdVec1, typename Vec2,
           require_std_vector_t<StdVec1>* = nullptr,
           require_st_arithmetic<Vec2>* = nullptr>
 inline void update_adjoints(StdVec1& x, const Vec2& y, const vari& z) {
+  for (size_t i = 0; i < x.size(); ++i) {
+    update_adjoints(x[i], y[i], z);
+  }
+}
+
+template <typename StdVec1, typename Vec2,
+          require_std_vector_t<StdVec1>* = nullptr,
+          require_st_arithmetic<Vec2>* = nullptr>
+inline void update_adjoints(StdVec1& x, const Vec2& y, const var& z) {
   for (size_t i = 0; i < x.size(); ++i) {
     update_adjoints(x[i], y[i], z);
   }
@@ -95,7 +128,7 @@ inline void update_adjoints(Matrix1& x, const Matrix2& y, const T3& z) {
   x.adj().array() += z.adj() * y.array();
 }
 
-template <typename Arith, typename Alt, require_st_arithmetic<Arith>* = nullptr, typename T3, require_eigen_t<T3>* = nullptr>
+template <typename Arith, typename Alt, typename T3, require_st_arithmetic<Arith>* = nullptr, require_eigen_t<T3>* = nullptr>
 inline constexpr void update_adjoints(Arith&& /* x */, Alt&& /* y */,
                                       const T3& /* z */) noexcept {}
 

--- a/stan/math/rev/functor/operands_and_partials.hpp
+++ b/stan/math/rev/functor/operands_and_partials.hpp
@@ -87,7 +87,7 @@ template <typename Scalar1, typename Scalar2, typename T3, require_var_t<Scalar1
 inline void update_adjoints(Scalar1 x, Scalar2 y, const T3& z) noexcept {
   x.adj() += sum(z.adj() * y);
 }
-template <typename Matrix1, typename Matrix2, typename T3
+template <typename Matrix1, typename Matrix2, typename T3,
           require_rev_matrix_t<Matrix1>* = nullptr,
           require_st_arithmetic<Matrix2>* = nullptr,
           require_eigen_t<T3>* = nullptr>
@@ -214,19 +214,19 @@ class operands_and_partials<Op1, Op2, Op3, Op4, Op5, var> {
             operand5 = edge5_.operand(),
             partial5 = edge5_.partial()]() mutable {
       if (!is_constant<Op1>::value) {
-        internal::update_adjoints(operand1, partial1, vi);
+        internal::update_adjoints(operand1, partial1, ret);
       }
       if (!is_constant<Op2>::value) {
-        internal::update_adjoints(operand2, partial2, vi);
+        internal::update_adjoints(operand2, partial2, ret);
       }
       if (!is_constant<Op3>::value) {
-        internal::update_adjoints(operand3, partial3, vi);
+        internal::update_adjoints(operand3, partial3, ret);
       }
       if (!is_constant<Op4>::value) {
-        internal::update_adjoints(operand4, partial4, vi);
+        internal::update_adjoints(operand4, partial4, ret);
       }
       if (!is_constant<Op5>::value) {
-        internal::update_adjoints(operand5, partial5, vi);
+        internal::update_adjoints(operand5, partial5, ret);
       }
     });
     return plain_type_t<promote_scalar_t<var, T>>(ret);

--- a/test/unit/math/fwd/prob/normal_vectorized_test.cpp
+++ b/test/unit/math/fwd/prob/normal_vectorized_test.cpp
@@ -1,0 +1,11 @@
+#include <stan/math/fwd.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbNormal, fvar_test_vlpdf) {
+  using stan::math::fvar;
+  Eigen::Matrix<fvar<double>, -1, 1> Y = Eigen::Matrix<double, -1, 1>::Random(5);
+  Eigen::Matrix<fvar<double>, -1, 1> Mu = Eigen::Matrix<double, -1, 1>::Random(5);
+  Eigen::Matrix<fvar<double>, -1, 1> Sigma = stan::math::abs(Eigen::Matrix<double, -1, 1>::Random(5));
+  Eigen::Matrix<fvar<double>, -1, 1> A = stan::math::normal_lpdf<false, stan::math::ProbReturnType::Vector>(Y, Mu, Sigma);
+
+}

--- a/test/unit/math/mix/prob/normal_test.cpp
+++ b/test/unit/math/mix/prob/normal_test.cpp
@@ -13,15 +13,15 @@ TEST(mathMixScalFun, normal_lpdf) {
 
 TEST(mathMixScalFun, vnormal_lpdf) {
   auto f = [](const auto& y, const auto& mu, const auto& sigma) {
-    return stan::math::normal_lpdf<true, stan::math::ProbReturnType::Vector>(y, mu, sigma);
+    return stan::math::normal_lpdf<true, stan::math::ProbReturnType::Vector>(
+        y, mu, sigma);
   };
   Eigen::VectorXd y = Eigen::VectorXd::Random(5);
-  //y << 0, 0;
+  // y << 0, 0;
   Eigen::VectorXd mu = Eigen::VectorXd::Random(5);
-  //mu << 0, 0;
+  // mu << 0, 0;
   Eigen::VectorXd sigma = stan::math::abs(Eigen::VectorXd::Random(5));
-  //sigma << 1, 1;
+  // sigma << 1, 1;
   stan::test::expect_ad_distribution(f, y, mu, sigma);
-  //stan::test::expect_ad(f, y, mu, sigma);
-
+  // stan::test::expect_ad(f, y, mu, sigma);
 }

--- a/test/unit/math/mix/prob/normal_test.cpp
+++ b/test/unit/math/mix/prob/normal_test.cpp
@@ -1,5 +1,5 @@
 #include <stan/math/mix.hpp>
-#include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/test_distribution_ad.hpp>
 
 TEST(mathMixScalFun, normal_lpdf) {
   auto f = [](const double mu, const double sigma) {
@@ -9,4 +9,19 @@ TEST(mathMixScalFun, normal_lpdf) {
   stan::test::expect_ad(f(0, 1), -2.3);
   stan::test::expect_ad(f(0, 1), 0.0);
   stan::test::expect_ad(f(0, 1), 1.7);
+}
+
+TEST(mathMixScalFun, vnormal_lpdf) {
+  auto f = [](const auto& y, const auto& mu, const auto& sigma) {
+    return stan::math::normal_lpdf<true, stan::math::ProbReturnType::Vector>(y, mu, sigma);
+  };
+  Eigen::VectorXd y = Eigen::VectorXd::Random(5);
+  //y << 0, 0;
+  Eigen::VectorXd mu = Eigen::VectorXd::Random(5);
+  //mu << 0, 0;
+  Eigen::VectorXd sigma = stan::math::abs(Eigen::VectorXd::Random(5));
+  //sigma << 1, 1;
+  stan::test::expect_ad_distribution(f, y, mu, sigma);
+  //stan::test::expect_ad(f, y, mu, sigma);
+
 }

--- a/test/unit/math/mix/prob/test_distribution_ad.hpp
+++ b/test/unit/math/mix/prob/test_distribution_ad.hpp
@@ -1,0 +1,172 @@
+#ifndef TEST_UNIT_MATH_TEST_DISTRIBUTION_AD_HPP
+#define TEST_UNIT_MATH_TEST_DISTRIBUTION_AD_HPP
+
+#include <stan/math/mix.hpp>
+#include <test/unit/math/test_ad.hpp>
+namespace stan {
+  namespace test {
+    template <typename Cast, typename T, stan::require_eigen_t<Cast>* = nullptr>
+    Cast do_cast(T&& x) {
+        return x;
+    }
+    template <typename Cast, typename T, stan::require_std_vector_t<Cast>* = nullptr>
+    Cast do_cast(T&& x) {
+        return Cast(x.data(), x.data() + x.size());
+    }
+    template <typename Cast, typename T, stan::require_arithmetic_t<Cast>* = nullptr>
+    Cast do_cast(T&& x) {
+        return x(0);
+    }
+
+  using unary_base_set = std::tuple<std::tuple<double>,
+    std::tuple<std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>>>;
+
+  using binary_base_set = std::tuple<std::tuple<double, double>,
+  std::tuple<double, std::vector<double>>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, double>,
+  std::tuple<std::vector<double>, std::vector<double>>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>>;
+
+
+  using ternary_base_sets = std::tuple<std::tuple<double, double, double>,
+  std::tuple<double, double, std::vector<double>>,
+  std::tuple<double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<double, std::vector<double>, double>,
+  std::tuple<double, std::vector<double>, std::vector<double>>,
+  std::tuple<double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, double, double>,
+  std::tuple<std::vector<double>, double, std::vector<double>>,
+  std::tuple<std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, std::vector<double>, double>,
+  std::tuple<std::vector<double>, std::vector<double>, std::vector<double>>,
+  std::tuple<std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>>;
+
+
+using quad_base_set = std::tuple<std::tuple<double, double, double, double>,
+  std::tuple<double, double, double, std::vector<double>>,
+  std::tuple<double, double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<double, double, std::vector<double>, double>,
+  std::tuple<double, double, std::vector<double>, std::vector<double>>,
+  std::tuple<double, double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<double, std::vector<double>, double, double>,
+  std::tuple<double, std::vector<double>, double, std::vector<double>>,
+  std::tuple<double, std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<double, std::vector<double>, std::vector<double>, double>,
+  std::tuple<double, std::vector<double>, std::vector<double>, std::vector<double>>,
+  std::tuple<double, std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, double, double, double>,
+  std::tuple<std::vector<double>, double, double, std::vector<double>>,
+  std::tuple<std::vector<double>, double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, double, std::vector<double>, double>,
+  std::tuple<std::vector<double>, double, std::vector<double>, std::vector<double>>,
+  std::tuple<std::vector<double>, double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, std::vector<double>, double, double>,
+  std::tuple<std::vector<double>, std::vector<double>, double, std::vector<double>>,
+  std::tuple<std::vector<double>, std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, std::vector<double>, std::vector<double>, double>,
+  std::tuple<std::vector<double>, std::vector<double>, std::vector<double>, std::vector<double>>,
+  std::tuple<std::vector<double>, std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>>;
+
+
+
+template <size_t sizeof_args>
+using base_set_t = std::conditional_t<sizeof_args == 1, unary_base_set,
+ std::conditional_t<sizeof_args == 2, binary_base_set,
+ std::conditional_t<sizeof_args == 3, ternary_base_sets,
+ std::conditional_t<sizeof_args == 4, quad_base_set, quad_base_set>>>>;
+
+
+
+    template <typename F, typename... EigVecs>
+    void expect_ad_distribution(F&& f, const EigVecs&... args) {
+      // Need to test all combinations of scalars, Eigen vectors, and std vectors
+      using base_set = base_set_t<sizeof...(args)>;
+      // TODO Write a version of for each that just takes in a template
+      // and not an object
+      stan::math::for_each([&f, &args...](auto&& type_tuple) {
+        stan::math::apply([&f, &args...](auto&&... types) {
+          stan::test::expect_ad(ad_tolerances{}, f, do_cast<std::decay_t<decltype(types)>>(args)...);
+        }, type_tuple);
+      }, base_set{});
+    }
+
+  }
+}
+#endif

--- a/test/unit/math/mix/prob/test_distribution_ad.hpp
+++ b/test/unit/math/mix/prob/test_distribution_ad.hpp
@@ -4,169 +4,279 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
 namespace stan {
-  namespace test {
-    template <typename Cast, typename T, stan::require_eigen_t<Cast>* = nullptr>
-    Cast do_cast(T&& x) {
-        return x;
-    }
-    template <typename Cast, typename T, stan::require_std_vector_t<Cast>* = nullptr>
-    Cast do_cast(T&& x) {
-        return Cast(x.data(), x.data() + x.size());
-    }
-    template <typename Cast, typename T, stan::require_arithmetic_t<Cast>* = nullptr>
-    Cast do_cast(T&& x) {
-        return x(0);
-    }
+namespace test {
+template <typename Cast, typename T, stan::require_eigen_t<Cast>* = nullptr>
+Cast do_cast(T&& x) {
+  return x;
+}
+template <typename Cast, typename T,
+          stan::require_std_vector_t<Cast>* = nullptr>
+Cast do_cast(T&& x) {
+  return Cast(x.data(), x.data() + x.size());
+}
+template <typename Cast, typename T,
+          stan::require_arithmetic_t<Cast>* = nullptr>
+Cast do_cast(T&& x) {
+  return x(0);
+}
 
-  using unary_base_set = std::tuple<std::tuple<double>,
-    std::tuple<std::vector<double>>,
-    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>>>;
+using unary_base_set
+    = std::tuple<std::tuple<double>, std::tuple<std::vector<double>>,
+                 std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>>>;
 
-  using binary_base_set = std::tuple<std::tuple<double, double>,
-  std::tuple<double, std::vector<double>>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, double>,
-  std::tuple<std::vector<double>, std::vector<double>>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>>;
+using binary_base_set = std::tuple<
+    std::tuple<double, double>, std::tuple<double, std::vector<double>>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, double>,
+    std::tuple<std::vector<double>, std::vector<double>>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>>;
 
+using ternary_base_sets = std::tuple<
+    std::tuple<double, double, double>,
+    std::tuple<double, double, std::vector<double>>,
+    std::tuple<double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<double, std::vector<double>, double>,
+    std::tuple<double, std::vector<double>, std::vector<double>>,
+    std::tuple<double, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               std::vector<double>>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, double, double>,
+    std::tuple<std::vector<double>, double, std::vector<double>>,
+    std::tuple<std::vector<double>, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, std::vector<double>, double>,
+    std::tuple<std::vector<double>, std::vector<double>, std::vector<double>>,
+    std::tuple<std::vector<double>, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               double>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               std::vector<double>>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>>;
 
-  using ternary_base_sets = std::tuple<std::tuple<double, double, double>,
-  std::tuple<double, double, std::vector<double>>,
-  std::tuple<double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<double, std::vector<double>, double>,
-  std::tuple<double, std::vector<double>, std::vector<double>>,
-  std::tuple<double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, double, double>,
-  std::tuple<std::vector<double>, double, std::vector<double>>,
-  std::tuple<std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, std::vector<double>, double>,
-  std::tuple<std::vector<double>, std::vector<double>, std::vector<double>>,
-  std::tuple<std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>>;
-
-
-using quad_base_set = std::tuple<std::tuple<double, double, double, double>,
-  std::tuple<double, double, double, std::vector<double>>,
-  std::tuple<double, double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<double, double, std::vector<double>, double>,
-  std::tuple<double, double, std::vector<double>, std::vector<double>>,
-  std::tuple<double, double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<double, std::vector<double>, double, double>,
-  std::tuple<double, std::vector<double>, double, std::vector<double>>,
-  std::tuple<double, std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<double, std::vector<double>, std::vector<double>, double>,
-  std::tuple<double, std::vector<double>, std::vector<double>, std::vector<double>>,
-  std::tuple<double, std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, double, double, double>,
-  std::tuple<std::vector<double>, double, double, std::vector<double>>,
-  std::tuple<std::vector<double>, double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, double, std::vector<double>, double>,
-  std::tuple<std::vector<double>, double, std::vector<double>, std::vector<double>>,
-  std::tuple<std::vector<double>, double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, std::vector<double>, double, double>,
-  std::tuple<std::vector<double>, std::vector<double>, double, std::vector<double>>,
-  std::tuple<std::vector<double>, std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, std::vector<double>, std::vector<double>, double>,
-  std::tuple<std::vector<double>, std::vector<double>, std::vector<double>, std::vector<double>>,
-  std::tuple<std::vector<double>, std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
-  std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>, Eigen::Matrix<double, Eigen::Dynamic, 1>>>;
-
-
+using quad_base_set = std::tuple<
+    std::tuple<double, double, double, double>,
+    std::tuple<double, double, double, std::vector<double>>,
+    std::tuple<double, double, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<double, double, std::vector<double>, double>,
+    std::tuple<double, double, std::vector<double>, std::vector<double>>,
+    std::tuple<double, double, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               double>,
+    std::tuple<double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               std::vector<double>>,
+    std::tuple<double, double, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<double, std::vector<double>, double, double>,
+    std::tuple<double, std::vector<double>, double, std::vector<double>>,
+    std::tuple<double, std::vector<double>, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<double, std::vector<double>, std::vector<double>, double>,
+    std::tuple<double, std::vector<double>, std::vector<double>,
+               std::vector<double>>,
+    std::tuple<double, std::vector<double>, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<double, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+    std::tuple<double, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+    std::tuple<double, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               double>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               std::vector<double>>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               std::vector<double>, double>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               std::vector<double>, std::vector<double>>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+    std::tuple<double, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, double, double, double>,
+    std::tuple<std::vector<double>, double, double, std::vector<double>>,
+    std::tuple<std::vector<double>, double, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, double, std::vector<double>, double>,
+    std::tuple<std::vector<double>, double, std::vector<double>,
+               std::vector<double>>,
+    std::tuple<std::vector<double>, double, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+    std::tuple<std::vector<double>, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+    std::tuple<std::vector<double>, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, std::vector<double>, double, double>,
+    std::tuple<std::vector<double>, std::vector<double>, double,
+               std::vector<double>>,
+    std::tuple<std::vector<double>, std::vector<double>, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, std::vector<double>, std::vector<double>,
+               double>,
+    std::tuple<std::vector<double>, std::vector<double>, std::vector<double>,
+               std::vector<double>>,
+    std::tuple<std::vector<double>, std::vector<double>, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+    std::tuple<std::vector<double>, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+    std::tuple<std::vector<double>, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               double, double>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               double, std::vector<double>>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               std::vector<double>, double>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               std::vector<double>, std::vector<double>>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+    std::tuple<std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double,
+               double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double,
+               std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               std::vector<double>, double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               std::vector<double>, std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               double, double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               double, std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               double, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               std::vector<double>, double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               std::vector<double>, std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               std::vector<double>, Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, double, double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, double,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, double>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>, std::vector<double>>,
+    std::tuple<Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>,
+               Eigen::Matrix<double, Eigen::Dynamic, 1>>>;
 
 template <size_t sizeof_args>
-using base_set_t = std::conditional_t<sizeof_args == 1, unary_base_set,
- std::conditional_t<sizeof_args == 2, binary_base_set,
- std::conditional_t<sizeof_args == 3, ternary_base_sets,
- std::conditional_t<sizeof_args == 4, quad_base_set, quad_base_set>>>>;
+using base_set_t = std::conditional_t<
+    sizeof_args == 1, unary_base_set,
+    std::conditional_t<
+        sizeof_args == 2, binary_base_set,
+        std::conditional_t<sizeof_args == 3, ternary_base_sets,
+                           std::conditional_t<sizeof_args == 4, quad_base_set,
+                                              quad_base_set>>>>;
 
-
-
-    template <typename F, typename... EigVecs>
-    void expect_ad_distribution(F&& f, const EigVecs&... args) {
-      // Need to test all combinations of scalars, Eigen vectors, and std vectors
-      using base_set = base_set_t<sizeof...(args)>;
-      // TODO Write a version of for each that just takes in a template
-      // and not an object
-      stan::math::for_each([&f, &args...](auto&& type_tuple) {
-        stan::math::apply([&f, &args...](auto&&... types) {
-          stan::test::expect_ad(ad_tolerances{}, f, do_cast<std::decay_t<decltype(types)>>(args)...);
-        }, type_tuple);
-      }, base_set{});
-    }
-
-  }
+template <typename F, typename... EigVecs>
+void expect_ad_distribution(F&& f, const EigVecs&... args) {
+  // Need to test all combinations of scalars, Eigen vectors, and std vectors
+  using base_set = base_set_t<sizeof...(args)>;
+  // Would be nice to have version of for_each that just took in a template
+  stan::math::for_each(
+      [&f, &args...](auto&& type_tuple) {
+        stan::math::apply(
+            [&f, &args...](auto&&... types) {
+              stan::test::expect_ad(
+                  ad_tolerances{}, f,
+                  do_cast<std::decay_t<decltype(types)>>(args)...);
+            },
+            type_tuple);
+      },
+      base_set{});
 }
+
+}  // namespace test
+}  // namespace stan
 #endif

--- a/test/unit/math/prim/prob/normal_log_test.cpp
+++ b/test/unit/math/prim/prob/normal_log_test.cpp
@@ -13,12 +13,20 @@ TEST(ProbNormal, log_matches_lpdf) {
   EXPECT_FLOAT_EQ((stan::math::normal_lpdf<false>(y, mu, sigma)),
                   (stan::math::normal_log<false>(y, mu, sigma)));
   EXPECT_FLOAT_EQ(
-      (stan::math::normal_lpdf<true, double, double, double>(y, mu, sigma)),
-      (stan::math::normal_log<true, double, double, double>(y, mu, sigma)));
+      (stan::math::normal_lpdf<true>(y, mu, sigma)),
+      (stan::math::normal_log<true>(y, mu, sigma)));
   EXPECT_FLOAT_EQ(
-      (stan::math::normal_lpdf<false, double, double, double>(y, mu, sigma)),
-      (stan::math::normal_log<false, double, double, double>(y, mu, sigma)));
+      (stan::math::normal_lpdf<false>(y, mu, sigma)),
+      (stan::math::normal_log<false>(y, mu, sigma)));
   EXPECT_FLOAT_EQ(
-      (stan::math::normal_lpdf<double, double, double>(y, mu, sigma)),
-      (stan::math::normal_log<double, double, double>(y, mu, sigma)));
+      (stan::math::normal_lpdf(y, mu, sigma)),
+      (stan::math::normal_log(y, mu, sigma)));
+}
+
+TEST(ProbNormal, test_vlpdf) {
+  Eigen::Matrix<double, -1, 1> Y = Eigen::Matrix<double, -1, 1>::Random(5);
+  Eigen::Matrix<double, -1, 1> Mu = Eigen::Matrix<double, -1, 1>::Random(5);
+  Eigen::Matrix<double, -1, 1> Sigma = stan::math::abs(Eigen::Matrix<double, -1, 1>::Random(5));
+  Eigen::Matrix<double, -1, 1> A = stan::math::normal_lpdf<false, stan::math::ProbReturnType::Vector>(Y, Mu, Sigma);
+
 }

--- a/test/unit/math/rev/prob/normal_log_test.cpp
+++ b/test/unit/math/rev/prob/normal_log_test.cpp
@@ -21,3 +21,13 @@ TEST(ProbDistributionsNormal, intVsDouble) {
     EXPECT_FLOAT_EQ(lp1adj, lp2adj);
   }
 }
+
+
+TEST(ProbNormal, test_vlpdf) {
+  using stan::math::var;
+  Eigen::Matrix<var, -1, 1> Y = Eigen::Matrix<double, -1, 1>::Random(5);
+  Eigen::Matrix<var, -1, 1> Mu = Eigen::Matrix<double, -1, 1>::Random(5);
+  Eigen::Matrix<var, -1, 1> Sigma = stan::math::abs(Eigen::Matrix<double, -1, 1>::Random(5));
+  Eigen::Matrix<var, -1, 1> A = stan::math::normal_lpdf<false, stan::math::ProbReturnType::Vector>(Y, Mu, Sigma);
+
+}

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -2150,6 +2150,7 @@ std::vector<Eigen::MatrixXd> square_test_matrices(int low, int high) {
   return xs;
 }
 
+
 }  // namespace test
 }  // namespace stan
 #endif


### PR DESCRIPTION
## Summary

This is a prototype for discussion about allowing our distributions to return back vectors instead of just scalars. I only did `normal_lpdf` as an example of how this would be implemented for the other functions. My goal was to try to reduce the amount of possible code duplication while still keeping our optimizations for the case where we are returning back a scalar type. 

The main components here are

1. A new template parameter `ReturnType` to the lpdf that is either `ProbReturnType::Scalar` or `ProbReturnType::Vector`
2.   a new class `prob_reducer`* that for `ProbReturnType::Scalar` a scalar or for `ProbReturnType::Vector` holds an Eigen array. For the scalar case, things like `+=` etc. will do summation when the rhs is an Eigen type. For `ProbReturnType::Vector` when operators such as `+=` see a scalar they propogate the scalar over the entire return Eigen array.

Getting this to work nicely does require a little bit of oddities, for instance in `normal_lpdf` we previously had 

```cpp
return_t logp = sum(-0.5 * y_scaled_sq);
```

But now we may want the rhs not summed, but `y_scaled_sq` could also just be a scalar. So now we sometimes need to construct `logp` with an explicit constructor telling it the size we want.

```cpp
prob_return_t<RetType, T_partials_return> logp(-0.5 * y_scaled_sq, N);
```

So that if `y_scaled_sq` is a scalar it propogates that for each value in the return matrix of size `N`


* `prob_reducer` is probably a bad name and a new one is very welcome. I would like a name that reflects that the class either holds a scalar and then does summations over vector inputs or is a vector which then just returns a vector at the end. Maybe `conditional_reducer`?

## Tests

After stealing a few things from the prob tests I was able to get a version working with the `expect_ad` test framework. A new function `expect_ad_distribution` applies the user input over all the possible combinations of types that can go into the probability distributions.

You can see an example of this in the mix test for the normal distribution

```
./runTests.py test/unit/math/mix/prob/normal_test.cpp
```

## Side Effects

I'm not sure about side effects necessarily but this is a big change that we should be very careful with.

## Release notes

Adds framework for probability distributions to return back scalars or Eigen vectors.

## Checklist

- [ ] Math issue #(issue number) (I couldn't find the issue but I know people have been requesting this forever and there is an issue somewhere)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
