### PR TITLE
Place template guards on prim/core operator overloads

### DIFF
--- a/stan/math/prim/core/operator_addition.hpp
+++ b/stan/math/prim/core/operator_addition.hpp
@@ -35,7 +35,7 @@ inline complex_return_t<U, V> complex_add(const U& lhs, const V& rhs) {
  * @param y second argument
  * @return sum of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_stan_scalar_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator+(const std::complex<U>& x,
                                         const std::complex<V>& y) {
   return internal::complex_add(x, y);
@@ -50,7 +50,7 @@ inline complex_return_t<U, V> operator+(const std::complex<U>& x,
  * @param y second argument
  * @return sum of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_stan_scalar_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator+(const std::complex<U>& x, const V& y) {
   return internal::complex_add(x, y);
 }
@@ -64,7 +64,7 @@ inline complex_return_t<U, V> operator+(const std::complex<U>& x, const V& y) {
  * @param y second argument
  * @return sum of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_stan_scalar_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator+(const U& x, const std::complex<V>& y) {
   return internal::complex_add(x, y);
 }

--- a/stan/math/prim/core/operator_division.hpp
+++ b/stan/math/prim/core/operator_division.hpp
@@ -35,7 +35,7 @@ inline complex_return_t<U, V> complex_divide(const U& lhs, const V& rhs) {
  * @param y second argument
  * @return quotient of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_stan_scalar_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator/(const std::complex<U>& x,
                                         const std::complex<V>& y) {
   return internal::complex_divide(x, y);
@@ -50,7 +50,7 @@ inline complex_return_t<U, V> operator/(const std::complex<U>& x,
  * @param y second argument
  * @return quotient of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_stan_scalar_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator/(const std::complex<U>& x, const V& y) {
   return internal::complex_divide(x, y);
 }
@@ -64,7 +64,7 @@ inline complex_return_t<U, V> operator/(const std::complex<U>& x, const V& y) {
  * @param y second argument
  * @return quotient of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_stan_scalar_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator/(const U& x, const std::complex<V>& y) {
   return internal::complex_divide(x, y);
 }

--- a/stan/math/prim/core/operator_multiplication.hpp
+++ b/stan/math/prim/core/operator_multiplication.hpp
@@ -37,7 +37,7 @@ inline complex_return_t<U, V> complex_multiply(const U& lhs, const V& rhs) {
  * @param y second argument
  * @return product of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_stan_scalar_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator*(const std::complex<U>& x,
                                         const std::complex<V>& y) {
   return internal::complex_multiply(x, y);

--- a/stan/math/prim/core/operator_subtraction.hpp
+++ b/stan/math/prim/core/operator_subtraction.hpp
@@ -35,7 +35,7 @@ inline complex_return_t<U, V> complex_subtract(const U& lhs, const V& rhs) {
  * @param y second argument
  * @return difference of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_stan_scalar_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator-(const std::complex<U>& x,
                                         const std::complex<V>& y) {
   return internal::complex_subtract(x, y);
@@ -50,7 +50,7 @@ inline complex_return_t<U, V> operator-(const std::complex<U>& x,
  * @param y second argument
  * @return difference of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_stan_scalar_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator-(const std::complex<U>& x, const V& y) {
   return internal::complex_subtract(x, y);
 }
@@ -64,7 +64,7 @@ inline complex_return_t<U, V> operator-(const std::complex<U>& x, const V& y) {
  * @param y second argument
  * @return difference of the arguments
  */
-template <typename U, typename V>
+template <typename U, typename V, require_all_stan_scalar_t<U, V>* = nullptr>
 inline complex_return_t<U, V> operator-(const U& x, const std::complex<V>& y) {
   return internal::complex_subtract(x, y);
 }


### PR DESCRIPTION
## Summary

We overload the basic operators (`*`, `/`, `-`, `+`) in `math/prim/core`, but we don't have any specific requirements on what the types are. This leads to issues like those noted in #2699 with signatures like `subtract(complex, complex_matrix) => complex_matrix`, and I believe it is also the source of some of the other template failures. 

## Tests
Existing tests are maintained, I've also tested that this allows ` subtract(complex, complex_matrix) => complex_matrix` and ` add(complex, complex_matrix) => complex_matrix`, which will be added to the expression tests following this.

## Side Effects

I do not believe so. Any place where these overloads were being used and a Stan scalar was not the internal type was most likely incorrect beforehand.

## Release notes



## Checklist

- [x] Math issue: Related to #2699 

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
