### PR TITLE
Additional tests for complex overloads

### DIFF
--- a/stan/math/prim/fun/singular_values.hpp
+++ b/stan/math/prim/fun/singular_values.hpp
@@ -20,7 +20,7 @@ namespace math {
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
           require_not_st_var<EigMat>* = nullptr>
-Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, 1> singular_values(
+auto singular_values(
     const EigMat& m) {
   check_nonzero_size("singular_values", "m", m);
 

--- a/stan/math/prim/fun/singular_values.hpp
+++ b/stan/math/prim/fun/singular_values.hpp
@@ -20,8 +20,7 @@ namespace math {
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
           require_not_st_var<EigMat>* = nullptr>
-auto singular_values(
-    const EigMat& m) {
+auto singular_values(const EigMat& m) {
   check_nonzero_size("singular_values", "m", m);
 
   return Eigen::JacobiSVD<Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic,

--- a/test/unit/math/mix/fun/singular_values_test.cpp
+++ b/test/unit/math/mix/fun/singular_values_test.cpp
@@ -29,4 +29,9 @@ TEST(MathMixMatFun, singularValues) {
   a22 << 1, 2, 3, 4;
   stan::test::expect_ad(f, a22);
   stan::test::expect_ad_matvar(f, a22);
+
+  Eigen::MatrixXcd c22(2, 2);
+  a22 << 1, 2, 3, 4;
+  stan::test::expect_ad(f, a22);
+  stan::test::expect_ad_matvar(f, a22);
 }

--- a/test/unit/math/mix/fun/svd_U_test.cpp
+++ b/test/unit/math/mix/fun/svd_U_test.cpp
@@ -31,4 +31,9 @@ TEST(MathMixMatFun, svd_U) {
   a22 << 1, 2, 3, 4;
   stan::test::expect_ad(f, a22);
   stan::test::expect_ad_matvar(f, a22);
+
+  Eigen::MatrixXcd c22(2, 2);
+  a22 << 1, 2, 3, 4;
+  stan::test::expect_ad(f, a22);
+  stan::test::expect_ad_matvar(f, a22);
 }

--- a/test/unit/math/mix/fun/svd_V_test.cpp
+++ b/test/unit/math/mix/fun/svd_V_test.cpp
@@ -31,4 +31,9 @@ TEST(MathMixMatFun, svd_V) {
   a22 << 1, 2, 3, 4;
   stan::test::expect_ad(f, a22);
   stan::test::expect_ad_matvar(f, a22);
+
+  Eigen::MatrixXcd c22(2, 2);
+  a22 << 1, 2, 3, 4;
+  stan::test::expect_ad(f, a22);
+  stan::test::expect_ad_matvar(f, a22);
 }

--- a/test/unit/math/prim/fun/singular_values_test.cpp
+++ b/test/unit/math/prim/fun/singular_values_test.cpp
@@ -2,11 +2,15 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 #include <stdexcept>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <complex>
 
 TEST(MathMatrixPrimMat, singular_values) {
   using stan::math::matrix_d;
   using stan::math::singular_values;
   using stan::math::vector_d;
+  using compl_t = std::complex<double>;
+  using matrix_c = Eigen::Matrix<compl_t, Eigen::Dynamic, Eigen::Dynamic>;
 
   matrix_d m0(0, 0);
   EXPECT_THROW(singular_values(m0), std::invalid_argument);
@@ -32,4 +36,14 @@ TEST(MathMatrixPrimMat, singular_values) {
   vector_d m32_D(2);
   m32_D << 16.698998232964481, 2.672724829728879;
   EXPECT_MATRIX_FLOAT_EQ(m32_D, singular_values(m32));
+
+  matrix_c c32(3, 2);
+  c32 << compl_t(0.86636546, 0.34306449), compl_t(0.28267243, 0.52462912),
+      compl_t(0.12104914, 0.2533793), compl_t(0.66889264, 0.39276455),
+      compl_t(0.02184348, 0.0614428), compl_t(0.96599692, 0.16180684);
+  vector_d c32_D(2);
+  c32_D << 1.50077492, 0.78435681;
+
+  EXPECT_MATRIX_FLOAT_EQ(c32_D, singular_values(c32));
+
 }

--- a/test/unit/math/prim/fun/singular_values_test.cpp
+++ b/test/unit/math/prim/fun/singular_values_test.cpp
@@ -45,5 +45,4 @@ TEST(MathMatrixPrimMat, singular_values) {
   c32_D << 1.50077492, 0.78435681;
 
   EXPECT_MATRIX_FLOAT_EQ(c32_D, singular_values(c32));
-
 }

--- a/test/unit/math/prim/fun/svd_U_test.cpp
+++ b/test/unit/math/prim/fun/svd_U_test.cpp
@@ -2,6 +2,8 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 #include <stdexcept>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <complex>
 
 TEST(MathMatrixPrimMat, svd_U) {
   using stan::math::matrix_d;

--- a/test/unit/math/prim/fun/svd_U_test.cpp
+++ b/test/unit/math/prim/fun/svd_U_test.cpp
@@ -6,6 +6,8 @@
 TEST(MathMatrixPrimMat, svd_U) {
   using stan::math::matrix_d;
   using stan::math::svd_U;
+  using compl_t = std::complex<double>;
+  using matrix_c = Eigen::Matrix<compl_t, Eigen::Dynamic, Eigen::Dynamic>;
 
   // Values generated using R base::svd
 
@@ -39,4 +41,15 @@ TEST(MathMatrixPrimMat, svd_U) {
       0.099934023569151917, -0.85060487438128174, 0.183028577355020677;
   EXPECT_MATRIX_FLOAT_EQ(
       m32_U, svd_U(m32));  // R's SVD returns different signs than Eigen.
+
+  matrix_c c32(3, 2);
+  c32 << compl_t(0.86636546, 0.34306449), compl_t(0.28267243, 0.52462912),
+      compl_t(0.12104914, 0.2533793), compl_t(0.66889264, 0.39276455),
+      compl_t(0.02184348, 0.0614428), compl_t(0.96599692, 0.16180684);
+  matrix_c c32_U(3, 2);
+  c32_U << compl_t(0.50789057, 0.35782384), compl_t(0.74507868, 0.14261495),
+      compl_t(0.4823205, 0.19300139), compl_t(-0.29600299, 0.17466116),
+      compl_t(0.58489862, -0.04494745), compl_t(-0.53765935, 0.13159357);
+
+  EXPECT_MATRIX_COMPLEX_FLOAT_EQ(c32_U, svd_U(c32));
 }

--- a/test/unit/math/prim/fun/svd_V_test.cpp
+++ b/test/unit/math/prim/fun/svd_V_test.cpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <complex>
 
-
 TEST(MathMatrixPrimMat, svd_V) {
   using stan::math::matrix_d;
   using stan::math::svd_V;
@@ -49,7 +48,7 @@ TEST(MathMatrixPrimMat, svd_V) {
   c32 << compl_t(0.86636546, 0.34306449), compl_t(0.28267243, 0.52462912),
       compl_t(0.12104914, 0.2533793), compl_t(0.66889264, 0.39276455),
       compl_t(0.02184348, 0.0614428), compl_t(0.96599692, 0.16180684);
-  matrix_c c32_V(2,2);
+  matrix_c c32_V(2, 2);
   c32_V << compl_t(0.45315061, 0.), compl_t(0.89143395, 0.),
       compl_t(0.85785925, -0.2423469), compl_t(-0.43608328, 0.12319437);
 

--- a/test/unit/math/prim/fun/svd_V_test.cpp
+++ b/test/unit/math/prim/fun/svd_V_test.cpp
@@ -2,6 +2,9 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 #include <stdexcept>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <complex>
+
 
 TEST(MathMatrixPrimMat, svd_V) {
   using stan::math::matrix_d;

--- a/test/unit/math/prim/fun/svd_V_test.cpp
+++ b/test/unit/math/prim/fun/svd_V_test.cpp
@@ -6,6 +6,8 @@
 TEST(MathMatrixPrimMat, svd_V) {
   using stan::math::matrix_d;
   using stan::math::svd_V;
+  using compl_t = std::complex<double>;
+  using matrix_c = Eigen::Matrix<compl_t, Eigen::Dynamic, Eigen::Dynamic>;
 
   // Values generated using R base::svd
 
@@ -39,4 +41,14 @@ TEST(MathMatrixPrimMat, svd_V) {
       0.60622380392317887;
   EXPECT_MATRIX_FLOAT_EQ(
       m32_V, svd_V(m32));  // R's SVD returns different signs than Eigen.
+
+  matrix_c c32(3, 2);
+  c32 << compl_t(0.86636546, 0.34306449), compl_t(0.28267243, 0.52462912),
+      compl_t(0.12104914, 0.2533793), compl_t(0.66889264, 0.39276455),
+      compl_t(0.02184348, 0.0614428), compl_t(0.96599692, 0.16180684);
+  matrix_c c32_V(2,2);
+  c32_V << compl_t(0.45315061, 0.), compl_t(0.89143395, 0.),
+      compl_t(0.85785925, -0.2423469), compl_t(-0.43608328, 0.12319437);
+
+  EXPECT_MATRIX_COMPLEX_FLOAT_EQ(c32_V, svd_V(c32));
 }

--- a/test/unit/util.hpp
+++ b/test/unit/util.hpp
@@ -53,8 +53,8 @@
 
 /**
  * Tests for elementwise equality of the input matrices
- * of doubles with the EXPECT_FLOAT_EQ macro from
- * GTest.
+ * of std::complex<double>s with the EXPECT_FLOAT_EQ macro
+ * from GTest.
  *
  * @param A first input matrix to compare
  * @param B second input matrix to compare

--- a/test/unit/util.hpp
+++ b/test/unit/util.hpp
@@ -52,6 +52,26 @@
   }
 
 /**
+ * Tests for elementwise equality of the input matrices
+ * of doubles with the EXPECT_FLOAT_EQ macro from
+ * GTest.
+ *
+ * @param A first input matrix to compare
+ * @param B second input matrix to compare
+ */
+#define EXPECT_MATRIX_COMPLEX_FLOAT_EQ(A, B)         \
+  {                                          \
+    const Eigen::MatrixXcd& A_eval = A;       \
+    const Eigen::MatrixXcd& B_eval = B;       \
+    EXPECT_EQ(A_eval.rows(), B_eval.rows()); \
+    EXPECT_EQ(A_eval.cols(), B_eval.cols()); \
+    for (int i = 0; i < A_eval.size(); i++)  {\
+      EXPECT_FLOAT_EQ(A_eval(i).real(), B_eval(i).real()); \
+      EXPECT_FLOAT_EQ(A_eval(i).imag(), B_eval(i).imag()); \
+    } \
+  }
+
+/**
  * Tests for elementwise equality of the input std::vectors
  * of any type with the EXPECT_FLOAT_EQ macro from GTest.
  *

--- a/test/unit/util.hpp
+++ b/test/unit/util.hpp
@@ -59,16 +59,16 @@
  * @param A first input matrix to compare
  * @param B second input matrix to compare
  */
-#define EXPECT_MATRIX_COMPLEX_FLOAT_EQ(A, B)         \
-  {                                          \
-    const Eigen::MatrixXcd& A_eval = A;       \
-    const Eigen::MatrixXcd& B_eval = B;       \
-    EXPECT_EQ(A_eval.rows(), B_eval.rows()); \
-    EXPECT_EQ(A_eval.cols(), B_eval.cols()); \
-    for (int i = 0; i < A_eval.size(); i++)  {\
+#define EXPECT_MATRIX_COMPLEX_FLOAT_EQ(A, B)               \
+  {                                                        \
+    const Eigen::MatrixXcd& A_eval = A;                    \
+    const Eigen::MatrixXcd& B_eval = B;                    \
+    EXPECT_EQ(A_eval.rows(), B_eval.rows());               \
+    EXPECT_EQ(A_eval.cols(), B_eval.cols());               \
+    for (int i = 0; i < A_eval.size(); i++) {              \
       EXPECT_FLOAT_EQ(A_eval(i).real(), B_eval(i).real()); \
       EXPECT_FLOAT_EQ(A_eval(i).imag(), B_eval(i).imag()); \
-    } \
+    }                                                      \
   }
 
 /**


### PR DESCRIPTION
## Summary

PR #2753 allowed complex numbers to work with the SVD family of functions. Before exposing them to stanc, I decided to add extra tests. Truth values taken from numpy

## Tests

Adds tests to `singular_values`, `svd_U`, and `svd_V` for a complex matrix input.

## Side Effects

Added `EXPECT_MATRIX_COMPLEX_FLOAT_EQ` to test equality of complex-valued matrices.

## Release notes


## Checklist

- [x] Math issue : Related to #2699 

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
