### PR TITLE
Cleanup clang warnings 

### DIFF
--- a/stan/math/prim/err/check_matching_dims.hpp
+++ b/stan/math/prim/err/check_matching_dims.hpp
@@ -30,7 +30,6 @@ inline void check_matching_dims(const char* function, const char* name1,
                                 const T1& y1, const char* name2, const T2& y2) {
   std::vector<int> y1_d = dims(y1);
   std::vector<int> y2_d = dims(y2);
-  bool error = false;
   auto error_throw = [&]() STAN_COLD_PATH {
     std::ostringstream y1s;
     if (y1_d.size() > 0) {

--- a/stan/math/prim/err/hmm_check.hpp
+++ b/stan/math/prim/err/hmm_check.hpp
@@ -30,7 +30,6 @@ template <typename T_omega, typename T_Gamma, typename T_rho,
 inline void hmm_check(const T_omega& log_omegas, const T_Gamma& Gamma,
                       const T_rho& rho, const char* function) {
   int n_states = log_omegas.rows();
-  int n_transitions = log_omegas.cols() - 1;
 
   check_consistent_size(function, "rho", rho, n_states);
   check_square(function, "Gamma", Gamma);

--- a/stan/math/prim/fun/gp_matern52_cov.hpp
+++ b/stan/math/prim/fun/gp_matern52_cov.hpp
@@ -301,7 +301,6 @@ gp_matern52_cov(const std::vector<Eigen::Matrix<T_x1, Eigen::Dynamic, 1>> &x1,
   T_s sigma_sq = square(sigma);
   double root_5 = sqrt(5.0);
   double five_thirds = 5.0 / 3.0;
-  double neg_root_5 = -root_5;
 
   std::vector<Eigen::Matrix<return_type_t<T_x1, T_l>, -1, 1>> x1_new
       = divide_columns(x1, length_scale);

--- a/stan/math/prim/fun/log_mix.hpp
+++ b/stan/math/prim/fun/log_mix.hpp
@@ -83,8 +83,6 @@ return_type_t<T_theta, T_lam> log_mix(const T_theta& theta,
   using T_theta_ref = ref_type_t<T_theta>;
   using T_lam_ref = ref_type_t<T_lam>;
 
-  const int N = stan::math::size(theta);
-
   check_consistent_sizes(function, "theta", theta, "lambda", lambda);
   T_theta_ref theta_ref = theta;
   T_lam_ref lambda_ref = lambda;

--- a/stan/math/prim/functor/operands_and_partials.hpp
+++ b/stan/math/prim/functor/operands_and_partials.hpp
@@ -30,7 +30,7 @@ class ops_partials_edge;
  */
 template <typename ViewElt, typename Op>
 class ops_partials_edge<ViewElt, Op, require_st_arithmetic<Op>> {
-  public:
+ public:
   using inner_op = std::conditional_t<is_eigen<value_type_t<Op>>::value,
                                       value_type_t<Op>, Op>;
   using partials_t = empty_broadcast_array<ViewElt, inner_op>;

--- a/stan/math/prim/functor/operands_and_partials.hpp
+++ b/stan/math/prim/functor/operands_and_partials.hpp
@@ -18,7 +18,7 @@ class operands_and_partials;  // Forward declaration
 
 namespace internal {
 template <typename ViewElt, typename Op, typename = void>
-struct ops_partials_edge;
+class ops_partials_edge;
 /**
  * Class representing an edge with an inner type of double. This class
  *  should never be used by the program and only exists so that
@@ -29,7 +29,8 @@ struct ops_partials_edge;
  *  for this specialization must be an `Arithmetic`
  */
 template <typename ViewElt, typename Op>
-struct ops_partials_edge<ViewElt, Op, require_st_arithmetic<Op>> {
+class ops_partials_edge<ViewElt, Op, require_st_arithmetic<Op>> {
+  public:
   using inner_op = std::conditional_t<is_eigen<value_type_t<Op>>::value,
                                       value_type_t<Op>, Op>;
   using partials_t = empty_broadcast_array<ViewElt, inner_op>;

--- a/stan/math/prim/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/prob/double_exponential_cdf.hpp
@@ -74,7 +74,6 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_cdf(
       (y_val - mu_val) * inv_sigma);
   const auto& exp_scaled_diff = to_ref(exp(scaled_diff));
 
-  size_t N = max_size(y, mu, sigma);
   T_rep_deriv rep_deriv;
   if (is_vector<T_y>::value || is_vector<T_loc>::value) {
     using array_bool = Eigen::Array<bool, Eigen::Dynamic, 1>;

--- a/stan/math/prim/prob/hmm_marginal.hpp
+++ b/stan/math/prim/prob/hmm_marginal.hpp
@@ -23,7 +23,6 @@ inline auto hmm_marginal_val(
     Eigen::Matrix<T_alpha, Eigen::Dynamic, Eigen::Dynamic>& alphas,
     Eigen::Matrix<T_alpha, Eigen::Dynamic, 1>& alpha_log_norms,
     T_alpha& norm_norm) {
-  const int n_states = omegas.rows();
   const int n_transitions = omegas.cols() - 1;
   alphas.col(0) = omegas.col(0).cwiseProduct(rho_val);
 

--- a/stan/math/prim/prob/skew_double_exponential_cdf.hpp
+++ b/stan/math/prim/prob/skew_double_exponential_cdf.hpp
@@ -77,7 +77,6 @@ return_type_t<T_y, T_loc, T_scale, T_skewness> skew_double_exponential_cdf(
   scalar_seq_view<std::decay_t<decltype(sigma_val)>> sigma_vec(sigma_val);
   scalar_seq_view<std::decay_t<decltype(tau_val)>> tau_vec(tau_val);
 
-  const int size_sigma = stan::math::size(sigma);
   const auto N = max_size(y, mu, sigma, tau);
   auto inv_sigma_val = to_ref(inv(sigma_val));
   scalar_seq_view<decltype(inv_sigma_val)> inv_sigma(inv_sigma_val);

--- a/stan/math/prim/prob/skew_double_exponential_lcdf.hpp
+++ b/stan/math/prim/prob/skew_double_exponential_lcdf.hpp
@@ -78,7 +78,6 @@ return_type_t<T_y, T_loc, T_scale, T_skewness> skew_double_exponential_lcdf(
   scalar_seq_view<std::decay_t<decltype(sigma_val)>> sigma_vec(sigma_val);
   scalar_seq_view<std::decay_t<decltype(tau_val)>> tau_vec(tau_val);
 
-  const int size_sigma = stan::math::size(sigma);
   const auto N = max_size(y, mu, sigma, tau);
   auto inv_sigma_val = to_ref(inv(sigma_val));
   scalar_seq_view<decltype(inv_sigma_val)> inv_sigma(inv_sigma_val);

--- a/stan/math/prim/prob/std_normal_rng.hpp
+++ b/stan/math/prim/prob/std_normal_rng.hpp
@@ -20,7 +20,6 @@ template <class RNG>
 inline double std_normal_rng(RNG& rng) {
   using boost::normal_distribution;
   using boost::variate_generator;
-  static const char* function = "std_normal_rng";
 
   variate_generator<RNG&, normal_distribution<>> norm_rng(
       rng, normal_distribution<>(0, 1));

--- a/stan/math/prim/prob/von_mises_cdf.hpp
+++ b/stan/math/prim/prob/von_mises_cdf.hpp
@@ -69,7 +69,6 @@ return_type_t<T_x, T_k> von_mises_cdf_normalapprox(const T_x& x, const T_k& k) {
  */
 template <typename T_x, typename T_k>
 return_type_t<T_x, T_k> von_mises_cdf_centered(const T_x& x, const T_k& k) {
-  double ck = 50;
   using return_t = return_type_t<T_x, T_k>;
   return_t f;
   if (k < 49) {

--- a/stan/math/rev/core/operator_addition.hpp
+++ b/stan/math/rev/core/operator_addition.hpp
@@ -77,7 +77,7 @@ inline var operator+(const var& a, Arith b) {
   }
   return make_callback_vari(
       a.vi_->val_ + b,
-      [avi = a.vi_, b](const auto& vi) mutable { avi->adj_ += vi.adj_; });
+      [avi = a.vi_](const auto& vi) mutable { avi->adj_ += vi.adj_; });
 }
 
 /**

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -81,7 +81,7 @@ inline var operator-(const var& a, Arith b) {
   }
   return make_callback_vari(
       a.vi_->val_ - b,
-      [avi = a.vi_, b](const auto& vi) mutable { avi->adj_ += vi.adj_; });
+      [avi = a.vi_](const auto& vi) mutable { avi->adj_ += vi.adj_; });
 }
 
 /**

--- a/stan/math/rev/core/set_zero_all_adjoints.hpp
+++ b/stan/math/rev/core/set_zero_all_adjoints.hpp
@@ -11,7 +11,7 @@ namespace math {
 /**
  * Reset all adjoint values in the stack to zero.
  */
-static void set_zero_all_adjoints() {
+static inline void set_zero_all_adjoints() {
   for (auto &x : ChainableStack::instance_->var_stack_) {
     x->set_zero_adjoint();
   }

--- a/stan/math/rev/fun/beta.hpp
+++ b/stan/math/rev/fun/beta.hpp
@@ -93,7 +93,7 @@ inline var beta(const var& a, double b) {
 inline var beta(double a, const var& b) {
   auto beta_val = beta(a, b.val());
   auto digamma_ab = (digamma(b.val()) - digamma(a + b.val())) * beta_val;
-  return make_callback_var(beta_val, [a, b, digamma_ab](auto& vi) mutable {
+  return make_callback_var(beta_val, [b, digamma_ab](auto& vi) mutable {
     b.adj() += vi.adj() * digamma_ab;
   });
 }

--- a/stan/math/rev/functor/idas_integrator.hpp
+++ b/stan/math/rev/functor/idas_integrator.hpp
@@ -64,7 +64,6 @@ class idas_integrator {
     N_Vector* yys = serv.nv_yys;
     N_Vector* yps = serv.nv_yps;
     const size_t n = dae.N;
-    const size_t ns = dae.ns;
 
     CHECK_IDAS_CALL(IDASStolerances(mem, rtol_, atol_));
     CHECK_IDAS_CALL(IDASetMaxNumSteps(mem, max_num_steps_));


### PR DESCRIPTION
## Summary

This PR addressed a few warnings I am seeing with the latest clang: 
- cleans up unused variables
- one instance of the ops_partials_edge was written as a struct, the rest as a class. This cleans that up so that they are all classes.
- add inline to set_zero_all_adjoints()

## Tests

/

## Side Effects

/

## Release notes

Cleaned up compiler warnings for unused variables and non-consistent use of class and struct for ops_partials_edge.

## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
