### PR TITLE
Check that y is positive finite in gamma_lpdf

### DIFF
--- a/stan/math/opencl/prim/gamma_lpdf.hpp
+++ b/stan/math/opencl/prim/gamma_lpdf.hpp
@@ -72,7 +72,7 @@ return_type_t<T_y_cl, T_shape_cl, T_inv_scale_cl> gamma_lpdf(
 
   auto check_y_not_nan
       = check_cl(function, "Random variable", y_val, "not NaN");
-  auto y_not_nan_expr = !isnan(y_val);
+  auto y_not_nan_expr = y_val > 0 && isfinite(y_val);
   auto check_alpha_pos_finite
       = check_cl(function, "Shape parameter", alpha_val, "positive finite");
   auto alpha_pos_finite_expr = alpha_val > 0 && isfinite(alpha_val);

--- a/stan/math/prim/prob/gamma_lpdf.hpp
+++ b/stan/math/prim/prob/gamma_lpdf.hpp
@@ -68,7 +68,7 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
   decltype(auto) alpha_val = to_ref(as_value_column_array_or_scalar(alpha_ref));
   decltype(auto) beta_val = to_ref(as_value_column_array_or_scalar(beta_ref));
 
-  check_not_nan(function, "Random variable", y_val);
+  check_positive_finite(function, "Random variable", y_val);
   check_positive_finite(function, "Shape parameter", alpha_val);
   check_positive_finite(function, "Inverse scale parameter", beta_val);
 

--- a/test/unit/math/opencl/rev/gamma_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/gamma_lpdf_test.cpp
@@ -9,7 +9,7 @@ TEST(ProbDistributionsGamma, error_checking) {
   int N = 3;
 
   Eigen::VectorXd y(N);
-  y << -2.0, 0.5, 1;
+  y << 2.0, 0.5, 1;
   Eigen::VectorXd y_size(N - 1);
   y_size << 0.1, 0.5;
   Eigen::VectorXd y_value(N);
@@ -81,7 +81,7 @@ TEST(ProbDistributionsGamma, opencl_matches_cpu_small) {
   int N = 3;
 
   Eigen::VectorXd y(N);
-  y << 0, 0.5, 1;
+  y << 0.1, 0.5, 1;
   Eigen::VectorXd alpha(N);
   alpha << 0.3, 0.8, 1.0;
   Eigen::VectorXd beta(N);
@@ -97,21 +97,6 @@ TEST(ProbDistributionsGamma, opencl_matches_cpu_small) {
   stan::math::test::compare_cpu_opencl_prim_rev(
       gamma_lpdf_functor_propto, y.transpose().eval(), alpha.transpose().eval(),
       beta.transpose().eval());
-}
-TEST(ProbDistributionsGamma, opencl_matches_cpu_small_negative_y) {
-  int N = 3;
-
-  Eigen::VectorXd y(N);
-  y << -10, 0.5, 1;
-  Eigen::VectorXd alpha(N);
-  alpha << 0.3, 0.8, 1.0;
-  Eigen::VectorXd beta(N);
-  beta << 0.3, 0.8, 1.0;
-
-  stan::math::test::compare_cpu_opencl_prim_rev(gamma_lpdf_functor, y, alpha,
-                                                beta);
-  stan::math::test::compare_cpu_opencl_prim_rev(gamma_lpdf_functor_propto, y,
-                                                alpha, beta);
 }
 
 TEST(ProbDistributionsGamma, opencl_broadcast_y) {


### PR DESCRIPTION
## Summary

This one is really simple. Fixes #2625 by changing the `check_nan` to `check_positive_finite` for `y` in `gamma_lpdf`. It does the matching change in the OpenCL code.

## Tests

/

## Side Effects

/

## Release notes

Fixed the check for `y` in `gamma_lpdf` so that it now errors if y is not a positive finite value.

## Checklist

- [x] Math issue #2625

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
