### PR TITLE
StanHeaders 2.26: Scalar falling out of scope

### DIFF
--- a/stan/math/prim/functor/apply_scalar_binary.hpp
+++ b/stan/math/prim/functor/apply_scalar_binary.hpp
@@ -201,7 +201,11 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
 template <typename T1, typename T2, typename F, require_eigen_t<T1>* = nullptr,
           require_stan_scalar_t<T2>* = nullptr>
 inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+#ifdef USE_STANC3
+  return x.unaryExpr([&f, y](const auto& v) { return f(v, y); });
+#else
   return x.unaryExpr([&f, &y](const auto& v) { return f(v, y); }).eval();
+#endif
 }
 
 /**
@@ -225,7 +229,11 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
 template <typename T1, typename T2, typename F,
           require_stan_scalar_t<T1>* = nullptr, require_eigen_t<T2>* = nullptr>
 inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+#ifdef USE_STANC3
+  return y.unaryExpr([&f, x](const auto& v) { return f(x, v); });
+#else
   return y.unaryExpr([&f, &x](const auto& v) { return f(x, v); }).eval();
+#endif
 }
 
 /**

--- a/stan/math/prim/functor/apply_scalar_binary.hpp
+++ b/stan/math/prim/functor/apply_scalar_binary.hpp
@@ -201,11 +201,7 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
 template <typename T1, typename T2, typename F, require_eigen_t<T1>* = nullptr,
           require_stan_scalar_t<T2>* = nullptr>
 inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
-#ifdef USE_STANC3
-  return x.unaryExpr([&f, &y](const auto& v) { return f(v, y); });
-#else
   return x.unaryExpr([&f, &y](const auto& v) { return f(v, y); }).eval();
-#endif
 }
 
 /**
@@ -229,11 +225,7 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
 template <typename T1, typename T2, typename F,
           require_stan_scalar_t<T1>* = nullptr, require_eigen_t<T2>* = nullptr>
 inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
-#ifdef USE_STANC3
-  return y.unaryExpr([&f, &x](const auto& v) { return f(x, v); });
-#else
   return y.unaryExpr([&f, &x](const auto& v) { return f(x, v); }).eval();
-#endif
 }
 
 /**


### PR DESCRIPTION
@hsbadr 

Some tests with the `geostan` package were failing because a captured scalar was falling out of scope in `apply_scalar_binary` under RStan 2.26, this PR removes the `ifdef`s and always evaluates
