### PR TITLE
StanHeaders 2.26 - Additional Evals

### DIFF
--- a/stan/math/prim/fun/add.hpp
+++ b/stan/math/prim/fun/add.hpp
@@ -62,7 +62,11 @@ template <typename Mat, typename Scal, require_eigen_t<Mat>* = nullptr,
           require_stan_scalar_t<Scal>* = nullptr,
           require_all_not_st_var<Mat, Scal>* = nullptr>
 inline auto add(const Mat& m, const Scal c) {
+#ifdef USE_STANC3
   return (m.array() + c).matrix();
+#else
+  return (m.array() + c).matrix().eval();
+#endif
 }
 
 /**

--- a/stan/math/prim/fun/rep_matrix.hpp
+++ b/stan/math/prim/fun/rep_matrix.hpp
@@ -12,20 +12,33 @@ template <typename T, require_stan_scalar_t<T>* = nullptr>
 inline auto rep_matrix(const T& x, int m, int n) {
   check_nonnegative("rep_matrix", "rows", m);
   check_nonnegative("rep_matrix", "cols", n);
+#ifdef USE_STANC3
   return Eigen::Matrix<return_type_t<T>, Eigen::Dynamic,
                        Eigen::Dynamic>::Constant(m, n, x);
+#else
+  return Eigen::Matrix<return_type_t<T>, Eigen::Dynamic,
+                       Eigen::Dynamic>::Constant(m, n, x).eval();
+#endif
 }
 
 template <typename ColVec, require_eigen_col_vector_t<ColVec>* = nullptr>
 inline auto rep_matrix(const ColVec& v, int n) {
   check_nonnegative("rep_matrix", "rows", n);
+#ifdef USE_STANC3
   return v.replicate(1, n);
+#else
+  return v.replicate(1, n).eval();
+#endif
 }
 
 template <typename RowVec, require_eigen_row_vector_t<RowVec>* = nullptr>
 inline auto rep_matrix(const RowVec& rv, int m) {
   check_nonnegative("rep_matrix", "cols", m);
+#ifdef USE_STANC3
   return rv.replicate(m, 1);
+#else
+  return rv.replicate(m, 1).eval();
+#endif
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/rep_row_vector.hpp
+++ b/stan/math/prim/fun/rep_row_vector.hpp
@@ -10,7 +10,12 @@ namespace math {
 template <typename T>
 inline auto rep_row_vector(const T& x, int m) {
   check_nonnegative("rep_row_vector", "m", m);
+#ifdef USE_STANC3
   return Eigen::Matrix<return_type_t<T>, 1, Eigen::Dynamic>::Constant(m, x);
+#else
+  return Eigen::Matrix<return_type_t<T>, 1, Eigen::Dynamic>::Constant(m, x)
+          .eval();
+#endif
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/rep_vector.hpp
+++ b/stan/math/prim/fun/rep_vector.hpp
@@ -10,7 +10,11 @@ namespace math {
 template <typename T>
 inline auto rep_vector(const T& x, int n) {
   check_nonnegative("rep_vector", "n", n);
+#ifdef USE_STANC3
   return Eigen::Matrix<return_type_t<T>, Eigen::Dynamic, 1>::Constant(n, x);
+#else
+  return Eigen::Matrix<return_type_t<T>, Eigen::Dynamic, 1>::Constant(n, x).eval();
+#endif
 }
 
 }  // namespace math


### PR DESCRIPTION
@hsbadr 

This PR adds some additional evals to fix compilation errors with the `geostan` and `epidemia` packages. The errors were caused by the user-defined functions only accepting Eigen plain types, but there were still some Math functions returning expressions (`add` for `epidemia` and `rep_vector` for `geostan`)