### PR TITLE
StanHeaders 2.26 - stanette fix

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -1,1 +1,2 @@
 #include "fun.hpp"
+#include "prob.hpp"


### PR DESCRIPTION
@hsbadr 

The `stanette` failures were caused by headers in the package calling `normal_rng` but only including the `prim/mat.hpp` Math header. This adds `prob.hpp` to that Math header so that `normal_rng` can be found