### PR TITLE
make grad_reg_lower_inc_gamma faster

### DIFF
--- a/stan/math/prim/fun/grad_reg_lower_inc_gamma.hpp
+++ b/stan/math/prim/fun/grad_reg_lower_inc_gamma.hpp
@@ -164,11 +164,13 @@ return_type_t<T1, T2> grad_reg_lower_inc_gamma(const T1& a, const T2& z,
 
   n = 1;
   a_plus_n = a + 1;
-  TP sum_b = digamma(a + 1) * exp(a * log_z - lgamma_a_plus_1);
+  TP digammap1 = digamma(a + 1);
+  TP sum_b = digammap1 * exp(a * log_z - lgamma_a_plus_1);
   lgamma_a_plus_n_plus_1 = lgamma_a_plus_1 + log(a_plus_n);
   while (true) {
+    digammap1 += 1 / a_plus_n;
     term = exp(a_plus_n * log_z - lgamma_a_plus_n_plus_1)
-           * digamma(a_plus_n + 1);
+           * digammap1;
     sum_b += term;
     if (term <= precision) {
       return emz * (log_z * sum_a - sum_b);


### PR DESCRIPTION
## Summary

As @andrjohns and I were reviewing and updating the `gamma_lcdf` code I noticed that one branch of `grad_reg_lower_inc_gamma` was calculating `digamma(a + i)` each loop where `++i`. However, the `digamma` function with 1 added each iteration can be calculated without calling `digamma` each time by the relation

$$
\psi(z + 1) = \psi(z) + \frac{1}{z}
$$

where $\psi(z)$ is `digamma(z)`.
 
## Tests

No new tests needed.

## Side Effects

No.

## Release notes

Replace this text with a short note on what will change if this pull request is merged in which case this will be included in the release notes.

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Sean Pinkneuy

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
