### PR TITLE
Add to_int function and tests

### DIFF
--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -335,6 +335,7 @@
 #include <stan/math/prim/fun/to_array_1d.hpp>
 #include <stan/math/prim/fun/to_array_2d.hpp>
 #include <stan/math/prim/fun/to_complex.hpp>
+#include <stan/math/prim/fun/to_int.hpp>
 #include <stan/math/prim/fun/to_matrix.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/to_row_vector.hpp>

--- a/stan/math/prim/fun/to_int.hpp
+++ b/stan/math/prim/fun/to_int.hpp
@@ -35,7 +35,7 @@ inline T to_int(T x) {
  *
  * @tparam T type of argument (must be arithmetic)
  * @param x argument
- * @return iIteger value of argument
+ * @return Integer value of argument
  */
 template <typename T, require_floating_point_t<T>* = nullptr>
 inline int to_int(T x) {

--- a/stan/math/prim/fun/to_int.hpp
+++ b/stan/math/prim/fun/to_int.hpp
@@ -1,25 +1,52 @@
 #ifndef STAN_MATH_PRIM_FUN_TO_INT_HPP
 #define STAN_MATH_PRIM_FUN_TO_INT_HPP
 
+#include <stan/math/prim/err/check_not_nan.hpp>
+#include <stan/math/prim/err/check_finite.hpp>
 #include <stan/math/prim/functor/apply_scalar_unary.hpp>
 
 namespace stan {
 namespace math {
 
 /**
- * Returns the input scalar as an integer type
+ * Returns the input scalar as an integer type. Specialisation for integral
+ * types which do not need conversion, reduces to a no-op.
+ *
+ * @tparam T type of integral argument
+ * @param x argument
+ * @return Input argument unchanged
+ */
+template <typename T, require_integral_t<T>* = nullptr>
+inline T to_int(T x) {
+  return std::forward<T>(x);
+}
+
+/**
+ * Returns the input scalar as an integer type. This function performs no
+ * rounding and simply truncates the decimal to return only the signficand as an
+ * integer.
+ *
+ * Casting NaN and Inf values to integers is considered undefined behavior as
+ * NaN and Inf cannot be represented as an integer and most implementations
+ * simply overflow, as such this function throws for these inputs.
+ *
+ * The function also throws for floating-point values that are too large to be
+ * represented as an integer.
  *
  * @tparam T type of argument (must be arithmetic)
  * @param x argument
  * @return iIteger value of argument
  */
-template <typename T, require_arithmetic_t<T>* = nullptr>
+template <typename T, require_floating_point_t<T>* = nullptr>
 inline int to_int(T x) {
+  static const char* function = "to_int";
+  check_not_nan(function, "x", x);
+  check_finite(function, "x", x);
   if (x < std::numeric_limits<int>::min()
       || x > std::numeric_limits<int>::max()) {
     std::ostringstream msg;
     msg << "Value " << x << " is too large to be represented as an integer";
-    throw std::invalid_argument(msg.str());
+    throw std::domain_error(msg.str());
   }
   return static_cast<int>(x);
 }

--- a/stan/math/prim/fun/to_int.hpp
+++ b/stan/math/prim/fun/to_int.hpp
@@ -1,8 +1,7 @@
 #ifndef STAN_MATH_PRIM_FUN_TO_INT_HPP
 #define STAN_MATH_PRIM_FUN_TO_INT_HPP
 
-#include <stan/math/prim/err/check_not_nan.hpp>
-#include <stan/math/prim/err/check_finite.hpp>
+#include <stan/math/prim/err/check_bounded.hpp>
 #include <stan/math/prim/functor/apply_scalar_unary.hpp>
 
 namespace stan {
@@ -36,18 +35,14 @@ inline T to_int(T x) {
  * @tparam T type of argument (must be arithmetic)
  * @param x argument
  * @return Integer value of argument
+ * @throw std::domain_error for NaN, Inf, or floating point values not in range
+ *        to be represented as int
  */
 template <typename T, require_floating_point_t<T>* = nullptr>
 inline int to_int(T x) {
   static const char* function = "to_int";
-  check_not_nan(function, "x", x);
-  check_finite(function, "x", x);
-  if (x < std::numeric_limits<int>::min()
-      || x > std::numeric_limits<int>::max()) {
-    std::ostringstream msg;
-    msg << "Value " << x << " is too large to be represented as an integer";
-    throw std::domain_error(msg.str());
-  }
+  check_bounded(function, "x", x, std::numeric_limits<int>::min(),
+                std::numeric_limits<int>::max());
   return static_cast<int>(x);
 }
 

--- a/stan/math/prim/fun/to_int.hpp
+++ b/stan/math/prim/fun/to_int.hpp
@@ -15,8 +15,8 @@ namespace math {
  */
 template <typename T, require_arithmetic_t<T>* = nullptr>
 inline int to_int(T x) {
-  if (x < std::numeric_limits<int>::min() ||
-      x > std::numeric_limits<int>::max()) {
+  if (x < std::numeric_limits<int>::min()
+      || x > std::numeric_limits<int>::max()) {
     std::ostringstream msg;
     msg << "Value " << x << " is too large to be represented as an integer";
     throw std::invalid_argument(msg.str());

--- a/stan/math/prim/fun/to_int.hpp
+++ b/stan/math/prim/fun/to_int.hpp
@@ -1,0 +1,59 @@
+#ifndef STAN_MATH_PRIM_FUN_TO_INT_HPP
+#define STAN_MATH_PRIM_FUN_TO_INT_HPP
+
+#include <stan/math/prim/functor/apply_scalar_unary.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the input scalar as an integer type
+ *
+ * @tparam T type of argument (must be arithmetic)
+ * @param x argument
+ * @return iIteger value of argument
+ */
+template <typename T, require_arithmetic_t<T>* = nullptr>
+inline int to_int(T x) {
+  if (x < std::numeric_limits<int>::min() ||
+      x > std::numeric_limits<int>::max()) {
+    std::ostringstream msg;
+    msg << "Value " << x << " is too large to be represented as an integer";
+    throw std::invalid_argument(msg.str());
+  }
+  return static_cast<int>(x);
+}
+
+/**
+ * Return elementwise integer value of the specified real-valued
+ * container.
+ *
+ * @tparam T type of argument
+ * @param x argument
+ * @return Integer value of argument
+ */
+struct to_int_fun {
+  template <typename T>
+  static inline auto fun(const T& x) {
+    return to_int(x);
+  }
+};
+
+/**
+ * Returns the elementwise `to_int()` of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
+ *
+ * @tparam Container type of container
+ * @param x argument
+ * @return Integer value of each variable in the container.
+ */
+template <typename Container,
+          require_std_vector_st<std::is_arithmetic, Container>* = nullptr>
+inline auto to_int(const Container& x) {
+  return apply_scalar_unary<to_int_fun, Container>::apply(x);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/test/unit/math/prim/fun/to_int_test.cpp
+++ b/test/unit/math/prim/fun/to_int_test.cpp
@@ -1,0 +1,41 @@
+#include <stan/math/prim.hpp>
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
+
+TEST(MathFunctions, to_int) {
+  using stan::math::to_int;
+
+  EXPECT_EQ(2, to_int(2.0));
+  EXPECT_EQ(2, to_int(2.1));
+  EXPECT_EQ(2, to_int(2.9));
+  EXPECT_EQ(2, to_int(2.999999999));
+
+  EXPECT_EQ(-36574, to_int(-36574.0));
+  EXPECT_EQ(-36574, to_int(-36574.1));
+  EXPECT_EQ(-36574, to_int(-36574.9));
+  EXPECT_EQ(-36574, to_int(-36574.999999999));
+
+  EXPECT_THROW(to_int(std::numeric_limits<int>::max() + 1.0),
+                std::invalid_argument);
+  EXPECT_THROW(to_int(std::numeric_limits<int>::min() - 1.0),
+                std::invalid_argument);
+}
+
+TEST(MathFunctions, to_int_vec) {
+  using stan::math::to_int;
+
+  std::vector<double> inputs_1{2.1, -34.64, 10.89, 1000000};
+  std::vector<double> inputs_2{-409831.987, 403.1, 10.61, -0.00001};
+  std::vector<std::vector<double>> inputs{inputs_1, inputs_2};
+
+  std::vector<int> target_result_1{2, -34, 10, 1000000};
+  std::vector<int> target_result_2{-409831, 403, 10, 0};
+  std::vector<std::vector<int>> target_result{target_result_1, target_result_2};
+
+  EXPECT_STD_VECTOR_EQ(to_int(inputs), target_result);
+
+  inputs[0][2] = std::numeric_limits<int>::min() - 1.0;
+  EXPECT_THROW(to_int(inputs), std::invalid_argument);
+}

--- a/test/unit/math/prim/fun/to_int_test.cpp
+++ b/test/unit/math/prim/fun/to_int_test.cpp
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <limits>
 
-TEST(MathFunctions, to_int) {
+TEST(MathFunctions, to_int_values) {
   using stan::math::to_int;
 
   EXPECT_EQ(2, to_int(2.0));
@@ -16,11 +16,25 @@ TEST(MathFunctions, to_int) {
   EXPECT_EQ(-36574, to_int(-36574.1));
   EXPECT_EQ(-36574, to_int(-36574.9));
   EXPECT_EQ(-36574, to_int(-36574.999999999));
+}
+
+TEST(MathFunctions, to_int_errors) {
+  using stan::math::to_int;
+  using stan::math::NOT_A_NUMBER;
+  using stan::math::INFTY;
+  using stan::math::NEGATIVE_INFTY;
 
   EXPECT_THROW(to_int(std::numeric_limits<int>::max() + 1.0),
-               std::invalid_argument);
+               std::domain_error);
   EXPECT_THROW(to_int(std::numeric_limits<int>::min() - 1.0),
-               std::invalid_argument);
+               std::domain_error);
+
+  EXPECT_THROW(to_int(NOT_A_NUMBER),
+               std::domain_error);
+  EXPECT_THROW(to_int(INFTY),
+               std::domain_error);
+  EXPECT_THROW(to_int(NEGATIVE_INFTY),
+               std::domain_error);
 }
 
 TEST(MathFunctions, to_int_vec) {
@@ -37,5 +51,11 @@ TEST(MathFunctions, to_int_vec) {
   EXPECT_STD_VECTOR_EQ(to_int(inputs), target_result);
 
   inputs[0][2] = std::numeric_limits<int>::min() - 1.0;
-  EXPECT_THROW(to_int(inputs), std::invalid_argument);
+  EXPECT_THROW(to_int(inputs), std::domain_error);
+
+  std::vector<double> inputs_empty;
+  std::vector<double> inputs_size_one{1.5};
+
+  EXPECT_NO_THROW(to_int(inputs_empty));
+  EXPECT_STD_VECTOR_EQ(to_int(inputs_size_one), std::vector<int>{1});
 }

--- a/test/unit/math/prim/fun/to_int_test.cpp
+++ b/test/unit/math/prim/fun/to_int_test.cpp
@@ -18,9 +18,9 @@ TEST(MathFunctions, to_int) {
   EXPECT_EQ(-36574, to_int(-36574.999999999));
 
   EXPECT_THROW(to_int(std::numeric_limits<int>::max() + 1.0),
-                std::invalid_argument);
+               std::invalid_argument);
   EXPECT_THROW(to_int(std::numeric_limits<int>::min() - 1.0),
-                std::invalid_argument);
+               std::invalid_argument);
 }
 
 TEST(MathFunctions, to_int_vec) {

--- a/test/unit/math/prim/fun/to_int_test.cpp
+++ b/test/unit/math/prim/fun/to_int_test.cpp
@@ -19,22 +19,19 @@ TEST(MathFunctions, to_int_values) {
 }
 
 TEST(MathFunctions, to_int_errors) {
-  using stan::math::to_int;
-  using stan::math::NOT_A_NUMBER;
   using stan::math::INFTY;
   using stan::math::NEGATIVE_INFTY;
+  using stan::math::NOT_A_NUMBER;
+  using stan::math::to_int;
 
   EXPECT_THROW(to_int(std::numeric_limits<int>::max() + 1.0),
                std::domain_error);
   EXPECT_THROW(to_int(std::numeric_limits<int>::min() - 1.0),
                std::domain_error);
 
-  EXPECT_THROW(to_int(NOT_A_NUMBER),
-               std::domain_error);
-  EXPECT_THROW(to_int(INFTY),
-               std::domain_error);
-  EXPECT_THROW(to_int(NEGATIVE_INFTY),
-               std::domain_error);
+  EXPECT_THROW(to_int(NOT_A_NUMBER), std::domain_error);
+  EXPECT_THROW(to_int(INFTY), std::domain_error);
+  EXPECT_THROW(to_int(NEGATIVE_INFTY), std::domain_error);
 }
 
 TEST(MathFunctions, to_int_vec) {


### PR DESCRIPTION
## Summary

This PR adds a function for casting `double` and `std::vector<double>` inputs to `int` types. This is intended to only be exposed for use with `data real` and `array[] data real` types in Stan

## Tests

Prim tests added for correctness of return as well as throwing if the input is too large to be represented as an `int` without overflowing

## Side Effects

N/A

## Release notes

Added function for casting `double` and `std::vector<double>` types to `int` and `std::vector<int>` types

## Checklist

- [x] Math issue #2770 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
