### PR TITLE
Split mix/fun tests to two workflows to avoid time limit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
       if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
-  
+
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
@@ -30,7 +30,7 @@ jobs:
     - uses: r-lib/actions/setup-r@v2
       with:
         r-version: 4.1.3
-    
+
     - name: Set path for Rtools40
       if: runner.os == 'Windows'
       run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
@@ -58,7 +58,7 @@ jobs:
         python.exe runTests.py -j2 test/unit/math/prim
         python.exe runTests.py -j2 test/unit/math/rev
         python.exe runTests.py -j2 test/unit/math/memory
-        
+
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v2
       if: failure()
@@ -77,7 +77,7 @@ jobs:
     - uses: r-lib/actions/setup-r@v2
       with:
         r-version: 4.1.3
-    
+
     - name: Set path for Rtools40
       if: runner.os == 'Windows'
       run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
@@ -99,7 +99,7 @@ jobs:
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Disable running fwd/mix tests
       shell: powershell
-      run: echo "CXXFLAGS+= -DSTAN_MATH_TESTS_REV_ONLY" | Out-File -Append -FilePath make/local -Encoding utf8      
+      run: echo "CXXFLAGS+= -DSTAN_MATH_TESTS_REV_ONLY" | Out-File -Append -FilePath make/local -Encoding utf8
     - name: Run fwd unit tests and all the mix tests except those in mix/fun
       shell: powershell
       run: |
@@ -116,8 +116,8 @@ jobs:
       with:
         name: gtest_outputs_xml
         path: '**/*_test.xml'
-  mix-fun:
-    name: mix/fun tests
+  mix-fun-1:
+    name: mix/fun tests 1
     runs-on: windows-latest
 
     steps:
@@ -128,7 +128,7 @@ jobs:
     - uses: r-lib/actions/setup-r@v2
       with:
         r-version: 4.1.3
-    
+
     - name: Set path for Rtools40
       if: runner.os == 'Windows'
       run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
@@ -147,12 +147,61 @@ jobs:
       run: mingw32-make -f make/standalone math-libs
     - name: Add TBB to PATH
       shell: powershell
-      run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8  
+      run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Run mix/fun unit tests
       shell: powershell
       run: |
-        python.exe runTests.py test/unit/math/mix/fun
-        
+        $MixFunTests = Get-ChildItem -Path test\unit\math\mix\fun\* -Include *.cpp | Resolve-Path -Relative
+        $NumberTests = $MixFunTests.Length
+        $HalfNumberTests = [math]::Floor($NumberTests / 2)
+        python.exe runTests.py $MixFunTests[0..$HalfNumberTests]
+
+    - name: Upload gtest_output xml
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: gtest_outputs_xml
+        path: '**/*_test.xml'
+  mix-fun-2:
+    name: mix/fun tests 2
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '2.x'
+    - uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: 4.1.3
+
+    - name: Set path for Rtools40
+      if: runner.os == 'Windows'
+      run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Install mingw32-make and check toolchain path
+      if: runner.os == 'Windows'
+      run: |
+        pacman -Syu mingw-w64-x86_64-make --noconfirm
+        g++ --version
+        Get-Command g++ | Select-Object -ExpandProperty Definition
+        mingw32-make --version
+        Get-Command mingw32-make | Select-Object -ExpandProperty Definition
+      shell: powershell
+
+    - name: Build Math libs
+      shell: powershell
+      run: mingw32-make -f make/standalone math-libs
+    - name: Add TBB to PATH
+      shell: powershell
+      run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Run mix/fun unit tests
+      shell: powershell
+      run: |
+        $MixFunTests = Get-ChildItem -Path test\unit\math\mix\fun\* -Include *.cpp | Resolve-Path -Relative
+        $NumberTests = $MixFunTests.Length
+        $HalfNumberTests = [math]::Floor($NumberTests / 2)
+        python.exe runTests.py $MixFunTests[($HalfNumberTests + 1)..($NumberTests - 1)]
+
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v2
       if: failure()


### PR DESCRIPTION
## Summary

CI changes only - splitting out the `mix/fun` GHA workflow to two runs to avoid time limit

## Tests

N/A

## Side Effects

N/A

## Release notes

N/A

## Checklist

- [x] Math issue #2773

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
