### PR TITLE
Improve Numerical Stability of Bernoulli CDF functions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -416,7 +416,7 @@ pipeline {
                         unstash 'MathSetup'
                         script {
                             sh "echo O=0 > make/local"
-                            sh "echo CXX=${CLANG_CXX} -Werror >> make/local"
+                            sh "echo CXX=${CLANG_CXX} -Werror -Wno-deprecated-declarations >> make/local"
                             sh "python ./test/code_generator_test.py"
                             sh "python ./test/signature_parser_test.py"
                             sh "python ./test/statement_types_test.py"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -416,7 +416,7 @@ pipeline {
                         unstash 'MathSetup'
                         script {
                             sh "echo O=0 > make/local"
-                            sh "echo CXX=${CLANG_CXX} -Werror -Wno-deprecated-declarations >> make/local"
+                            sh "echo CXX=${CLANG_CXX} -Werror >> make/local"
                             sh "python ./test/code_generator_test.py"
                             sh "python ./test/signature_parser_test.py"
                             sh "python ./test/statement_types_test.py"

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -196,7 +196,7 @@ endif
 CXXFLAGS_OS += -D_REENTRANT
 
 ## silence warnings occuring due to the TBB and Eigen libraries
-CXXFLAGS_WARNINGS += -Wno-ignored-attributes
+CXXFLAGS_WARNINGS += -Wno-ignored-attributes -Wno-deprecated-declarations
 
 ################################################################################
 # Setup OpenCL

--- a/stan/math/opencl/kernel_generator/select.hpp
+++ b/stan/math/opencl/kernel_generator/select.hpp
@@ -3,6 +3,7 @@
 #ifdef STAN_OPENCL
 
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/select.hpp>
 #include <stan/math/opencl/matrix_cl_view.hpp>
 #include <stan/math/opencl/kernel_generator/type_str.hpp>
 #include <stan/math/opencl/kernel_generator/name_generator.hpp>

--- a/stan/math/opencl/kernel_generator/select.hpp
+++ b/stan/math/opencl/kernel_generator/select.hpp
@@ -150,22 +150,6 @@ select(T_condition&& condition, T_then&& then, T_else&& els) {  // NOLINT
           as_operation_cl(std::forward<T_else>(els))};
 }
 
-/**
- * Scalar overload of the selection operation.
- * @tparam T_then type of then scalar
- * @tparam T_else type of else scalar
- * @param condition condition
- * @param then then result
- * @param els else result
- * @return `condition ? then : els`
- */
-template <typename T_then, typename T_else,
-          require_all_arithmetic_t<T_then, T_else>* = nullptr>
-inline std::common_type_t<T_then, T_else> select(bool condition, T_then then,
-                                                 T_else els) {
-  return condition ? then : els;
-}
-
 /** @}*/
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -301,6 +301,7 @@
 #include <stan/math/prim/fun/scaled_add.hpp>
 #include <stan/math/prim/fun/sd.hpp>
 #include <stan/math/prim/fun/segment.hpp>
+#include <stan/math/prim/fun/select.hpp>
 #include <stan/math/prim/fun/sign.hpp>
 #include <stan/math/prim/fun/signbit.hpp>
 #include <stan/math/prim/fun/simplex_constrain.hpp>

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -31,13 +31,19 @@ inline auto select(const bool c, const T_true y_true, const T_false y_false) {
 template <typename T_true, typename T_false,
           require_all_eigen_t<T_true, T_false>* = nullptr>
 inline auto select(const bool c, const T_true y_true, const T_false y_false) {
-  return c ? y_true : y_false;
+  using return_scalar_t = return_type_t<T_true, T_false>;
+  if (c) {
+    return y_true.template cast<return_scalar_t>().eval();
+  }
+
+  return y_false.template cast<return_scalar_t>().eval();
 }
 
 template <typename T_true, typename T_false,
           require_eigen_t<T_true>* = nullptr,
           require_stan_scalar_t<T_false>* = nullptr>
-inline plain_type_t<T_true> select(const bool c, const T_true& y_true, const T_false& y_false) {
+inline plain_type_t<T_true> select(const bool c, const T_true& y_true,
+                                    const T_false& y_false) {
   if (c) {
     return y_true;
   }

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -1,0 +1,83 @@
+#ifndef STAN_MATH_PRIM_FUN_SELECT_HPP
+#define STAN_MATH_PRIM_FUN_SELECT_HPP
+
+#include <stan/math/prim/meta.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the second argument if the first argument is true
+ * and otherwise return the second argument.
+ *
+ * <p>This is just a convenience method to provide a function
+ * with the same behavior as the built-in ternary operator.
+ * In general, this function behaves as if defined by
+ *
+ * <p><code>select(c, y1, y0) = c ? y1 : y0</code>.
+ *
+ * @tparam T_true type of the true argument
+ * @tparam T_false type of the false argument
+ * @param c Boolean condition value.
+ * @param y_true Value to return if condition is true.
+ * @param y_false Value to return if condition is false.
+ */
+template <typename T_true, typename T_false,
+          require_all_stan_scalar_t<T_true, T_false>* = nullptr>
+inline auto select(const bool c, const T_true y_true, const T_false y_false) {
+  return c ? y_true : y_false;
+}
+
+template <typename T_true, typename T_false,
+          require_all_eigen_t<T_true, T_false>* = nullptr>
+inline auto select(const bool c, const T_true y_true, const T_false y_false) {
+  return c ? y_true : y_false;
+}
+
+template <typename T_true, typename T_false,
+          require_eigen_t<T_true>* = nullptr,
+          require_stan_scalar_t<T_false>* = nullptr>
+inline plain_type_t<T_true> select(const bool c, const T_true& y_true, const T_false& y_false) {
+  if (c) {
+    return y_true;
+  }
+
+  return y_true.unaryExpr([&](auto&& y){ return y_false; });
+}
+
+
+template <typename T_true, typename T_false,
+          require_stan_scalar_t<T_true>* = nullptr,
+          require_eigen_t<T_false>* = nullptr>
+inline plain_type_t<T_false> select(const bool c, const T_true y_true, const T_false y_false) {
+  if (c) {
+  return y_false.unaryExpr([&](auto&& y){ return y_true; });
+  }
+
+  return y_false;
+}
+
+template <typename T_bool, typename T_true, typename T_false,
+          require_eigen_array_t<T_bool>* = nullptr,
+          require_all_stan_scalar_t<T_true, T_false>* = nullptr>
+inline auto select(const T_bool c, const T_true y_true,
+                    const T_false y_false) {
+  return c.unaryExpr([&](bool cond){
+    return cond ? y_true : y_false;
+  }).eval();
+}
+
+template <typename T_bool, typename T_true, typename T_false,
+          require_eigen_array_t<T_bool>* = nullptr,
+          require_any_eigen_array_t<T_true, T_false>* = nullptr>
+inline auto select(const T_bool c,
+                                              const T_true y_true,
+                                              const T_false y_false) {
+  return c.select(y_true, y_false).eval();
+}
+
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -38,9 +38,9 @@ inline auto select(const bool c, const T_true y_true, const T_false y_false) {
 template <typename T_true, typename T_false,
           require_all_eigen_t<T_true, T_false>* = nullptr>
 inline auto select(const bool c, const T_true y_true, const T_false y_false) {
-  return y_true.binaryExpr(y_false, [&](auto&& x, auto&& y) {
-    return c ? x : y;
-  }).eval();
+  return y_true
+      .binaryExpr(y_false, [&](auto&& x, auto&& y) { return c ? x : y; })
+      .eval();
 }
 
 /**
@@ -55,16 +55,15 @@ inline auto select(const bool c, const T_true y_true, const T_false y_false) {
  * @param y_true Value to return if condition is true.
  * @param y_false Value to return if condition is false.
  */
-template <typename T_true, typename T_false,
-          require_eigen_t<T_true>* = nullptr,
+template <typename T_true, typename T_false, require_eigen_t<T_true>* = nullptr,
           require_stan_scalar_t<T_false>* = nullptr>
 inline plain_type_t<T_true> select(const bool c, const T_true& y_true,
-                                    const T_false& y_false) {
+                                   const T_false& y_false) {
   if (c) {
     return y_true;
   }
 
-  return y_true.unaryExpr([&](auto&& y){ return y_false; });
+  return y_true.unaryExpr([&](auto&& y) { return y_false; });
 }
 
 /**
@@ -85,7 +84,7 @@ template <typename T_true, typename T_false,
 inline plain_type_t<T_false> select(const bool c, const T_true y_true,
                                     const T_false y_false) {
   if (c) {
-    return y_false.unaryExpr([&](auto&& y){ return y_true; });
+    return y_false.unaryExpr([&](auto&& y) { return y_true; });
   }
 
   return y_false;
@@ -107,11 +106,8 @@ inline plain_type_t<T_false> select(const bool c, const T_true y_true,
 template <typename T_bool, typename T_true, typename T_false,
           require_eigen_array_t<T_bool>* = nullptr,
           require_all_stan_scalar_t<T_true, T_false>* = nullptr>
-inline auto select(const T_bool c, const T_true y_true,
-                    const T_false y_false) {
-  return c.unaryExpr([&](bool cond){
-    return cond ? y_true : y_false;
-  }).eval();
+inline auto select(const T_bool c, const T_true y_true, const T_false y_false) {
+  return c.unaryExpr([&](bool cond) { return cond ? y_true : y_false; }).eval();
 }
 
 /**
@@ -129,12 +125,9 @@ inline auto select(const T_bool c, const T_true y_true,
 template <typename T_bool, typename T_true, typename T_false,
           require_eigen_array_t<T_bool>* = nullptr,
           require_any_eigen_array_t<T_true, T_false>* = nullptr>
-inline auto select(const T_bool c,
-                                              const T_true y_true,
-                                              const T_false y_false) {
+inline auto select(const T_bool c, const T_true y_true, const T_false y_false) {
   return c.select(y_true, y_false).eval();
 }
-
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -61,7 +61,7 @@ template <typename T_true, typename T_false,
           require_eigen_t<T_true>* = nullptr,
           require_stan_scalar_t<T_false>* = nullptr>
 inline ReturnT select(const bool c, const T_true& y_true,
-                                   const T_false& y_false) {
+                      const T_false& y_false) {
   if (c) {
     return y_true;
   }
@@ -87,7 +87,7 @@ template <typename T_true, typename T_false,
           require_stan_scalar_t<T_true>* = nullptr,
           require_eigen_t<T_false>* = nullptr>
 inline ReturnT select(const bool c, const T_true y_true,
-                                    const T_false y_false) {
+                      const T_false y_false) {
   if (c) {
     return y_false.unaryExpr([&](auto&& y) { return y_true; });
   }

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -55,9 +55,12 @@ inline auto select(const bool c, const T_true y_true, const T_false y_false) {
  * @param y_true Value to return if condition is true.
  * @param y_false Value to return if condition is false.
  */
-template <typename T_true, typename T_false, require_eigen_t<T_true>* = nullptr,
+template <typename T_true, typename T_false,
+          typename ReturnT = promote_scalar_t<return_type_t<T_true, T_false>,
+                                              plain_type_t<T_true>>,
+          require_eigen_t<T_true>* = nullptr,
           require_stan_scalar_t<T_false>* = nullptr>
-inline plain_type_t<T_true> select(const bool c, const T_true& y_true,
+inline ReturnT select(const bool c, const T_true& y_true,
                                    const T_false& y_false) {
   if (c) {
     return y_true;
@@ -79,9 +82,11 @@ inline plain_type_t<T_true> select(const bool c, const T_true& y_true,
  * @param y_false Value to return if condition is false.
  */
 template <typename T_true, typename T_false,
+          typename ReturnT = promote_scalar_t<return_type_t<T_true, T_false>,
+                                              plain_type_t<T_false>>,
           require_stan_scalar_t<T_true>* = nullptr,
           require_eigen_t<T_false>* = nullptr>
-inline plain_type_t<T_false> select(const bool c, const T_true y_true,
+inline ReturnT select(const bool c, const T_true y_true,
                                     const T_false y_false) {
   if (c) {
     return y_false.unaryExpr([&](auto&& y) { return y_true; });

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -8,13 +8,9 @@ namespace math {
 
 /**
  * Return the second argument if the first argument is true
- * and otherwise return the second argument.
+ * and otherwise return the third argument.
  *
- * <p>This is just a convenience method to provide a function
- * with the same behavior as the built-in ternary operator.
- * In general, this function behaves as if defined by
- *
- * <p><code>select(c, y1, y0) = c ? y1 : y0</code>.
+ * <code>select(c, y1, y0) = c ? y1 : y0</code>.
  *
  * @tparam T_true type of the true argument
  * @tparam T_false type of the false argument
@@ -28,17 +24,37 @@ inline auto select(const bool c, const T_true y_true, const T_false y_false) {
   return c ? y_true : y_false;
 }
 
+/**
+ * Return the second argument if the first argument is true
+ * and otherwise return the third argument. Overload for use with two Eigen
+ * objects.
+ *
+ * @tparam T_true type of the true argument
+ * @tparam T_false type of the false argument
+ * @param c Boolean condition value.
+ * @param y_true Value to return if condition is true.
+ * @param y_false Value to return if condition is false.
+ */
 template <typename T_true, typename T_false,
           require_all_eigen_t<T_true, T_false>* = nullptr>
 inline auto select(const bool c, const T_true y_true, const T_false y_false) {
-  using return_scalar_t = return_type_t<T_true, T_false>;
-  if (c) {
-    return y_true.template cast<return_scalar_t>().eval();
-  }
-
-  return y_false.template cast<return_scalar_t>().eval();
+  return y_true.binaryExpr(y_false, [&](auto&& x, auto&& y) {
+    return c ? x : y;
+  }).eval();
 }
 
+/**
+ * Return the second Eigen argument if the first argument is true
+ * and otherwise return the second Eigen argument. Overload for use with one
+ * scalar and one Eigen object. If chosen, the scalar is returned as an Eigen
+ * object of the same size and type as the provided argument.
+ *
+ * @tparam T_true type of the true argument
+ * @tparam T_false type of the false argument
+ * @param c Boolean condition value.
+ * @param y_true Value to return if condition is true.
+ * @param y_false Value to return if condition is false.
+ */
 template <typename T_true, typename T_false,
           require_eigen_t<T_true>* = nullptr,
           require_stan_scalar_t<T_false>* = nullptr>
@@ -51,18 +67,43 @@ inline plain_type_t<T_true> select(const bool c, const T_true& y_true,
   return y_true.unaryExpr([&](auto&& y){ return y_false; });
 }
 
-
+/**
+ * Return the second Eigen argument if the first argument is true
+ * and otherwise return the second Eigen argument. Overload for use with one
+ * scalar and one Eigen object. If chosen, the scalar is returned as an Eigen
+ * object of the same size and type as the provided argument.
+ *
+ * @tparam T_true type of the true argument
+ * @tparam T_false type of the false argument
+ * @param c Boolean condition value.
+ * @param y_true Value to return if condition is true.
+ * @param y_false Value to return if condition is false.
+ */
 template <typename T_true, typename T_false,
           require_stan_scalar_t<T_true>* = nullptr,
           require_eigen_t<T_false>* = nullptr>
-inline plain_type_t<T_false> select(const bool c, const T_true y_true, const T_false y_false) {
+inline plain_type_t<T_false> select(const bool c, const T_true y_true,
+                                    const T_false y_false) {
   if (c) {
-  return y_false.unaryExpr([&](auto&& y){ return y_true; });
+    return y_false.unaryExpr([&](auto&& y){ return y_true; });
   }
 
   return y_false;
 }
 
+/**
+ * Return the second argument if the first argument is true
+ * and otherwise return the third argument. Overload for use with an Eigen
+ * object of booleans, and two scalars. The chosen scalar is returned as an
+ * Eigen object of the same dimension as the input Eigen argument
+ *
+ * @tparam T_bool type of Eigen boolean object
+ * @tparam T_true type of the true argument
+ * @tparam T_false type of the false argument
+ * @param c Eigen object of boolean condition values.
+ * @param y_true Value to return if condition is true.
+ * @param y_false Value to return if condition is false.
+ */
 template <typename T_bool, typename T_true, typename T_false,
           require_eigen_array_t<T_bool>* = nullptr,
           require_all_stan_scalar_t<T_true, T_false>* = nullptr>
@@ -73,6 +114,18 @@ inline auto select(const T_bool c, const T_true y_true,
   }).eval();
 }
 
+/**
+ * Return the second argument if the first argument is true
+ * and otherwise return the third argument. Overload for use with an Eigen
+ * object of booleans, and at least one Eigen object as input.
+ *
+ * @tparam T_bool type of Eigen boolean object
+ * @tparam T_true type of the true argument
+ * @tparam T_false type of the false argument
+ * @param c Eigen object of boolean condition values.
+ * @param y_true Value to return if condition is true.
+ * @param y_false Value to return if condition is false.
+ */
 template <typename T_bool, typename T_true, typename T_false,
           require_eigen_array_t<T_bool>* = nullptr,
           require_any_eigen_array_t<T_true, T_false>* = nullptr>

--- a/stan/math/prim/prob/bernoulli_cdf.hpp
+++ b/stan/math/prim/prob/bernoulli_cdf.hpp
@@ -43,7 +43,7 @@ return_type_t<T_prob> bernoulli_cdf(const T_n& n, const T_prob& theta) {
     return 1.0;
   }
 
-  T_partials_return P(1.0);
+  T_partials_return P(0.0);
   operands_and_partials<T_theta_ref> ops_partials(theta_ref);
 
   scalar_seq_view<T_n> n_vec(n);
@@ -75,7 +75,7 @@ return_type_t<T_prob> bernoulli_cdf(const T_n& n, const T_prob& theta) {
     }
   }
 
-  const auto& exp_P = to_ref(exp(P));
+  plain_type_t<decltype(exp(P))> exp_P = exp(P);
 
   if (!is_constant_all<T_prob>::value) {
     for (size_t i = 0; i < stan::math::size(theta); ++i) {

--- a/stan/math/prim/prob/bernoulli_cdf.hpp
+++ b/stan/math/prim/prob/bernoulli_cdf.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/select.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/scalar_seq_view.hpp>
 #include <stan/math/prim/fun/size.hpp>
@@ -36,6 +37,7 @@ return_type_t<T_prob> bernoulli_cdf(const T_n& n, const T_prob& theta) {
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
   T_theta_ref theta_ref = theta;
+  const auto& n_arr = as_array_or_scalar(n);
   check_bounded(function, "Probability parameter", value_of(theta_ref), 0.0,
                 1.0);
 
@@ -43,46 +45,23 @@ return_type_t<T_prob> bernoulli_cdf(const T_n& n, const T_prob& theta) {
     return 1.0;
   }
 
-  T_partials_return P(0.0);
   operands_and_partials<T_theta_ref> ops_partials(theta_ref);
-
-  scalar_seq_view<T_n> n_vec(n);
-  const auto& log1m_theta = to_ref(log1m(theta_ref));
-  scalar_seq_view<decltype(log1m_theta)> theta_vec(log1m_theta);
-  scalar_seq_view<decltype(exp(-log1m_theta))> partials_vec(exp(-log1m_theta));
-
-  size_t max_size_seq_view = max_size(n, theta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
-  for (size_t i = 0; i < stan::math::size(n); i++) {
-    if (n_vec.val(i) < 0) {
-      return ops_partials.build(0.0);
-    }
+  if (sum(n_arr < 0)) {
+    return ops_partials.build(0.0);
   }
+  const auto& theta_arr = as_value_column_array_or_scalar(theta_ref);
+  const auto& log1m_theta = select(theta_arr == 1, 0.0, log1m(theta_arr));
+  const auto& P1 = select(n_arr == 0, log1m_theta, 0.0);
 
-  for (size_t i = 0; i < max_size_seq_view; i++) {
-    // Explicit results for extreme values
-    // The gradients are technically ill-defined, but treated as zero
-    if (n_vec.val(i) >= 1) {
-      continue;
-    }
-
-    P += theta_vec.val(i);
-
-    if (!is_constant_all<T_prob>::value) {
-      ops_partials.edge1_.partials_[i] -= partials_vec.val(i);
-    }
-  }
-
-  plain_type_t<decltype(exp(P))> exp_P = exp(P);
+  T_partials_return P = sum(P1);
 
   if (!is_constant_all<T_prob>::value) {
-    for (size_t i = 0; i < stan::math::size(theta); ++i) {
-      ops_partials.edge1_.partials_[i] *= exp_P;
-    }
+    ops_partials.edge1_.partials_ = select(n_arr == 0, -exp(P - P1), 0.0);
   }
-  return ops_partials.build(exp_P);
+  return ops_partials.build(exp(P));
 }
 
 }  // namespace math

--- a/stan/math/prim/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lccdf.hpp
@@ -51,7 +51,9 @@ return_type_t<T_prob> bernoulli_lccdf(const T_n& n, const T_prob& theta) {
   operands_and_partials<T_theta_ref> ops_partials(theta_ref);
 
   scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_theta_ref> theta_vec(theta_ref);
+  const auto& log1m_theta = to_ref(log1m(theta_ref));
+  scalar_seq_view<decltype(log1m_theta)> theta_vec(log1m_theta);
+  scalar_seq_view<decltype(exp(-log1m_theta))> partials_vec(exp(-log1m_theta));
   size_t max_size_seq_view = max_size(n, theta);
 
   // Explicit return for extreme values
@@ -67,12 +69,11 @@ return_type_t<T_prob> bernoulli_lccdf(const T_n& n, const T_prob& theta) {
   }
 
   for (size_t i = 0; i < max_size_seq_view; i++) {
-    const T_partials_return Pi = theta_vec.val(i);
 
-    P += log(Pi);
+    P += theta_vec.val(i);
 
     if (!is_constant_all<T_prob>::value) {
-      ops_partials.edge1_.partials_[i] += inv(Pi);
+      ops_partials.edge1_.partials_[i] -= partials_vec.val(i);
     }
   }
 

--- a/stan/math/prim/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lccdf.hpp
@@ -8,6 +8,7 @@
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/scalar_seq_view.hpp>
+#include <stan/math/prim/fun/select.hpp>
 #include <stan/math/prim/fun/size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/value_of.hpp>

--- a/stan/math/prim/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lccdf.hpp
@@ -33,7 +33,6 @@ template <typename T_n, typename T_prob,
           require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
               T_n, T_prob>* = nullptr>
 return_type_t<T_prob> bernoulli_lccdf(const T_n& n, const T_prob& theta) {
-  using T_partials_return = partials_return_t<T_n, T_prob>;
   using T_theta_ref = ref_type_t<T_prob>;
   using std::log;
   static const char* function = "bernoulli_lccdf";

--- a/stan/math/prim/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lccdf.hpp
@@ -69,7 +69,6 @@ return_type_t<T_prob> bernoulli_lccdf(const T_n& n, const T_prob& theta) {
   }
 
   for (size_t i = 0; i < max_size_seq_view; i++) {
-
     P += theta_vec.val(i);
 
     if (!is_constant_all<T_prob>::value) {

--- a/stan/math/prim/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lcdf.hpp
@@ -8,6 +8,7 @@
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/scalar_seq_view.hpp>
+#include <stan/math/prim/fun/select.hpp>
 #include <stan/math/prim/fun/size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/value_of.hpp>

--- a/stan/math/prim/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lcdf.hpp
@@ -40,6 +40,7 @@ return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
   T_theta_ref theta_ref = theta;
+  const auto& n_arr = as_array_or_scalar(n);
   check_bounded(function, "Probability parameter", value_of(theta_ref), 0.0,
                 1.0);
 
@@ -47,38 +48,22 @@ return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
     return 0.0;
   }
 
-  T_partials_return P(0.0);
   operands_and_partials<T_theta_ref> ops_partials(theta_ref);
-
-  scalar_seq_view<T_n> n_vec(n);
-  const auto& log1m_theta = to_ref(log1m(theta_ref));
-  scalar_seq_view<decltype(log1m_theta)> theta_vec(log1m_theta);
-  scalar_seq_view<decltype(exp(-log1m_theta))> partials_vec(exp(-log1m_theta));
-  size_t max_size_seq_view = max_size(n, theta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
-  for (size_t i = 0; i < stan::math::size(n); i++) {
-    if (n_vec.val(i) < 0) {
-      return ops_partials.build(NEGATIVE_INFTY);
-    }
+  if (sum(n_arr < 0)) {
+    return ops_partials.build(NEGATIVE_INFTY);
   }
 
-  for (size_t i = 0; i < max_size_seq_view; i++) {
-    // Explicit results for extreme values
-    // The gradients are technically ill-defined, but treated as zero
-    if (n_vec.val(i) >= 1) {
-      continue;
-    }
+  const auto& theta_arr = as_value_column_array_or_scalar(theta_ref);
+  const auto& log1m_theta = select(theta_arr == 1, 0.0, log1m(theta_arr));
 
-    P += theta_vec.val(i);
-
-    if (!is_constant_all<T_prob>::value) {
-      ops_partials.edge1_.partials_[i] -= partials_vec.val(i);
-    }
+  if (!is_constant_all<T_prob>::value) {
+    ops_partials.edge1_.partials_ = select(n_arr == 0, -exp(-log1m_theta), 0.0);
   }
 
-  return ops_partials.build(P);
+  return ops_partials.build(sum(select(n_arr == 0, log1m_theta, 0.0)));
 }
 
 }  // namespace math

--- a/stan/math/prim/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lcdf.hpp
@@ -33,7 +33,6 @@ template <typename T_n, typename T_prob,
           require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
               T_n, T_prob>* = nullptr>
 return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
-  using T_partials_return = partials_return_t<T_n, T_prob>;
   using T_theta_ref = ref_type_t<T_prob>;
   using std::log;
   static const char* function = "bernoulli_lcdf";

--- a/stan/math/prim/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lcdf.hpp
@@ -51,7 +51,9 @@ return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
   operands_and_partials<T_theta_ref> ops_partials(theta_ref);
 
   scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_theta_ref> theta_vec(theta_ref);
+  const auto& log1m_theta = to_ref(log1m(theta_ref));
+  scalar_seq_view<decltype(log1m_theta)> theta_vec(log1m_theta);
+  scalar_seq_view<decltype(exp(-log1m_theta))> partials_vec(exp(-log1m_theta));
   size_t max_size_seq_view = max_size(n, theta);
 
   // Explicit return for extreme values
@@ -69,12 +71,10 @@ return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
       continue;
     }
 
-    const T_partials_return Pi = 1 - theta_vec.val(i);
-
-    P += log(Pi);
+    P += theta_vec.val(i);
 
     if (!is_constant_all<T_prob>::value) {
-      ops_partials.edge1_.partials_[i] -= inv(Pi);
+      ops_partials.edge1_.partials_[i] -= partials_vec.val(i);
     }
   }
 

--- a/test/unit/math/mix/prob/bernoulli_cdf_test.cpp
+++ b/test/unit/math/mix/prob/bernoulli_cdf_test.cpp
@@ -4,8 +4,7 @@
 TEST(mathMixScalFun, bernoulliCDF) {
   // bind integer arg because can't autodiff through
   auto f = [](const auto& x1) {
-    return
-        [=](const auto& x2) { return stan::math::bernoulli_cdf(x1, x2); };
+    return [=](const auto& x2) { return stan::math::bernoulli_cdf(x1, x2); };
   };
   stan::test::expect_ad(f(0), 0.1);
   stan::test::expect_ad(f(0), std::numeric_limits<double>::quiet_NaN());

--- a/test/unit/math/mix/prob/bernoulli_cdf_test.cpp
+++ b/test/unit/math/mix/prob/bernoulli_cdf_test.cpp
@@ -13,12 +13,10 @@ TEST(mathMixScalFun, bernoulliCDF) {
   stan::test::expect_ad(f(1), std::numeric_limits<double>::quiet_NaN());
   stan::test::expect_ad(f(1), 0.2);
 
-  
   std::vector<int> std_in1{0, 1};
   Eigen::VectorXd in2(2);
   in2 << 0.5, 0.9;
 
-  
   stan::test::expect_ad(f(std_in1), 0.2);
   stan::test::expect_ad(f(std_in1), std::numeric_limits<double>::quiet_NaN());
   stan::test::expect_ad(f(1), in2);

--- a/test/unit/math/mix/prob/bernoulli_cdf_test.cpp
+++ b/test/unit/math/mix/prob/bernoulli_cdf_test.cpp
@@ -1,0 +1,27 @@
+#include <test/unit/math/test_ad.hpp>
+#include <limits>
+
+TEST(mathMixScalFun, bernoulliCDF) {
+  // bind integer arg because can't autodiff through
+  auto f = [](const auto& x1) {
+    return
+        [=](const auto& x2) { return stan::math::bernoulli_cdf(x1, x2); };
+  };
+  stan::test::expect_ad(f(0), 0.1);
+  stan::test::expect_ad(f(0), std::numeric_limits<double>::quiet_NaN());
+  stan::test::expect_ad(f(1), 0.5);
+  stan::test::expect_ad(f(1), std::numeric_limits<double>::quiet_NaN());
+  stan::test::expect_ad(f(1), 0.2);
+
+  
+  std::vector<int> std_in1{0, 1};
+  Eigen::VectorXd in2(2);
+  in2 << 0.5, 0.9;
+
+  
+  stan::test::expect_ad(f(std_in1), 0.2);
+  stan::test::expect_ad(f(std_in1), std::numeric_limits<double>::quiet_NaN());
+  stan::test::expect_ad(f(1), in2);
+  stan::test::expect_ad(f(std_in1), in2);
+  stan::test::expect_ad(f(std_in1), std::numeric_limits<double>::quiet_NaN());
+}

--- a/test/unit/math/mix/prob/bernoulli_lccdf_test.cpp
+++ b/test/unit/math/mix/prob/bernoulli_lccdf_test.cpp
@@ -4,8 +4,7 @@
 TEST(mathMixScalFun, bernoulliLCCDF) {
   // bind integer arg because can't autodiff through
   auto f = [](const auto& x1) {
-    return
-        [=](const auto& x2) { return stan::math::bernoulli_lccdf(x1, x2); };
+    return [=](const auto& x2) { return stan::math::bernoulli_lccdf(x1, x2); };
   };
   stan::test::expect_ad(f(0), 0.1);
   stan::test::expect_ad(f(0), std::numeric_limits<double>::quiet_NaN());

--- a/test/unit/math/mix/prob/bernoulli_lccdf_test.cpp
+++ b/test/unit/math/mix/prob/bernoulli_lccdf_test.cpp
@@ -13,12 +13,10 @@ TEST(mathMixScalFun, bernoulliLCCDF) {
   stan::test::expect_ad(f(1), std::numeric_limits<double>::quiet_NaN());
   stan::test::expect_ad(f(1), 0.2);
 
-  
   std::vector<int> std_in1{0, 1};
   Eigen::VectorXd in2(2);
   in2 << 0.5, 0.9;
 
-  
   stan::test::expect_ad(f(std_in1), 0.2);
   stan::test::expect_ad(f(std_in1), std::numeric_limits<double>::quiet_NaN());
   stan::test::expect_ad(f(1), in2);

--- a/test/unit/math/mix/prob/bernoulli_lccdf_test.cpp
+++ b/test/unit/math/mix/prob/bernoulli_lccdf_test.cpp
@@ -1,0 +1,27 @@
+#include <test/unit/math/test_ad.hpp>
+#include <limits>
+
+TEST(mathMixScalFun, bernoulliLCCDF) {
+  // bind integer arg because can't autodiff through
+  auto f = [](const auto& x1) {
+    return
+        [=](const auto& x2) { return stan::math::bernoulli_lccdf(x1, x2); };
+  };
+  stan::test::expect_ad(f(0), 0.1);
+  stan::test::expect_ad(f(0), std::numeric_limits<double>::quiet_NaN());
+  stan::test::expect_ad(f(1), 0.5);
+  stan::test::expect_ad(f(1), std::numeric_limits<double>::quiet_NaN());
+  stan::test::expect_ad(f(1), 0.2);
+
+  
+  std::vector<int> std_in1{0, 1};
+  Eigen::VectorXd in2(2);
+  in2 << 0.5, 0.9;
+
+  
+  stan::test::expect_ad(f(std_in1), 0.2);
+  stan::test::expect_ad(f(std_in1), std::numeric_limits<double>::quiet_NaN());
+  stan::test::expect_ad(f(1), in2);
+  stan::test::expect_ad(f(std_in1), in2);
+  stan::test::expect_ad(f(std_in1), std::numeric_limits<double>::quiet_NaN());
+}

--- a/test/unit/math/mix/prob/bernoulli_lcdf_test.cpp
+++ b/test/unit/math/mix/prob/bernoulli_lcdf_test.cpp
@@ -1,0 +1,27 @@
+#include <test/unit/math/test_ad.hpp>
+#include <limits>
+
+TEST(mathMixScalFun, bernoulliLCDF) {
+  // bind integer arg because can't autodiff through
+  auto f = [](const auto& x1) {
+    return
+        [=](const auto& x2) { return stan::math::bernoulli_lcdf(x1, x2); };
+  };
+  stan::test::expect_ad(f(0), 0.1);
+  stan::test::expect_ad(f(0), std::numeric_limits<double>::quiet_NaN());
+  stan::test::expect_ad(f(1), 0.5);
+  stan::test::expect_ad(f(1), std::numeric_limits<double>::quiet_NaN());
+  stan::test::expect_ad(f(1), 0.2);
+
+  
+  std::vector<int> std_in1{0, 1};
+  Eigen::VectorXd in2(2);
+  in2 << 0.5, 0.9;
+
+  
+  stan::test::expect_ad(f(std_in1), 0.2);
+  stan::test::expect_ad(f(std_in1), std::numeric_limits<double>::quiet_NaN());
+  stan::test::expect_ad(f(1), in2);
+  stan::test::expect_ad(f(std_in1), in2);
+  stan::test::expect_ad(f(std_in1), std::numeric_limits<double>::quiet_NaN());
+}

--- a/test/unit/math/mix/prob/bernoulli_lcdf_test.cpp
+++ b/test/unit/math/mix/prob/bernoulli_lcdf_test.cpp
@@ -13,12 +13,10 @@ TEST(mathMixScalFun, bernoulliLCDF) {
   stan::test::expect_ad(f(1), std::numeric_limits<double>::quiet_NaN());
   stan::test::expect_ad(f(1), 0.2);
 
-  
   std::vector<int> std_in1{0, 1};
   Eigen::VectorXd in2(2);
   in2 << 0.5, 0.9;
 
-  
   stan::test::expect_ad(f(std_in1), 0.2);
   stan::test::expect_ad(f(std_in1), std::numeric_limits<double>::quiet_NaN());
   stan::test::expect_ad(f(1), in2);

--- a/test/unit/math/mix/prob/bernoulli_lcdf_test.cpp
+++ b/test/unit/math/mix/prob/bernoulli_lcdf_test.cpp
@@ -4,8 +4,7 @@
 TEST(mathMixScalFun, bernoulliLCDF) {
   // bind integer arg because can't autodiff through
   auto f = [](const auto& x1) {
-    return
-        [=](const auto& x2) { return stan::math::bernoulli_lcdf(x1, x2); };
+    return [=](const auto& x2) { return stan::math::bernoulli_lcdf(x1, x2); };
   };
   stan::test::expect_ad(f(0), 0.1);
   stan::test::expect_ad(f(0), std::numeric_limits<double>::quiet_NaN());


### PR DESCRIPTION
## Summary

This PR updates the Bernoulli CDF functions (`_cdf`, `_lcdf`, and `_lccdf`) to operate on the log scale as much as possible, to avoid issues with underflow and resolution around 1

## Tests

Additional `mix/prob` tests have been added to ensure that the gradients aren't impacted (`prim` behaviour covered by the distribution tests)

## Side Effects

N/A

## Release notes

Improved numerical stability of Bernoulli CDF functions

## Checklist

- [x] Math issue #2783

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
