### PR TITLE
Add guards to promote_scalar to allow similar tuples

### DIFF
--- a/stan/math/prim/fun/promote_scalar.hpp
+++ b/stan/math/prim/fun/promote_scalar.hpp
@@ -20,7 +20,8 @@ namespace math {
  */
 template <typename PromotionScalar, typename UnPromotedType,
           require_constructible_t<PromotionScalar, UnPromotedType>* = nullptr,
-          require_not_same_t<PromotionScalar, UnPromotedType>* = nullptr>
+          require_not_same_t<PromotionScalar, UnPromotedType>* = nullptr,
+          require_all_not_tuple_t<PromotionScalar, UnPromotedType>* = nullptr>
 inline constexpr auto promote_scalar(UnPromotedType&& x) {
   return PromotionScalar(std::forward<UnPromotedType>(x));
 }

--- a/test/unit/math/mix/fun/promote_scalar_test.cpp
+++ b/test/unit/math/mix/fun/promote_scalar_test.cpp
@@ -65,6 +65,7 @@ void test_promote_scalar() {
                  inner_promo_type>>(tester);
   stan::math::test::expect_same_value_of_rec(tester, result);
 }
+
 TEST(mixFun, promote_scalar_tuple) {
   using stan::math::fvar;
   using stan::math::var;
@@ -82,4 +83,23 @@ TEST(mixFun, promote_scalar_tuple) {
   test_promote_scalar<std::complex<double>, double>();
   test_promote_scalar<std::complex<var>, double>();
   test_promote_scalar<std::complex<fvar<var>>, double>();
+}
+
+template <typename UnPromotedType>
+void test_promote_scalar_basic() {
+  std::tuple<UnPromotedType, UnPromotedType> x{UnPromotedType(3.5),
+                                               UnPromotedType(4.5)};
+  std::tuple<std::complex<UnPromotedType>, UnPromotedType> z
+      = stan::math::promote_scalar<
+          std::tuple<std::complex<UnPromotedType>, UnPromotedType>>(x);
+  stan::math::test::expect_same_value_of_rec(x, z);
+}
+
+TEST(mixFun, promote_scalar_tuple_basic) {
+  using stan::math::fvar;
+  using stan::math::var;
+  test_promote_scalar_basic<double>();
+  test_promote_scalar_basic<var>();
+  test_promote_scalar_basic<fvar<double>>();
+  test_promote_scalar_basic<fvar<var>>();
 }


### PR DESCRIPTION
## Summary

Follow on from #2701. The existing code has an ambiguous template overload when the tuple being promoted is only slightly different from the existing tuple

## Tests

This adds a test for promoting `tuple<scalar, scalar>` to `tuple<complex<scalar>, scalar>` for double, var, fvar.

## Side Effects


## Release notes


## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
