### PR TITLE
Allow varmat for owens_t 

### DIFF
--- a/stan/math/prim/fun/owens_t.hpp
+++ b/stan/math/prim/fun/owens_t.hpp
@@ -67,10 +67,11 @@ inline double owens_t(double h, double a) { return boost::math::owens_t(h, a); }
  * @param b Second input
  * @return owens_t function applied to the two inputs.
  */
-template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
+ require_all_not_var_and_matrix_types<T1, T2>* = nullptr>
 inline auto owens_t(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return owens_t(c, d); });
+      a, b, [](const auto& c, const auto& d) { return owens_t(c, d); });
 }
 
 }  // namespace math

--- a/stan/math/prim/meta.hpp
+++ b/stan/math/prim/meta.hpp
@@ -207,6 +207,7 @@
 #include <stan/math/prim/meta/is_string_convertible.hpp>
 #include <stan/math/prim/meta/is_tuple.hpp>
 #include <stan/math/prim/meta/is_var.hpp>
+#include <stan/math/prim/meta/is_var_and_matrix_types.hpp>
 #include <stan/math/prim/meta/is_var_matrix.hpp>
 #include <stan/math/prim/meta/is_var_dense_dynamic.hpp>
 #include <stan/math/prim/meta/is_var_eigen.hpp>

--- a/stan/math/prim/meta.hpp
+++ b/stan/math/prim/meta.hpp
@@ -220,6 +220,7 @@
 #include <stan/math/prim/meta/partials_return_type.hpp>
 #include <stan/math/prim/meta/partials_type.hpp>
 #include <stan/math/prim/meta/plain_type.hpp>
+#include <stan/math/prim/meta/possibly_sum.hpp>
 #include <stan/math/prim/meta/promote_args.hpp>
 #include <stan/math/prim/meta/promote_scalar_type.hpp>
 #include <stan/math/prim/meta/ref_type.hpp>

--- a/stan/math/prim/meta/is_var_and_matrix_types.hpp
+++ b/stan/math/prim/meta/is_var_and_matrix_types.hpp
@@ -1,0 +1,26 @@
+#ifndef STAN_MATH_PRIM_META_IS_VAR_AND_MATRIX_TYPES_HPP
+#define STAN_MATH_PRIM_META_IS_VAR_AND_MATRIX_TYPES_HPP
+
+#include <stan/math/prim/meta/is_var.hpp>
+#include <stan/math/prim/meta/is_matrix.hpp>
+
+namespace stan {
+
+/** \ingroup type_trait
+ * Extends std::true_type when instantiated with one type that has a var `scalar_type` and
+ * another that is a matrix. Extends std::false_type otherwise.
+ * @tparam Types Types to test
+ */
+template <typename... Types>
+using is_var_and_matrix_types = bool_constant<is_var<return_type_t<Types...>>::value &&
+  stan::math::disjunction<is_matrix<Types>...>::value>;
+
+template <typename... Types>
+using require_all_var_and_matrix_types = require_t<is_var_and_matrix_types<Types...>>;
+
+template <typename... Types>
+using require_all_not_var_and_matrix_types = require_not_t<is_var_and_matrix_types<Types...>>;
+
+
+}  // namespace stan
+#endif

--- a/stan/math/prim/meta/possibly_sum.hpp
+++ b/stan/math/prim/meta/possibly_sum.hpp
@@ -1,0 +1,39 @@
+#ifndef STAN_MATH_PRIM_META_POSSIBLY_SUM_HPP
+#define STAN_MATH_PRIM_META_POSSIBLY_SUM_HPP
+
+
+#include <stan/math/prim/fun/sum.hpp>
+#include <stan/math/prim/meta/require_helpers.hpp>
+
+namespace stan {
+  namespace math{
+
+/**
+ * Conditionally sum the input at compile time.
+ * @tparam CondSum A struct with a static boolean member `value` which if true
+ *  will allow the input value to be summed
+ * @tparam T A scalar, Eigen type, or standard vector with inner scalar type.
+ * @param x The value to be summed.
+ */
+template <typename CondSum, typename T, require_t<CondSum>* = nullptr>
+inline auto possibly_sum(T&& x) {
+    return sum(std::forward<T>(x));
+}
+
+/**
+ * Conditionally sum the input at compile time. This overload does not sum.
+ * @tparam CondSum A struct with a static boolean member `value` which if false
+ *  will pass the input to the output.
+ * @tparam T A scalar, Eigen type, or standard vector with inner scalar type.
+ * @param x The value to be passed trhough.
+ */
+template <typename CondSum, typename T1, require_not_t<CondSum>* = nullptr>
+inline auto possibly_sum(T1&& x) {
+    return std::forward<T1>(x);
+}
+
+}
+}
+
+
+#endif

--- a/stan/math/rev/fun/log_sum_exp.hpp
+++ b/stan/math/rev/fun/log_sum_exp.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_REV_FUN_LOG_SUM_EXP_HPP
 
 #include <stan/math/rev/meta.hpp>
-#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/core.hpp>1
 #include <stan/math/rev/core/typedefs.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/constants.hpp>

--- a/stan/math/rev/fun/log_sum_exp.hpp
+++ b/stan/math/rev/fun/log_sum_exp.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_REV_FUN_LOG_SUM_EXP_HPP
 
 #include <stan/math/rev/meta.hpp>
-#include <stan/math/rev/core.hpp>1
+#include <stan/math/rev/core.hpp>
 #include <stan/math/rev/core/typedefs.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/constants.hpp>

--- a/stan/math/rev/fun/owens_t.hpp
+++ b/stan/math/rev/fun/owens_t.hpp
@@ -18,27 +18,31 @@ namespace math {
  * Used to compute the cumulative density function for the skew normal
  * distribution.
  *
- * @tparam VarVal1 A scalar or Eigen type.
- * @tparam VarVal2 A scalar or Eigen type.
+ * @tparam Var1 A scalar or Eigen type whose `scalar_type` is an var.
+ * @tparam Var2 A scalar or Eigen type whose `scalar_type` is an var.
  * @param h var parameter.
  * @param a var parameter.
  * @return The Owen's T function.
  */
-template <typename VarVal1, typename VarVal2>
-inline auto owens_t(const var_value<VarVal1>& h, const var_value<VarVal2>& a) {
+template <typename Var1, typename Var2, require_all_st_var<Var1, Var2>* = nullptr,
+ require_all_not_std_vector_t<Var1, Var2>* = nullptr>
+inline auto owens_t(const Var1& h, const Var2& a) {
   auto h_arena = to_arena(h);
   auto a_arena = to_arena(a);
-  return make_callback_var(owens_t(h.val(), a.val()), [h_arena, a_arena](auto&& vi) {
+  using return_type = return_var_matrix_t<decltype(owens_t(h_arena.val(), a_arena.val())), Var1, Var2>;
+  arena_t<return_type> vi = owens_t(h_arena.val(), a_arena.val());
+  reverse_pass_callback([h_arena, a_arena, vi]() mutable {
     const auto& h_val = as_array_or_scalar(h_arena).val();
     const auto& a_val = as_array_or_scalar(a_arena).val();
     const auto neg_avi_sq_div_2 = -square(h_val) * 0.5;
     const auto one_p_bvi_sq = 1.0 + square(a_val);
-    h_arena.adj() += possibly_sum<is_stan_scalar<VarVal1>>(as_array_or_scalar(vi.adj()) * erf(a_val * h_val * INV_SQRT_TWO)
+    as_array_or_scalar(h_arena).adj() += possibly_sum<is_stan_scalar<Var1>>(as_array_or_scalar(vi.adj()) * erf(a_val * h_val * INV_SQRT_TWO)
                   * exp(neg_avi_sq_div_2) * INV_SQRT_TWO_PI * -0.5);
-    a_arena.adj() += possibly_sum<is_stan_scalar<VarVal2>>(as_array_or_scalar(vi.adj()) * exp(neg_avi_sq_div_2 * one_p_bvi_sq)
+    as_array_or_scalar(a_arena).adj() += possibly_sum<is_stan_scalar<Var2>>(as_array_or_scalar(vi.adj()) * exp(neg_avi_sq_div_2 * one_p_bvi_sq)
                   / (one_p_bvi_sq * TWO_PI));
 
   });
+  return return_type(vi);
 }
 
 /**
@@ -47,21 +51,21 @@ inline auto owens_t(const var_value<VarVal1>& h, const var_value<VarVal2>& a) {
  * Used to compute the cumulative density function for the skew normal
  * distribution.
  *
- * @tparam VarValue A scalar or Eigen type.
+ * @tparam Var A scalar or Eigen type whose `scalar_type` is an var.
  * @tparam Arith A scalar or Eigen type with an inner arirthmetic scalar value.
  * @param h var parameter.
  * @param a double parameter.
  * @return The Owen's T function.
  */
-template <typename VarValue, typename Arith, require_vt_arithmetic<Arith>* = nullptr,
- require_not_std_vector_t<Arith>* = nullptr>
-inline auto owens_t(const var_value<VarValue>& h, const Arith& a) {
+template <typename Var, typename Arith, require_st_arithmetic<Arith>* = nullptr,
+ require_all_not_std_vector_t<Var, Arith>* = nullptr, require_st_var<Var>* = nullptr>
+inline auto owens_t(const Var& h, const Arith& a) {
   auto h_arena = to_arena(h);
   auto a_arena = to_arena(a);
-  using return_type = return_var_matrix_t<decltype(owens_t(h_arena.val(), a_arena)), VarValue, Arith>;
+  using return_type = return_var_matrix_t<decltype(owens_t(h_arena.val(), a_arena)), Var, Arith>;
   arena_t<return_type> vi = owens_t(h_arena.val(), a_arena);
-  reverse_pass_callback([h_arena, a_arena, vi]() {
-    h_arena.adj() += possibly_sum<is_stan_scalar<VarValue>>(as_array_or_scalar(vi.adj()) *
+  reverse_pass_callback([h_arena, a_arena, vi]() mutable {
+    as_array_or_scalar(h_arena).adj() += possibly_sum<is_stan_scalar<Var>>(as_array_or_scalar(vi.adj()) *
     erf(as_array_or_scalar(a_arena) * as_array_or_scalar(h_arena).val() * INV_SQRT_TWO)
                   * exp(-square(as_array_or_scalar(h_arena).val()) * 0.5) * INV_SQRT_TWO_PI
                   * -0.5);
@@ -76,22 +80,22 @@ inline auto owens_t(const var_value<VarValue>& h, const Arith& a) {
  * Used to compute the cumulative density function for the skew normal
  * distribution.
  *
- * @tparam VarValue A scalar or Eigen type.
- * @tparam Arith A scalar or Eigen type with an inner arirthmetic scalar value.
+ * @tparam Var A scalar or Eigen type whose `scalar_type` is an var.
+ * @tparam Arith A scalar or Eigen type with an inner arithmetic scalar value.
  * @param h double parameter.
  * @param a var parameter.
  * @return The Owen's T function.
  */
-template <typename Arith, typename VarValue, require_vt_arithmetic<Arith>* = nullptr,
- require_not_std_vector_t<Arith>* = nullptr>
-inline auto owens_t(const Arith& h, const var_value<VarValue>& a) {
+template <typename Arith, typename Var, require_st_arithmetic<Arith>* = nullptr,
+ require_all_not_std_vector_t<Var, Arith>* = nullptr, require_st_var<Var>* = nullptr>
+inline auto owens_t(const Arith& h, const Var& a) {
   auto h_arena = to_arena(h);
   auto a_arena = to_arena(a);
-  using return_type = return_var_matrix_t<decltype(owens_t(h_arena, a_arena.val())), VarValue, Arith>;
+  using return_type = return_var_matrix_t<decltype(owens_t(h_arena, a_arena.val())), Var, Arith>;
   arena_t<return_type> vi = owens_t(h_arena, a_arena.val());
-  reverse_pass_callback([h_arena, a_arena, vi]() {
+  reverse_pass_callback([h_arena, a_arena, vi]() mutable {
     const auto one_p_bvi_sq = eval(1.0 + square(as_array_or_scalar(a_arena.val())));
-    a_arena.adj() += possibly_sum<is_stan_scalar<VarValue>>(as_array_or_scalar(vi.adj()) * exp(-0.5 * square(as_array_or_scalar(h_arena)) * one_p_bvi_sq)
+    as_array_or_scalar(a_arena).adj() += possibly_sum<is_stan_scalar<Var>>(as_array_or_scalar(vi.adj()) * exp(-0.5 * square(as_array_or_scalar(h_arena)) * one_p_bvi_sq)
                   / (one_p_bvi_sq * TWO_PI));
 
   });

--- a/stan/math/rev/fun/owens_t.hpp
+++ b/stan/math/rev/fun/owens_t.hpp
@@ -12,57 +12,33 @@
 namespace stan {
 namespace math {
 
-namespace internal {
-class owens_t_vv_vari : public op_vv_vari {
- public:
-  owens_t_vv_vari(vari* avi, vari* bvi)
-      : op_vv_vari(owens_t(avi->val_, bvi->val_), avi, bvi) {}
-  void chain() {
-    const double neg_avi_sq_div_2 = -square(avi_->val_) * 0.5;
-    const double one_p_bvi_sq = 1.0 + square(bvi_->val_);
-
-    avi_->adj_ += adj_ * erf(bvi_->val_ * avi_->val_ * INV_SQRT_TWO)
-                  * std::exp(neg_avi_sq_div_2) * INV_SQRT_TWO_PI * -0.5;
-    bvi_->adj_ += adj_ * std::exp(neg_avi_sq_div_2 * one_p_bvi_sq)
-                  / (one_p_bvi_sq * TWO_PI);
-  }
-};
-
-class owens_t_vd_vari : public op_vd_vari {
- public:
-  owens_t_vd_vari(vari* avi, double b)
-      : op_vd_vari(owens_t(avi->val_, b), avi, b) {}
-  void chain() {
-    avi_->adj_ += adj_ * erf(bd_ * avi_->val_ * INV_SQRT_TWO)
-                  * std::exp(-square(avi_->val_) * 0.5) * INV_SQRT_TWO_PI
-                  * -0.5;
-  }
-};
-
-class owens_t_dv_vari : public op_dv_vari {
- public:
-  owens_t_dv_vari(double a, vari* bvi)
-      : op_dv_vari(owens_t(a, bvi->val_), a, bvi) {}
-  void chain() {
-    const double one_p_bvi_sq = 1.0 + square(bvi_->val_);
-    bvi_->adj_ += adj_ * std::exp(-0.5 * square(ad_) * one_p_bvi_sq)
-                  / (one_p_bvi_sq * TWO_PI);
-  }
-};
-}  // namespace internal
-
 /**
  * The Owen's T function of h and a.
  *
  * Used to compute the cumulative density function for the skew normal
  * distribution.
  *
+ * @tparam VarVal1 A scalar or Eigen type.
+ * @tparam VarVal2 A scalar or Eigen type.
  * @param h var parameter.
  * @param a var parameter.
  * @return The Owen's T function.
  */
-inline var owens_t(const var& h, const var& a) {
-  return var(new internal::owens_t_vv_vari(h.vi_, a.vi_));
+template <typename VarVal1, typename VarVal2>
+inline auto owens_t(const var_value<VarVal1>& h, const var_value<VarVal2>& a) {
+  auto h_arena = to_arena(h);
+  auto a_arena = to_arena(a);
+  return make_callback_var(owens_t(h.val(), a.val()), [h_arena, a_arena](auto&& vi) {
+    const auto& h_val = as_array_or_scalar(h_arena).val();
+    const auto& a_val = as_array_or_scalar(a_arena).val();
+    const auto neg_avi_sq_div_2 = -square(h_val) * 0.5;
+    const auto one_p_bvi_sq = 1.0 + square(a_val);
+    h_arena.adj() += possibly_sum<is_stan_scalar<VarVal1>>(as_array_or_scalar(vi.adj()) * erf(a_val * h_val * INV_SQRT_TWO)
+                  * exp(neg_avi_sq_div_2) * INV_SQRT_TWO_PI * -0.5);
+    a_arena.adj() += possibly_sum<is_stan_scalar<VarVal2>>(as_array_or_scalar(vi.adj()) * exp(neg_avi_sq_div_2 * one_p_bvi_sq)
+                  / (one_p_bvi_sq * TWO_PI));
+
+  });
 }
 
 /**
@@ -71,12 +47,27 @@ inline var owens_t(const var& h, const var& a) {
  * Used to compute the cumulative density function for the skew normal
  * distribution.
  *
+ * @tparam VarValue A scalar or Eigen type.
+ * @tparam Arith A scalar or Eigen type with an inner arirthmetic scalar value.
  * @param h var parameter.
  * @param a double parameter.
  * @return The Owen's T function.
  */
-inline var owens_t(const var& h, double a) {
-  return var(new internal::owens_t_vd_vari(h.vi_, a));
+template <typename VarValue, typename Arith, require_vt_arithmetic<Arith>* = nullptr,
+ require_not_std_vector_t<Arith>* = nullptr>
+inline auto owens_t(const var_value<VarValue>& h, const Arith& a) {
+  auto h_arena = to_arena(h);
+  auto a_arena = to_arena(a);
+  using return_type = return_var_matrix_t<decltype(owens_t(h_arena.val(), a_arena)), VarValue, Arith>;
+  arena_t<return_type> vi = owens_t(h_arena.val(), a_arena);
+  reverse_pass_callback([h_arena, a_arena, vi]() {
+    h_arena.adj() += possibly_sum<is_stan_scalar<VarValue>>(as_array_or_scalar(vi.adj()) *
+    erf(as_array_or_scalar(a_arena) * as_array_or_scalar(h_arena).val() * INV_SQRT_TWO)
+                  * exp(-square(as_array_or_scalar(h_arena).val()) * 0.5) * INV_SQRT_TWO_PI
+                  * -0.5);
+
+  });
+  return return_type(vi);
 }
 
 /**
@@ -85,12 +76,26 @@ inline var owens_t(const var& h, double a) {
  * Used to compute the cumulative density function for the skew normal
  * distribution.
  *
+ * @tparam VarValue A scalar or Eigen type.
+ * @tparam Arith A scalar or Eigen type with an inner arirthmetic scalar value.
  * @param h double parameter.
  * @param a var parameter.
  * @return The Owen's T function.
  */
-inline var owens_t(double h, const var& a) {
-  return var(new internal::owens_t_dv_vari(h, a.vi_));
+template <typename Arith, typename VarValue, require_vt_arithmetic<Arith>* = nullptr,
+ require_not_std_vector_t<Arith>* = nullptr>
+inline auto owens_t(const Arith& h, const var_value<VarValue>& a) {
+  auto h_arena = to_arena(h);
+  auto a_arena = to_arena(a);
+  using return_type = return_var_matrix_t<decltype(owens_t(h_arena, a_arena.val())), VarValue, Arith>;
+  arena_t<return_type> vi = owens_t(h_arena, a_arena.val());
+  reverse_pass_callback([h_arena, a_arena, vi]() {
+    const auto one_p_bvi_sq = eval(1.0 + square(as_array_or_scalar(a_arena.val())));
+    a_arena.adj() += possibly_sum<is_stan_scalar<VarValue>>(as_array_or_scalar(vi.adj()) * exp(-0.5 * square(as_array_or_scalar(h_arena)) * one_p_bvi_sq)
+                  / (one_p_bvi_sq * TWO_PI));
+
+  });
+  return return_type(vi);
 }
 
 }  // namespace math

--- a/test/unit/math/mix/fun/owens_t_test.cpp
+++ b/test/unit/math/mix/fun/owens_t_test.cpp
@@ -15,6 +15,21 @@ TEST(mathMixScalFun, owensT) {
   stan::test::expect_ad(f, nan, nan);
 }
 
+TEST(mathMixScalFun, owensT_varmat) {
+  auto f = [](const auto& x1, const auto& x2) {
+    return stan::math::owens_t(x1, x2);
+  };
+  double scal = 2.0;
+  Eigen::MatrixXd mat = Eigen::MatrixXd::Random(2, 2);
+  Eigen::VectorXd vec = Eigen::VectorXd::Random(2);
+  stan::test::expect_ad_matvar(f, mat, mat);
+  stan::test::expect_ad_matvar(f, mat, scal);
+  stan::test::expect_ad_matvar(f, scal, mat);
+  stan::test::expect_ad_matvar(f, vec, vec);
+  stan::test::expect_ad_matvar(f, vec, scal);
+  stan::test::expect_ad_matvar(f, scal, vec);
+}
+
 TEST(mathMixScalFun, owensT_vec) {
   auto f = [](const auto& x1, const auto& x2) {
     using stan::math::owens_t;
@@ -27,3 +42,15 @@ TEST(mathMixScalFun, owensT_vec) {
   in2 << 3.0, 4.0;
   stan::test::expect_ad_vectorized_binary(f, in1, in2);
 }
+
+TEST(mathMixScalFun, owensT_vec_matvar) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::owens_t;
+    return owens_t(x1, x2);
+  };
+
+  Eigen::MatrixXd in1(2, 2);
+  in1 << 0.5, 3.4, 5.2, 0.5;
+  Eigen::MatrixXd in2(2, 2);
+  in2 << 3.3, 0.9, 6.7, 3.3;
+  stan::test::expect_ad_vectorized_matvar(f, in1, in2);}


### PR DESCRIPTION
## Summary

This adds an overload of `owens_t()` that works for mixes of `var<Matrix>`, `Matrix<var/double>`, and `var/double` types.

@andrjohns I added you as a reviewer here because I could use your help brainstorming a nice way to turn off the binary vectorization framework for when we have specializations that works for mixes of the types above. I think whatever I do here I would do for other binary functions like `log_sum_exp` and friends. Right now I just wrote `owens_t()` in rev to work with all of the above (as long as one input has a `var` scalar type and none are standard vectors. I think I could pretty easily take this pattern and apply it to the rest of the binary functions. Though I think binary functions that accept integers / arrays of integers as an input will still need special care.

## Tests

The `owens_t` test in `mix` has new tests for combinations of matrices and scalars and their vectorized versions as well. It can be run with the following

```
./runTests.py ./test/unit/math/mix/fun/owens_t_test 
```

## Side Effects

@andrjohns I'm curious if you can think of a nicer way to turn off the binary vectorization framework when we don't need it. I _think_, as long as I use the same pattern for other binary functions this should be fine.

One thing we may also want to do is still explicitly have `owens_t(var/double, var/double)` signatures. I did not test it but I would guess that there would be a small slowdown from using the `reverse_pass_callback()` pattern

## Release notes

Adds varmat overload for `owens_t`

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
