### PR TITLE
Bugfix - OpenCL with Integrated GPU

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -219,6 +219,12 @@ ifdef STAN_OPENCL
   CPPFLAGS_OPENCL += -DCL_HPP_TARGET_OPENCL_VERSION=120 -DCL_HPP_MINIMUM_OPENCL_VERSION=120
   CPPFLAGS_OPENCL += -DCL_HPP_ENABLE_EXCEPTIONS -Wno-ignored-attributes
   CXXFLAGS_OPENCL ?= -I $(OPENCL)
+
+	ifdef INTEGRATED_OPENCL
+		CPPFLAGS_OPENCL += -DINTEGRATED_OPENCL=1
+	else
+		CPPFLAGS_OPENCL += -DINTEGRATED_OPENCL=0
+	endif
 endif
 
 ################################################################################

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -546,8 +546,8 @@ class matrix_cl : public matrix_cl_base {
     try {
       if (opencl_context.device()[0].getInfo<CL_DEVICE_HOST_UNIFIED_MEMORY>()) {
         constexpr auto copy_or_share
-          = CL_MEM_COPY_HOST_PTR * INTEGRATED_OPENCL
-            | (CL_MEM_USE_HOST_PTR * !INTEGRATED_OPENCL);
+            = CL_MEM_COPY_HOST_PTR * INTEGRATED_OPENCL
+              | (CL_MEM_USE_HOST_PTR * !INTEGRATED_OPENCL);
         buffer_cl_
             = cl::Buffer(ctx, CL_MEM_READ_WRITE | copy_or_share,
                          sizeof(T) * size(), A);  // this is always synchronous

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -545,8 +545,11 @@ class matrix_cl : public matrix_cl_base {
     cl::CommandQueue& queue = opencl_context.queue();
     try {
       if (opencl_context.device()[0].getInfo<CL_DEVICE_HOST_UNIFIED_MEMORY>()) {
+        constexpr auto copy_or_share
+          = CL_MEM_COPY_HOST_PTR * INTEGRATED_OPENCL
+            | (CL_MEM_USE_HOST_PTR * !INTEGRATED_OPENCL);
         buffer_cl_
-            = cl::Buffer(ctx, CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR,
+            = cl::Buffer(ctx, CL_MEM_READ_WRITE | copy_or_share,
                          sizeof(T) * size(), A);  // this is always synchronous
       } else {
         buffer_cl_ = cl::Buffer(ctx, CL_MEM_READ_WRITE, sizeof(T) * size());


### PR DESCRIPTION
## Summary

Calling OpenCL Math code with integrated graphics results in a buffer allocation error - due to the use of shared memory between the CPU and GPU.  To resolve this, the data needs an additional copy to be made.

This PR adds the use of `make/local` flag: `INTEGRATED_OPENCL=true` to indicate that integrated graphics is being used and that this additional copy should be made

## Tests

N/A

## Side Effects

N/A

## Release notes

Fixed running OpenCL code with integrated GPUs

## Checklist

- [x] Math issue #2789

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
