### PR TITLE
Expose hypergeometric_2F1 function

### DIFF
--- a/stan/math/fwd/fun.hpp
+++ b/stan/math/fwd/fun.hpp
@@ -41,6 +41,7 @@
 #include <stan/math/fwd/fun/gamma_p.hpp>
 #include <stan/math/fwd/fun/gamma_q.hpp>
 #include <stan/math/fwd/fun/grad_inc_beta.hpp>
+#include <stan/math/fwd/fun/hypergeometric_2F1.hpp>
 #include <stan/math/fwd/fun/hypergeometric_pFq.hpp>
 #include <stan/math/fwd/fun/hypot.hpp>
 #include <stan/math/fwd/fun/inc_beta.hpp>

--- a/stan/math/fwd/fun/grad_inc_beta.hpp
+++ b/stan/math/fwd/fun/grad_inc_beta.hpp
@@ -41,9 +41,10 @@ void grad_inc_beta(fvar<T>& g1, fvar<T>& g2, fvar<T> a, fvar<T> b, fvar<T> z) {
   fvar<T> dF1 = 0;
   fvar<T> dF2 = 0;
   fvar<T> dF3 = 0;
+  fvar<T> dFz = 0;
 
   if (value_of(value_of(C))) {
-    grad_2F1(dF1, dF2, dF3, a + b, fvar<T>(1.0), a + 1, z);
+    grad_2F1(dF1, dF2, dF3, dFz, a + b, fvar<T>(1.0), a + 1, z);
   }
 
   g1 = (c1 - 1.0 / a) * c3 + C * (dF1 + dF3);

--- a/stan/math/fwd/fun/grad_inc_beta.hpp
+++ b/stan/math/fwd/fun/grad_inc_beta.hpp
@@ -44,7 +44,9 @@ void grad_inc_beta(fvar<T>& g1, fvar<T>& g2, fvar<T> a, fvar<T> b, fvar<T> z) {
   fvar<T> dFz = 0;
 
   if (value_of(value_of(C))) {
-    grad_2F1(dF1, dF2, dF3, dFz, a + b, fvar<T>(1.0), a + 1, z);
+    auto grad_tuple = grad_2F1<true>(a + b, fvar<T>(1.0), a + 1, z);
+    dF1 = std::get<0>(grad_tuple);
+    dF3 = std::get<2>(grad_tuple);
   }
 
   g1 = (c1 - 1.0 / a) * c3 + C * (dF1 + dF3);

--- a/stan/math/fwd/fun/grad_inc_beta.hpp
+++ b/stan/math/fwd/fun/grad_inc_beta.hpp
@@ -43,10 +43,9 @@ void grad_inc_beta(fvar<T>& g1, fvar<T>& g2, fvar<T> a, fvar<T> b, fvar<T> z) {
   fvar<T> dF3 = 0;
   fvar<T> dFz = 0;
 
-  if (value_of(value_of(C))) {
-    auto grad_tuple = grad_2F1<true>(a + b, fvar<T>(1.0), a + 1, z);
-    dF1 = std::get<0>(grad_tuple);
-    dF3 = std::get<2>(grad_tuple);
+  if (value_of_rec(C)) {
+    std::forward_as_tuple(dF1, dF2, dF3, dFz)
+       = grad_2F1<true>(a + b, fvar<T>(1.0), a + 1, z);
   }
 
   g1 = (c1 - 1.0 / a) * c3 + C * (dF1 + dF3);

--- a/stan/math/fwd/fun/grad_inc_beta.hpp
+++ b/stan/math/fwd/fun/grad_inc_beta.hpp
@@ -45,7 +45,7 @@ void grad_inc_beta(fvar<T>& g1, fvar<T>& g2, fvar<T> a, fvar<T> b, fvar<T> z) {
 
   if (value_of_rec(C)) {
     std::forward_as_tuple(dF1, dF2, dF3, dFz)
-       = grad_2F1<true>(a + b, fvar<T>(1.0), a + 1, z);
+        = grad_2F1<true>(a + b, fvar<T>(1.0), a + 1, z);
   }
 
   g1 = (c1 - 1.0 / a) * c3 + C * (dF1 + dF3);

--- a/stan/math/fwd/fun/hypergeometric_2F1.hpp
+++ b/stan/math/fwd/fun/hypergeometric_2F1.hpp
@@ -45,9 +45,7 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   decltype(b_val) g_b;
   decltype(z_val) g_z;
 
-  grad_2F1<!is_constant<Ta1>::value, !is_constant<Ta2>::value,
-            !is_constant<Tb>::value, !is_constant<Tz>::value>
-                 (g_a1, g_a2, g_b, g_z, a1_val, a2_val, b_val, z_val);
+  grad_2F1(g_a1, g_a2, g_b, g_z, a1_val, a2_val, b_val, z_val);
 
   typename fvar_t::Scalar grad = 0;
 

--- a/stan/math/fwd/fun/hypergeometric_2F1.hpp
+++ b/stan/math/fwd/fun/hypergeometric_2F1.hpp
@@ -16,6 +16,10 @@ namespace math {
  *
  * See 'grad_2F1.hpp' for the derivatives wrt each parameter
  *
+ * @tparam Ta1 Type of scalar first 'a' argument
+ * @tparam Ta2 Type of scalar second 'a' argument
+ * @tparam Tb Type of scalar 'b' argument
+ * @tparam Tz Type of scalar 'z' argument
  * @param[in] a1 First of 'a' arguments to function
  * @param[in] a2 Second of 'a' arguments to function
  * @param[in] b 'b' argument to function
@@ -25,7 +29,7 @@ namespace math {
 template <typename Ta1, typename Ta2, typename Tb, typename Tz,
           require_all_stan_scalar_t<Ta1, Ta2, Tb, Tz>* = nullptr,
           require_any_fvar_t<Ta1, Ta2, Tb, Tz>* = nullptr>
-return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1, const Ta2& a2,
+inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1, const Ta2& a2,
                                                    const Tb& b, const Tz& z) {
   using fvar_t = return_type_t<Ta1, Ta1, Tb, Tz>;
 

--- a/stan/math/fwd/fun/hypergeometric_2F1.hpp
+++ b/stan/math/fwd/fun/hypergeometric_2F1.hpp
@@ -1,0 +1,69 @@
+#ifndef STAN_MATH_FWD_FUN_HYPERGEOMETRIC_2F1_HPP
+#define STAN_MATH_FWD_FUN_HYPERGEOMETRIC_2F1_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/fwd/core.hpp>
+#include <stan/math/prim/fun/hypergeometric_2F1.hpp>
+#include <stan/math/prim/fun/grad_2F1.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the Gauss hypergeometric function applied to the
+ * input arguments:
+ * \f$_2F_1(a_1,a_2;b;z)\f$
+ *
+ * See 'grad_2F1.hpp' for the derivatives wrt each parameter
+ *
+ * @param[in] a1 First of 'a' arguments to function
+ * @param[in] a2 Second of 'a' arguments to function
+ * @param[in] b 'b' argument to function
+ * @param[in] z Scalar z argument
+ * @return Gauss hypergeometric function
+ */
+template <typename Ta1, typename Ta2, typename Tb, typename Tz,
+          require_all_stan_scalar_t<Ta1, Ta2, Tb, Tz>* = nullptr,
+          require_any_fvar_t<Ta1, Ta2, Tb, Tz>* = nullptr>
+return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
+                                                    const Ta2& a2,
+                                                    const Tb& b,
+                                                    const Tz& z) {
+  using fvar_t = return_type_t<Ta1, Ta1, Tb, Tz>;
+
+  auto a1_val = value_of(a1);
+  auto a2_val = value_of(a2);
+  auto b_val = value_of(b);
+  auto z_val = value_of(z);
+
+  decltype(a1_val) g_a1;
+  decltype(a2_val) g_a2;
+  decltype(b_val) g_b;
+
+  grad_2F1(g_a1, g_a2, g_b, a1_val, a2_val, b_val, z_val);
+
+  typename fvar_t::Scalar grad = 0;
+
+  if (!is_constant<Ta1>::value) {
+    grad += forward_as<fvar_t>(a1).d() * g_a1;
+  }
+  if (!is_constant<Ta2>::value) {
+    grad += forward_as<fvar_t>(a2).d() * g_a2;
+  }
+  if (!is_constant<Tb>::value) {
+    grad += forward_as<fvar_t>(b).d() * g_b;
+  }
+  if (!is_constant<Tz>::value) {
+  auto hyper_2f1_dz =
+    hypergeometric_2F1(a1_val + 1, a2_val + 1, b_val + 1, z_val);
+  grad += forward_as<fvar_t>(z).d()
+    * (a1_val * a2_val * hyper_2f1_dz) / b_val;
+  }
+
+  return fvar_t(
+      hypergeometric_2F1(a1_val, a2_val, b_val, z_val), grad);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/fwd/fun/hypergeometric_2F1.hpp
+++ b/stan/math/fwd/fun/hypergeometric_2F1.hpp
@@ -40,26 +40,21 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   auto b_val = value_of(b);
   auto z_val = value_of(z);
 
-  decltype(a1_val) g_a1;
-  decltype(a2_val) g_a2;
-  decltype(b_val) g_b;
-  decltype(z_val) g_z;
-
-  grad_2F1(g_a1, g_a2, g_b, g_z, a1, a2, b, z);
+  auto grad_tuple = grad_2F1(a1, a2, b, z);
 
   typename fvar_t::Scalar grad = 0;
 
   if (!is_constant<Ta1>::value) {
-    grad += forward_as<fvar_t>(a1).d() * g_a1;
+    grad += forward_as<fvar_t>(a1).d() * std::get<0>(grad_tuple);
   }
   if (!is_constant<Ta2>::value) {
-    grad += forward_as<fvar_t>(a2).d() * g_a2;
+    grad += forward_as<fvar_t>(a2).d() * std::get<1>(grad_tuple);
   }
   if (!is_constant<Tb>::value) {
-    grad += forward_as<fvar_t>(b).d() * g_b;
+    grad += forward_as<fvar_t>(b).d() * std::get<2>(grad_tuple);
   }
   if (!is_constant<Tz>::value) {
-    grad += forward_as<fvar_t>(z).d() * g_z;
+    grad += forward_as<fvar_t>(z).d() * std::get<3>(grad_tuple);
   }
 
   return fvar_t(hypergeometric_2F1(a1_val, a2_val, b_val, z_val), grad);

--- a/stan/math/fwd/fun/hypergeometric_2F1.hpp
+++ b/stan/math/fwd/fun/hypergeometric_2F1.hpp
@@ -45,7 +45,7 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   decltype(b_val) g_b;
   decltype(z_val) g_z;
 
-  grad_2F1(g_a1, g_a2, g_b, g_z, a1_val, a2_val, b_val, z_val);
+  grad_2F1(g_a1, g_a2, g_b, g_z, a1, a2, b, z);
 
   typename fvar_t::Scalar grad = 0;
 

--- a/stan/math/fwd/fun/hypergeometric_2F1.hpp
+++ b/stan/math/fwd/fun/hypergeometric_2F1.hpp
@@ -25,10 +25,8 @@ namespace math {
 template <typename Ta1, typename Ta2, typename Tb, typename Tz,
           require_all_stan_scalar_t<Ta1, Ta2, Tb, Tz>* = nullptr,
           require_any_fvar_t<Ta1, Ta2, Tb, Tz>* = nullptr>
-return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
-                                                    const Ta2& a2,
-                                                    const Tb& b,
-                                                    const Tz& z) {
+return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1, const Ta2& a2,
+                                                   const Tb& b, const Tz& z) {
   using fvar_t = return_type_t<Ta1, Ta1, Tb, Tz>;
 
   auto a1_val = value_of(a1);
@@ -54,14 +52,13 @@ return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
     grad += forward_as<fvar_t>(b).d() * g_b;
   }
   if (!is_constant<Tz>::value) {
-    auto hyper_2f1_dz =
-      hypergeometric_2F1(a1_val + 1, a2_val + 1, b_val + 1, z_val);
-    grad += forward_as<fvar_t>(z).d()
-      * (a1_val * a2_val * hyper_2f1_dz) / b_val;
+    auto hyper_2f1_dz
+        = hypergeometric_2F1(a1_val + 1, a2_val + 1, b_val + 1, z_val);
+    grad
+        += forward_as<fvar_t>(z).d() * (a1_val * a2_val * hyper_2f1_dz) / b_val;
   }
 
-  return fvar_t(
-      hypergeometric_2F1(a1_val, a2_val, b_val, z_val), grad);
+  return fvar_t(hypergeometric_2F1(a1_val, a2_val, b_val, z_val), grad);
 }
 
 }  // namespace math

--- a/stan/math/fwd/fun/hypergeometric_2F1.hpp
+++ b/stan/math/fwd/fun/hypergeometric_2F1.hpp
@@ -54,10 +54,10 @@ return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
     grad += forward_as<fvar_t>(b).d() * g_b;
   }
   if (!is_constant<Tz>::value) {
-  auto hyper_2f1_dz =
-    hypergeometric_2F1(a1_val + 1, a2_val + 1, b_val + 1, z_val);
-  grad += forward_as<fvar_t>(z).d()
-    * (a1_val * a2_val * hyper_2f1_dz) / b_val;
+    auto hyper_2f1_dz =
+      hypergeometric_2F1(a1_val + 1, a2_val + 1, b_val + 1, z_val);
+    grad += forward_as<fvar_t>(z).d()
+      * (a1_val * a2_val * hyper_2f1_dz) / b_val;
   }
 
   return fvar_t(

--- a/stan/math/fwd/fun/hypergeometric_2F1.hpp
+++ b/stan/math/fwd/fun/hypergeometric_2F1.hpp
@@ -29,8 +29,10 @@ namespace math {
 template <typename Ta1, typename Ta2, typename Tb, typename Tz,
           require_all_stan_scalar_t<Ta1, Ta2, Tb, Tz>* = nullptr,
           require_any_fvar_t<Ta1, Ta2, Tb, Tz>* = nullptr>
-inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1, const Ta2& a2,
-                                                   const Tb& b, const Tz& z) {
+inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
+                                                          const Ta2& a2,
+                                                          const Tb& b,
+                                                          const Tz& z) {
   using fvar_t = return_type_t<Ta1, Ta1, Tb, Tz>;
 
   auto a1_val = value_of(a1);

--- a/stan/math/fwd/fun/hypergeometric_2F1.hpp
+++ b/stan/math/fwd/fun/hypergeometric_2F1.hpp
@@ -43,8 +43,11 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   decltype(a1_val) g_a1;
   decltype(a2_val) g_a2;
   decltype(b_val) g_b;
+  decltype(z_val) g_z;
 
-  grad_2F1(g_a1, g_a2, g_b, a1_val, a2_val, b_val, z_val);
+  grad_2F1<!is_constant<Ta1>::value, !is_constant<Ta2>::value,
+            !is_constant<Tb>::value, !is_constant<Tz>::value>
+                 (g_a1, g_a2, g_b, g_z, a1_val, a2_val, b_val, z_val);
 
   typename fvar_t::Scalar grad = 0;
 
@@ -58,10 +61,7 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
     grad += forward_as<fvar_t>(b).d() * g_b;
   }
   if (!is_constant<Tz>::value) {
-    auto hyper_2f1_dz
-        = hypergeometric_2F1(a1_val + 1, a2_val + 1, b_val + 1, z_val);
-    grad
-        += forward_as<fvar_t>(z).d() * (a1_val * a2_val * hyper_2f1_dz) / b_val;
+    grad += forward_as<fvar_t>(z).d() * g_z;
   }
 
   return fvar_t(hypergeometric_2F1(a1_val, a2_val, b_val, z_val), grad);

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -129,8 +129,9 @@
 #include <stan/math/prim/fun/grad_reg_inc_gamma.hpp>
 #include <stan/math/prim/fun/grad_reg_lower_inc_gamma.hpp>
 #include <stan/math/prim/fun/head.hpp>
-#include <stan/math/prim/fun/hypergeometric_pFq.hpp>
+#include <stan/math/prim/fun/hypergeometric_2F1.hpp>
 #include <stan/math/prim/fun/hypergeometric_2F2.hpp>
+#include <stan/math/prim/fun/hypergeometric_pFq.hpp>
 #include <stan/math/prim/fun/hypot.hpp>
 #include <stan/math/prim/fun/identity_constrain.hpp>
 #include <stan/math/prim/fun/identity_free.hpp>

--- a/stan/math/prim/fun/grad_2F1.hpp
+++ b/stan/math/prim/fun/grad_2F1.hpp
@@ -57,15 +57,15 @@ namespace internal {
  *   to truncate the sum
  * @param[in] max_steps number of steps to take
  */
-template <bool calc_a1, bool calc_a2, bool calc_b1, bool calc_z,
-          typename Tg1, typename Tg2, typename Tg3, typename T_gz,
-          typename T1, typename T2, typename T3, typename T_z,
+template <bool calc_a1, bool calc_a2, bool calc_b1, bool calc_z, typename Tg1,
+          typename Tg2, typename Tg3, typename T_gz, typename T1, typename T2,
+          typename T3, typename T_z,
           typename ScalarT = return_type_t<T1, T2, T3, T_z>,
           typename TupleT = std::tuple<T1, T2, T3, T_z>,
           typename OptT = boost::optional<TupleT>>
 void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
-              const T2& a2, const T3& b1, const T_z& z,
-              double precision = 1e-14, int max_steps = 1e6) {
+                   const T2& a2, const T3& b1, const T_z& z,
+                   double precision = 1e-14, int max_steps = 1e6) {
   bool euler_transform = false;
   try {
     check_2F1_converges("hypergeometric_2F1", a1, a2, b1, z);
@@ -90,8 +90,9 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
       auto hyper2 = hypergeometric_2F1(1 + a2, 1 - a1 + b1, 1 + b1, z_t);
       auto pre_mult = a2 * pow(1 - z, -1 - a2);
       g_z = a2 * pow(1 - z, -1 - a2) * hyper1
-        + (a2 * (b1 - a1) * pow(1 - z, -a2)
-              * (inv(z - 1) - z / square(z - 1)) * hyper2) / b1;
+            + (a2 * (b1 - a1) * pow(1 - z, -a2)
+               * (inv(z - 1) - z / square(z - 1)) * hyper2)
+                  / b1;
     } else {
       auto hyper_2f1_dz = hypergeometric_2F1(a1 + 1.0, a2 + 1.0, b1 + 1.0, z);
       g_z = (a1 * a2 * hyper_2f1_dz) / b1;
@@ -155,10 +156,9 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
     log_t_new_sign = sign(value_of_rec(p)) * log_t_new_sign;
 
     if (calc_a1_euler) {
-      ret_t term_a1 = log_g_old_sign(0)
-                      * log_t_old_sign
-                      * exp(log_g_old(0) - log_t_old)
-                      + inv(a1_t + k);
+      ret_t term_a1
+          = log_g_old_sign(0) * log_t_old_sign * exp(log_g_old(0) - log_t_old)
+            + inv(a1_t + k);
       log_g_old(0) = log_t_new + log(abs(term_a1));
       log_g_old_sign(0) = sign(value_of_rec(term_a1)) * log_t_new_sign;
       g_current(0) = log_g_old_sign(0) * exp(log_g_old(0)) * sign_zk;
@@ -166,10 +166,9 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
     }
 
     if (calc_a2_euler) {
-      ret_t term_a2 = log_g_old_sign(1)
-                      * log_t_old_sign
-                      * exp(log_g_old(1) - log_t_old)
-                      + inv(a2_t + k);
+      ret_t term_a2
+          = log_g_old_sign(1) * log_t_old_sign * exp(log_g_old(1) - log_t_old)
+            + inv(a2_t + k);
       log_g_old(1) = log_t_new + log(abs(term_a2));
       log_g_old_sign(1) = sign(value_of_rec(term_a2)) * log_t_new_sign;
       g_current(1) = log_g_old_sign(1) * exp(log_g_old(1)) * sign_zk;
@@ -177,10 +176,9 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
     }
 
     if (calc_b1) {
-      ret_t term_b1 = log_g_old_sign(2)
-                      * log_t_old_sign
-                      * exp(log_g_old(2) - log_t_old)
-                      + inv(-(b1 + k));
+      ret_t term_b1
+          = log_g_old_sign(2) * log_t_old_sign * exp(log_g_old(2) - log_t_old)
+            + inv(-(b1 + k));
       log_g_old(2) = log_t_new + log(abs(term_b1));
       log_g_old_sign(2) = sign(value_of_rec(term_b1)) * log_t_new_sign;
       g_current(2) = log_g_old_sign(2) * exp(log_g_old(2)) * sign_zk;
@@ -217,8 +215,8 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
   if (k > max_steps) {
     throw_domain_error("grad_2F1", "k (internal counter)", max_steps,
                        "exceeded ",
-                      " iterations, hypergeometric function gradient "
-                      "did not converge.");
+                       " iterations, hypergeometric function gradient "
+                       "did not converge.");
   }
   return;
 }
@@ -250,19 +248,15 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
  *   to truncate the sum
  * @param[in] max_steps number of steps to take
  */
-template <typename Tg1, typename Tg2, typename Tg3, typename T_gz,
-          typename T1, typename T2, typename T3, typename T_z>
+template <typename Tg1, typename Tg2, typename Tg3, typename T_gz, typename T1,
+          typename T2, typename T3, typename T_z>
 void grad_2F1(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
               const T2& a2, const T3& b1, const T_z& z,
               double precision = 1e-14, int max_steps = 1e6) {
-  internal::grad_2F1_impl<
-    !is_constant<T1>::value,
-    !is_constant<T2>::value,
-    !is_constant<T3>::value,
-    !is_constant<T_z>::value>(
-      g_a1, g_a2, g_b1, g_z,
-      value_of(a1), value_of(a2), value_of(b1), value_of(z),
-      precision, max_steps);
+  internal::grad_2F1_impl<!is_constant<T1>::value, !is_constant<T2>::value,
+                          !is_constant<T3>::value, !is_constant<T_z>::value>(
+      g_a1, g_a2, g_b1, g_z, value_of(a1), value_of(a2), value_of(b1),
+      value_of(z), precision, max_steps);
   return;
 }
 
@@ -295,8 +289,8 @@ template <typename T1, typename T2, typename T3, typename T_z>
 void grad_2F1(T1& g_a1, T2& g_a2, T3& g_b1, T_z& g_z, const T1& a1,
               const T2& a2, const T3& b1, const T_z& z,
               double precision = 1e-14, int max_steps = 1e6) {
-  internal::grad_2F1_impl<true, true, true, true>(
-      g_a1, g_a2, g_b1, g_z, a1, a2, b1, z, precision, max_steps);
+  internal::grad_2F1_impl<true, true, true, true>(g_a1, g_a2, g_b1, g_z, a1, a2,
+                                                  b1, z, precision, max_steps);
   return;
 }
 

--- a/stan/math/prim/fun/grad_2F1.hpp
+++ b/stan/math/prim/fun/grad_2F1.hpp
@@ -21,6 +21,119 @@ namespace math {
 namespace internal {
 /**
  * Implementation function to calculate the gradients of the hypergeometric
+ * function, 2F1 with respect to the a1, a2, and b2 parameters.
+ *
+ * Calculate the gradients of the hypergeometric function (2F1)
+ * as the power series stopping when the series converges
+ * to within <code>precision</code> or throwing when the
+ * function takes <code>max_steps</code> steps.
+ *
+ * @tparam calc_a1 boolean for whether to calculate gradients w.r.t a1
+ * @tparam calc_a2 boolean for whether to calculate gradients w.r.t a2
+ * @tparam calc_b1 boolean for whether to calculate gradients w.r.t b1
+ * @tparam T1 scalar type of a1
+ * @tparam T2 scalar type of a2
+ * @tparam T3 scalar type of b1
+ * @tparam T_z scalar type of z
+ * @param[in] a1 see generalized hypergeometric function definition
+ * @param[in] a2 see generalized hypergeometric function definition
+ * @param[in] b1 see generalized hypergeometric function definition
+ * @param[in] z see generalized hypergeometric function definition
+ * @param[in] precision magnitude of the increment of the infinite sum
+ *   to truncate the sum
+ * @param[in] max_steps number of steps to take
+ * @return Three-element tuple containing gradients w.r.t. a1, a2, and b1,
+ *   as indicated by the calc_a1, calc_a2, and calc_b1 booleans
+ */
+template <bool calc_a1, bool calc_a2, bool calc_b1,
+          typename T1, typename T2, typename T3, typename T_z,
+          typename ScalarT = return_type_t<T1, T2, T3, T_z>,
+          typename TupleT = std::tuple<ScalarT, ScalarT, ScalarT>>
+TupleT grad_2F1_impl_ab(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
+                      double precision = 1e-14, int max_steps = 1e6) {
+  TupleT grad_tuple = TupleT(0, 0, 0);
+
+  if (z == 0) {
+    return grad_tuple;
+  }
+
+  using ScalarArrayT = Eigen::Array<ScalarT, 3, 1>;
+  ScalarArrayT log_g_old = ScalarArrayT::Constant(3, 1, NEGATIVE_INFTY);
+
+  ScalarT log_t_old = 0.0;
+  ScalarT log_t_new = 0.0;
+  int sign_z = sign(z);
+  auto log_z = log(abs(z));
+
+  double log_precision = log(precision);
+  int log_t_new_sign = 1.0;
+  int log_t_old_sign = 1.0;
+
+  Eigen::Array<int, 3, 1> log_g_old_sign = Eigen::Array<int, 3, 1>::Ones(3);
+
+  int sign_zk = sign_z;
+  int k = 0;
+  ScalarT inner_diff = 1;
+  ScalarArrayT g_current = ScalarArrayT::Zero(3);
+
+  while (inner_diff > precision && k < max_steps) {
+    ScalarT p = ((a1 + k) * (a2 + k) / ((b1 + k) * (1.0 + k)));
+    if (p == 0) {
+      return grad_tuple;
+    }
+    log_t_new += log(fabs(p)) + log_z;
+    log_t_new_sign = sign(value_of_rec(p)) * log_t_new_sign;
+
+    if (calc_a1) {
+      ScalarT term_a1
+          = log_g_old_sign(0) * log_t_old_sign * exp(log_g_old(0) - log_t_old)
+            + inv(a1 + k);
+      log_g_old(0) = log_t_new + log(abs(term_a1));
+      log_g_old_sign(0) = sign(value_of_rec(term_a1)) * log_t_new_sign;
+      g_current(0) = log_g_old_sign(0) * exp(log_g_old(0)) * sign_zk;
+      std::get<0>(grad_tuple) += g_current(0);
+    }
+
+    if (calc_a2) {
+      ScalarT term_a2
+          = log_g_old_sign(1) * log_t_old_sign * exp(log_g_old(1) - log_t_old)
+            + inv(a2 + k);
+      log_g_old(1) = log_t_new + log(abs(term_a2));
+      log_g_old_sign(1) = sign(value_of_rec(term_a2)) * log_t_new_sign;
+      g_current(1) = log_g_old_sign(1) * exp(log_g_old(1)) * sign_zk;
+      std::get<1>(grad_tuple) += g_current(1);
+    }
+
+    if (calc_b1) {
+      ScalarT term_b1
+          = log_g_old_sign(2) * log_t_old_sign * exp(log_g_old(2) - log_t_old)
+            + inv(-(b1 + k));
+      log_g_old(2) = log_t_new + log(abs(term_b1));
+      log_g_old_sign(2) = sign(value_of_rec(term_b1)) * log_t_new_sign;
+      g_current(2) = log_g_old_sign(2) * exp(log_g_old(2)) * sign_zk;
+      std::get<2>(grad_tuple) += g_current(2);
+    }
+
+    inner_diff = g_current.array().abs().maxCoeff();
+
+    log_t_old = log_t_new;
+    log_t_old_sign = log_t_new_sign;
+    sign_zk *= sign_z;
+    ++k;
+  }
+
+  if (k > max_steps) {
+    throw_domain_error("grad_2F1", "k (internal counter)", max_steps,
+                       "exceeded ",
+                       " iterations, hypergeometric function gradient "
+                       "did not converge.");
+  }
+  return grad_tuple;
+}
+
+
+/**
+ * Implementation function to calculate the gradients of the hypergeometric
  * function, 2F1.
  *
  * Calculate the gradients of the hypergeometric function (2F1)
@@ -37,18 +150,10 @@ namespace internal {
  * @tparam calc_a2 boolean for whether to calculate gradients w.r.t a2
  * @tparam calc_b1 boolean for whether to calculate gradients w.r.t b1
  * @tparam calc_z boolean for whether to calculate gradients w.r.t z
- * @tparam Tg1 type of outcome variable to store a1 gradient
- * @tparam Tg2 type of outcome variable to store a2 gradient
- * @tparam Tg3 type of outcome variable to store b1 gradient
- * @tparam T_gz type of outcome variable to store z gradient
  * @tparam T1 scalar type of a1
  * @tparam T2 scalar type of a2
  * @tparam T3 scalar type of b1
  * @tparam T_z scalar type of z
- * @param[out] g_a1 reference to gradient of 2F1 w.r.t. a1, result
- * @param[out] g_a2 reference to gradient of 2F1 w.r.t. a2, result
- * @param[out] g_b1 reference to gradient of 2F1 w.r.t. b1, result
- * @param[out] g_z reference to gradient of 2F1 w.r.t. z, result
  * @param[in] a1 see generalized hypergeometric function definition
  * @param[in] a2 see generalized hypergeometric function definition
  * @param[in] b1 see generalized hypergeometric function definition
@@ -56,169 +161,86 @@ namespace internal {
  * @param[in] precision magnitude of the increment of the infinite sum
  *   to truncate the sum
  * @param[in] max_steps number of steps to take
+ * @return Four-element tuple containing gradients w.r.t. to each parameter,
+ *   as indicated by the calc_* booleans
  */
 template <bool calc_a1, bool calc_a2, bool calc_b1, bool calc_z,
-          typename TupleT, typename T1, typename T2, typename T3, typename T_z,
-          typename ScalarT = return_type_t<T1, T2, T3, T_z>>
-TupleT grad_2F1_impl(TupleT&& grad_tuple, const T1& a1, const T2& a2,
-                     const T3& b1, const T_z& z, double precision = 1e-14,
-                     int max_steps = 1e6) {
+          typename T1, typename T2, typename T3, typename T_z,
+          typename ScalarT = return_type_t<T1, T2, T3, T_z>,
+          typename TupleT = std::tuple<ScalarT, ScalarT, ScalarT, ScalarT>>
+TupleT grad_2F1_impl(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
+                    double precision = 1e-14, int max_steps = 1e6) {
   bool euler_transform = false;
   try {
     check_2F1_converges("hypergeometric_2F1", a1, a2, b1, z);
   } catch (const std::exception& e) {
     // Apply Euler's hypergeometric transformation if function
     // will not converge with current arguments
-    check_2F1_converges("hypergeometric_2F1", b1 - a1, a2, b1, z / (z - 1));
+    check_2F1_converges("hypergeometric_2F1 (euler transform)",
+                        b1 - a1, a2, b1, z / (z - 1));
     euler_transform = true;
   }
 
-  ScalarT a1_transformed = euler_transform ? a2 : a1;
-  ScalarT a2_transformed = euler_transform ? b1 - a1 : a2;
-  ScalarT z_transformed = euler_transform ? z / (z - 1) : z;
-
-  using stan::math::value_of_rec;
-  using std::max;
-  using ret_t = return_type_t<T1, T2, T3, T_z>;
-
-  if (calc_z) {
-    if (euler_transform) {
-      auto hyper1 = hypergeometric_2F1(a1_transformed, a2_transformed, b1,
-                                       z_transformed);
-      auto hyper2
-          = hypergeometric_2F1(1 + a2, 1 - a1 + b1, 1 + b1, z_transformed);
+  std::tuple<ScalarT, ScalarT, ScalarT> grad_tuple_ab;
+  TupleT grad_tuple_rtn = TupleT(0, 0, 0, 0);
+  if (euler_transform) {
+    ScalarT a1_euler = a2;
+    ScalarT a2_euler = b1 - a1;
+    ScalarT z_euler = z / (z - 1);
+    if (calc_z) {
+      auto hyper1 = hypergeometric_2F1(a1_euler, a2_euler, b1, z_euler);
+      auto hyper2 = hypergeometric_2F1(1 + a2, 1 - a1 + b1, 1 + b1, z_euler);
       auto pre_mult = a2 * pow(1 - z, -1 - a2);
-      std::get<3>(grad_tuple) = a2 * pow(1 - z, -1 - a2) * hyper1
+      std::get<3>(grad_tuple_rtn) = a2 * pow(1 - z, -1 - a2) * hyper1
                                 + (a2 * (b1 - a1) * pow(1 - z, -a2)
                                    * (inv(z - 1) - z / square(z - 1)) * hyper2)
                                       / b1;
-    } else {
+    }
+    if (calc_a1 || calc_a2 || calc_b1) {
+      // 'a' gradients under Euler transform are constructed using the gradients
+      // of both elements, so need to compute both if any are required
+      constexpr bool calc_a1_euler = calc_a1 || calc_a2;
+      // 'b' gradients under Euler transform require gradients from 'a2'
+      constexpr bool calc_a2_euler = calc_a1 || calc_a2 || calc_b1;
+      grad_tuple_ab = grad_2F1_impl_ab<calc_a1_euler, calc_a2_euler, calc_b1>(
+        a1_euler, a2_euler, b1, z_euler);
+
+      auto pre_mult_ab = inv(pow(1.0 - z, a2));
+      if (calc_a1) {
+        std::get<0>(grad_tuple_rtn) = -pre_mult_ab * std::get<1>(grad_tuple_ab);
+      }
+      if (calc_a2) {
+        auto hyper_da2
+            = hypergeometric_2F1(a1_euler, a2, b1, z_euler);
+        std::get<1>(grad_tuple_rtn)
+            = -pre_mult_ab * hyper_da2 * log1m(z)
+              + pre_mult_ab * std::get<0>(grad_tuple_ab);
+      }
+      if (calc_b1) {
+        std::get<2>(grad_tuple_rtn) = pre_mult_ab
+          * (std::get<1>(grad_tuple_ab) + std::get<2>(grad_tuple_ab));
+      }
+    }
+  } else {
+    if (calc_z) {
       auto hyper_2f1_dz = hypergeometric_2F1(a1 + 1.0, a2 + 1.0, b1 + 1.0, z);
-      std::get<3>(grad_tuple) = (a1 * a2 * hyper_2f1_dz) / b1;
+      std::get<3>(grad_tuple_rtn) = (a1 * a2 * hyper_2f1_dz) / b1;
+    }
+    if (calc_a1 || calc_a2 || calc_b1) {
+      grad_tuple_ab
+        = grad_2F1_impl_ab<calc_a1, calc_a2, calc_b1>(a1, a2, b1, z);
+      if (calc_a1) {
+        std::get<0>(grad_tuple_rtn) = std::get<0>(grad_tuple_ab);
+      }
+      if (calc_a2) {
+        std::get<1>(grad_tuple_rtn) = std::get<1>(grad_tuple_ab);
+      }
+      if (calc_b1) {
+        std::get<2>(grad_tuple_rtn) = std::get<2>(grad_tuple_ab);
+      }
     }
   }
-
-  if (z == 0) {
-    return grad_tuple;
-  }
-
-  if (!(calc_a1 || calc_a2 || calc_b1)) {
-    return grad_tuple;
-  }
-
-  bool calc_a1_euler = calc_a1;
-  bool calc_a2_euler = calc_a2;
-
-  if (euler_transform) {
-    // 'a' gradients under Euler transform are constructed using the gradients
-    // of both elements, so need to compute both if any are required
-    if (calc_a1 || calc_a2) {
-      calc_a1_euler = true;
-      calc_a2_euler = true;
-    }
-    // 'b' gradients under Euler transform require gradients from 'a2'
-    if (calc_b1) {
-      calc_a2_euler = true;
-    }
-  }
-
-  using ret_array_t = Eigen::Array<ret_t, 3, 1>;
-  ret_array_t g = ret_array_t::Zero(3);
-
-  ret_array_t log_g_old = ret_array_t::Constant(3, 1, NEGATIVE_INFTY);
-
-  ret_t log_t_old = 0.0;
-  ret_t log_t_new = 0.0;
-  int sign_z = sign(z_transformed);
-  auto log_z = log(abs(z_transformed));
-
-  double log_precision = log(precision);
-  int log_t_new_sign = 1.0;
-  int log_t_old_sign = 1.0;
-
-  Eigen::Array<int, 3, 1> log_g_old_sign = Eigen::Array<int, 3, 1>::Ones(3);
-
-  int sign_zk = sign_z;
-  int k = 0;
-  ret_t inner_diff = 1;
-  ret_array_t g_current = ret_array_t::Zero(3);
-
-  while (inner_diff > precision && k < max_steps) {
-    ret_t p = ((a1_transformed + k) * (a2_transformed + k)
-               / ((b1 + k) * (1.0 + k)));
-    if (p == 0) {
-      return grad_tuple;
-    }
-    log_t_new += log(fabs(p)) + log_z;
-    log_t_new_sign = sign(value_of_rec(p)) * log_t_new_sign;
-
-    if (calc_a1_euler) {
-      ret_t term_a1
-          = log_g_old_sign(0) * log_t_old_sign * exp(log_g_old(0) - log_t_old)
-            + inv(a1_transformed + k);
-      log_g_old(0) = log_t_new + log(abs(term_a1));
-      log_g_old_sign(0) = sign(value_of_rec(term_a1)) * log_t_new_sign;
-      g_current(0) = log_g_old_sign(0) * exp(log_g_old(0)) * sign_zk;
-      g(0) += g_current(0);
-    }
-
-    if (calc_a2_euler) {
-      ret_t term_a2
-          = log_g_old_sign(1) * log_t_old_sign * exp(log_g_old(1) - log_t_old)
-            + inv(a2_transformed + k);
-      log_g_old(1) = log_t_new + log(abs(term_a2));
-      log_g_old_sign(1) = sign(value_of_rec(term_a2)) * log_t_new_sign;
-      g_current(1) = log_g_old_sign(1) * exp(log_g_old(1)) * sign_zk;
-      g(1) += g_current(1);
-    }
-
-    if (calc_b1) {
-      ret_t term_b1
-          = log_g_old_sign(2) * log_t_old_sign * exp(log_g_old(2) - log_t_old)
-            + inv(-(b1 + k));
-      log_g_old(2) = log_t_new + log(abs(term_b1));
-      log_g_old_sign(2) = sign(value_of_rec(term_b1)) * log_t_new_sign;
-      g_current(2) = log_g_old_sign(2) * exp(log_g_old(2)) * sign_zk;
-      g(2) += g_current(2);
-    }
-
-    inner_diff = g_current.array().abs().maxCoeff();
-
-    log_t_old = log_t_new;
-    log_t_old_sign = log_t_new_sign;
-    sign_zk *= sign_z;
-    ++k;
-  }
-
-  auto pre_mult_ab = inv(pow(1.0 - z, a2));
-
-  if (calc_a1) {
-    std::get<0>(grad_tuple) = euler_transform ? -pre_mult_ab * g(1) : g(0);
-  }
-
-  if (calc_a2) {
-    if (euler_transform) {
-      auto hyper_da2
-          = hypergeometric_2F1(a1_transformed, a2, b1, z_transformed);
-      std::get<1>(grad_tuple)
-          = -pre_mult_ab * hyper_da2 * log1m(z) + pre_mult_ab * g(0);
-    } else {
-      std::get<1>(grad_tuple) = g(1);
-    }
-  }
-
-  if (calc_b1) {
-    std::get<2>(grad_tuple)
-        = euler_transform ? pre_mult_ab * (g(1) + g(2)) : g(2);
-  }
-
-  if (k > max_steps) {
-    throw_domain_error("grad_2F1", "k (internal counter)", max_steps,
-                       "exceeded ",
-                       " iterations, hypergeometric function gradient "
-                       "did not converge.");
-  }
-  return grad_tuple;
+  return grad_tuple_rtn;
 }
 }  // namespace internal
 
@@ -228,20 +250,15 @@ TupleT grad_2F1_impl(TupleT&& grad_tuple, const T1& a1, const T2& a2,
  * to within <code>precision</code> or throwing when the
  * function takes <code>max_steps</code> steps.
  *
+ * Overload for use where the destination gradients are not required to be the
+ * same type as the input variables (most use-cases except grad_inc_beta)
+ *
  * @tparam ReturnSameT Whether return gradients need to be the same type as
  *  as inputs
- * @tparam Tg1 type of outcome variable to store a1 gradient
- * @tparam Tg2 type of outcome variable to store a2 gradient
- * @tparam Tg3 type of outcome variable to store b1 gradient
- * @tparam T_gz type of outcome variable to store z gradient
  * @tparam T1 scalar type of a1
  * @tparam T2 scalar type of a2
  * @tparam T3 scalar type of b1
  * @tparam T_z scalar type of z
- * @param[out] g_a1 reference to gradient of 2F1 w.r.t. a1, result
- * @param[out] g_a2 reference to gradient of 2F1 w.r.t. a2, result
- * @param[out] g_b1 reference to gradient of 2F1 w.r.t. b1, result
- * @param[out] g_z reference to gradient of 2F1 w.r.t. z, result
  * @param[in] a1 see generalized hypergeometric function definition
  * @param[in] a2 see generalized hypergeometric function definition
  * @param[in] b1 see generalized hypergeometric function definition
@@ -254,12 +271,9 @@ template <bool ReturnSameT, typename T1, typename T2, typename T3, typename T_z,
           require_not_t<std::integral_constant<bool, ReturnSameT>>* = nullptr>
 auto grad_2F1(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
               double precision = 1e-14, int max_steps = 1e6) {
-  using partials_t = partials_return_t<T1, T2, T3, T_z>;
-  std::tuple<partials_t, partials_t, partials_t, partials_t> ret_tuple;
-
   return internal::grad_2F1_impl<
       !is_constant<T1>::value, !is_constant<T2>::value, !is_constant<T3>::value,
-      !is_constant<T_z>::value>(ret_tuple, value_of(a1), value_of(a2),
+      !is_constant<T_z>::value>(value_of(a1), value_of(a2),
                                 value_of(b1), value_of(z), precision,
                                 max_steps);
 }
@@ -275,18 +289,10 @@ auto grad_2F1(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
  *
  * @tparam ReturnSameT Whether return gradients need to be the same type as
  *  as inputs
- * @tparam Tg1 type of outcome variable to store a1 gradient
- * @tparam Tg2 type of outcome variable to store a2 gradient
- * @tparam Tg3 type of outcome variable to store b1 gradient
- * @tparam T_gz type of outcome variable to store z gradient
  * @tparam T1 scalar type of a1
  * @tparam T2 scalar type of a2
  * @tparam T3 scalar type of b1
  * @tparam T_z scalar type of z
- * @param[out] g_a1 reference to gradient of 2F1 w.r.t. a1, result
- * @param[out] g_a2 reference to gradient of 2F1 w.r.t. a2, result
- * @param[out] g_b1 reference to gradient of 2F1 w.r.t. b1, result
- * @param[out] g_z reference to gradient of 2F1 w.r.t. z, result
  * @param[in] a1 see generalized hypergeometric function definition
  * @param[in] a2 see generalized hypergeometric function definition
  * @param[in] b1 see generalized hypergeometric function definition
@@ -299,11 +305,8 @@ template <bool ReturnSameT, typename T1, typename T2, typename T3, typename T_z,
           require_t<std::integral_constant<bool, ReturnSameT>>* = nullptr>
 auto grad_2F1(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
               double precision = 1e-14, int max_steps = 1e6) {
-  using return_t = return_type_t<T1, T2, T3, T_z>;
-  std::tuple<return_t, return_t, return_t, return_t> ret_tuple;
-
   return internal::grad_2F1_impl<true, true, true, true>(
-      ret_tuple, a1, a2, b1, z, precision, max_steps);
+      a1, a2, b1, z, precision, max_steps);
 }
 
 /**
@@ -316,10 +319,6 @@ auto grad_2F1(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
  * @tparam T2 scalar type of a2
  * @tparam T3 scalar type of b1
  * @tparam T_z scalar type of z
- * @param[out] g_a1 reference to gradient of 2F1 w.r.t. a1, result
- * @param[out] g_a2 reference to gradient of 2F1 w.r.t. a2, result
- * @param[out] g_b1 reference to gradient of 2F1 w.r.t. b1, result
- * @param[out] g_z reference to gradient of 2F1 w.r.t. z, result
  * @param[in] a1 see generalized hypergeometric function definition
  * @param[in] a2 see generalized hypergeometric function definition
  * @param[in] b1 see generalized hypergeometric function definition

--- a/stan/math/prim/fun/grad_2F1.hpp
+++ b/stan/math/prim/fun/grad_2F1.hpp
@@ -57,28 +57,26 @@ namespace internal {
  *   to truncate the sum
  * @param[in] max_steps number of steps to take
  */
-template <bool calc_a1, bool calc_a2, bool calc_b1, bool calc_z, typename Tg1,
-          typename Tg2, typename Tg3, typename T_gz, typename T1, typename T2,
+template <bool calc_a1, bool calc_a2, bool calc_b1, bool calc_z,
+          typename TupleT, typename T1, typename T2,
           typename T3, typename T_z,
-          typename ScalarT = return_type_t<T1, T2, T3, T_z>,
-          typename TupleT = std::tuple<T1, T2, T3, T_z>,
-          typename OptT = boost::optional<TupleT>>
-void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
-                   const T2& a2, const T3& b1, const T_z& z,
-                   double precision = 1e-14, int max_steps = 1e6) {
+          typename ScalarT = return_type_t<T1, T2, T3, T_z>>
+TupleT grad_2F1_impl(TupleT&& grad_tuple, const T1& a1, const T2& a2,
+                      const T3& b1, const T_z& z, double precision = 1e-14,
+                      int max_steps = 1e6) {
   bool euler_transform = false;
   try {
     check_2F1_converges("hypergeometric_2F1", a1, a2, b1, z);
-  } catch (...) {
+  } catch (const std::exception& e) {
     // Apply Euler's hypergeometric transformation if function
     // will not converge with current arguments
     check_2F1_converges("hypergeometric_2F1", b1 - a1, a2, b1, z / (z - 1));
     euler_transform = true;
   }
 
-  ScalarT a1_t = euler_transform ? a2 : a1;
-  ScalarT a2_t = euler_transform ? b1 - a1 : a2;
-  ScalarT z_t = euler_transform ? z / (z - 1) : z;
+  ScalarT a1_transformed = euler_transform ? a2 : a1;
+  ScalarT a2_transformed = euler_transform ? b1 - a1 : a2;
+  ScalarT z_transformed = euler_transform ? z / (z - 1) : z;
 
   using stan::math::value_of_rec;
   using std::max;
@@ -86,25 +84,27 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
 
   if (calc_z) {
     if (euler_transform) {
-      auto hyper1 = hypergeometric_2F1(a1_t, a2_t, b1, z_t);
-      auto hyper2 = hypergeometric_2F1(1 + a2, 1 - a1 + b1, 1 + b1, z_t);
+      auto hyper1 = hypergeometric_2F1(a1_transformed, a2_transformed, b1,
+                                        z_transformed);
+      auto hyper2 = hypergeometric_2F1(1 + a2, 1 - a1 + b1, 1 + b1,
+                                        z_transformed);
       auto pre_mult = a2 * pow(1 - z, -1 - a2);
-      g_z = a2 * pow(1 - z, -1 - a2) * hyper1
+      std::get<3>(grad_tuple) = a2 * pow(1 - z, -1 - a2) * hyper1
             + (a2 * (b1 - a1) * pow(1 - z, -a2)
                * (inv(z - 1) - z / square(z - 1)) * hyper2)
                   / b1;
     } else {
       auto hyper_2f1_dz = hypergeometric_2F1(a1 + 1.0, a2 + 1.0, b1 + 1.0, z);
-      g_z = (a1 * a2 * hyper_2f1_dz) / b1;
+      std::get<3>(grad_tuple) = (a1 * a2 * hyper_2f1_dz) / b1;
     }
   }
 
   if (z == 0) {
-    return;
+    return grad_tuple;
   }
 
   if (!(calc_a1 || calc_a2 || calc_b1)) {
-    return;
+    return grad_tuple;
   }
 
   bool calc_a1_euler = calc_a1;
@@ -123,34 +123,32 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
     }
   }
 
-  Eigen::Array<ret_t, Eigen::Dynamic, 1> g(3);
-  g << 0.0, 0.0, 0.0;
+  using ret_array_t =  Eigen::Array<ret_t, 3, 1>;
+  ret_array_t g = ret_array_t::Zero(3);
 
-  Eigen::Array<ret_t, Eigen::Dynamic, 1> log_g_old(3);
-  log_g_old << NEGATIVE_INFTY, NEGATIVE_INFTY, NEGATIVE_INFTY;
+  ret_array_t log_g_old = ret_array_t::Constant(3, 1, NEGATIVE_INFTY);
 
   ret_t log_t_old = 0.0;
   ret_t log_t_new = 0.0;
-  int sign_z = sign(z_t);
-  auto log_z = log(abs(z_t));
+  int sign_z = sign(z_transformed);
+  auto log_z = log(abs(z_transformed));
 
   double log_precision = log(precision);
   int log_t_new_sign = 1.0;
   int log_t_old_sign = 1.0;
 
-  Eigen::ArrayXi log_g_old_sign(3);
-  log_g_old_sign << 1, 1, 1;
+  Eigen::Array<int, 3, 1> log_g_old_sign = Eigen::Array<int, 3, 1>::Ones(3);
 
   int sign_zk = sign_z;
   int k = 0;
   ret_t inner_diff = 1;
-  Eigen::Matrix<ret_t, -1, 1> g_current(3);
-  g_current << 0, 0, 0;
+  ret_array_t g_current = ret_array_t::Zero(3);
 
   while (inner_diff > precision && k < max_steps) {
-    ret_t p = ((a1_t + k) * (a2_t + k) / ((b1 + k) * (1.0 + k)));
+    ret_t p = ((a1_transformed + k) * (a2_transformed + k)
+                / ((b1 + k) * (1.0 + k)));
     if (p == 0) {
-      return;
+      return grad_tuple;
     }
     log_t_new += log(fabs(p)) + log_z;
     log_t_new_sign = sign(value_of_rec(p)) * log_t_new_sign;
@@ -158,7 +156,7 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
     if (calc_a1_euler) {
       ret_t term_a1
           = log_g_old_sign(0) * log_t_old_sign * exp(log_g_old(0) - log_t_old)
-            + inv(a1_t + k);
+            + inv(a1_transformed + k);
       log_g_old(0) = log_t_new + log(abs(term_a1));
       log_g_old_sign(0) = sign(value_of_rec(term_a1)) * log_t_new_sign;
       g_current(0) = log_g_old_sign(0) * exp(log_g_old(0)) * sign_zk;
@@ -168,7 +166,7 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
     if (calc_a2_euler) {
       ret_t term_a2
           = log_g_old_sign(1) * log_t_old_sign * exp(log_g_old(1) - log_t_old)
-            + inv(a2_t + k);
+            + inv(a2_transformed + k);
       log_g_old(1) = log_t_new + log(abs(term_a2));
       log_g_old_sign(1) = sign(value_of_rec(term_a2)) * log_t_new_sign;
       g_current(1) = log_g_old_sign(1) * exp(log_g_old(1)) * sign_zk;
@@ -196,20 +194,23 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
   auto pre_mult_ab = inv(pow(1.0 - z, a2));
 
   if (calc_a1) {
-    g_a1 = euler_transform ? -pre_mult_ab * g(1) : g(0);
+    std::get<0>(grad_tuple) = euler_transform ? -pre_mult_ab * g(1) : g(0);
   }
 
   if (calc_a2) {
     if (euler_transform) {
-      auto hyper_da2 = hypergeometric_2F1(a1_t, a2, b1, z_t);
-      g_a2 = -pre_mult_ab * hyper_da2 * log1m(z) + pre_mult_ab * g(0);
+      auto hyper_da2 = hypergeometric_2F1(a1_transformed, a2, b1,
+                                          z_transformed);
+      std::get<1>(grad_tuple) =
+        -pre_mult_ab * hyper_da2 * log1m(z) + pre_mult_ab * g(0);
     } else {
-      g_a2 = g(1);
+      std::get<1>(grad_tuple) = g(1);
     }
   }
 
   if (calc_b1) {
-    g_b1 = euler_transform ? pre_mult_ab * (g(1) + g(2)) : g(2);
+    std::get<2>(grad_tuple) =
+      euler_transform ? pre_mult_ab * (g(1) + g(2)) : g(2);
   }
 
   if (k > max_steps) {
@@ -218,7 +219,7 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
                        " iterations, hypergeometric function gradient "
                        "did not converge.");
   }
-  return;
+  return grad_tuple;
 }
 }  // namespace internal
 
@@ -228,6 +229,8 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
  * to within <code>precision</code> or throwing when the
  * function takes <code>max_steps</code> steps.
  *
+ * @tparam ReturnSameT Whether return gradients need to be the same type as
+ *  as inputs
  * @tparam Tg1 type of outcome variable to store a1 gradient
  * @tparam Tg2 type of outcome variable to store a2 gradient
  * @tparam Tg3 type of outcome variable to store b1 gradient
@@ -248,16 +251,23 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
  *   to truncate the sum
  * @param[in] max_steps number of steps to take
  */
-template <typename Tg1, typename Tg2, typename Tg3, typename T_gz, typename T1,
-          typename T2, typename T3, typename T_z>
-void grad_2F1(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
+template <bool ReturnSameT, typename T1, typename T2, typename T3, typename T_z,
+          require_not_t<std::integral_constant<bool, ReturnSameT>>* = nullptr>
+auto grad_2F1(const T1& a1,
               const T2& a2, const T3& b1, const T_z& z,
               double precision = 1e-14, int max_steps = 1e6) {
-  internal::grad_2F1_impl<!is_constant<T1>::value, !is_constant<T2>::value,
-                          !is_constant<T3>::value, !is_constant<T_z>::value>(
-      g_a1, g_a2, g_b1, g_z, value_of(a1), value_of(a2), value_of(b1),
+  using partials_t = partials_return_t<T1, T2, T3, T_z>;
+  std::tuple<partials_t, partials_t, partials_t, partials_t>
+      ret_tuple;
+
+  return internal::grad_2F1_impl<
+  !is_constant<T1>::value,
+  !is_constant<T2>::value,
+  !is_constant<T3>::value,
+  !is_constant<T_z>::value>(
+    ret_tuple,
+      value_of(a1), value_of(a2), value_of(b1),
       value_of(z), precision, max_steps);
-  return;
 }
 
 /**
@@ -268,6 +278,49 @@ void grad_2F1(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
  *
  * Overload for use where the destination gradients should be the same type
  * as the input variables (needed for the grad_inc_beta overloads)
+ *
+ * @tparam ReturnSameT Whether return gradients need to be the same type as
+ *  as inputs
+ * @tparam Tg1 type of outcome variable to store a1 gradient
+ * @tparam Tg2 type of outcome variable to store a2 gradient
+ * @tparam Tg3 type of outcome variable to store b1 gradient
+ * @tparam T_gz type of outcome variable to store z gradient
+ * @tparam T1 scalar type of a1
+ * @tparam T2 scalar type of a2
+ * @tparam T3 scalar type of b1
+ * @tparam T_z scalar type of z
+ * @param[out] g_a1 reference to gradient of 2F1 w.r.t. a1, result
+ * @param[out] g_a2 reference to gradient of 2F1 w.r.t. a2, result
+ * @param[out] g_b1 reference to gradient of 2F1 w.r.t. b1, result
+ * @param[out] g_z reference to gradient of 2F1 w.r.t. z, result
+ * @param[in] a1 see generalized hypergeometric function definition
+ * @param[in] a2 see generalized hypergeometric function definition
+ * @param[in] b1 see generalized hypergeometric function definition
+ * @param[in] z see generalized hypergeometric function definition
+ * @param[in] precision magnitude of the increment of the infinite sum
+ *   to truncate the sum
+ * @param[in] max_steps number of steps to take
+ */
+template <bool ReturnSameT, typename T1, typename T2, typename T3, typename T_z,
+          require_t<std::integral_constant<bool, ReturnSameT>>* = nullptr>
+auto grad_2F1(const T1& a1,
+              const T2& a2, const T3& b1, const T_z& z,
+              double precision = 1e-14, int max_steps = 1e6) {
+  using return_t = return_type_t<T1, T2, T3, T_z>;
+  std::tuple<return_t, return_t, return_t, return_t>
+      ret_tuple;
+
+  return internal::grad_2F1_impl<true, true, true, true>(
+    ret_tuple,
+      a1, a2, b1,
+      z, precision, max_steps);
+}
+
+/**
+ * Calculate the gradients of the hypergeometric function (2F1)
+ * as the power series stopping when the series converges
+ * to within <code>precision</code> or throwing when the
+ * function takes <code>max_steps</code> steps.
  *
  * @tparam T1 scalar type of a1
  * @tparam T2 scalar type of a2
@@ -286,12 +339,9 @@ void grad_2F1(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
  * @param[in] max_steps number of steps to take
  */
 template <typename T1, typename T2, typename T3, typename T_z>
-void grad_2F1(T1& g_a1, T2& g_a2, T3& g_b1, T_z& g_z, const T1& a1,
-              const T2& a2, const T3& b1, const T_z& z,
+auto grad_2F1(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
               double precision = 1e-14, int max_steps = 1e6) {
-  internal::grad_2F1_impl<true, true, true, true>(g_a1, g_a2, g_b1, g_z, a1, a2,
-                                                  b1, z, precision, max_steps);
-  return;
+  return grad_2F1<false>(a1, a2, b1, z, precision, max_steps);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/grad_2F1.hpp
+++ b/stan/math/prim/fun/grad_2F1.hpp
@@ -45,12 +45,12 @@ namespace internal {
  * @return Three-element tuple containing gradients w.r.t. a1, a2, and b1,
  *   as indicated by the calc_a1, calc_a2, and calc_b1 booleans
  */
-template <bool calc_a1, bool calc_a2, bool calc_b1,
-          typename T1, typename T2, typename T3, typename T_z,
+template <bool calc_a1, bool calc_a2, bool calc_b1, typename T1, typename T2,
+          typename T3, typename T_z,
           typename ScalarT = return_type_t<T1, T2, T3, T_z>,
           typename TupleT = std::tuple<ScalarT, ScalarT, ScalarT>>
 TupleT grad_2F1_impl_ab(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
-                      double precision = 1e-14, int max_steps = 1e6) {
+                        double precision = 1e-14, int max_steps = 1e6) {
   TupleT grad_tuple = TupleT(0, 0, 0);
 
   if (z == 0) {
@@ -131,7 +131,6 @@ TupleT grad_2F1_impl_ab(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
   return grad_tuple;
 }
 
-
 /**
  * Implementation function to calculate the gradients of the hypergeometric
  * function, 2F1.
@@ -164,20 +163,20 @@ TupleT grad_2F1_impl_ab(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
  * @return Four-element tuple containing gradients w.r.t. to each parameter,
  *   as indicated by the calc_* booleans
  */
-template <bool calc_a1, bool calc_a2, bool calc_b1, bool calc_z,
-          typename T1, typename T2, typename T3, typename T_z,
+template <bool calc_a1, bool calc_a2, bool calc_b1, bool calc_z, typename T1,
+          typename T2, typename T3, typename T_z,
           typename ScalarT = return_type_t<T1, T2, T3, T_z>,
           typename TupleT = std::tuple<ScalarT, ScalarT, ScalarT, ScalarT>>
 TupleT grad_2F1_impl(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
-                    double precision = 1e-14, int max_steps = 1e6) {
+                     double precision = 1e-14, int max_steps = 1e6) {
   bool euler_transform = false;
   try {
     check_2F1_converges("hypergeometric_2F1", a1, a2, b1, z);
   } catch (const std::exception& e) {
     // Apply Euler's hypergeometric transformation if function
     // will not converge with current arguments
-    check_2F1_converges("hypergeometric_2F1 (euler transform)",
-                        b1 - a1, a2, b1, z / (z - 1));
+    check_2F1_converges("hypergeometric_2F1 (euler transform)", b1 - a1, a2, b1,
+                        z / (z - 1));
     euler_transform = true;
   }
 
@@ -191,10 +190,11 @@ TupleT grad_2F1_impl(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
       auto hyper1 = hypergeometric_2F1(a1_euler, a2_euler, b1, z_euler);
       auto hyper2 = hypergeometric_2F1(1 + a2, 1 - a1 + b1, 1 + b1, z_euler);
       auto pre_mult = a2 * pow(1 - z, -1 - a2);
-      std::get<3>(grad_tuple_rtn) = a2 * pow(1 - z, -1 - a2) * hyper1
-                                + (a2 * (b1 - a1) * pow(1 - z, -a2)
-                                   * (inv(z - 1) - z / square(z - 1)) * hyper2)
-                                      / b1;
+      std::get<3>(grad_tuple_rtn)
+          = a2 * pow(1 - z, -1 - a2) * hyper1
+            + (a2 * (b1 - a1) * pow(1 - z, -a2)
+               * (inv(z - 1) - z / square(z - 1)) * hyper2)
+                  / b1;
     }
     if (calc_a1 || calc_a2 || calc_b1) {
       // 'a' gradients under Euler transform are constructed using the gradients
@@ -203,22 +203,22 @@ TupleT grad_2F1_impl(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
       // 'b' gradients under Euler transform require gradients from 'a2'
       constexpr bool calc_a2_euler = calc_a1 || calc_a2 || calc_b1;
       grad_tuple_ab = grad_2F1_impl_ab<calc_a1_euler, calc_a2_euler, calc_b1>(
-        a1_euler, a2_euler, b1, z_euler);
+          a1_euler, a2_euler, b1, z_euler);
 
       auto pre_mult_ab = inv(pow(1.0 - z, a2));
       if (calc_a1) {
         std::get<0>(grad_tuple_rtn) = -pre_mult_ab * std::get<1>(grad_tuple_ab);
       }
       if (calc_a2) {
-        auto hyper_da2
-            = hypergeometric_2F1(a1_euler, a2, b1, z_euler);
+        auto hyper_da2 = hypergeometric_2F1(a1_euler, a2, b1, z_euler);
         std::get<1>(grad_tuple_rtn)
             = -pre_mult_ab * hyper_da2 * log1m(z)
               + pre_mult_ab * std::get<0>(grad_tuple_ab);
       }
       if (calc_b1) {
-        std::get<2>(grad_tuple_rtn) = pre_mult_ab
-          * (std::get<1>(grad_tuple_ab) + std::get<2>(grad_tuple_ab));
+        std::get<2>(grad_tuple_rtn)
+            = pre_mult_ab
+              * (std::get<1>(grad_tuple_ab) + std::get<2>(grad_tuple_ab));
       }
     }
   } else {
@@ -228,7 +228,7 @@ TupleT grad_2F1_impl(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
     }
     if (calc_a1 || calc_a2 || calc_b1) {
       grad_tuple_ab
-        = grad_2F1_impl_ab<calc_a1, calc_a2, calc_b1>(a1, a2, b1, z);
+          = grad_2F1_impl_ab<calc_a1, calc_a2, calc_b1>(a1, a2, b1, z);
       if (calc_a1) {
         std::get<0>(grad_tuple_rtn) = std::get<0>(grad_tuple_ab);
       }
@@ -273,9 +273,8 @@ auto grad_2F1(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
               double precision = 1e-14, int max_steps = 1e6) {
   return internal::grad_2F1_impl<
       !is_constant<T1>::value, !is_constant<T2>::value, !is_constant<T3>::value,
-      !is_constant<T_z>::value>(value_of(a1), value_of(a2),
-                                value_of(b1), value_of(z), precision,
-                                max_steps);
+      !is_constant<T_z>::value>(value_of(a1), value_of(a2), value_of(b1),
+                                value_of(z), precision, max_steps);
 }
 
 /**
@@ -305,8 +304,8 @@ template <bool ReturnSameT, typename T1, typename T2, typename T3, typename T_z,
           require_t<std::integral_constant<bool, ReturnSameT>>* = nullptr>
 auto grad_2F1(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
               double precision = 1e-14, int max_steps = 1e6) {
-  return internal::grad_2F1_impl<true, true, true, true>(
-      a1, a2, b1, z, precision, max_steps);
+  return internal::grad_2F1_impl<true, true, true, true>(a1, a2, b1, z,
+                                                         precision, max_steps);
 }
 
 /**

--- a/stan/math/prim/fun/grad_2F1.hpp
+++ b/stan/math/prim/fun/grad_2F1.hpp
@@ -10,53 +10,11 @@
 #include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/sign.hpp>
+#include <stan/math/prim/fun/hypergeometric_2F1.hpp>
 #include <cmath>
 
 namespace stan {
 namespace math {
-namespace internal {
-/**
- * Returns the intermediate calculations for the gradient of the
- * hypergeometric function (2F1).
- *
- * @tparam T scalar type or `var_value`
- * @tparam T_StdVec std::array of doubles or `var_values`
- * @tparam T_StdVecInt array of int
- * @tparam T_int integer
- * @param[out] log_g_old log of previous gradient values
- * @param[out] log_g_old_sign sign of previous gradient values
- * @param[out] log_t_new log of power series calculation
- * @param[out] log_t_new_sign sign of power series calcuation
- * @param[in] p intermediate power series value
- * @param[in] log_z see hypergeometric function 2F1 definition
- * @param[in] log_t_old log of previous power series calculation
- * @param[in] log_t_old_sign log of previous power series calculation
- * @param[in] k loop iteration
- * @param[in] a1 see hypergeometric function 2F1 definition
- * @param[in] a2 see hypergeometric function 2F1 definition
- * @param[in] b1 see hypergeometric function 2F1 definition
- */
-template <typename T, typename T_StdVec, typename T_StdVecInt, typename T_int>
-void calc_lambda(T_StdVec& log_g_old, T_StdVecInt& log_g_old_sign, T& log_t_new,
-                 T_int& log_t_new_sign, const T& p, const T& log_z,
-                 const T& log_t_old, const T_int& log_t_old_sign, const int k,
-                 const T& a1, const T& a2, const T& b1) {
-  using ret_t = return_type_t<T, T_int, T_StdVec, T_StdVecInt>;
-
-  log_t_new += log(fabs(p)) + log_z;
-  log_t_new_sign = sign(value_of_rec(p)) * log_t_new_sign;
-
-  Eigen::Array<ret_t, Eigen::Dynamic, 1> hyper_args(3);
-  hyper_args << a1 + k, a2 + k, -(b1 + k);
-
-  Eigen::Array<ret_t, Eigen::Dynamic, 1> term
-      = log_g_old_sign * log_t_old_sign * exp(log_g_old - log_t_old)
-        + inv(hyper_args);
-
-  log_g_old = log_t_new + log(abs(term));
-  log_g_old_sign = sign(value_of_rec(term)) * log_t_new_sign;
-}
-}  // namespace internal
 
 /**
  * Gradients of the hypergeometric function, 2F1.
@@ -76,6 +34,7 @@ void calc_lambda(T_StdVec& log_g_old, T_StdVecInt& log_g_old_sign, T& log_t_new,
  * @param[out] g_a1 reference to gradient of 2F1 w.r.t. a1, result
  * @param[out] g_a2 reference to gradient of 2F1 w.r.t. a2, result
  * @param[out] g_b1 reference to gradient of 2F1 w.r.t. b1, result
+ * @param[out] g_z reference to gradient of 2F1 w.r.t. z, result
  * @param[in] a1 see generalized hypergeometric function definition
  * @param[in] a2 see generalized hypergeometric function definition
  * @param[in] b1 see generalized hypergeometric function definition
@@ -84,22 +43,33 @@ void calc_lambda(T_StdVec& log_g_old, T_StdVecInt& log_g_old_sign, T& log_t_new,
  *   to truncate the sum
  * @param[in] max_steps number of steps to take
  */
-template <typename T1, typename T2, typename T3, typename T_z>
-void grad_2F1(T1& g_a1, T2& g_a2, T3& g_b1, const T1& a1, const T2& a2,
-              const T3& b1, const T_z& z, double precision = 1e-14,
-              int max_steps = 1e6) {
+template <bool calc_a1, bool calc_a2, bool calc_b1, bool calc_z,
+          typename T1, typename T2, typename T3, typename T_z>
+void grad_2F1(T1& g_a1, T2& g_a2, T3& g_b1, T_z& g_z, const T1& a1,
+              const T2& a2, const T3& b1, const T_z& z,
+              double precision = 1e-14, int max_steps = 1e6) {
   check_2F1_converges("grad_2F1", a1, a2, b1, z);
 
   using stan::math::value_of_rec;
   using std::max;
   using ret_t = return_type_t<T1, T2, T3, T_z>;
 
+  if (calc_z) {
+    auto hyper_2f1_dz = hypergeometric_2F1(a1 + 1.0, a2 + 1.0, b1 + 1.0, z);
+    g_z = (a1 * a2 * hyper_2f1_dz) / b1;
+  }
+
   if (z == 0) {
+    return;
+  }
+
+  if (!(calc_a1 || calc_a2 || calc_b1)) {
     return;
   }
 
   Eigen::Array<ret_t, Eigen::Dynamic, 1> g(3);
   g << 0.0, 0.0, 0.0;
+
 
   Eigen::Array<ret_t, Eigen::Dynamic, 1> log_g_old(3);
   log_g_old << NEGATIVE_INFTY, NEGATIVE_INFTY, NEGATIVE_INFTY;
@@ -107,46 +77,86 @@ void grad_2F1(T1& g_a1, T2& g_a2, T3& g_b1, const T1& a1, const T2& a2,
   ret_t log_t_old = 0.0;
   ret_t log_t_new = 0.0;
   int sign_z = sign(z);
-  ret_t log_z = log(abs(z));
+  auto log_z = log(abs(z));
 
-  ret_t log_precision = log(precision);
-  ret_t log_t_new_sign = 1.0;
-  ret_t log_t_old_sign = 1.0;
+  double log_precision = log(precision);
+  int log_t_new_sign = 1.0;
+  int log_t_old_sign = 1.0;
 
   Eigen::Array<ret_t, Eigen::Dynamic, 1> log_g_old_sign(3);
   log_g_old_sign << 1., 1., 1.;
 
   int sign_zk = sign_z;
-
-  for (int k = 0; k <= max_steps; ++k) {
+  int k = 0;
+  ret_t inner_diff = precision;
+  while (!(inner_diff < precision) && k < max_steps) {
     ret_t p = ((a1 + k) * (a2 + k) / ((b1 + k) * (1 + k)));
     if (p == 0) {
       return;
     }
-    internal::calc_lambda(log_g_old, log_g_old_sign, log_t_new, log_t_new_sign,
-                          p, log_z, log_t_old, log_t_old_sign, k, a1, a2, b1);
+    log_t_new += log(fabs(p)) + log_z;
+    log_t_new_sign = sign(value_of_rec(p)) * log_t_new_sign;
 
-    g += log_g_old_sign * exp(log_g_old) * sign_zk;
-    g_a1 = g(0);
-    g_a2 = g(1);
-    g_b1 = g(2);
-
-    if (log_g_old(0)
-            <= max(log(abs(value_of_rec(g(0)))) + log_precision, log_precision)
-        && log_g_old(1) <= max(
-               log(std::abs(value_of_rec(g(1)))) + log_precision, log_precision)
-        && log_g_old(2) <= max(log(abs(value_of_rec(g(2)))) + log_precision,
-                               log_precision)) {
-      return;
+    if (calc_a1) {
+      ret_t term_a1 = log_g_old_sign(0)
+                      * log_t_old_sign
+                      * exp(log_g_old(0) - log_t_old)
+                      + inv(a1 + k);
+      log_g_old(0) = log_t_new + log(abs(term_a1));
+      log_g_old_sign(0) = sign(value_of_rec(term_a1)) * log_t_new_sign;
+      ret_t g_a1 = log_g_old_sign(0) * exp(log_g_old(0)) * sign_zk;
+      g(0) += g_a1;
+      inner_diff = max(g_a1, inner_diff);
     }
+
+    if (calc_a2) {
+      ret_t term_a2 = log_g_old_sign(1)
+                      * log_t_old_sign
+                      * exp(log_g_old(1) - log_t_old)
+                      + inv(a2 + k);
+      log_g_old(1) = log_t_new + log(abs(term_a2));
+      log_g_old_sign(1) = sign(value_of_rec(term_a2)) * log_t_new_sign;
+      ret_t g_a2 = log_g_old_sign(1) * exp(log_g_old(1)) * sign_zk;
+      g(1) += g_a2;
+      inner_diff = max(g_a2, inner_diff);
+    }
+
+    if (calc_b1) {
+      ret_t term_b1 = log_g_old_sign(2)
+                      * log_t_old_sign
+                      * exp(log_g_old(2) - log_t_old)
+                      + inv(-(b1 + k));
+      log_g_old(2) = log_t_new + log(abs(term_b1));
+      log_g_old_sign(2) = sign(value_of_rec(term_b1)) * log_t_new_sign;
+      ret_t g_b1 = log_g_old_sign(2) * exp(log_g_old(2)) * sign_zk;
+      g(2) += g_b1;
+      inner_diff = max(g_b1, inner_diff);
+    }
+
     log_t_old = log_t_new;
     log_t_old_sign = log_t_new_sign;
     sign_zk *= sign_z;
+    inner_diff = precision;
+    ++k;
   }
-  throw_domain_error("grad_2F1", "k (internal counter)", max_steps, "exceeded ",
-                     " iterations, hypergeometric function gradient "
-                     "did not converge.");
+
+  g_a1 = g(0);
+  g_a2 = g(1);
+  g_b1 = g(2);
+
+  if (k > max_steps) {
+    throw_domain_error("grad_2F1", "k (internal counter)", max_steps, "exceeded ",
+                      " iterations, hypergeometric function gradient "
+                      "did not converge.");
+  }
   return;
+}
+
+template <typename T1, typename T2, typename T3, typename T_z>
+void grad_2F1(T1& g_a1, T2& g_a2, T3& g_b1, T_z& g_z, const T1& a1,
+              const T2& a2, const T3& b1, const T_z& z,
+              double precision = 1e-14, int max_steps = 1e6) {
+  grad_2F1<true, true, true, true>(g_a1, g_a2, g_b1, g_z, a1, a2, b1, z, precision, max_steps);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/grad_2F1.hpp
+++ b/stan/math/prim/fun/grad_2F1.hpp
@@ -88,8 +88,11 @@ void grad_2F1(T1& g_a1, T2& g_a2, T3& g_b1, T_z& g_z, const T1& a1,
 
   int sign_zk = sign_z;
   int k = 0;
-  ret_t inner_diff = precision;
-  while (!(inner_diff < precision) && k < max_steps) {
+  ret_t inner_diff = 1;
+  Eigen::Matrix<ret_t, -1, 1> g_current(3);
+  g_current << 0, 0, 0;
+
+  while (inner_diff > precision && k < max_steps) {
     ret_t p = ((a1 + k) * (a2 + k) / ((b1 + k) * (1 + k)));
     if (p == 0) {
       return;
@@ -104,9 +107,8 @@ void grad_2F1(T1& g_a1, T2& g_a2, T3& g_b1, T_z& g_z, const T1& a1,
                       + inv(a1 + k);
       log_g_old(0) = log_t_new + log(abs(term_a1));
       log_g_old_sign(0) = sign(value_of_rec(term_a1)) * log_t_new_sign;
-      ret_t g_a1 = log_g_old_sign(0) * exp(log_g_old(0)) * sign_zk;
-      g(0) += g_a1;
-      inner_diff = max(g_a1, inner_diff);
+      g_current(0) = log_g_old_sign(0) * exp(log_g_old(0)) * sign_zk;
+      g(0) += g_current(0);
     }
 
     if (calc_a2) {
@@ -116,9 +118,8 @@ void grad_2F1(T1& g_a1, T2& g_a2, T3& g_b1, T_z& g_z, const T1& a1,
                       + inv(a2 + k);
       log_g_old(1) = log_t_new + log(abs(term_a2));
       log_g_old_sign(1) = sign(value_of_rec(term_a2)) * log_t_new_sign;
-      ret_t g_a2 = log_g_old_sign(1) * exp(log_g_old(1)) * sign_zk;
-      g(1) += g_a2;
-      inner_diff = max(g_a2, inner_diff);
+      g_current(1) = log_g_old_sign(1) * exp(log_g_old(1)) * sign_zk;
+      g(1) += g_current(1);
     }
 
     if (calc_b1) {
@@ -128,15 +129,15 @@ void grad_2F1(T1& g_a1, T2& g_a2, T3& g_b1, T_z& g_z, const T1& a1,
                       + inv(-(b1 + k));
       log_g_old(2) = log_t_new + log(abs(term_b1));
       log_g_old_sign(2) = sign(value_of_rec(term_b1)) * log_t_new_sign;
-      ret_t g_b1 = log_g_old_sign(2) * exp(log_g_old(2)) * sign_zk;
-      g(2) += g_b1;
-      inner_diff = max(g_b1, inner_diff);
+      g_current(2) = log_g_old_sign(2) * exp(log_g_old(2)) * sign_zk;
+      g(2) += g_current(2);
     }
+
+    inner_diff = g_current.maxCoeff();
 
     log_t_old = log_t_new;
     log_t_old_sign = log_t_new_sign;
     sign_zk *= sign_z;
-    inner_diff = precision;
     ++k;
   }
 

--- a/stan/math/prim/fun/grad_2F1.hpp
+++ b/stan/math/prim/fun/grad_2F1.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/fun/as_array_or_scalar.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/exp.hpp>
-#include <stan/math/prim/fun/log1m.hpp>
 #include <stan/math/prim/fun/abs.hpp>
 #include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/log.hpp>
@@ -223,7 +222,7 @@ void grad_2F1_impl(Tg1& g_a1, Tg2& g_a2, Tg3& g_b1, T_gz& g_z, const T1& a1,
   }
   return;
 }
-} // namespace internal
+}  // namespace internal
 
 /**
  * Calculate the gradients of the hypergeometric function (2F1)

--- a/stan/math/prim/fun/grad_inc_beta.hpp
+++ b/stan/math/prim/fun/grad_inc_beta.hpp
@@ -31,8 +31,9 @@ inline void grad_inc_beta(double& g1, double& g2, double a, double b,
   double dF1 = 0;
   double dF2 = 0;
   double dF3 = 0;
+  double dFz = 0;
   if (C) {
-    grad_2F1(dF1, dF2, dF3, a + b, 1.0, a + 1, z);
+    grad_2F1<true, false, true, false>(dF1, dF2, dF3, dFz, a + b, 1.0, a + 1, z);
   }
   g1 = fma((c1 - inv(a)), c3, C * (dF1 + dF3));
   g2 = fma(c2, c3, C * dF1);

--- a/stan/math/prim/fun/grad_inc_beta.hpp
+++ b/stan/math/prim/fun/grad_inc_beta.hpp
@@ -34,7 +34,7 @@ inline void grad_inc_beta(double& g1, double& g2, double a, double b,
   double dFz = 0;
   if (C) {
     std::forward_as_tuple(dF1, dF2, dF3, dFz)
-      = grad_2F1<true>(a + b, 1.0, a + 1, z);
+        = grad_2F1<true>(a + b, 1.0, a + 1, z);
   }
   g1 = fma((c1 - inv(a)), c3, C * (dF1 + dF3));
   g2 = fma(c2, c3, C * dF1);

--- a/stan/math/prim/fun/grad_inc_beta.hpp
+++ b/stan/math/prim/fun/grad_inc_beta.hpp
@@ -33,7 +33,7 @@ inline void grad_inc_beta(double& g1, double& g2, double a, double b,
   double dF3 = 0;
   double dFz = 0;
   if (C) {
-    grad_2F1<true>(dF1, dF2, dF3, dFz, a + b, 1.0, a + 1, z);
+    grad_2F1(dF1, dF2, dF3, dFz, a + b, 1.0, a + 1, z);
   }
   g1 = fma((c1 - inv(a)), c3, C * (dF1 + dF3));
   g2 = fma(c2, c3, C * dF1);

--- a/stan/math/prim/fun/grad_inc_beta.hpp
+++ b/stan/math/prim/fun/grad_inc_beta.hpp
@@ -33,7 +33,9 @@ inline void grad_inc_beta(double& g1, double& g2, double a, double b,
   double dF3 = 0;
   double dFz = 0;
   if (C) {
-    grad_2F1(dF1, dF2, dF3, dFz, a + b, 1.0, a + 1, z);
+    auto grad_tuple = grad_2F1<true>(a + b, 1.0, a + 1, z);
+    dF1 = std::get<0>(grad_tuple);
+    dF3 = std::get<2>(grad_tuple);
   }
   g1 = fma((c1 - inv(a)), c3, C * (dF1 + dF3));
   g2 = fma(c2, c3, C * dF1);

--- a/stan/math/prim/fun/grad_inc_beta.hpp
+++ b/stan/math/prim/fun/grad_inc_beta.hpp
@@ -33,7 +33,7 @@ inline void grad_inc_beta(double& g1, double& g2, double a, double b,
   double dF3 = 0;
   double dFz = 0;
   if (C) {
-    grad_2F1<true, false, true, false>(dF1, dF2, dF3, dFz, a + b, 1.0, a + 1, z);
+    grad_2F1<true>(dF1, dF2, dF3, dFz, a + b, 1.0, a + 1, z);
   }
   g1 = fma((c1 - inv(a)), c3, C * (dF1 + dF3));
   g2 = fma(c2, c3, C * dF1);

--- a/stan/math/prim/fun/grad_inc_beta.hpp
+++ b/stan/math/prim/fun/grad_inc_beta.hpp
@@ -33,9 +33,8 @@ inline void grad_inc_beta(double& g1, double& g2, double a, double b,
   double dF3 = 0;
   double dFz = 0;
   if (C) {
-    auto grad_tuple = grad_2F1<true>(a + b, 1.0, a + 1, z);
-    dF1 = std::get<0>(grad_tuple);
-    dF3 = std::get<2>(grad_tuple);
+    std::forward_as_tuple(dF1, dF2, dF3, dFz)
+      = grad_2F1<true>(a + b, 1.0, a + 1, z);
   }
   g1 = fma((c1 - inv(a)), c3, C * (dF1 + dF3));
   g2 = fma(c2, c3, C * dF1);

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -44,7 +44,7 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   check_2F1_converges("hypergeometric_2F1", a1, a2, b, z);
 
   return boost::math::hypergeometric_pFq(
-    std::vector<return_type_t<Ta1, Ta2>>{a1, a2}, {b}, z);
+      std::vector<return_type_t<Ta1, Ta2>>{a1, a2}, {b}, z);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -6,10 +6,7 @@
 #include <stan/math/prim/fun/asin.hpp>
 #include <stan/math/prim/fun/asinh.hpp>
 #include <stan/math/prim/fun/constants.hpp>
-<<<<<<< HEAD
 #include <stan/math/prim/fun/digamma.hpp>
-=======
->>>>>>> 6011bfa293 (Begin updating grad_2f1)
 #include <stan/math/prim/fun/exp.hpp>
 #include <stan/math/prim/fun/floor.hpp>
 #include <stan/math/prim/fun/inv.hpp>

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -46,24 +46,28 @@ template <typename Ta1, typename Ta2, typename Tb, typename Tz,
           require_all_arithmetic_t<Ta1, Ta2, Tb, Tz>* = nullptr>
 inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
                                     const Tz& z) {
-  // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/01/ // NOLINT
+  // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/01/
+  // // NOLINT
   if (z == 0.0) {
     return 1.0;
   }
 
-  // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/06/01/0001/ // NOLINT
+  // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/06/01/0001/
+  // // NOLINT
   if (a1 == b) {
     return inv(pow(1.0 - z, a2));
   }
 
-  // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/06/01/0003/ // NOLINT
+  // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/06/01/0003/
+  // // NOLINT
   if (b == (a2 - 1.0)) {
     return (pow((1.0 - z), -a1 - 1.0) * (a2 + z * (a1 - a2 + 1.0) - 1.0))
            / (a2 - 1);
   }
 
   if (a1 == a2) {
-    // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2C+1%2C+2%2C+-z%29 // NOLINT
+    // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2C+1%2C+2%2C+-z%29
+    // // NOLINT
     if (a1 == 1.0 && b == 2.0 && z < 0) {
       auto pos_z = abs(z);
       return log1p(pos_z) / pos_z;
@@ -72,14 +76,17 @@ inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
     if (a1 == 0.5 && b == 1.5 && z < 1.0) {
       auto sqrt_z = sqrt(abs(z));
       auto numerator = (z > 0.0)
-        // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2F2%2C+1%2F2%2C+3%2F2%2C+z%29 // NOLINT
-        ? asin(sqrt_z)
-        // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2F2%2C+1%2F2%2C+3%2F2%2C+-z%29 // NOLINT
-        : asinh(sqrt_z);
+                           // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2F2%2C+1%2F2%2C+3%2F2%2C+z%29
+                           // // NOLINT
+                           ? asin(sqrt_z)
+                           // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2F2%2C+1%2F2%2C+3%2F2%2C+-z%29
+                           // // NOLINT
+                           : asinh(sqrt_z);
       return numerator / sqrt_z;
     }
 
-    // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/04/03/ // NOLINT
+    // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/04/03/
+    // // NOLINT
     if (b == (a1 + 1) && z == 0.5) {
       return pow(2, a1 - 1) * a1
              * (digamma((a1 + 1) / 2.0) - digamma(a1 / 2.0));
@@ -87,11 +94,13 @@ inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
   }
 
   if (z == 1.0) {
-    // https://www.wolframalpha.com/input?i=Hypergeometric2F1%28a1%2C+a2%2C+a1+%2B+a2+%2B+2%2C+1%29 // NOLINT
+    // https://www.wolframalpha.com/input?i=Hypergeometric2F1%28a1%2C+a2%2C+a1+%2B+a2+%2B+2%2C+1%29
+    // // NOLINT
     if (b == (a1 + a2 + 2)) {
       auto log_2f1 = lgamma(b) - (lgamma(a1 + 2) + lgamma(a2 + 2));
       return exp(log_2f1);
-    // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/02/0001/ // NOLINT
+      // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/02/0001/
+      // // NOLINT
     } else if (b > (a1 + a2)) {
       auto log_2f1 = (lgamma(b) + lgamma(b - a1 - a2))
                      - (lgamma(b - a1) + lgamma(b - a2));
@@ -99,7 +108,8 @@ inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
     }
   }
 
-  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%283%2F2%2C+2%2C+3%2C+-z%29 // NOLINT
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%283%2F2%2C+2%2C+3%2C+-z%29
+  // // NOLINT
   if (a1 == 1.5 && a2 == 2.0 && b == 3.0 && z < 0.0) {
     auto abs_z = abs(z);
     auto sqrt_1pz = sqrt(1 + abs_z);

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -43,7 +43,8 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
 
   check_2F1_converges("hypergeometric_2F1", a1, a2, b, z);
 
-  return boost::math::hypergeometric_pFq({a1, a2}, {b}, z);
+  return boost::math::hypergeometric_pFq(
+    std::vector<return_type_t<Ta1, Ta2>>{a1, a2}, {b}, z);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -37,7 +37,7 @@ return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   check_not_nan("hypergeometric_2F1", "b", b);
   check_not_nan("hypergeometric_2F1", "z", z);
 
-  check_2F1_converges("hypergeometric_2F1", a1, a2, b1, z);
+  check_2F1_converges("hypergeometric_2F1", a1, a2, b, z);
 
   return boost::math::hypergeometric_pFq({a1, a2}, {b}, z);
 }

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -27,8 +27,10 @@ namespace math {
  */
 template <typename Ta1, typename Ta2, typename Tb, typename Tz,
           require_all_arithmetic_t<Ta1, Ta2, Tb, Tz>* = nullptr>
-inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1, const Ta2& a2,
-                                                   const Tb& b, const Tz& z) {
+inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
+                                                          const Ta2& a2,
+                                                          const Tb& b,
+                                                          const Tz& z) {
   check_finite("hypergeometric_2F1", "a1", a1);
   check_finite("hypergeometric_2F1", "a2", a2);
   check_finite("hypergeometric_2F1", "b", b);

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -178,8 +178,8 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
     return special_case_a2a1.get();
   }
 
-  Eigen::VectorXd a_args(2);
-  Eigen::VectorXd b_args(1);
+  Eigen::Matrix<double, 2, 1> a_args(2);
+  Eigen::Matrix<double, 1, 1> b_args(1);
 
   try {
     check_2F1_converges("hypergeometric_2F1", a1, a2, b, z);
@@ -187,7 +187,7 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
     a_args << a1, a2;
     b_args << b;
     return hypergeometric_pFq(a_args, b_args, z);
-  } catch (...) {
+  } catch (const std::exception& e) {
     // Apply Euler's hypergeometric transformation if function
     // will not converge with current arguments
     ScalarT a1_t = b - a1;

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -56,7 +56,7 @@ inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
 
   if (b == (a2 - 1.0)) {
     return (pow((1.0 - z), -a1 - 1.0) * (a2 + z * (a1 - a2 + 1.0) - 1.0))
-      / (a2 - 1);
+           / (a2 - 1);
   }
 
   if (a1 == a2) {
@@ -66,14 +66,14 @@ inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
     }
 
     if (a1 == 0.5 && b == 1.5 && z < 1.0) {
-        auto sqrt_z = sqrt(abs(z));
-        auto numerator = (z > 0.0) ? asin(sqrt_z) : asinh(sqrt_z);
-        return numerator / sqrt_z;
+      auto sqrt_z = sqrt(abs(z));
+      auto numerator = (z > 0.0) ? asin(sqrt_z) : asinh(sqrt_z);
+      return numerator / sqrt_z;
     }
 
     if (b == (a1 + 1) && z == 0.5) {
       return pow(2, a1 - 1) * a1
-        * (digamma((a1 + 1) / 2.0) - digamma(a1 / 2.0));
+             * (digamma((a1 + 1) / 2.0) - digamma(a1 / 2.0));
     }
   }
 
@@ -83,7 +83,7 @@ inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
       return exp(log_2f1);
     } else if (b > (a1 + a2)) {
       auto log_2f1 = (lgamma(b) + lgamma(b - a1 - a2))
-        - (lgamma(b - a1) + lgamma(b - a2));
+                     - (lgamma(b - a1) + lgamma(b - a2));
       return exp(log_2f1);
     }
   }
@@ -91,7 +91,7 @@ inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
   if (a1 == 1.5 && a2 == 2.0 && b == 3.0 && z < 0.0) {
     auto abs_z = abs(z);
     auto sqrt_1pz = sqrt(1 + abs_z);
-    return - 4 * (2 * sqrt_1pz + z - 2) / (sqrt_1pz * square(z));
+    return -4 * (2 * sqrt_1pz + z - 2) / (sqrt_1pz * square(z));
   }
 
   return {};

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -46,20 +46,24 @@ template <typename Ta1, typename Ta2, typename Tb, typename Tz,
           require_all_arithmetic_t<Ta1, Ta2, Tb, Tz>* = nullptr>
 inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
                                     const Tz& z) {
+  // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/01/ // NOLINT
   if (z == 0.0) {
     return 1.0;
   }
 
+  // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/06/01/0001/ // NOLINT
   if (a1 == b) {
     return inv(pow(1.0 - z, a2));
   }
 
+  // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/06/01/0003/ // NOLINT
   if (b == (a2 - 1.0)) {
     return (pow((1.0 - z), -a1 - 1.0) * (a2 + z * (a1 - a2 + 1.0) - 1.0))
            / (a2 - 1);
   }
 
   if (a1 == a2) {
+    // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2C+1%2C+2%2C+-z%29 // NOLINT
     if (a1 == 1.0 && b == 2.0 && z < 0) {
       auto pos_z = abs(z);
       return log1p(pos_z) / pos_z;
@@ -67,10 +71,15 @@ inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
 
     if (a1 == 0.5 && b == 1.5 && z < 1.0) {
       auto sqrt_z = sqrt(abs(z));
-      auto numerator = (z > 0.0) ? asin(sqrt_z) : asinh(sqrt_z);
+      auto numerator = (z > 0.0)
+        // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2F2%2C+1%2F2%2C+3%2F2%2C+z%29 // NOLINT
+        ? asin(sqrt_z)
+        // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2F2%2C+1%2F2%2C+3%2F2%2C+-z%29 // NOLINT
+        : asinh(sqrt_z);
       return numerator / sqrt_z;
     }
 
+    // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/04/03/ // NOLINT
     if (b == (a1 + 1) && z == 0.5) {
       return pow(2, a1 - 1) * a1
              * (digamma((a1 + 1) / 2.0) - digamma(a1 / 2.0));
@@ -78,9 +87,11 @@ inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
   }
 
   if (z == 1.0) {
+    // https://www.wolframalpha.com/input?i=Hypergeometric2F1%28a1%2C+a2%2C+a1+%2B+a2+%2B+2%2C+1%29 // NOLINT
     if (b == (a1 + a2 + 2)) {
       auto log_2f1 = lgamma(b) - (lgamma(a1 + 2) + lgamma(a2 + 2));
       return exp(log_2f1);
+    // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/02/0001/ // NOLINT
     } else if (b > (a1 + a2)) {
       auto log_2f1 = (lgamma(b) + lgamma(b - a1 - a2))
                      - (lgamma(b - a1) + lgamma(b - a2));
@@ -88,6 +99,7 @@ inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
     }
   }
 
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%283%2F2%2C+2%2C+3%2C+-z%29 // NOLINT
   if (a1 == 1.5 && a2 == 2.0 && b == 3.0 && z < 0.0) {
     auto abs_z = abs(z);
     auto sqrt_1pz = sqrt(1 + abs_z);

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -23,10 +23,8 @@ namespace math {
  */
 template <typename Ta1, typename Ta2, typename Tb, typename Tz,
           require_all_arithmetic_t<Ta1, Ta2, Tb, Tz>* = nullptr>
-return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
-                                                    const Ta2& a2,
-                                                    const Tb& b,
-                                                    const Tz& z) {
+return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1, const Ta2& a2,
+                                                   const Tb& b, const Tz& z) {
   check_finite("hypergeometric_2F1", "a1", a1);
   check_finite("hypergeometric_2F1", "a2", a2);
   check_finite("hypergeometric_2F1", "b", b);

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -75,13 +75,14 @@ inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
 
     if (a1 == 0.5 && b == 1.5 && z < 1.0) {
       auto sqrt_z = sqrt(abs(z));
-      auto numerator = (z > 0.0)
-                           // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2F2%2C+1%2F2%2C+3%2F2%2C+z%29
-                           // // NOLINT
-                           ? asin(sqrt_z)
-                           // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2F2%2C+1%2F2%2C+3%2F2%2C+-z%29
-                           // // NOLINT
-                           : asinh(sqrt_z);
+      auto numerator
+          = (z > 0.0)
+                // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2F2%2C+1%2F2%2C+3%2F2%2C+z%29
+                // // NOLINT
+                ? asin(sqrt_z)
+                // https://www.wolframalpha.com/input?i=Hypergeometric2F1%281%2F2%2C+1%2F2%2C+3%2F2%2C+-z%29
+                // // NOLINT
+                : asinh(sqrt_z);
       return numerator / sqrt_z;
     }
 

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MATH_PRIM_FUN_HYPERGEOMETRIC_2F2_HPP
-#define STAN_MATH_PRIM_FUN_HYPERGEOMETRIC_2F2_HPP
+#ifndef STAN_MATH_PRIM_FUN_HYPERGEOMETRIC_2F1_HPP
+#define STAN_MATH_PRIM_FUN_HYPERGEOMETRIC_2F1_HPP
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/hypergeometric_pFq.hpp>
@@ -15,6 +15,10 @@ namespace math {
  *
  * See 'grad_2F1.hpp' for the derivatives wrt each parameter
  *
+ * @tparam Ta1 Type of scalar first 'a' argument
+ * @tparam Ta2 Type of scalar second 'a' argument
+ * @tparam Tb Type of scalar 'b' argument
+ * @tparam Tz Type of scalar 'z' argument
  * @param[in] a1 First of 'a' arguments to function
  * @param[in] a2 Second of 'a' arguments to function
  * @param[in] b 'b' argument to function
@@ -23,7 +27,7 @@ namespace math {
  */
 template <typename Ta1, typename Ta2, typename Tb, typename Tz,
           require_all_arithmetic_t<Ta1, Ta2, Tb, Tz>* = nullptr>
-return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1, const Ta2& a2,
+inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1, const Ta2& a2,
                                                    const Tb& b, const Tz& z) {
   check_finite("hypergeometric_2F1", "a1", a1);
   check_finite("hypergeometric_2F1", "a2", a2);

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -1,0 +1,46 @@
+#ifndef STAN_MATH_PRIM_FUN_HYPERGEOMETRIC_2F2_HPP
+#define STAN_MATH_PRIM_FUN_HYPERGEOMETRIC_2F2_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/hypergeometric_pFq.hpp>
+#include <boost/math/special_functions/hypergeometric_pFq.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the Gauss hypergeometric function applied to the
+ * input arguments:
+ * \f$_2F_1(a_1,a_2;b;z)\f$
+ *
+ * See 'grad_2F1.hpp' for the derivatives wrt each parameter
+ *
+ * @param[in] a1 First of 'a' arguments to function
+ * @param[in] a2 Second of 'a' arguments to function
+ * @param[in] b 'b' argument to function
+ * @param[in] z Scalar z argument
+ * @return Gauss hypergeometric function
+ */
+template <typename Ta1, typename Ta2, typename Tb, typename Tz,
+          require_all_arithmetic_t<Ta1, Ta2, Tb, Tz>* = nullptr>
+return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
+                                                    const Ta2& a2,
+                                                    const Tb& b,
+                                                    const Tz& z) {
+  check_finite("hypergeometric_2F1", "a1", a1);
+  check_finite("hypergeometric_2F1", "a2", a2);
+  check_finite("hypergeometric_2F1", "b", b);
+  check_finite("hypergeometric_2F1", "z", z);
+
+  check_not_nan("hypergeometric_2F1", "a1", a1);
+  check_not_nan("hypergeometric_2F1", "a2", a2);
+  check_not_nan("hypergeometric_2F1", "b", b);
+  check_not_nan("hypergeometric_2F1", "z", z);
+
+  check_2F1_converges("hypergeometric_2F1", a1, a2, b1, z);
+
+  return boost::math::hypergeometric_pFq({a1, a2}, {b}, z);
+}
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -2,16 +2,114 @@
 #define STAN_MATH_PRIM_FUN_HYPERGEOMETRIC_2F1_HPP
 
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/abs.hpp>
+#include <stan/math/prim/fun/asin.hpp>
+#include <stan/math/prim/fun/asinh.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/digamma.hpp>
+#include <stan/math/prim/fun/exp.hpp>
+#include <stan/math/prim/fun/floor.hpp>
+#include <stan/math/prim/fun/inv.hpp>
+#include <stan/math/prim/fun/log.hpp>
+#include <stan/math/prim/fun/lgamma.hpp>
+#include <stan/math/prim/fun/pow.hpp>
+#include <stan/math/prim/fun/sqrt.hpp>
+#include <stan/math/prim/fun/square.hpp>
 #include <stan/math/prim/fun/hypergeometric_pFq.hpp>
-#include <boost/math/special_functions/hypergeometric_pFq.hpp>
+#include <boost/optional.hpp>
 
 namespace stan {
 namespace math {
+namespace internal {
+
+/**
+ * Calculate the Gauss Hypergeometric (2F1) function for special-case
+ * combinations of parameters which can be calculated in closed-form. For
+ * more background (and other possible special-cases), see:
+ * https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/
+ *
+ * The return value is wrapped in a boost::optional<> type so that a void
+ * return is possible if no special-case rules are applicable
+ *
+ * @tparam Ta1 Type of scalar first 'a' argument
+ * @tparam Ta2 Type of scalar second 'a' argument
+ * @tparam Tb Type of scalar 'b' argument
+ * @tparam Tz Type of scalar 'z' argument
+ * @param[in] a1 First of 'a' arguments to function
+ * @param[in] a2 Second of 'a' arguments to function
+ * @param[in] b 'b' argument to function
+ * @param[in] z Scalar z argument
+ * @return Gauss hypergeometric function
+ */
+template <typename Ta1, typename Ta2, typename Tb, typename Tz,
+          typename RtnT = boost::optional<return_type_t<Ta1, Ta1, Tb, Tz>>,
+          require_all_arithmetic_t<Ta1, Ta2, Tb, Tz>* = nullptr>
+inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
+                                    const Tz& z) {
+  if (z == 0.0) {
+    return 1.0;
+  }
+
+  if (a1 == b) {
+    return inv(pow(1.0 - z, a2));
+  }
+
+  if (b == (a2 - 1.0)) {
+    return (pow((1.0 - z), -a1 - 1.0) * (a2 + z * (a1 - a2 + 1.0) - 1.0))
+      / (a2 - 1);
+  }
+
+  if (a1 == a2) {
+    if (a1 == 1.0 && b == 2.0 && z < 0) {
+      auto pos_z = abs(z);
+      return log1p(pos_z) / pos_z;
+    }
+
+    if (a1 == 0.5 && b == 1.5 && z < 1.0) {
+        auto sqrt_z = sqrt(abs(z));
+        auto numerator = (z > 0.0) ? asin(sqrt_z) : asinh(sqrt_z);
+        return numerator / sqrt_z;
+    }
+
+    if (b == (a1 + 1) && z == 0.5) {
+      return pow(2, a1 - 1) * a1
+        * (digamma((a1 + 1) / 2.0) - digamma(a1 / 2.0));
+    }
+  }
+
+  if (z == 1.0) {
+    if (b == (a1 + a2 + 2)) {
+      auto log_2f1 = lgamma(b) - (lgamma(a1 + 2) + lgamma(a2 + 2));
+      return exp(log_2f1);
+    } else if (b > (a1 + a2)) {
+      auto log_2f1 = (lgamma(b) + lgamma(b - a1 - a2))
+        - (lgamma(b - a1) + lgamma(b - a2));
+      return exp(log_2f1);
+    }
+  }
+
+  if (a1 == 1.5 && a2 == 2.0 && b == 3.0 && z < 0.0) {
+    auto abs_z = abs(z);
+    auto sqrt_1pz = sqrt(1 + abs_z);
+    return - 4 * (2 * sqrt_1pz + z - 2) / (sqrt_1pz * square(z));
+  }
+
+  return {};
+}
+}  // namespace internal
 
 /**
  * Returns the Gauss hypergeometric function applied to the
  * input arguments:
  * \f$_2F_1(a_1,a_2;b;z)\f$
+ *
+ * If the input parameters do not meet convergence criteria, then Euler's
+ * transformation is applied to resolve this:
+ * https://mathworld.wolfram.com/EulerTransform.html
+ *
+ * For some special-case combinations of parameters the series is calculated
+ * in closed form, see the internal::hyper_2F1_special_cases function for more
+ * details.
  *
  * See 'grad_2F1.hpp' for the derivatives wrt each parameter
  *
@@ -26,6 +124,8 @@ namespace math {
  * @return Gauss hypergeometric function
  */
 template <typename Ta1, typename Ta2, typename Tb, typename Tz,
+          typename ScalarT = return_type_t<Ta1, Ta1, Tb, Tz>,
+          typename OptT = boost::optional<ScalarT>,
           require_all_arithmetic_t<Ta1, Ta2, Tb, Tz>* = nullptr>
 inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
                                                           const Ta2& a2,
@@ -41,10 +141,43 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   check_not_nan("hypergeometric_2F1", "b", b);
   check_not_nan("hypergeometric_2F1", "z", z);
 
-  check_2F1_converges("hypergeometric_2F1", a1, a2, b, z);
+  // Check whether value can be calculated by any special-case rules
+  // before estimating infinite sum
+  OptT special_case_a1a2 = internal::hyper_2F1_special_cases(a1, a2, b, z);
+  if (special_case_a1a2.is_initialized()) {
+    return special_case_a1a2.get();
+  }
 
-  return boost::math::hypergeometric_pFq(
-      std::vector<return_type_t<Ta1, Ta2>>{a1, a2}, {b}, z);
+  // Check whether any special case rules apply with 'a' arguments reversed
+  // as 2F1(a1, a2, b, z) = 2F1(a2, a1, b, z)
+  OptT special_case_a2a1 = internal::hyper_2F1_special_cases(a2, a1, b, z);
+  if (special_case_a2a1.is_initialized()) {
+    return special_case_a2a1.get();
+  }
+
+  Eigen::VectorXd a_args(2);
+  Eigen::VectorXd b_args(1);
+
+  try {
+    check_2F1_converges("hypergeometric_2F1", a1, a2, b, z);
+
+    a_args << a1, a2;
+    b_args << b;
+    return hypergeometric_pFq(a_args, b_args, z);
+  } catch (...) {
+    // Apply Euler's hypergeometric transformation if function
+    // will not converge with current arguments
+    ScalarT a1_t = b - a1;
+    ScalarT a2_t = a2;
+    ScalarT b_t = b;
+    ScalarT z_t = z / (z - 1);
+
+    check_2F1_converges("hypergeometric_2F1", a1_t, a2_t, b_t, z_t);
+
+    a_args << a1_t, a2_t;
+    b_args << b_t;
+    return hypergeometric_pFq(a_args, b_args, z_t) / pow(1 - z, a2);
+  }
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -6,7 +6,10 @@
 #include <stan/math/prim/fun/asin.hpp>
 #include <stan/math/prim/fun/asinh.hpp>
 #include <stan/math/prim/fun/constants.hpp>
+<<<<<<< HEAD
 #include <stan/math/prim/fun/digamma.hpp>
+=======
+>>>>>>> 6011bfa293 (Begin updating grad_2f1)
 #include <stan/math/prim/fun/exp.hpp>
 #include <stan/math/prim/fun/floor.hpp>
 #include <stan/math/prim/fun/inv.hpp>

--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -75,6 +75,7 @@
 #include <stan/math/rev/fun/gp_periodic_cov.hpp>
 #include <stan/math/rev/fun/grad.hpp>
 #include <stan/math/rev/fun/grad_inc_beta.hpp>
+#include <stan/math/rev/fun/hypergeometric_2F1.hpp>
 #include <stan/math/rev/fun/hypergeometric_pFq.hpp>
 #include <stan/math/rev/fun/hypot.hpp>
 #include <stan/math/rev/fun/identity_constrain.hpp>

--- a/stan/math/rev/fun/grad_inc_beta.hpp
+++ b/stan/math/rev/fun/grad_inc_beta.hpp
@@ -44,10 +44,9 @@ inline void grad_inc_beta(var& g1, var& g2, const var& a, const var& b,
   var dF2 = 0;
   var dF3 = 0;
   var dFz = 0;
-  if (value_of(value_of(C))) {
-    auto grad_tuple = grad_2F1<true>(a + b, var(1.0), a + 1, z);
-    dF1 = std::get<0>(grad_tuple);
-    dF3 = std::get<2>(grad_tuple);
+  if (value_of_rec(C)) {
+    std::forward_as_tuple(dF1, dF2, dF3, dFz)
+       = grad_2F1<true>(a + b, var(1.0), a + 1, z);
   }
   g1 = (c1 - 1.0 / a) * c3 + C * (dF1 + dF3);
   g2 = c2 * c3 + C * dF1;

--- a/stan/math/rev/fun/grad_inc_beta.hpp
+++ b/stan/math/rev/fun/grad_inc_beta.hpp
@@ -15,6 +15,7 @@
 #include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/prim/fun/grad_2F1.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/rev/fun/hypergeometric_2F1.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/rev/fun/grad_inc_beta.hpp
+++ b/stan/math/rev/fun/grad_inc_beta.hpp
@@ -45,7 +45,7 @@ inline void grad_inc_beta(var& g1, var& g2, const var& a, const var& b,
   var dF3 = 0;
   var dFz = 0;
   if (value_of(value_of(C))) {
-    grad_2F1<true, false, true, false>(dF1, dF2, dF3, dFz, a + b, var(1.0), a + 1, z);
+    grad_2F1(dF1, dF2, dF3, dFz, a + b, var(1.0), a + 1, z);
   }
   g1 = (c1 - 1.0 / a) * c3 + C * (dF1 + dF3);
   g2 = c2 * c3 + C * dF1;

--- a/stan/math/rev/fun/grad_inc_beta.hpp
+++ b/stan/math/rev/fun/grad_inc_beta.hpp
@@ -42,8 +42,9 @@ inline void grad_inc_beta(var& g1, var& g2, const var& a, const var& b,
   var dF1 = 0;
   var dF2 = 0;
   var dF3 = 0;
+  var dFz = 0;
   if (value_of(value_of(C))) {
-    grad_2F1(dF1, dF2, dF3, a + b, var(1.0), a + 1, z);
+    grad_2F1<true, false, true, false>(dF1, dF2, dF3, dFz, a + b, var(1.0), a + 1, z);
   }
   g1 = (c1 - 1.0 / a) * c3 + C * (dF1 + dF3);
   g2 = c2 * c3 + C * dF1;

--- a/stan/math/rev/fun/grad_inc_beta.hpp
+++ b/stan/math/rev/fun/grad_inc_beta.hpp
@@ -45,7 +45,9 @@ inline void grad_inc_beta(var& g1, var& g2, const var& a, const var& b,
   var dF3 = 0;
   var dFz = 0;
   if (value_of(value_of(C))) {
-    grad_2F1(dF1, dF2, dF3, dFz, a + b, var(1.0), a + 1, z);
+    auto grad_tuple = grad_2F1<true>(a + b, var(1.0), a + 1, z);
+    dF1 = std::get<0>(grad_tuple);
+    dF3 = std::get<2>(grad_tuple);
   }
   g1 = (c1 - 1.0 / a) * c3 + C * (dF1 + dF3);
   g2 = c2 * c3 + C * dF1;

--- a/stan/math/rev/fun/grad_inc_beta.hpp
+++ b/stan/math/rev/fun/grad_inc_beta.hpp
@@ -46,7 +46,7 @@ inline void grad_inc_beta(var& g1, var& g2, const var& a, const var& b,
   var dFz = 0;
   if (value_of_rec(C)) {
     std::forward_as_tuple(dF1, dF2, dF3, dFz)
-       = grad_2F1<true>(a + b, var(1.0), a + 1, z);
+        = grad_2F1<true>(a + b, var(1.0), a + 1, z);
   }
   g1 = (c1 - 1.0 / a) * c3 + C * (dF1 + dF3);
   g2 = c2 * c3 + C * dF1;

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -45,9 +45,7 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
         double g_a2;
         double g_b;
         double g_z;
-        grad_2F1<!is_constant<Ta1>::value, !is_constant<Ta2>::value,
-                 !is_constant<Tb>::value, !is_constant<Tz>::value>
-                 (g_a1, g_a2, g_b, g_z, a1_dbl, a2_dbl, b_dbl, z_dbl);
+        grad_2F1(g_a1, g_a2, g_b, g_z, a1_dbl, a2_dbl, b_dbl, z_dbl);
 
         if (!is_constant<Ta1>::value) {
           forward_as<var>(a1).adj() += vi.adj() * g_a1;

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -38,27 +38,24 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   double b_dbl = value_of(b);
   double z_dbl = value_of(z);
 
-  return make_callback_var(hypergeometric_2F1(a1_dbl, a2_dbl, b_dbl, z_dbl),
-                           [a1, a2, b, z](auto& vi) mutable {
-                             double g_a1;
-                             double g_a2;
-                             double g_b;
-                             double g_z;
-                             grad_2F1(g_a1, g_a2, g_b, g_z, a1, a2, b, z);
+  return make_callback_var(
+    hypergeometric_2F1(a1_dbl, a2_dbl, b_dbl, z_dbl),
+    [a1, a2, b, z](auto& vi) mutable {
+      auto grad_tuple = grad_2F1(a1, a2, b, z);
 
-                             if (!is_constant<Ta1>::value) {
-                               forward_as<var>(a1).adj() += vi.adj() * g_a1;
-                             }
-                             if (!is_constant<Ta2>::value) {
-                               forward_as<var>(a2).adj() += vi.adj() * g_a2;
-                             }
-                             if (!is_constant<Tb>::value) {
-                               forward_as<var>(b).adj() += vi.adj() * g_b;
-                             }
-                             if (!is_constant<Tz>::value) {
-                               forward_as<var>(z).adj() += vi.adj() * g_z;
-                             }
-                           });
+      if (!is_constant<Ta1>::value) {
+        forward_as<var>(a1).adj() += vi.adj() * std::get<0>(grad_tuple);
+      }
+      if (!is_constant<Ta2>::value) {
+        forward_as<var>(a2).adj() += vi.adj() * std::get<1>(grad_tuple);
+      }
+      if (!is_constant<Tb>::value) {
+        forward_as<var>(b).adj() += vi.adj() * std::get<2>(grad_tuple);
+      }
+      if (!is_constant<Tz>::value) {
+        forward_as<var>(z).adj() += vi.adj() * std::get<3>(grad_tuple);
+      }
+    });
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -39,23 +39,23 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   double z_dbl = value_of(z);
 
   return make_callback_var(
-    hypergeometric_2F1(a1_dbl, a2_dbl, b_dbl, z_dbl),
-    [a1, a2, b, z](auto& vi) mutable {
-      auto grad_tuple = grad_2F1(a1, a2, b, z);
+      hypergeometric_2F1(a1_dbl, a2_dbl, b_dbl, z_dbl),
+      [a1, a2, b, z](auto& vi) mutable {
+        auto grad_tuple = grad_2F1(a1, a2, b, z);
 
-      if (!is_constant<Ta1>::value) {
-        forward_as<var>(a1).adj() += vi.adj() * std::get<0>(grad_tuple);
-      }
-      if (!is_constant<Ta2>::value) {
-        forward_as<var>(a2).adj() += vi.adj() * std::get<1>(grad_tuple);
-      }
-      if (!is_constant<Tb>::value) {
-        forward_as<var>(b).adj() += vi.adj() * std::get<2>(grad_tuple);
-      }
-      if (!is_constant<Tz>::value) {
-        forward_as<var>(z).adj() += vi.adj() * std::get<3>(grad_tuple);
-      }
-    });
+        if (!is_constant<Ta1>::value) {
+          forward_as<var>(a1).adj() += vi.adj() * std::get<0>(grad_tuple);
+        }
+        if (!is_constant<Ta2>::value) {
+          forward_as<var>(a2).adj() += vi.adj() * std::get<1>(grad_tuple);
+        }
+        if (!is_constant<Tb>::value) {
+          forward_as<var>(b).adj() += vi.adj() * std::get<2>(grad_tuple);
+        }
+        if (!is_constant<Tz>::value) {
+          forward_as<var>(z).adj() += vi.adj() * std::get<3>(grad_tuple);
+        }
+      });
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -29,8 +29,10 @@ namespace math {
 template <typename Ta1, typename Ta2, typename Tb, typename Tz,
           require_all_stan_scalar_t<Ta1, Ta2, Tb, Tz>* = nullptr,
           require_any_var_t<Ta1, Ta2, Tb, Tz>* = nullptr>
-inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1, const Ta2& a2,
-                                                   const Tb& b, const Tz& z) {
+inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
+                                                          const Ta2& a2,
+                                                          const Tb& b,
+                                                          const Tz& z) {
   double a1_dbl = value_of(a1);
   double a2_dbl = value_of(a2);
   double b_dbl = value_of(b);

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -40,12 +40,12 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
 
   return make_callback_var(
       hypergeometric_2F1(a1_dbl, a2_dbl, b_dbl, z_dbl),
-      [a1, a2, b, z, a1_dbl, a2_dbl, b_dbl, z_dbl](auto& vi) mutable {
+      [a1, a2, b, z](auto& vi) mutable {
         double g_a1;
         double g_a2;
         double g_b;
         double g_z;
-        grad_2F1(g_a1, g_a2, g_b, g_z, a1_dbl, a2_dbl, b_dbl, z_dbl);
+        grad_2F1(g_a1, g_a2, g_b, g_z, a1, a2, b, z);
 
         if (!is_constant<Ta1>::value) {
           forward_as<var>(a1).adj() += vi.adj() * g_a1;

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -38,28 +38,27 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   double b_dbl = value_of(b);
   double z_dbl = value_of(z);
 
-  return make_callback_var(
-      hypergeometric_2F1(a1_dbl, a2_dbl, b_dbl, z_dbl),
-      [a1, a2, b, z](auto& vi) mutable {
-        double g_a1;
-        double g_a2;
-        double g_b;
-        double g_z;
-        grad_2F1(g_a1, g_a2, g_b, g_z, a1, a2, b, z);
+  return make_callback_var(hypergeometric_2F1(a1_dbl, a2_dbl, b_dbl, z_dbl),
+                           [a1, a2, b, z](auto& vi) mutable {
+                             double g_a1;
+                             double g_a2;
+                             double g_b;
+                             double g_z;
+                             grad_2F1(g_a1, g_a2, g_b, g_z, a1, a2, b, z);
 
-        if (!is_constant<Ta1>::value) {
-          forward_as<var>(a1).adj() += vi.adj() * g_a1;
-        }
-        if (!is_constant<Ta2>::value) {
-          forward_as<var>(a2).adj() += vi.adj() * g_a2;
-        }
-        if (!is_constant<Tb>::value) {
-          forward_as<var>(b).adj() += vi.adj() * g_b;
-        }
-        if (!is_constant<Tz>::value) {
-          forward_as<var>(z).adj() += vi.adj() * g_z;
-        }
-      });
+                             if (!is_constant<Ta1>::value) {
+                               forward_as<var>(a1).adj() += vi.adj() * g_a1;
+                             }
+                             if (!is_constant<Ta2>::value) {
+                               forward_as<var>(a2).adj() += vi.adj() * g_a2;
+                             }
+                             if (!is_constant<Tb>::value) {
+                               forward_as<var>(b).adj() += vi.adj() * g_b;
+                             }
+                             if (!is_constant<Tz>::value) {
+                               forward_as<var>(z).adj() += vi.adj() * g_z;
+                             }
+                           });
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -1,0 +1,65 @@
+#ifndef STAN_MATH_REV_FUN_HYPERGEOMETRIC_2F1_HPP
+#define STAN_MATH_REV_FUN_HYPERGEOMETRIC_2F1_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/prim/fun/hypergeometric_2F1.hpp>
+#include <stan/math/prim/fun/grad_2F1.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the Gauss hypergeometric function applied to the
+ * input arguments:
+ * \f$_2F_1(a_1,a_2;b;z)\f$
+ *
+ * See 'grad_2F1.hpp' for the derivatives wrt each parameter
+ *
+ * @param[in] a1 First of 'a' arguments to function
+ * @param[in] a2 Second of 'a' arguments to function
+ * @param[in] b 'b' argument to function
+ * @param[in] z Scalar z argument
+ * @return Gauss hypergeometric function
+ */
+template <typename Ta1, typename Ta2, typename Tb, typename Tz,
+          require_all_stan_scalar_t<Ta1, Ta2, Tb, Tz>* = nullptr,
+          require_any_var_t<Ta1, Ta2, Tb, Tz>* = nullptr>
+return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
+                                                    const Ta2& a2,
+                                                    const Tb& b,
+                                                    const Tz& z) {
+  double a1_dbl = value_of(a1);
+  double a2_dbl = value_of(a2);
+  double b_dbl = value_of(b);
+  double z_dbl = value_of(z);
+
+  return make_callback_var(
+      hypergeometric_2F1(a1_dbl, a2_dbl, b_dbl, z_dbl),
+      [a1, a2, b, z, a1_dbl, a2_dbl, b_dbl, z_dbl](auto& vi) mutable {
+        double g_a1;
+        double g_a2;
+        double g_b;
+        grad_2F1(g_a1, g_a2, g_b, a1_dbl, a2_dbl, b_dbl, z_dbl);
+
+        if (!is_constant<Ta1>::value) {
+          forward_as<var>(a1).adj() += vi.adj() * g_a1;
+        }
+        if (!is_constant<Ta2>::value) {
+          forward_as<var>(a2).adj() += vi.adj() * g_a2;
+        }
+        if (!is_constant<Tb>::value) {
+          forward_as<var>(b).adj() += vi.adj() * g_b;
+        }
+        if (!is_constant<Tz>::value) {
+          double hyper_2f1_dz =
+            hypergeometric_2F1(a1_dbl + 1, a2_dbl + 1, b_dbl + 1, z_dbl);
+          forward_as<var>(z).adj() += vi.adj()
+            * (a1_dbl * a2_dbl * hyper_2f1_dz) / b_dbl;
+        }
+
+      });
+}
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -8,9 +8,7 @@
 
 namespace stan {
 namespace math {
-namespace internal {
 
-} // namespace internal
 /**
  * Returns the Gauss hypergeometric function applied to the
  * input arguments:

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -8,7 +8,9 @@
 
 namespace stan {
 namespace math {
+namespace internal {
 
+} // namespace internal
 /**
  * Returns the Gauss hypergeometric function applied to the
  * input arguments:
@@ -44,7 +46,10 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
         double g_a1;
         double g_a2;
         double g_b;
-        grad_2F1(g_a1, g_a2, g_b, a1_dbl, a2_dbl, b_dbl, z_dbl);
+        double g_z;
+        grad_2F1<!is_constant<Ta1>::value, !is_constant<Ta2>::value,
+                 !is_constant<Tb>::value, !is_constant<Tz>::value>
+                 (g_a1, g_a2, g_b, g_z, a1_dbl, a2_dbl, b_dbl, z_dbl);
 
         if (!is_constant<Ta1>::value) {
           forward_as<var>(a1).adj() += vi.adj() * g_a1;
@@ -56,10 +61,7 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
           forward_as<var>(b).adj() += vi.adj() * g_b;
         }
         if (!is_constant<Tz>::value) {
-          double hyper_2f1_dz
-              = hypergeometric_2F1(a1_dbl + 1, a2_dbl + 1, b_dbl + 1, z_dbl);
-          forward_as<var>(z).adj()
-              += vi.adj() * (a1_dbl * a2_dbl * hyper_2f1_dz) / b_dbl;
+          forward_as<var>(z).adj() += vi.adj() * g_z;
         }
       });
 }

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -57,7 +57,6 @@ return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
           forward_as<var>(z).adj() += vi.adj()
             * (a1_dbl * a2_dbl * hyper_2f1_dz) / b_dbl;
         }
-
       });
 }
 }  // namespace math

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -16,6 +16,10 @@ namespace math {
  *
  * See 'grad_2F1.hpp' for the derivatives wrt each parameter
  *
+ * @tparam Ta1 Type of scalar first 'a' argument
+ * @tparam Ta2 Type of scalar second 'a' argument
+ * @tparam Tb Type of scalar 'b' argument
+ * @tparam Tz Type of scalar 'z' argument
  * @param[in] a1 First of 'a' arguments to function
  * @param[in] a2 Second of 'a' arguments to function
  * @param[in] b 'b' argument to function
@@ -25,7 +29,7 @@ namespace math {
 template <typename Ta1, typename Ta2, typename Tb, typename Tz,
           require_all_stan_scalar_t<Ta1, Ta2, Tb, Tz>* = nullptr,
           require_any_var_t<Ta1, Ta2, Tb, Tz>* = nullptr>
-return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1, const Ta2& a2,
+inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1, const Ta2& a2,
                                                    const Tb& b, const Tz& z) {
   double a1_dbl = value_of(a1);
   double a2_dbl = value_of(a2);

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -25,10 +25,8 @@ namespace math {
 template <typename Ta1, typename Ta2, typename Tb, typename Tz,
           require_all_stan_scalar_t<Ta1, Ta2, Tb, Tz>* = nullptr,
           require_any_var_t<Ta1, Ta2, Tb, Tz>* = nullptr>
-return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
-                                                    const Ta2& a2,
-                                                    const Tb& b,
-                                                    const Tz& z) {
+return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1, const Ta2& a2,
+                                                   const Tb& b, const Tz& z) {
   double a1_dbl = value_of(a1);
   double a2_dbl = value_of(a2);
   double b_dbl = value_of(b);
@@ -52,10 +50,10 @@ return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
           forward_as<var>(b).adj() += vi.adj() * g_b;
         }
         if (!is_constant<Tz>::value) {
-          double hyper_2f1_dz =
-            hypergeometric_2F1(a1_dbl + 1, a2_dbl + 1, b_dbl + 1, z_dbl);
-          forward_as<var>(z).adj() += vi.adj()
-            * (a1_dbl * a2_dbl * hyper_2f1_dz) / b_dbl;
+          double hyper_2f1_dz
+              = hypergeometric_2F1(a1_dbl + 1, a2_dbl + 1, b_dbl + 1, z_dbl);
+          forward_as<var>(z).adj()
+              += vi.adj() * (a1_dbl * a2_dbl * hyper_2f1_dz) / b_dbl;
         }
       });
 }

--- a/test/unit/math/mix/fun/grad_2F1_test.cpp
+++ b/test/unit/math/mix/fun/grad_2F1_test.cpp
@@ -10,23 +10,18 @@ TEST(ProbInternalMath, grad2F1_zero_z) {
   fvar<double> b1 = 2.70975;
   fvar<double> z = 0;
 
-  fvar<double> grad_a1;
-  fvar<double> grad_a2;
-  fvar<double> grad_b1;
-  fvar<double> grad_z;
-
   a1.d_ = 1;
   a2.d_ = 1;
   b1.d_ = 1;
 
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
-  EXPECT_FLOAT_EQ(0, grad_a1.val_);
-  EXPECT_FLOAT_EQ(0, grad_a2.val_);
-  EXPECT_FLOAT_EQ(0, grad_b1.val_);
+  auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z);
+  EXPECT_FLOAT_EQ(0, std::get<0>(grad_tuple).val_);
+  EXPECT_FLOAT_EQ(0, std::get<1>(grad_tuple).val_);
+  EXPECT_FLOAT_EQ(0, std::get<2>(grad_tuple).val_);
 
-  EXPECT_FLOAT_EQ(0, grad_a1.d_);
-  EXPECT_FLOAT_EQ(0, grad_a2.d_);
-  EXPECT_FLOAT_EQ(0, grad_b1.d_);
+  EXPECT_FLOAT_EQ(0, std::get<0>(grad_tuple).d_);
+  EXPECT_FLOAT_EQ(0, std::get<1>(grad_tuple).d_);
+  EXPECT_FLOAT_EQ(0, std::get<2>(grad_tuple).d_);
 }
 
 TEST(ProbInternalMath, grad2F1_fnegative_z) {
@@ -37,19 +32,14 @@ TEST(ProbInternalMath, grad2F1_fnegative_z) {
   fvar<double> c = 2.70975;
   fvar<double> z = -0.2;
 
-  fvar<double> gradA;
-  fvar<double> gradB;
-  fvar<double> gradC;
-  fvar<double> gradZ;
-
   a.d_ = 1;
   b.d_ = 1;
   c.d_ = 1;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
-  EXPECT_NEAR(-0.0488658806159776, gradA.val_, 1e-9);
-  EXPECT_NEAR(-0.193844936204681, gradB.val_, 1e-9);
-  EXPECT_NEAR(0.0677809985598383, gradC.val_, 1e-9);
+  auto grad_tuple = stan::math::grad_2F1(a, b, c, z);
+  EXPECT_NEAR(-0.0488658806159776, std::get<0>(grad_tuple), 1e-9);
+  EXPECT_NEAR(-0.193844936204681, std::get<1>(grad_tuple), 1e-9);
+  EXPECT_NEAR(0.0677809985598383, std::get<2>(grad_tuple), 1e-9);
 }
 
 TEST(ProbInternalMath, grad2F1_fd1) {
@@ -60,16 +50,13 @@ TEST(ProbInternalMath, grad2F1_fd1) {
   fvar<double> b = 1;
   fvar<double> c = 2;
   fvar<double> z = 0.4;
-  fvar<double> gradA;
-  fvar<double> gradB;
-  fvar<double> gradC;
-  fvar<double> gradZ;
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
 
-  EXPECT_NEAR(0.46177343153972, gradA.val_, 1e-8);
-  EXPECT_NEAR(0.16371487651638, gradA.d_, 1e-8);
-  EXPECT_NEAR(0.85137603960998, gradB.val_, 1e-8);
-  EXPECT_NEAR(-0.4617734352303, gradC.val_, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
+
+  EXPECT_NEAR(0.46177343153972, std::get<0>(grad_tuple).val_, 1e-8);
+  EXPECT_NEAR(0.16371487651638, std::get<0>(grad_tuple).d_, 1e-8);
+  EXPECT_NEAR(0.85137603960998, std::get<1>(grad_tuple).val_, 1e-8);
+  EXPECT_NEAR(-0.4617734352303, std::get<2>(grad_tuple).val_, 1e-8);
 }
 TEST(ProbInternalMath, grad2F1_fd2) {
   using stan::math::fvar;
@@ -79,16 +66,13 @@ TEST(ProbInternalMath, grad2F1_fd2) {
   fvar<double> c = 2;
   b.d_ = 1;
   fvar<double> z = 0.4;
-  fvar<double> gradA;
-  fvar<double> gradB;
-  fvar<double> gradC;
-  fvar<double> gradZ;
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
 
-  EXPECT_NEAR(0.461773431539720, gradA.val_, 1e-8);
-  EXPECT_NEAR(0.851376039609984, gradB.val_, 1e-8);
-  EXPECT_NEAR(-0.46177343523032, gradC.val_, 1e-8);
-  EXPECT_NEAR(0.434904696493189, gradB.d_, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
+
+  EXPECT_NEAR(0.461773431539720, std::get<0>(grad_tuple).val_, 1e-8);
+  EXPECT_NEAR(0.851376039609984, std::get<1>(grad_tuple).val_, 1e-8);
+  EXPECT_NEAR(-0.46177343523032, std::get<2>(grad_tuple).val_, 1e-8);
+  EXPECT_NEAR(0.434904696493189, std::get<1>(grad_tuple).d_, 1e-8);
 }
 
 TEST(ProbInternalMath, grad2F1_fd3) {
@@ -99,16 +83,13 @@ TEST(ProbInternalMath, grad2F1_fd3) {
   fvar<double> c = 2;
   c.d_ = 1;
   fvar<double> z = 0.4;
-  fvar<double> gradA;
-  fvar<double> gradB;
-  fvar<double> gradC;
-  fvar<double> gradZ;
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
 
-  EXPECT_NEAR(0.461773431539720, gradA.val_, 1e-8);
-  EXPECT_NEAR(0.851376039609984, gradB.val_, 1e-8);
-  EXPECT_NEAR(-0.46177343523032, gradC.val_, 1e-8);
-  EXPECT_NEAR(0.574406330443730, gradC.d_, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
+
+  EXPECT_NEAR(0.461773431539720, std::get<0>(grad_tuple).val_, 1e-8);
+  EXPECT_NEAR(0.851376039609984, std::get<1>(grad_tuple).val_, 1e-8);
+  EXPECT_NEAR(-0.46177343523032, std::get<2>(grad_tuple).val_, 1e-8);
+  EXPECT_NEAR(0.574406330443730, std::get<2>(grad_tuple).d_, 1e-8);
 }
 TEST(ProbInternalMath, grad2F1_ffd1) {
   using stan::math::fvar;
@@ -118,16 +99,12 @@ TEST(ProbInternalMath, grad2F1_ffd1) {
   fvar<fvar<double> > b = 1;
   fvar<fvar<double> > c = 2;
   fvar<fvar<double> > z = 0.4;
-  fvar<fvar<double> > gradA;
-  fvar<fvar<double> > gradB;
-  fvar<fvar<double> > gradC;
-  fvar<fvar<double> > gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
-  EXPECT_NEAR(0.461773431539720, gradA.val_.val_, 1e-8);
-  EXPECT_NEAR(0.163714876516383, gradA.d_.val_, 1e-8);
-  EXPECT_NEAR(0.851376039609984, gradB.val_.val_, 1e-8);
-  EXPECT_NEAR(-0.46177343523032, gradC.val_.val_, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
+  EXPECT_NEAR(0.461773431539720, std::get<0>(grad_tuple).val_.val_, 1e-8);
+  EXPECT_NEAR(0.163714876516383, std::get<0>(grad_tuple).d_.val_, 1e-8);
+  EXPECT_NEAR(0.851376039609984, std::get<1>(grad_tuple).val_.val_, 1e-8);
+  EXPECT_NEAR(-0.46177343523032, std::get<2>(grad_tuple).val_.val_, 1e-8);
 }
 TEST(ProbInternalMath, grad2F1_ffd2) {
   using stan::math::fvar;
@@ -137,16 +114,12 @@ TEST(ProbInternalMath, grad2F1_ffd2) {
   fvar<fvar<double> > c = 2;
   b.d_ = 1;
   fvar<fvar<double> > z = 0.4;
-  fvar<fvar<double> > gradA;
-  fvar<fvar<double> > gradB;
-  fvar<fvar<double> > gradC;
-  fvar<fvar<double> > gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
-  EXPECT_NEAR(0.461773431539720, gradA.val_.val_, 1e-8);
-  EXPECT_NEAR(0.851376039609984, gradB.val_.val_, 1e-8);
-  EXPECT_NEAR(0.434904696493189, gradB.d_.val_, 1e-8);
-  EXPECT_NEAR(-0.461773435230326, gradC.val_.val_, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
+  EXPECT_NEAR(0.461773431539720, std::get<0>(grad_tuple).val_.val_, 1e-8);
+  EXPECT_NEAR(0.851376039609984, std::get<1>(grad_tuple).val_.val_, 1e-8);
+  EXPECT_NEAR(0.434904696493189, std::get<1>(grad_tuple).d_.val_, 1e-8);
+  EXPECT_NEAR(-0.461773435230326, std::get<2>(grad_tuple).val_.val_, 1e-8);
 }
 
 TEST(ProbInternalMath, grad2F1_ffd3) {
@@ -157,16 +130,12 @@ TEST(ProbInternalMath, grad2F1_ffd3) {
   fvar<fvar<double> > c = 2;
   c.d_ = 1;
   fvar<fvar<double> > z = 0.4;
-  fvar<fvar<double> > gradA;
-  fvar<fvar<double> > gradB;
-  fvar<fvar<double> > gradC;
-  fvar<fvar<double> > gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
-  EXPECT_NEAR(0.461773431539720, gradA.val_.val_, 1e-8);
-  EXPECT_NEAR(0.851376039609984, gradB.val_.val_, 1e-8);
-  EXPECT_NEAR(-0.461773435230326, gradC.val_.val_, 1e-8);
-  EXPECT_NEAR(0.574406330443730, gradC.d_.val_, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
+  EXPECT_NEAR(0.461773431539720, std::get<0>(grad_tuple).val_.val_, 1e-8);
+  EXPECT_NEAR(0.851376039609984, std::get<1>(grad_tuple).val_.val_, 1e-8);
+  EXPECT_NEAR(-0.461773435230326, std::get<2>(grad_tuple).val_.val_, 1e-8);
+  EXPECT_NEAR(0.574406330443730, std::get<2>(grad_tuple).d_.val_, 1e-8);
 }
 
 TEST(ProbInternalMath, grad2F1_fv1) {
@@ -178,16 +147,12 @@ TEST(ProbInternalMath, grad2F1_fv1) {
   fvar<var> b = 1;
   fvar<var> c = 2;
   fvar<var> z = 0.4;
-  fvar<var> gradA;
-  fvar<var> gradB;
-  fvar<var> gradC;
-  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
-  EXPECT_NEAR(0.461773431539720, gradA.val_.val(), 1e-8);
-  EXPECT_NEAR(0.163714876516383, gradA.d_.val(), 1e-8);
-  EXPECT_NEAR(0.851376039609984, gradB.val_.val(), 1e-8);
-  EXPECT_NEAR(-0.46177343523032, gradC.val_.val(), 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
+  EXPECT_NEAR(0.461773431539720, std::get<0>(grad_tuple).val_.val(), 1e-8);
+  EXPECT_NEAR(0.163714876516383, std::get<0>(grad_tuple).d_.val(), 1e-8);
+  EXPECT_NEAR(0.851376039609984, std::get<1>(grad_tuple).val_.val(), 1e-8);
+  EXPECT_NEAR(-0.46177343523032, std::get<2>(grad_tuple).val_.val(), 1e-8);
 }
 TEST(ProbInternalMath, grad2F1_fv2) {
   using stan::math::fvar;
@@ -198,16 +163,12 @@ TEST(ProbInternalMath, grad2F1_fv2) {
   b.d_ = 1;
   fvar<var> c = 2;
   fvar<var> z = 0.4;
-  fvar<var> gradA;
-  fvar<var> gradB;
-  fvar<var> gradC;
-  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
-  EXPECT_NEAR(0.461773431539720, gradA.val_.val(), 1e-8);
-  EXPECT_NEAR(0.851376039609984, gradB.val_.val(), 1e-8);
-  EXPECT_NEAR(0.434904696493189, gradB.d_.val(), 1e-8);
-  EXPECT_NEAR(-0.46177343523032, gradC.val_.val(), 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
+  EXPECT_NEAR(0.461773431539720, std::get<0>(grad_tuple).val_.val(), 1e-8);
+  EXPECT_NEAR(0.851376039609984, std::get<1>(grad_tuple).val_.val(), 1e-8);
+  EXPECT_NEAR(0.434904696493189, std::get<1>(grad_tuple).d_.val(), 1e-8);
+  EXPECT_NEAR(-0.46177343523032, std::get<2>(grad_tuple).val_.val(), 1e-8);
 }
 TEST(ProbInternalMath, grad2F1_fv3) {
   using stan::math::fvar;
@@ -218,16 +179,12 @@ TEST(ProbInternalMath, grad2F1_fv3) {
   fvar<var> c = 2;
   c.d_ = 1;
   fvar<var> z = 0.4;
-  fvar<var> gradA;
-  fvar<var> gradB;
-  fvar<var> gradC;
-  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
-  EXPECT_NEAR(0.461773431539720, gradA.val_.val(), 1e-8);
-  EXPECT_NEAR(0.851376039609984, gradB.val_.val(), 1e-8);
-  EXPECT_NEAR(-0.46177343523032, gradC.val_.val(), 1e-8);
-  EXPECT_NEAR(0.574406330443730, gradC.d_.val(), 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
+  EXPECT_NEAR(0.461773431539720, std::get<0>(grad_tuple).val_.val(), 1e-8);
+  EXPECT_NEAR(0.851376039609984, std::get<1>(grad_tuple).val_.val(), 1e-8);
+  EXPECT_NEAR(-0.46177343523032, std::get<2>(grad_tuple).val_.val(), 1e-8);
+  EXPECT_NEAR(0.574406330443730, std::get<2>(grad_tuple).d_.val(), 1e-8);
 }
 
 TEST(ProbInternalMath, grad2F1_fv_1stderiv1) {
@@ -239,16 +196,12 @@ TEST(ProbInternalMath, grad2F1_fv_1stderiv1) {
   fvar<var> b = 1;
   fvar<var> c = 2;
   fvar<var> z = 0.4;
-  fvar<var> gradA;
-  fvar<var> gradB;
-  fvar<var> gradC;
-  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
 
   std::vector<stan::math::var> y1{a.val_};
   std::vector<double> grad1;
-  gradA.val_.grad(y1, grad1);
+  std::get<0>(grad_tuple).val_.grad(y1, grad1);
   EXPECT_NEAR(0.163714876516383, grad1[0], 1e-8);
 }
 TEST(ProbInternalMath, grad2F1_fv_1stderiv2) {
@@ -260,16 +213,12 @@ TEST(ProbInternalMath, grad2F1_fv_1stderiv2) {
   b.d_ = 1;
   fvar<var> c = 2;
   fvar<var> z = 0.4;
-  fvar<var> gradA;
-  fvar<var> gradB;
-  fvar<var> gradC;
-  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
 
   std::vector<stan::math::var> y1{b.val_};
   std::vector<double> grad1;
-  gradB.val_.grad(y1, grad1);
+  std::get<1>(grad_tuple).val_.grad(y1, grad1);
   EXPECT_NEAR(0.434904696493189, grad1[0], 1e-8);
 }
 TEST(ProbInternalMath, grad2F1_fv_1stderiv3) {
@@ -281,16 +230,12 @@ TEST(ProbInternalMath, grad2F1_fv_1stderiv3) {
   fvar<var> c = 2;
   c.d_ = 1;
   fvar<var> z = 0.4;
-  fvar<var> gradA;
-  fvar<var> gradB;
-  fvar<var> gradC;
-  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
 
   std::vector<stan::math::var> y1{c.val_};
   std::vector<double> grad1;
-  gradC.val_.grad(y1, grad1);
+  std::get<2>(grad_tuple).val_.grad(y1, grad1);
   EXPECT_NEAR(0.574406330443730, grad1[0], 1e-8);
 }
 
@@ -303,16 +248,12 @@ TEST(ProbInternalMath, grad2F1_fv_2ndderiv1) {
   fvar<var> b = 1;
   fvar<var> c = 2;
   fvar<var> z = 0.4;
-  fvar<var> gradA;
-  fvar<var> gradB;
-  fvar<var> gradC;
-  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
 
   std::vector<stan::math::var> y1{a.val_};
   std::vector<double> grad1;
-  gradA.d_.grad(y1, grad1);
+  std::get<0>(grad_tuple).d_.grad(y1, grad1);
   EXPECT_NEAR(0.064256527613079, grad1[0], 1e-8);
 }
 
@@ -325,16 +266,12 @@ TEST(ProbInternalMath, grad2F1_fv_2ndderiv2) {
   b.d_ = 1;
   fvar<var> c = 2;
   fvar<var> z = 0.4;
-  fvar<var> gradA;
-  fvar<var> gradB;
-  fvar<var> gradC;
-  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
 
   std::vector<stan::math::var> y1{b.val_};
   std::vector<double> grad1;
-  gradB.d_.grad(y1, grad1);
+  std::get<1>(grad_tuple).d_.grad(y1, grad1);
   EXPECT_NEAR(0.222160462864892, grad1[0], 1e-8);
 }
 
@@ -347,15 +284,11 @@ TEST(ProbInternalMath, grad2F1_fv_2ndderiv3) {
   fvar<var> c = 2;
   c.d_ = 1;
   fvar<var> z = 0.4;
-  fvar<var> gradA;
-  fvar<var> gradB;
-  fvar<var> gradC;
-  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
+  auto grad_tuple = stan::math::grad_2F1<true>(a, b, c, z);
 
   std::vector<stan::math::var> y1{c.val_};
   std::vector<double> grad1;
-  gradC.d_.grad(y1, grad1);
+  std::get<2>(grad_tuple).d_.grad(y1, grad1);
   EXPECT_NEAR(-1.00024553725447, grad1[0], 1e-8);
 }

--- a/test/unit/math/mix/fun/grad_2F1_test.cpp
+++ b/test/unit/math/mix/fun/grad_2F1_test.cpp
@@ -13,12 +13,13 @@ TEST(ProbInternalMath, grad2F1_zero_z) {
   fvar<double> grad_a1;
   fvar<double> grad_a2;
   fvar<double> grad_b1;
+  fvar<double> grad_z;
 
   a1.d_ = 1;
   a2.d_ = 1;
   b1.d_ = 1;
 
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z);
+  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
   EXPECT_FLOAT_EQ(0, grad_a1.val_);
   EXPECT_FLOAT_EQ(0, grad_a2.val_);
   EXPECT_FLOAT_EQ(0, grad_b1.val_);
@@ -39,12 +40,13 @@ TEST(ProbInternalMath, grad2F1_fnegative_z) {
   fvar<double> gradA;
   fvar<double> gradB;
   fvar<double> gradC;
+  fvar<double> gradZ;
 
   a.d_ = 1;
   b.d_ = 1;
   c.d_ = 1;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
   EXPECT_NEAR(-0.0488658806159776, gradA.val_, 1e-9);
   EXPECT_NEAR(-0.193844936204681, gradB.val_, 1e-9);
   EXPECT_NEAR(0.0677809985598383, gradC.val_, 1e-9);
@@ -61,7 +63,8 @@ TEST(ProbInternalMath, grad2F1_fd1) {
   fvar<double> gradA;
   fvar<double> gradB;
   fvar<double> gradC;
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  fvar<double> gradZ;
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
 
   EXPECT_NEAR(0.46177343153972, gradA.val_, 1e-8);
   EXPECT_NEAR(0.16371487651638, gradA.d_, 1e-8);
@@ -79,7 +82,8 @@ TEST(ProbInternalMath, grad2F1_fd2) {
   fvar<double> gradA;
   fvar<double> gradB;
   fvar<double> gradC;
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  fvar<double> gradZ;
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
 
   EXPECT_NEAR(0.461773431539720, gradA.val_, 1e-8);
   EXPECT_NEAR(0.851376039609984, gradB.val_, 1e-8);
@@ -98,7 +102,8 @@ TEST(ProbInternalMath, grad2F1_fd3) {
   fvar<double> gradA;
   fvar<double> gradB;
   fvar<double> gradC;
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  fvar<double> gradZ;
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
 
   EXPECT_NEAR(0.461773431539720, gradA.val_, 1e-8);
   EXPECT_NEAR(0.851376039609984, gradB.val_, 1e-8);
@@ -116,8 +121,9 @@ TEST(ProbInternalMath, grad2F1_ffd1) {
   fvar<fvar<double> > gradA;
   fvar<fvar<double> > gradB;
   fvar<fvar<double> > gradC;
+  fvar<fvar<double> > gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
   EXPECT_NEAR(0.461773431539720, gradA.val_.val_, 1e-8);
   EXPECT_NEAR(0.163714876516383, gradA.d_.val_, 1e-8);
   EXPECT_NEAR(0.851376039609984, gradB.val_.val_, 1e-8);
@@ -134,8 +140,9 @@ TEST(ProbInternalMath, grad2F1_ffd2) {
   fvar<fvar<double> > gradA;
   fvar<fvar<double> > gradB;
   fvar<fvar<double> > gradC;
+  fvar<fvar<double> > gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
   EXPECT_NEAR(0.461773431539720, gradA.val_.val_, 1e-8);
   EXPECT_NEAR(0.851376039609984, gradB.val_.val_, 1e-8);
   EXPECT_NEAR(0.434904696493189, gradB.d_.val_, 1e-8);
@@ -153,8 +160,9 @@ TEST(ProbInternalMath, grad2F1_ffd3) {
   fvar<fvar<double> > gradA;
   fvar<fvar<double> > gradB;
   fvar<fvar<double> > gradC;
+  fvar<fvar<double> > gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
   EXPECT_NEAR(0.461773431539720, gradA.val_.val_, 1e-8);
   EXPECT_NEAR(0.851376039609984, gradB.val_.val_, 1e-8);
   EXPECT_NEAR(-0.461773435230326, gradC.val_.val_, 1e-8);
@@ -173,8 +181,9 @@ TEST(ProbInternalMath, grad2F1_fv1) {
   fvar<var> gradA;
   fvar<var> gradB;
   fvar<var> gradC;
+  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
   EXPECT_NEAR(0.461773431539720, gradA.val_.val(), 1e-8);
   EXPECT_NEAR(0.163714876516383, gradA.d_.val(), 1e-8);
   EXPECT_NEAR(0.851376039609984, gradB.val_.val(), 1e-8);
@@ -192,8 +201,9 @@ TEST(ProbInternalMath, grad2F1_fv2) {
   fvar<var> gradA;
   fvar<var> gradB;
   fvar<var> gradC;
+  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
   EXPECT_NEAR(0.461773431539720, gradA.val_.val(), 1e-8);
   EXPECT_NEAR(0.851376039609984, gradB.val_.val(), 1e-8);
   EXPECT_NEAR(0.434904696493189, gradB.d_.val(), 1e-8);
@@ -211,8 +221,9 @@ TEST(ProbInternalMath, grad2F1_fv3) {
   fvar<var> gradA;
   fvar<var> gradB;
   fvar<var> gradC;
+  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
   EXPECT_NEAR(0.461773431539720, gradA.val_.val(), 1e-8);
   EXPECT_NEAR(0.851376039609984, gradB.val_.val(), 1e-8);
   EXPECT_NEAR(-0.46177343523032, gradC.val_.val(), 1e-8);
@@ -231,8 +242,9 @@ TEST(ProbInternalMath, grad2F1_fv_1stderiv1) {
   fvar<var> gradA;
   fvar<var> gradB;
   fvar<var> gradC;
+  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
 
   std::vector<stan::math::var> y1{a.val_};
   std::vector<double> grad1;
@@ -251,8 +263,9 @@ TEST(ProbInternalMath, grad2F1_fv_1stderiv2) {
   fvar<var> gradA;
   fvar<var> gradB;
   fvar<var> gradC;
+  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
 
   std::vector<stan::math::var> y1{b.val_};
   std::vector<double> grad1;
@@ -271,8 +284,9 @@ TEST(ProbInternalMath, grad2F1_fv_1stderiv3) {
   fvar<var> gradA;
   fvar<var> gradB;
   fvar<var> gradC;
+  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
 
   std::vector<stan::math::var> y1{c.val_};
   std::vector<double> grad1;
@@ -292,8 +306,9 @@ TEST(ProbInternalMath, grad2F1_fv_2ndderiv1) {
   fvar<var> gradA;
   fvar<var> gradB;
   fvar<var> gradC;
+  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
 
   std::vector<stan::math::var> y1{a.val_};
   std::vector<double> grad1;
@@ -313,8 +328,9 @@ TEST(ProbInternalMath, grad2F1_fv_2ndderiv2) {
   fvar<var> gradA;
   fvar<var> gradB;
   fvar<var> gradC;
+  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
 
   std::vector<stan::math::var> y1{b.val_};
   std::vector<double> grad1;
@@ -334,8 +350,9 @@ TEST(ProbInternalMath, grad2F1_fv_2ndderiv3) {
   fvar<var> gradA;
   fvar<var> gradB;
   fvar<var> gradC;
+  fvar<var> gradZ;
 
-  stan::math::grad_2F1(gradA, gradB, gradC, a, b, c, z);
+  stan::math::grad_2F1(gradA, gradB, gradC, gradZ, a, b, c, z);
 
   std::vector<stan::math::var> y1{c.val_};
   std::vector<double> grad1;

--- a/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
@@ -34,9 +34,25 @@ TEST(mathMixScalFun, hypergeometric2F1_11) {
 
   fvar<double> res = stan::math::hypergeometric_2F1(a1, a2, b, z);
 
-  EXPECT_FLOAT_EQ(-0.321040199556840 - 0.321040199556840 + 0.129536268190289
-                      + 0.0383370454357889,
+  EXPECT_FLOAT_EQ(-0.321040199556840
+                  - 0.321040199556840
+                  + 0.129536268190289
+                  + 0.0383370454357889,
                   res.d_);
+}
+
+TEST(mathMixScalFun, hypergeometric2F1_12) {
+  auto f = [](const auto& x1) {
+    using stan::math::hypergeometric_2F1;
+    return hypergeometric_2F1(x1[0], x1[1], x1[2], x1[3]);
+  };
+
+  Eigen::VectorXd in1(4);
+  in1 << 4, 6, 5, 0.5;
+  stan::test::expect_ad(f, in1);
+
+  //in1 << 3.70975, 1, 2.70975, -0.2;
+  //stan::test::expect_ad(f, in1);
 }
 
 TEST(mathMixScalFun, hypergeometric2F1_2) {

--- a/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
@@ -20,7 +20,24 @@ TEST(mathMixScalFun, hypergeometric2F1_1) {
                   res.d_);
 }
 
-TEST(mathMixScalFun, hypergeometric2F1_11) {
+TEST(mathMixScalFun, hypergeometric2F1_2) {
+  using stan::math::fvar;
+  using stan::math::var;
+  fvar<var> a1 = 2;
+  fvar<var> a2 = 1;
+  fvar<var> b = 2;
+  fvar<var> z = 0.4;
+
+  fvar<var> res = stan::math::hypergeometric_2F1(a1, a2, b, z);
+  res.val_.grad();
+
+  EXPECT_FLOAT_EQ(0.461773432358295, a1.val().adj());
+  EXPECT_FLOAT_EQ(0.851376039609984, a2.val().adj());
+  EXPECT_FLOAT_EQ(-0.461773432358295, b.val().adj());
+  EXPECT_FLOAT_EQ(2.77777777777778, z.val().adj());
+}
+
+TEST(mathMixScalFun, hypergeometric2F1_3_euler) {
   using stan::math::fvar;
   fvar<double> a1 = 1;
   fvar<double> a2 = 1;
@@ -39,35 +56,4 @@ TEST(mathMixScalFun, hypergeometric2F1_11) {
                   + 0.129536268190289
                   + 0.0383370454357889,
                   res.d_);
-}
-
-TEST(mathMixScalFun, hypergeometric2F1_12) {
-  auto f = [](const auto& x1) {
-    using stan::math::hypergeometric_2F1;
-    return hypergeometric_2F1(x1[0], x1[1], x1[2], x1[3]);
-  };
-
-  Eigen::VectorXd in1(4);
-  in1 << 4, 6, 5, 0.5;
-  stan::test::expect_ad(f, in1);
-
-  //in1 << 3.70975, 1, 2.70975, -0.2;
-  //stan::test::expect_ad(f, in1);
-}
-
-TEST(mathMixScalFun, hypergeometric2F1_2) {
-  using stan::math::fvar;
-  using stan::math::var;
-  fvar<var> a1 = 2;
-  fvar<var> a2 = 1;
-  fvar<var> b = 2;
-  fvar<var> z = 0.4;
-
-  fvar<var> res = stan::math::hypergeometric_2F1(a1, a2, b, z);
-  res.val_.grad();
-
-  EXPECT_FLOAT_EQ(0.461773432358295, a1.val().adj());
-  EXPECT_FLOAT_EQ(0.851376039609984, a2.val().adj());
-  EXPECT_FLOAT_EQ(-0.461773432358295, b.val().adj());
-  EXPECT_FLOAT_EQ(2.77777777777778, z.val().adj());
 }

--- a/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
@@ -1,3 +1,4 @@
+#include <stan/math/rev/fun/hypergeometric_2F1.hpp>
 #include <test/unit/math/test_ad.hpp>
 
 TEST(mathMixScalFun, hypergeometric2F1_1) {
@@ -16,6 +17,25 @@ TEST(mathMixScalFun, hypergeometric2F1_1) {
 
   EXPECT_FLOAT_EQ(-0.0488658806159776 - 0.193844936204681 + 0.0677809985598383
                       + 0.865295247272367,
+                  res.d_);
+}
+
+TEST(mathMixScalFun, hypergeometric2F1_11) {
+  using stan::math::fvar;
+  fvar<double> a1 = 1;
+  fvar<double> a2 = 1;
+  fvar<double> b = 2;
+  fvar<double> z = -5;
+
+  a1.d_ = 1;
+  a2.d_ = 1;
+  b.d_ = 1;
+  z.d_ = 1;
+
+  fvar<double> res = stan::math::hypergeometric_2F1(a1, a2, b, z);
+
+  EXPECT_FLOAT_EQ(-0.321040199556840 - 0.321040199556840 + 0.129536268190289
+                      + 0.0383370454357889,
                   res.d_);
 }
 

--- a/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
@@ -1,0 +1,39 @@
+#include <test/unit/math/test_ad.hpp>
+
+TEST(mathMixScalFun, hypergeometric2F1_1) {
+  using stan::math::fvar;
+  fvar<double> a1 = 3.70975;
+  fvar<double> a2 = 1;
+  fvar<double> b = 2.70975;
+  fvar<double> z = -0.2;
+
+  a1.d_ = 1;
+  a2.d_ = 1;
+  b.d_ = 1;
+  z.d_ = 1;
+
+  fvar<double> res = stan::math::hypergeometric_2F1(a1, a2, b, z);
+
+  EXPECT_FLOAT_EQ(
+    -0.0488658806159776
+    - 0.193844936204681
+    + 0.0677809985598383
+    + 0.865295247272367, res.d_);
+}
+
+TEST(mathMixScalFun, hypergeometric2F1_2) {
+  using stan::math::fvar;
+  using stan::math::var;
+  fvar<var> a1 = 2;
+  fvar<var> a2 = 1;
+  fvar<var> b = 2;
+  fvar<var> z = 0.4;
+
+  fvar<var> res = stan::math::hypergeometric_2F1(a1, a2, b, z);
+  res.val_.grad();
+
+  EXPECT_FLOAT_EQ(0.461773432358295, a1.val().adj());
+  EXPECT_FLOAT_EQ(0.851376039609984, a2.val().adj());
+  EXPECT_FLOAT_EQ(-0.461773432358295, b.val().adj());
+  EXPECT_FLOAT_EQ(2.77777777777778, z.val().adj());
+}

--- a/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
@@ -14,11 +14,9 @@ TEST(mathMixScalFun, hypergeometric2F1_1) {
 
   fvar<double> res = stan::math::hypergeometric_2F1(a1, a2, b, z);
 
-  EXPECT_FLOAT_EQ(
-    -0.0488658806159776
-    - 0.193844936204681
-    + 0.0677809985598383
-    + 0.865295247272367, res.d_);
+  EXPECT_FLOAT_EQ(-0.0488658806159776 - 0.193844936204681 + 0.0677809985598383
+                      + 0.865295247272367,
+                  res.d_);
 }
 
 TEST(mathMixScalFun, hypergeometric2F1_2) {

--- a/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
@@ -51,9 +51,7 @@ TEST(mathMixScalFun, hypergeometric2F1_3_euler) {
 
   fvar<double> res = stan::math::hypergeometric_2F1(a1, a2, b, z);
 
-  EXPECT_FLOAT_EQ(-0.321040199556840
-                  - 0.321040199556840
-                  + 0.129536268190289
-                  + 0.0383370454357889,
+  EXPECT_FLOAT_EQ(-0.321040199556840 - 0.321040199556840 + 0.129536268190289
+                      + 0.0383370454357889,
                   res.d_);
 }

--- a/test/unit/math/prim/fun/grad_2F1_test.cpp
+++ b/test/unit/math/prim/fun/grad_2F1_test.cpp
@@ -68,9 +68,8 @@ TEST(MathPrimScalFun, grad2F1_4) {
   double b1 = 10;
   double z = 1;
 
-  EXPECT_THROW(
-      auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z),
-      std::domain_error);
+  EXPECT_THROW(auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z),
+               std::domain_error);
 }
 
 TEST(MathPrimScalFun, grad2F1_5) {
@@ -79,9 +78,8 @@ TEST(MathPrimScalFun, grad2F1_5) {
   double b1 = 20;
   double z = 1.2;
 
-  EXPECT_THROW(
-      auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z),
-      std::domain_error);
+  EXPECT_THROW(auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z),
+               std::domain_error);
 }
 
 TEST(MathPrimScalFun, grad2F1_6) {

--- a/test/unit/math/prim/fun/grad_2F1_test.cpp
+++ b/test/unit/math/prim/fun/grad_2F1_test.cpp
@@ -8,14 +8,10 @@ TEST(MathPrimScalFun, grad2F1_negative_z) {
   double b1 = 2.70975;
   double z = -0.2;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
-  EXPECT_NEAR(-0.0488658806159776, grad_a1, 1e-9);
-  EXPECT_NEAR(-0.193844936204681, grad_a2, 1e-9);
-  EXPECT_NEAR(0.0677809985598383, grad_b1, 1e-9);
+  auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z);
+  EXPECT_NEAR(-0.0488658806159776, std::get<0>(grad_tuple), 1e-9);
+  EXPECT_NEAR(-0.193844936204681, std::get<1>(grad_tuple), 1e-9);
+  EXPECT_NEAR(0.0677809985598383, std::get<2>(grad_tuple), 1e-9);
 }
 
 TEST(MathPrimScalFun, grad2F1_zero_z) {
@@ -24,14 +20,10 @@ TEST(MathPrimScalFun, grad2F1_zero_z) {
   double b1 = 2.70975;
   double z = 0;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
-  EXPECT_FLOAT_EQ(0, grad_a1);
-  EXPECT_FLOAT_EQ(0, grad_a2);
-  EXPECT_FLOAT_EQ(0, grad_b1);
+  auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z);
+  EXPECT_FLOAT_EQ(0, std::get<0>(grad_tuple));
+  EXPECT_FLOAT_EQ(0, std::get<1>(grad_tuple));
+  EXPECT_FLOAT_EQ(0, std::get<2>(grad_tuple));
 }
 
 TEST(MathPrimScalFun, grad2F1_1) {
@@ -40,14 +32,10 @@ TEST(MathPrimScalFun, grad2F1_1) {
   double b1 = 1;
   double z = 0.6;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
-  EXPECT_NEAR(2.290726829685388, grad_a1, 1e-9);
-  EXPECT_NEAR(2.290726829685388, grad_a2, 1e-9);
-  EXPECT_NEAR(-2.290726829685388, grad_b1, 1e-9);
+  auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z);
+  EXPECT_NEAR(2.290726829685388, std::get<0>(grad_tuple), 1e-9);
+  EXPECT_NEAR(2.290726829685388, std::get<1>(grad_tuple), 1e-9);
+  EXPECT_NEAR(-2.290726829685388, std::get<2>(grad_tuple), 1e-9);
 }
 
 TEST(MathPrimScalFun, grad2F1_2) {
@@ -56,14 +44,10 @@ TEST(MathPrimScalFun, grad2F1_2) {
   double b1 = 41;
   double z = 1;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
-  EXPECT_NEAR(6.825270649241036, grad_a1, 1e-8);
-  EXPECT_NEAR(0.4938271604938271, grad_a2, 1e-8);
-  EXPECT_NEAR(-0.382716049382716, grad_b1, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z);
+  EXPECT_NEAR(6.825270649241036, std::get<0>(grad_tuple), 1e-8);
+  EXPECT_NEAR(0.4938271604938271, std::get<1>(grad_tuple), 1e-8);
+  EXPECT_NEAR(-0.382716049382716, std::get<2>(grad_tuple), 1e-8);
 }
 
 TEST(MathPrimScalFun, grad2F1_3) {
@@ -72,14 +56,10 @@ TEST(MathPrimScalFun, grad2F1_3) {
   double b1 = 41;
   double z = 1;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
-  EXPECT_NEAR(-0.04921317604093563, grad_a1, 1e-8);
-  EXPECT_NEAR(0.02256814168279349, grad_a2, 1e-8);
-  EXPECT_NEAR(0.00118482743834665, grad_b1, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z);
+  EXPECT_NEAR(-0.04921317604093563, std::get<0>(grad_tuple), 1e-8);
+  EXPECT_NEAR(0.02256814168279349, std::get<1>(grad_tuple), 1e-8);
+  EXPECT_NEAR(0.00118482743834665, std::get<2>(grad_tuple), 1e-8);
 }
 
 TEST(MathPrimScalFun, grad2F1_4) {
@@ -88,12 +68,8 @@ TEST(MathPrimScalFun, grad2F1_4) {
   double b1 = 10;
   double z = 1;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
   EXPECT_THROW(
-      stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z),
+      auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z),
       std::domain_error);
 }
 
@@ -103,12 +79,8 @@ TEST(MathPrimScalFun, grad2F1_5) {
   double b1 = 20;
   double z = 1.2;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
   EXPECT_THROW(
-      stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z),
+      auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z),
       std::domain_error);
 }
 
@@ -118,14 +90,10 @@ TEST(MathPrimScalFun, grad2F1_6) {
   double b1 = 10.6;
   double z = 0.3;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
-  EXPECT_NEAR(-0.01443822031245647, grad_a1, 1e-8);
-  EXPECT_NEAR(0.02829710651967078, grad_a2, 1e-8);
-  EXPECT_NEAR(0.00136986255602642, grad_b1, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z);
+  EXPECT_NEAR(-0.01443822031245647, std::get<0>(grad_tuple), 1e-8);
+  EXPECT_NEAR(0.02829710651967078, std::get<1>(grad_tuple), 1e-8);
+  EXPECT_NEAR(0.00136986255602642, std::get<2>(grad_tuple), 1e-8);
 }
 
 TEST(MathPrimScalFun, grad2F1_7) {
@@ -134,14 +102,10 @@ TEST(MathPrimScalFun, grad2F1_7) {
   double b1 = 10;
   double z = 0.3;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
-  EXPECT_NEAR(-0.0153218866216130, grad_a1, 1e-8);
-  EXPECT_NEAR(0.02999436412836072, grad_a2, 1e-8);
-  EXPECT_NEAR(0.0015413242328729, grad_b1, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z);
+  EXPECT_NEAR(-0.0153218866216130, std::get<0>(grad_tuple), 1e-8);
+  EXPECT_NEAR(0.02999436412836072, std::get<1>(grad_tuple), 1e-8);
+  EXPECT_NEAR(0.0015413242328729, std::get<2>(grad_tuple), 1e-8);
 }
 
 TEST(MathPrimScalFun, grad2F1_8) {
@@ -150,14 +114,10 @@ TEST(MathPrimScalFun, grad2F1_8) {
   double b1 = 11;
   double z = 0.3;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
-  EXPECT_NEAR(-0.1227022810085707, grad_a1, 1e-8);
-  EXPECT_NEAR(-0.01298849638043795, grad_a2, 1e-8);
-  EXPECT_NEAR(-0.0053540982315572, grad_b1, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z);
+  EXPECT_NEAR(-0.1227022810085707, std::get<0>(grad_tuple), 1e-8);
+  EXPECT_NEAR(-0.01298849638043795, std::get<1>(grad_tuple), 1e-8);
+  EXPECT_NEAR(-0.0053540982315572, std::get<2>(grad_tuple), 1e-8);
 }
 
 TEST(MathPrimScalFun, grad2F1_9) {
@@ -166,14 +126,10 @@ TEST(MathPrimScalFun, grad2F1_9) {
   double b1 = -3.2;
   double z = 0.9;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
-  EXPECT_NEAR(0.85880025358111, grad_a1, 1e-8);
-  EXPECT_NEAR(0.4677704416159314, grad_a2, 1e-8);
-  EXPECT_NEAR(-4.19010422485256, grad_b1, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z);
+  EXPECT_NEAR(0.85880025358111, std::get<0>(grad_tuple), 1e-8);
+  EXPECT_NEAR(0.4677704416159314, std::get<1>(grad_tuple), 1e-8);
+  EXPECT_NEAR(-4.19010422485256, std::get<2>(grad_tuple), 1e-8);
 }
 
 TEST(MathPrimScalFun, grad2F1_10) {
@@ -182,14 +138,10 @@ TEST(MathPrimScalFun, grad2F1_10) {
   double b1 = 2;
   double z = 0.4;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
-  EXPECT_NEAR(0.4617734323582945, grad_a1, 1e-8);
-  EXPECT_NEAR(0.851376039609984, grad_a2, 1e-8);
-  EXPECT_NEAR(-0.4617734323582945, grad_b1, 1e-8);
+  auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z);
+  EXPECT_NEAR(0.4617734323582945, std::get<0>(grad_tuple), 1e-8);
+  EXPECT_NEAR(0.851376039609984, std::get<1>(grad_tuple), 1e-8);
+  EXPECT_NEAR(-0.4617734323582945, std::get<2>(grad_tuple), 1e-8);
 }
 
 TEST(MathPrimScalFun, grad2F1_11) {
@@ -198,15 +150,11 @@ TEST(MathPrimScalFun, grad2F1_11) {
   double b1 = 2.70975;
   double z = 0.999696;
 
-  double grad_a1;
-  double grad_a2;
-  double grad_b1;
-  double grad_z;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
+  auto grad_tuple = stan::math::grad_2F1<true>(a1, a2, b1, z);
 
-  EXPECT_NEAR(29369830.002773938200417693317785, grad_a1,
+  EXPECT_NEAR(29369830.002773938200417693317785, std::get<0>(grad_tuple),
               1e-1);  // reference: discrete diff in mathematica
-  EXPECT_NEAR(36347869.41885337, grad_a2, 1e-1);
-  EXPECT_NEAR(-30843032.10697079073015067426929807, grad_b1,
+  EXPECT_NEAR(36347869.41885337, std::get<1>(grad_tuple), 1e-1);
+  EXPECT_NEAR(-30843032.10697079073015067426929807, std::get<2>(grad_tuple),
               1e-1);  // reference: discrete diff in mathematica
 }

--- a/test/unit/math/prim/fun/grad_2F1_test.cpp
+++ b/test/unit/math/prim/fun/grad_2F1_test.cpp
@@ -93,8 +93,8 @@ TEST(MathPrimScalFun, grad2F1_4) {
   double grad_b1;
   double grad_z;
   EXPECT_THROW(
-    stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z),
-    std::domain_error);
+      stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z),
+      std::domain_error);
 }
 
 TEST(MathPrimScalFun, grad2F1_5) {
@@ -108,8 +108,8 @@ TEST(MathPrimScalFun, grad2F1_5) {
   double grad_b1;
   double grad_z;
   EXPECT_THROW(
-    stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z),
-    std::domain_error);
+      stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z),
+      std::domain_error);
 }
 
 TEST(MathPrimScalFun, grad2F1_6) {

--- a/test/unit/math/prim/fun/grad_2F1_test.cpp
+++ b/test/unit/math/prim/fun/grad_2F1_test.cpp
@@ -11,7 +11,8 @@ TEST(MathPrimScalFun, grad2F1_negative_z) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z);
+  double grad_z;
+  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
   EXPECT_NEAR(-0.0488658806159776, grad_a1, 1e-9);
   EXPECT_NEAR(-0.193844936204681, grad_a2, 1e-9);
   EXPECT_NEAR(0.0677809985598383, grad_b1, 1e-9);
@@ -26,7 +27,8 @@ TEST(MathPrimScalFun, grad2F1_zero_z) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z);
+  double grad_z;
+  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
   EXPECT_FLOAT_EQ(0, grad_a1);
   EXPECT_FLOAT_EQ(0, grad_a2);
   EXPECT_FLOAT_EQ(0, grad_b1);
@@ -41,7 +43,8 @@ TEST(MathPrimScalFun, grad2F1_1) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z);
+  double grad_z;
+  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
   EXPECT_NEAR(2.290726829685388, grad_a1, 1e-9);
   EXPECT_NEAR(2.290726829685388, grad_a2, 1e-9);
   EXPECT_NEAR(-2.290726829685388, grad_b1, 1e-9);
@@ -56,7 +59,8 @@ TEST(MathPrimScalFun, grad2F1_2) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z, 1e-11);
+  double grad_z;
+  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
   EXPECT_NEAR(6.825270649241036, grad_a1, 1e-8);
   EXPECT_NEAR(0.4938271604938271, grad_a2, 1e-8);
   EXPECT_NEAR(-0.382716049382716, grad_b1, 1e-8);
@@ -71,7 +75,8 @@ TEST(MathPrimScalFun, grad2F1_3) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z);
+  double grad_z;
+  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
   EXPECT_NEAR(-0.04921317604093563, grad_a1, 1e-8);
   EXPECT_NEAR(0.02256814168279349, grad_a2, 1e-8);
   EXPECT_NEAR(0.00118482743834665, grad_b1, 1e-8);
@@ -86,8 +91,10 @@ TEST(MathPrimScalFun, grad2F1_4) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  EXPECT_THROW(stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z),
-               std::domain_error);
+  double grad_z;
+  EXPECT_THROW(
+    stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z),
+    std::domain_error);
 }
 
 TEST(MathPrimScalFun, grad2F1_5) {
@@ -99,8 +106,10 @@ TEST(MathPrimScalFun, grad2F1_5) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  EXPECT_THROW(stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z),
-               std::domain_error);
+  double grad_z;
+  EXPECT_THROW(
+    stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z),
+    std::domain_error);
 }
 
 TEST(MathPrimScalFun, grad2F1_6) {
@@ -112,7 +121,8 @@ TEST(MathPrimScalFun, grad2F1_6) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z);
+  double grad_z;
+  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
   EXPECT_NEAR(-0.01443822031245647, grad_a1, 1e-8);
   EXPECT_NEAR(0.02829710651967078, grad_a2, 1e-8);
   EXPECT_NEAR(0.00136986255602642, grad_b1, 1e-8);
@@ -127,7 +137,8 @@ TEST(MathPrimScalFun, grad2F1_7) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z);
+  double grad_z;
+  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
   EXPECT_NEAR(-0.0153218866216130, grad_a1, 1e-8);
   EXPECT_NEAR(0.02999436412836072, grad_a2, 1e-8);
   EXPECT_NEAR(0.0015413242328729, grad_b1, 1e-8);
@@ -142,7 +153,8 @@ TEST(MathPrimScalFun, grad2F1_8) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z);
+  double grad_z;
+  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
   EXPECT_NEAR(-0.1227022810085707, grad_a1, 1e-8);
   EXPECT_NEAR(-0.01298849638043795, grad_a2, 1e-8);
   EXPECT_NEAR(-0.0053540982315572, grad_b1, 1e-8);
@@ -157,7 +169,8 @@ TEST(MathPrimScalFun, grad2F1_9) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z);
+  double grad_z;
+  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
   EXPECT_NEAR(0.85880025358111, grad_a1, 1e-8);
   EXPECT_NEAR(0.4677704416159314, grad_a2, 1e-8);
   EXPECT_NEAR(-4.19010422485256, grad_b1, 1e-8);
@@ -172,7 +185,8 @@ TEST(MathPrimScalFun, grad2F1_10) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z);
+  double grad_z;
+  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
   EXPECT_NEAR(0.4617734323582945, grad_a1, 1e-8);
   EXPECT_NEAR(0.851376039609984, grad_a2, 1e-8);
   EXPECT_NEAR(-0.4617734323582945, grad_b1, 1e-8);
@@ -187,7 +201,8 @@ TEST(MathPrimScalFun, grad2F1_11) {
   double grad_a1;
   double grad_a2;
   double grad_b1;
-  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, a1, a2, b1, z);
+  double grad_z;
+  stan::math::grad_2F1(grad_a1, grad_a2, grad_b1, grad_z, a1, a2, b1, z);
 
   EXPECT_NEAR(29369830.002773938200417693317785, grad_a1,
               1e-1);  // reference: discrete diff in mathematica

--- a/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
@@ -43,16 +43,14 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   a << 0.5, 0.5;
   b << 1.5;
   z = 0.8;
-  // https://www.wolframalpha.com/input
-  //  ?i=Hypergeometric2F1%5B1%2F2%2C1%2F2%2C3%2F2%2C0.8%5D
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B1%2F2%2C1%2F2%2C3%2F2%2C0.8%5D // NOLINT
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
                   1.2378298970946586875911981729041590167);
 
   a << 0.5, 0.5;
   b << 1.5;
   z = -0.8;
-  // https://www.wolframalpha.com/input
-  //  ?i=Hypergeometric2F1[1%2F2%2C1%2F2%2C3%2F2%2C-0.8]
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1[1%2F2%2C1%2F2%2C3%2F2%2C-0.8] // NOLINT
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
                   0.8997031444420006140233288415980043158);
 
@@ -74,8 +72,7 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   b << 3.0;
   z = -1.5;
 
-  // https://www.wolframalpha.com/input
-  //  ?i=Hypergeometric2F1%5B3%2F2%2C+2%2C+3%2C+-1.5%5D
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B3%2F2%2C+2%2C+3%2C+-1.5%5D  // NOLINT
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
                   0.3797233104317609464875119664051608419);
 
@@ -83,8 +80,7 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   b << 5.5;
   z = 1.0;
 
-  // https://www.wolframalpha.com/input
-  //  ?i=Hypergeometric2F1%5B1.5%2C+2.0%2C+5.5%2C+1.0%5D
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B1.5%2C+2.0%2C+5.5%2C+1.0%5D  // NOLINT
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z), 2.625);
 
   a << 4, 4;

--- a/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
@@ -6,9 +6,9 @@
 // taken from WolframAlpha instead
 TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   using Eigen::VectorXd;
-  using stan::math::inv;
-  using stan::math::hypergeometric_pFq;
   using stan::math::hypergeometric_2F1;
+  using stan::math::hypergeometric_pFq;
+  using stan::math::inv;
 
   VectorXd a(2);
   VectorXd b(1);
@@ -17,8 +17,7 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   double z = -5;
 
   // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B1%2C1%2C2%2C-5%5D
-  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
-                  std::log(6) / 5);
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z), std::log(6) / 5);
 
   a << 4, 4;
   b << 10;
@@ -32,16 +31,14 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   z = 8;
 
   // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B6%2C4%2C4%2C8%5D
-  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
-                  inv(117649));
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z), inv(117649));
 
   a << 4, 6;
   b << 4;
   z = 8;
 
   // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B6%2C4%2C4%2C8%5D
-  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
-                  inv(117649));
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z), inv(117649));
 
   a << 0.5, 0.5;
   b << 1.5;
@@ -88,8 +85,7 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
 
   // https://www.wolframalpha.com/input
   //  ?i=Hypergeometric2F1%5B1.5%2C+2.0%2C+5.5%2C+1.0%5D
-  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
-                  2.625);
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z), 2.625);
 
   a << 4, 4;
   b << 5;
@@ -104,15 +100,12 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   z = 4;
 
   // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B4%2C6%2C5%2C4%5D
-  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
-                  -inv(1215));
-
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z), -inv(1215));
 
   a << 4, 1;
   b << 0.5;
   z = -5;
 
   // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B4%2C6%2C5%2C4%5D
-  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
-                  -0.0399473);
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z), -0.0399473);
 }

--- a/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
@@ -1,0 +1,126 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+
+// Several special case not able to be estimated by Boost's pFq for reference
+// test values (as they fail convergence checks for the infinite sums) and are
+// taken from WolframAlpha instead
+TEST(MathFunctions, hypergeometric_2F1_special_cases) {
+  using Eigen::VectorXd;
+  using stan::math::inv;
+  using stan::math::hypergeometric_pFq;
+  using stan::math::hypergeometric_2F1;
+
+  VectorXd a(2);
+  VectorXd b(1);
+  a << 1, 1;
+  b << 2;
+  double z = -5;
+
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B1%2C1%2C2%2C-5%5D
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  std::log(6) / 5);
+
+  a << 4, 4;
+  b << 10;
+  z = 1;
+
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  hypergeometric_pFq(a, b, z));
+
+  a << 6, 4;
+  b << 4;
+  z = 8;
+
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B6%2C4%2C4%2C8%5D
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  inv(117649));
+
+  a << 4, 6;
+  b << 4;
+  z = 8;
+
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B6%2C4%2C4%2C8%5D
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  inv(117649));
+
+  a << 0.5, 0.5;
+  b << 1.5;
+  z = 0.8;
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B1%2F2%2C1%2F2%2C3%2F2%2C0.8%5D
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  1.2378298970946586875911981729041590167);
+
+  a << 0.5, 0.5;
+  b << 1.5;
+  z = -0.8;
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1[1%2F2%2C1%2F2%2C3%2F2%2C-0.8]
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  0.8997031444420006140233288415980043158);
+
+  a << 4, 4;
+  b << 10;
+  z = 0.0;
+
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  hypergeometric_pFq(a, b, z));
+
+  a << 1, 4;
+  b << 4;
+  z = -0.8;
+
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  hypergeometric_pFq(a, b, z));
+
+  a << 1.5, 2.0;
+  b << 3.0;
+  z = -1.5;
+
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B3%2F2%2C+2%2C+3%2C+-1.5%5D
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  0.3797233104317609464875119664051608419);
+
+  a << 1.5, 2.0;
+  b << 5.5;
+  z = 1.0;
+
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B1.5%2C+2.0%2C+5.5%2C+1.0%5D
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  2.625);
+
+  a << 4, 4;
+  b << 5;
+  z = 0.5;
+
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B4%2C4%2C5%2C0.5%5D
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  8.9719137774968335306304775600100329765);
+
+  a << 4, 6;
+  b << 5;
+  z = 4;
+
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B4%2C6%2C5%2C4%5D
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  -inv(1215));
+}
+/*
+TEST(MathFunctions, hypergeometric_pFq_errors) {
+  using Eigen::VectorXd;
+  using stan::math::hypergeometric_pFq;
+  using stan::math::INFTY;
+  using stan::math::NOT_A_NUMBER;
+
+  VectorXd a(2);
+  VectorXd b(2);
+  a << 4, INFTY;
+  b << 5, 5;
+  double z = 2;
+
+  EXPECT_THROW(hypergeometric_pFq(a, b, z), std::domain_error);
+
+  a << 6, 4;
+  b << NOT_A_NUMBER, 1;
+
+  EXPECT_THROW(hypergeometric_pFq(a, b, z), std::domain_error);
+}
+*/

--- a/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
@@ -43,14 +43,16 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   a << 0.5, 0.5;
   b << 1.5;
   z = 0.8;
-  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B1%2F2%2C1%2F2%2C3%2F2%2C0.8%5D // NOLINT
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B1%2F2%2C1%2F2%2C3%2F2%2C0.8%5D
+  // // NOLINT
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
                   1.2378298970946586875911981729041590167);
 
   a << 0.5, 0.5;
   b << 1.5;
   z = -0.8;
-  // https://www.wolframalpha.com/input?i=Hypergeometric2F1[1%2F2%2C1%2F2%2C3%2F2%2C-0.8] // NOLINT
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1[1%2F2%2C1%2F2%2C3%2F2%2C-0.8]
+  // // NOLINT
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
                   0.8997031444420006140233288415980043158);
 
@@ -72,7 +74,8 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   b << 3.0;
   z = -1.5;
 
-  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B3%2F2%2C+2%2C+3%2C+-1.5%5D  // NOLINT
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B3%2F2%2C+2%2C+3%2C+-1.5%5D
+  // // NOLINT
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
                   0.3797233104317609464875119664051608419);
 
@@ -80,7 +83,8 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   b << 5.5;
   z = 1.0;
 
-  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B1.5%2C+2.0%2C+5.5%2C+1.0%5D  // NOLINT
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B1.5%2C+2.0%2C+5.5%2C+1.0%5D
+  // // NOLINT
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z), 2.625);
 
   a << 4, 4;

--- a/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
@@ -102,6 +102,15 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B4%2C6%2C5%2C4%5D
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
                   -inv(1215));
+
+
+  a << 4, 1;
+  b << 0.5;
+  z = -5;
+
+  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B4%2C6%2C5%2C4%5D
+  EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
+                  -0.0399473);
 }
 /*
 TEST(MathFunctions, hypergeometric_pFq_errors) {

--- a/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
@@ -46,14 +46,16 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   a << 0.5, 0.5;
   b << 1.5;
   z = 0.8;
-  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B1%2F2%2C1%2F2%2C3%2F2%2C0.8%5D
+  // https://www.wolframalpha.com/input
+  //  ?i=Hypergeometric2F1%5B1%2F2%2C1%2F2%2C3%2F2%2C0.8%5D
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
                   1.2378298970946586875911981729041590167);
 
   a << 0.5, 0.5;
   b << 1.5;
   z = -0.8;
-  // https://www.wolframalpha.com/input?i=Hypergeometric2F1[1%2F2%2C1%2F2%2C3%2F2%2C-0.8]
+  // https://www.wolframalpha.com/input
+  //  ?i=Hypergeometric2F1[1%2F2%2C1%2F2%2C3%2F2%2C-0.8]
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
                   0.8997031444420006140233288415980043158);
 
@@ -75,7 +77,8 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   b << 3.0;
   z = -1.5;
 
-  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B3%2F2%2C+2%2C+3%2C+-1.5%5D
+  // https://www.wolframalpha.com/input
+  //  ?i=Hypergeometric2F1%5B3%2F2%2C+2%2C+3%2C+-1.5%5D
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
                   0.3797233104317609464875119664051608419);
 
@@ -83,7 +86,8 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   b << 5.5;
   z = 1.0;
 
-  // https://www.wolframalpha.com/input?i=Hypergeometric2F1%5B1.5%2C+2.0%2C+5.5%2C+1.0%5D
+  // https://www.wolframalpha.com/input
+  //  ?i=Hypergeometric2F1%5B1.5%2C+2.0%2C+5.5%2C+1.0%5D
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
                   2.625);
 
@@ -112,24 +116,3 @@ TEST(MathFunctions, hypergeometric_2F1_special_cases) {
   EXPECT_FLOAT_EQ(hypergeometric_2F1(a[0], a[1], b[0], z),
                   -0.0399473);
 }
-/*
-TEST(MathFunctions, hypergeometric_pFq_errors) {
-  using Eigen::VectorXd;
-  using stan::math::hypergeometric_pFq;
-  using stan::math::INFTY;
-  using stan::math::NOT_A_NUMBER;
-
-  VectorXd a(2);
-  VectorXd b(2);
-  a << 4, INFTY;
-  b << 5, 5;
-  double z = 2;
-
-  EXPECT_THROW(hypergeometric_pFq(a, b, z), std::domain_error);
-
-  a << 6, 4;
-  b << NOT_A_NUMBER, 1;
-
-  EXPECT_THROW(hypergeometric_pFq(a, b, z), std::domain_error);
-}
-*/

--- a/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/prim/fun/hypergeometric_2F1_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 
-// Several special case not able to be estimated by Boost's pFq for reference
+// Several special cases can't be estimated by Boost's pFq for reference
 // test values (as they fail convergence checks for the infinite sums) and are
 // taken from WolframAlpha instead
 TEST(MathFunctions, hypergeometric_2F1_special_cases) {

--- a/test/unit/math/prim/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_test.cpp
@@ -81,7 +81,7 @@ TEST(ProbDistributionsWishartCholesky, dof_0) {
   MatrixXd L_Y = Y.llt().matrixL();
   MatrixXd L_S = Sigma.llt().matrixL();
 
-  unsigned int dof = std::numeric_limits<double>::quiet_NaN();
+  unsigned int dof = 0;
   EXPECT_THROW(stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S),
                std::domain_error);
 }

--- a/test/unit/math/rev/fun/grad_pFq_test.cpp
+++ b/test/unit/math/rev/fun/grad_pFq_test.cpp
@@ -127,14 +127,16 @@ TEST(RevMath, grad_2F1_derivs_match) {
   double g_a1;
   double g_a2;
   double g_b1;
+  double g_z;
 
-  grad_2F1(g_a1, g_a2, g_b1, a_v[0].val(), a_v[1].val(), b_v[0].val(),
+  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
            z_v.val());
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
   EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
   EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_2) {
@@ -152,14 +154,16 @@ TEST(RevMath, grad2F1_2) {
   double g_a1;
   double g_a2;
   double g_b1;
+  double g_z;
 
-  grad_2F1(g_a1, g_a2, g_b1, a_v[0].val(), a_v[1].val(), b_v[0].val(),
+  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
            z_v.val());
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
   EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
   EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_3) {
@@ -177,14 +181,16 @@ TEST(RevMath, grad2F1_3) {
   double g_a1;
   double g_a2;
   double g_b1;
+  double g_z;
 
-  grad_2F1(g_a1, g_a2, g_b1, a_v[0].val(), a_v[1].val(), b_v[0].val(),
+  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
            z_v.val());
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
   EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
   EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_6) {
@@ -202,14 +208,16 @@ TEST(RevMath, grad2F1_6) {
   double g_a1;
   double g_a2;
   double g_b1;
+  double g_z;
 
-  grad_2F1(g_a1, g_a2, g_b1, a_v[0].val(), a_v[1].val(), b_v[0].val(),
+  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
            z_v.val());
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
   EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
   EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_7) {
@@ -227,14 +235,16 @@ TEST(RevMath, grad2F1_7) {
   double g_a1;
   double g_a2;
   double g_b1;
+  double g_z;
 
-  grad_2F1(g_a1, g_a2, g_b1, a_v[0].val(), a_v[1].val(), b_v[0].val(),
+  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
            z_v.val());
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
   EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
   EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_8) {
@@ -252,14 +262,16 @@ TEST(RevMath, grad2F1_8) {
   double g_a1;
   double g_a2;
   double g_b1;
+  double g_z;
 
-  grad_2F1(g_a1, g_a2, g_b1, a_v[0].val(), a_v[1].val(), b_v[0].val(),
+  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
            z_v.val());
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
   EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
   EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_9) {
@@ -277,14 +289,16 @@ TEST(RevMath, grad2F1_9) {
   double g_a1;
   double g_a2;
   double g_b1;
+  double g_z;
 
-  grad_2F1(g_a1, g_a2, g_b1, a_v[0].val(), a_v[1].val(), b_v[0].val(),
+  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
            z_v.val());
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
   EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
   EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_10) {
@@ -302,14 +316,16 @@ TEST(RevMath, grad2F1_10) {
   double g_a1;
   double g_a2;
   double g_b1;
+  double g_z;
 
-  grad_2F1(g_a1, g_a2, g_b1, a_v[0].val(), a_v[1].val(), b_v[0].val(),
+  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
            z_v.val());
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
   EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
   EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
 }
 /*
 TEST(RevMath, grad2F1_11) {

--- a/test/unit/math/rev/fun/grad_pFq_test.cpp
+++ b/test/unit/math/rev/fun/grad_pFq_test.cpp
@@ -124,19 +124,14 @@ TEST(RevMath, grad_2F1_derivs_match) {
   b_v << 1;
   var z_v = 0.6;
 
-  double g_a1;
-  double g_a2;
-  double g_b1;
-  double g_z;
-
-  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
-           z_v.val());
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
+           z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
-  EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
-  EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
+  EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<1>(grad_2F1_tuple), std::get<0>(grad_tuple)[1]);
+  EXPECT_FLOAT_EQ(std::get<2>(grad_2F1_tuple), std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<3>(grad_2F1_tuple), std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_2) {
@@ -151,19 +146,14 @@ TEST(RevMath, grad2F1_2) {
   b_v << 41;
   var z_v = 1;
 
-  double g_a1;
-  double g_a2;
-  double g_b1;
-  double g_z;
-
-  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
-           z_v.val());
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
+           z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
-  EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
-  EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
+  EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<1>(grad_2F1_tuple), std::get<0>(grad_tuple)[1]);
+  EXPECT_FLOAT_EQ(std::get<2>(grad_2F1_tuple), std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<3>(grad_2F1_tuple), std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_3) {
@@ -178,19 +168,14 @@ TEST(RevMath, grad2F1_3) {
   b_v << 41.0;
   var z_v = 1.0;
 
-  double g_a1;
-  double g_a2;
-  double g_b1;
-  double g_z;
-
-  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
-           z_v.val());
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
+           z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
-  EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
-  EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
+  EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<1>(grad_2F1_tuple), std::get<0>(grad_tuple)[1]);
+  EXPECT_FLOAT_EQ(std::get<2>(grad_2F1_tuple), std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<3>(grad_2F1_tuple), std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_6) {
@@ -205,19 +190,14 @@ TEST(RevMath, grad2F1_6) {
   b_v << 10.6;
   var z_v = 0.3;
 
-  double g_a1;
-  double g_a2;
-  double g_b1;
-  double g_z;
-
-  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
-           z_v.val());
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
+           z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
-  EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
-  EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
+  EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<1>(grad_2F1_tuple), std::get<0>(grad_tuple)[1]);
+  EXPECT_FLOAT_EQ(std::get<2>(grad_2F1_tuple), std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<3>(grad_2F1_tuple), std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_7) {
@@ -232,19 +212,14 @@ TEST(RevMath, grad2F1_7) {
   b_v << 10;
   var z_v = 0.3;
 
-  double g_a1;
-  double g_a2;
-  double g_b1;
-  double g_z;
-
-  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
-           z_v.val());
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
+           z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
-  EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
-  EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
+  EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<1>(grad_2F1_tuple), std::get<0>(grad_tuple)[1]);
+  EXPECT_FLOAT_EQ(std::get<2>(grad_2F1_tuple), std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<3>(grad_2F1_tuple), std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_8) {
@@ -259,19 +234,14 @@ TEST(RevMath, grad2F1_8) {
   b_v << 11;
   var z_v = 0.3;
 
-  double g_a1;
-  double g_a2;
-  double g_b1;
-  double g_z;
-
-  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
-           z_v.val());
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
+           z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
-  EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
-  EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
+  EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<1>(grad_2F1_tuple), std::get<0>(grad_tuple)[1]);
+  EXPECT_FLOAT_EQ(std::get<2>(grad_2F1_tuple), std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<3>(grad_2F1_tuple), std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_9) {
@@ -286,19 +256,14 @@ TEST(RevMath, grad2F1_9) {
   b_v << -3.2;
   var z_v = 0.9;
 
-  double g_a1;
-  double g_a2;
-  double g_b1;
-  double g_z;
-
-  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
-           z_v.val());
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
+           z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
-  EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
-  EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
+  EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<1>(grad_2F1_tuple), std::get<0>(grad_tuple)[1]);
+  EXPECT_FLOAT_EQ(std::get<2>(grad_2F1_tuple), std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<3>(grad_2F1_tuple), std::get<2>(grad_tuple));
 }
 
 TEST(RevMath, grad2F1_10) {
@@ -313,19 +278,14 @@ TEST(RevMath, grad2F1_10) {
   b_v << 2;
   var z_v = 0.4;
 
-  double g_a1;
-  double g_a2;
-  double g_b1;
-  double g_z;
-
-  grad_2F1(g_a1, g_a2, g_b1, g_z, a_v[0].val(), a_v[1].val(), b_v[0].val(),
-           z_v.val());
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
+           z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
-  EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_a2, std::get<0>(grad_tuple)[1]);
-  EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_z, std::get<2>(grad_tuple));
+  EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<1>(grad_2F1_tuple), std::get<0>(grad_tuple)[1]);
+  EXPECT_FLOAT_EQ(std::get<2>(grad_2F1_tuple), std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<3>(grad_2F1_tuple), std::get<2>(grad_tuple));
 }
 /*
 TEST(RevMath, grad2F1_11) {
@@ -340,14 +300,14 @@ TEST(RevMath, grad2F1_11) {
   b_v << 2.70975;
   var z_v = 0.999696;
 
-  double g_a1;
-  double g_b1;
+  double std::get<0>(grad_2F1_tuple);
+  double std::get<2>(grad_2F1_tuple);
 
-  grad_2F1(g_a1, g_b1, a_v[0].val(), a_v[1].val(), b_v[0].val(), z_v.val());
+  grad_2F1(std::get<0>(grad_2F1_tuple), std::get<2>(grad_2F1_tuple), a_v[0], a_v[1], b_v[0], z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
-  EXPECT_FLOAT_EQ(g_a1, std::get<0>(grad_tuple)[0]);
-  EXPECT_FLOAT_EQ(g_b1, std::get<1>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
+  EXPECT_FLOAT_EQ(std::get<2>(grad_2F1_tuple), std::get<1>(grad_tuple)[0]);
 }*/
 
 TEST(RevMath, F32_converges_by_z) {

--- a/test/unit/math/rev/fun/grad_pFq_test.cpp
+++ b/test/unit/math/rev/fun/grad_pFq_test.cpp
@@ -124,8 +124,7 @@ TEST(RevMath, grad_2F1_derivs_match) {
   b_v << 1;
   var z_v = 0.6;
 
-  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
-           z_v);
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0], z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
@@ -146,8 +145,7 @@ TEST(RevMath, grad2F1_2) {
   b_v << 41;
   var z_v = 1;
 
-  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
-           z_v);
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0], z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
@@ -168,8 +166,7 @@ TEST(RevMath, grad2F1_3) {
   b_v << 41.0;
   var z_v = 1.0;
 
-  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
-           z_v);
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0], z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
@@ -190,8 +187,7 @@ TEST(RevMath, grad2F1_6) {
   b_v << 10.6;
   var z_v = 0.3;
 
-  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
-           z_v);
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0], z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
@@ -212,8 +208,7 @@ TEST(RevMath, grad2F1_7) {
   b_v << 10;
   var z_v = 0.3;
 
-  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
-           z_v);
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0], z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
@@ -234,8 +229,7 @@ TEST(RevMath, grad2F1_8) {
   b_v << 11;
   var z_v = 0.3;
 
-  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
-           z_v);
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0], z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
@@ -256,8 +250,7 @@ TEST(RevMath, grad2F1_9) {
   b_v << -3.2;
   var z_v = 0.9;
 
-  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
-           z_v);
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0], z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
@@ -278,8 +271,7 @@ TEST(RevMath, grad2F1_10) {
   b_v << 2;
   var z_v = 0.4;
 
-  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0],
-           z_v);
+  auto grad_2F1_tuple = grad_2F1(a_v[0], a_v[1], b_v[0], z_v);
   auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
@@ -303,8 +295,8 @@ TEST(RevMath, grad2F1_11) {
   double std::get<0>(grad_2F1_tuple);
   double std::get<2>(grad_2F1_tuple);
 
-  grad_2F1(std::get<0>(grad_2F1_tuple), std::get<2>(grad_2F1_tuple), a_v[0], a_v[1], b_v[0], z_v);
-  auto grad_tuple = grad_pFq(a_v, b_v, z_v);
+  grad_2F1(std::get<0>(grad_2F1_tuple), std::get<2>(grad_2F1_tuple), a_v[0],
+a_v[1], b_v[0], z_v); auto grad_tuple = grad_pFq(a_v, b_v, z_v);
 
   EXPECT_FLOAT_EQ(std::get<0>(grad_2F1_tuple), std::get<0>(grad_tuple)[0]);
   EXPECT_FLOAT_EQ(std::get<2>(grad_2F1_tuple), std::get<1>(grad_tuple)[0]);


### PR DESCRIPTION
## Summary

This PR adds the `hypergeometric_2F1` function, using the existing `grad_2f1` function to calculate the gradients.

## Tests

Minimal `mix` tests are added as the values are calculated using `boost::math::hypergeometric_pFq`, which is tested through the `hypergeometric_pFq` tests, and the gradients through `grad_2F1` which already has extensive tests. 

## Side Effects

N/A

## Release notes

Added `hypergeometric_2F1` function

## Checklist

- [x] Math issue #2664

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
