### PR TITLE
Bugfix - `pow(Eigen, Eigen)` forcing `Matrix` return

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -387,10 +387,10 @@ pipeline {
                             echo N_TESTS=${N_TESTS} >> make/local
                             """
                         script {
-                            //if (params.withRowVector || isBranch('develop') || isBranch('master')) {
+                            if (params.withRowVector || isBranch('develop') || isBranch('master')) {
                                 sh "echo CXXFLAGS+=-DSTAN_TEST_ROW_VECTORS >> make/local"
                                 sh "echo CXXFLAGS+=-DSTAN_PROB_TEST_ALL >> make/local"
-                            //}
+                            }
                         }
                         sh "./runTests.py -j${PARALLEL} test/prob > dist.log 2>&1"
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -387,10 +387,10 @@ pipeline {
                             echo N_TESTS=${N_TESTS} >> make/local
                             """
                         script {
-                            if (params.withRowVector || isBranch('develop') || isBranch('master')) {
+                            //if (params.withRowVector || isBranch('develop') || isBranch('master')) {
                                 sh "echo CXXFLAGS+=-DSTAN_TEST_ROW_VECTORS >> make/local"
                                 sh "echo CXXFLAGS+=-DSTAN_PROB_TEST_ALL >> make/local"
-                            }
+                            //}
                         }
                         sh "./runTests.py -j${PARALLEL} test/prob > dist.log 2>&1"
                     }

--- a/stan/math/rev/fun/pow.hpp
+++ b/stan/math/rev/fun/pow.hpp
@@ -121,11 +121,12 @@ template <typename Mat1, typename Mat2,
           require_all_not_stan_scalar_t<Mat1, Mat2>* = nullptr>
 inline auto pow(const Mat1& base, const Mat2& exponent) {
   check_consistent_sizes("pow", "base", base, "exponent", exponent);
-
-  using val_type = decltype(as_array_or_scalar(value_of(base))
-                                .pow(as_array_or_scalar(value_of(exponent)))
-                                .matrix()
-                                .eval());
+  using expr_type = decltype(as_array_or_scalar(value_of(base))
+                                .pow(as_array_or_scalar(value_of(exponent))));
+  using val_type = std::conditional_t<
+    math::disjunction<is_eigen_array<Mat1>, is_eigen_array<Mat2>>::value,
+    decltype(std::declval<expr_type>().eval()),
+    decltype(std::declval<expr_type>().matrix().eval())>;
   using ret_type = return_var_matrix_t<val_type, Mat1, Mat2>;
   using base_t = decltype(as_array_or_scalar(base));
   using exp_t = decltype(as_array_or_scalar(exponent));

--- a/stan/math/rev/fun/pow.hpp
+++ b/stan/math/rev/fun/pow.hpp
@@ -122,11 +122,11 @@ template <typename Mat1, typename Mat2,
 inline auto pow(const Mat1& base, const Mat2& exponent) {
   check_consistent_sizes("pow", "base", base, "exponent", exponent);
   using expr_type = decltype(as_array_or_scalar(value_of(base))
-                                .pow(as_array_or_scalar(value_of(exponent))));
+                                 .pow(as_array_or_scalar(value_of(exponent))));
   using val_type = std::conditional_t<
-    math::disjunction<is_eigen_array<Mat1>, is_eigen_array<Mat2>>::value,
-    decltype(std::declval<expr_type>().eval()),
-    decltype(std::declval<expr_type>().matrix().eval())>;
+      math::disjunction<is_eigen_array<Mat1>, is_eigen_array<Mat2>>::value,
+      decltype(std::declval<expr_type>().eval()),
+      decltype(std::declval<expr_type>().matrix().eval())>;
   using ret_type = return_var_matrix_t<val_type, Mat1, Mat2>;
   using base_t = decltype(as_array_or_scalar(base));
   using exp_t = decltype(as_array_or_scalar(exponent));


### PR DESCRIPTION
## Summary

As identified [here](https://github.com/stan-dev/math/pull/2791#issuecomment-1182944961) the changes to `pow` introduced by #2546 have broken the extended distribution tests by forcing the return to always be an `Eigen::Matrix` input, even when `Eigen::Array` inputs have been passed.

This PR updates the return type deduction to correctly return `Eigen::Array` inputs where appropriate.

## Tests

Extended distribution tests have been temporarily enabled to ensure that this fixes the issue

## Side Effects

N/A

## Release notes

Fix bug with vectorised `pow()` incorrectly forcing `Eigen::Matrix` return instead of `Eigen::Array`

## Checklist

- [x] Math issue N/A

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
