### PR TITLE
Bugfix: Handling of Inf x argument to `log_inv_logit_diff`

### DIFF
--- a/stan/math/prim/fun/log_inv_logit_diff.hpp
+++ b/stan/math/prim/fun/log_inv_logit_diff.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_FUN_LOG_INV_LOGIT_DIFF_HPP
 
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/is_inf.hpp>
 #include <stan/math/prim/fun/log1m_exp.hpp>
 #include <stan/math/prim/fun/log1p_exp.hpp>
 #include <stan/math/prim/functor/apply_scalar_binary.hpp>
@@ -34,6 +35,9 @@ namespace math {
  */
 template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
 inline return_type_t<T1, T2> log_inv_logit_diff(const T1& x, const T2& y) {
+  if (is_inf(x) && x >= 0) {
+    return -log1p_exp(y);
+  }
   return x - log1p_exp(x) + log1m_exp(y - x) - log1p_exp(y);
 }
 

--- a/test/unit/math/prim/fun/log_inv_logit_diff_test.cpp
+++ b/test/unit/math/prim/fun/log_inv_logit_diff_test.cpp
@@ -3,6 +3,14 @@
 #include <gtest/gtest.h>
 #include <cmath>
 
+TEST(MathFunctions, log_inv_logit_diff_inf) {
+  using stan::math::log_inv_logit_diff;
+  using stan::math::INFTY;
+
+  EXPECT_FLOAT_EQ(-0.0916494, log_inv_logit_diff(INFTY, -2.34361));
+  EXPECT_TRUE(std::isnan(log_inv_logit_diff(-INFTY, -2.34361)));
+}
+
 TEST(MathFunctions, log_inv_logit_diff) {
   using stan::math::log_inv_logit_diff;
 

--- a/test/unit/math/prim/fun/log_inv_logit_diff_test.cpp
+++ b/test/unit/math/prim/fun/log_inv_logit_diff_test.cpp
@@ -4,8 +4,8 @@
 #include <cmath>
 
 TEST(MathFunctions, log_inv_logit_diff_inf) {
-  using stan::math::log_inv_logit_diff;
   using stan::math::INFTY;
+  using stan::math::log_inv_logit_diff;
 
   EXPECT_FLOAT_EQ(-0.0916494, log_inv_logit_diff(INFTY, -2.34361));
   EXPECT_TRUE(std::isnan(log_inv_logit_diff(-INFTY, -2.34361)));


### PR DESCRIPTION
## Summary

The `log_inv_logit_diff` function was incorrectly returning `NaN` if (positive) infinity was provided as the first argument. This PR adds handling of this case and a test of the new behaviour.

## Tests
Additional `prim` tests for `Inf` inputs

## Side Effects
N/A

## Release notes
Fixed incorrect return from `log_inv_logit_diff` with positive infinity first argument

## Checklist

- [x] Math issue #2796 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
