### PR TITLE
adds varmat for log_inv_logit

### DIFF
--- a/stan/math/prim/fun/log_inv_logit.hpp
+++ b/stan/math/prim/fun/log_inv_logit.hpp
@@ -79,7 +79,8 @@ struct log_inv_logit_fun {
  * @return elementwise log_inv_logit of members of container
  */
 template <typename T,
-          require_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr>
+          require_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
+          require_not_var_matrix_t<T>* = nullptr>
 inline auto log_inv_logit(const T& x) {
   return apply_scalar_unary<log_inv_logit_fun, T>::apply(x);
 }

--- a/stan/math/rev/fun/log_inv_logit.hpp
+++ b/stan/math/rev/fun/log_inv_logit.hpp
@@ -16,11 +16,13 @@ namespace math {
  * @param u argument
  * @return log inverse logit of the argument
  */
-inline var log_inv_logit(const var& u) {
+template <typename T>
+inline auto log_inv_logit(const var_value<T>& u) {
   return make_callback_var(log_inv_logit(u.val()), [u](auto& vi) mutable {
-    u.adj() += vi.adj() * inv_logit(-u.val());
+    as_array_or_scalar(u.adj()) += as_array_or_scalar(vi.adj()) * as_array_or_scalar(inv_logit(-u.val()));
   });
 }
+
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/fun/log_inv_logit.hpp
+++ b/stan/math/rev/fun/log_inv_logit.hpp
@@ -19,10 +19,10 @@ namespace math {
 template <typename T>
 inline auto log_inv_logit(const var_value<T>& u) {
   return make_callback_var(log_inv_logit(u.val()), [u](auto& vi) mutable {
-    as_array_or_scalar(u.adj()) += as_array_or_scalar(vi.adj()) * as_array_or_scalar(inv_logit(-u.val()));
+    as_array_or_scalar(u.adj()) += as_array_or_scalar(vi.adj())
+                                   * as_array_or_scalar(inv_logit(-u.val()));
   });
 }
-
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/fun/log_inv_logit.hpp
+++ b/stan/math/rev/fun/log_inv_logit.hpp
@@ -13,14 +13,29 @@ namespace math {
  * Return the natural logarithm of the inverse logit of the
  * specified argument.
  *
- * @param u argument
+ * @tparam T An arithmetic type
+ * @param u `var_value` with inner arithmetic type
  * @return log inverse logit of the argument
  */
-template <typename T>
+template <typename T, require_arithmetic_t<T>* = nullptr>
 inline auto log_inv_logit(const var_value<T>& u) {
   return make_callback_var(log_inv_logit(u.val()), [u](auto& vi) mutable {
-    as_array_or_scalar(u.adj()) += as_array_or_scalar(vi.adj())
-                                   * as_array_or_scalar(inv_logit(-u.val()));
+    u.adj() += vi.adj() * inv_logit(-u.val());
+  });
+}
+
+/**
+ * Return the natural logarithm of the inverse logit of the
+ * specified argument.
+ *
+ * @tparam T A type derived from `Eigen::EigenBase`
+ * @param u `var_value` with inner Eigen type
+ * @return log inverse logit of the argument
+ */
+template <typename T, require_eigen_t<T>* = nullptr>
+inline auto log_inv_logit(const var_value<T>& u) {
+  return make_callback_var(log_inv_logit(u.val()), [u](auto& vi) mutable {
+    u.adj().array() += vi.adj().array() * inv_logit(-u.val()).array();
   });
 }
 

--- a/test/unit/math/mix/fun/log_inv_logit_test.cpp
+++ b/test/unit/math/mix/fun/log_inv_logit_test.cpp
@@ -6,7 +6,6 @@ TEST(mathMixMatFun, logInvLogit) {
   stan::test::expect_unary_vectorized(f, -1.0, -0.5, 0.5, 1.3, 5);
 }
 
-
 TEST(mathMixMatFun, logInvLogitVarMat) {
   using stan::math::vec_concat;
   using stan::test::expect_ad_vector_matvar;

--- a/test/unit/math/mix/fun/log_inv_logit_test.cpp
+++ b/test/unit/math/mix/fun/log_inv_logit_test.cpp
@@ -5,3 +5,24 @@ TEST(mathMixMatFun, logInvLogit) {
   stan::test::expect_common_unary_vectorized(f);
   stan::test::expect_unary_vectorized(f, -1.0, -0.5, 0.5, 1.3, 5);
 }
+
+
+TEST(mathMixMatFun, logInvLogitVarMat) {
+  using stan::math::vec_concat;
+  using stan::test::expect_ad_vector_matvar;
+  using stan::test::internal::common_nonzero_args;
+  auto f = [](const auto& x1) {
+    using stan::math::acos;
+    return stan::math::log_inv_logit(x1);
+  };
+  std::vector<double> com_args = common_nonzero_args();
+  std::vector<double> args{
+      -2.2, -0.8, 0.5, 1 + std::numeric_limits<double>::epsilon(),
+      1.5,  3,    3.4, 4};
+  auto all_args = vec_concat(com_args, args);
+  Eigen::VectorXd A(all_args.size());
+  for (int i = 0; i < all_args.size(); ++i) {
+    A(i) = all_args[i];
+  }
+  expect_ad_vector_matvar(f, A);
+}


### PR DESCRIPTION

## Summary

Adds varmat for log_inv_logit

## Tests

Tests added to test varmat and standard vectors of varmats to make sure the vectorization framework works.

## Side Effects

Nope

## Release notes

Allows `log_inv_logit` to use struct of arrays

## Checklist

- [x] Math issue #2804 

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
