### PR TITLE
Fix out of order initializers

### DIFF
--- a/stan/math/rev/functor/reduce_sum.hpp
+++ b/stan/math/rev/functor/reduce_sum.hpp
@@ -66,7 +66,6 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
           num_vars_shared_terms_(num_vars_shared_terms),
           sliced_partials_(sliced_partials),
           vmapped_(std::forward<VecT>(vmapped)),
-          local_args_tuple_scope_(),
           args_tuple_(std::forward<ArgsT>(args)...) {}
 
     /*
@@ -80,7 +79,6 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
           num_vars_shared_terms_(other.num_vars_shared_terms_),
           sliced_partials_(other.sliced_partials_),
           vmapped_(other.vmapped_),
-          local_args_tuple_scope_(),
           args_tuple_(other.args_tuple_) {}
 
     /**


### PR DESCRIPTION
## Summary

Fixes #2807

## Tests

/

## Side Effects

/

## Release notes

Removed the cause of the out-of-order initializer compiler warning.

## Checklist

- [x] Math issue #2807

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
