### PR TITLE
Feature/2704 Add complex Schur decomposition

### DIFF
--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -46,6 +46,7 @@
 #include <stan/math/prim/fun/cols.hpp>
 #include <stan/math/prim/fun/columns_dot_product.hpp>
 #include <stan/math/prim/fun/columns_dot_self.hpp>
+#include <stan/math/prim/fun/complex_schur_decompose.hpp>
 #include <stan/math/prim/fun/conj.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/copysign.hpp>

--- a/stan/math/prim/fun/complex_schur_decompose.hpp
+++ b/stan/math/prim/fun/complex_schur_decompose.hpp
@@ -27,7 +27,8 @@ namespace math {
 template <typename M, require_eigen_dense_dynamic_t<M>* = nullptr>
 inline Eigen::Matrix<complex_return_t<scalar_type_t<M>>, -1, -1>
 complex_schur_decompose_u(const M& m) {
-  check_nonzero_size("complex_schur_decompose_u", "m", m);
+  if (m.size() == 0)
+    return m;
   check_square("complex_schur_decompose_u", "m", m);
   using MatType = Eigen::Matrix<scalar_type_t<M>, -1, -1>;
   // copy because ComplexSchur requires Eigen::Matrix type
@@ -50,7 +51,8 @@ complex_schur_decompose_u(const M& m) {
 template <typename M, require_eigen_dense_dynamic_t<M>* = nullptr>
 inline Eigen::Matrix<complex_return_t<scalar_type_t<M>>, -1, -1>
 complex_schur_decompose_t(const M& m) {
-  check_nonzero_size("complex_schur_decompose_t", "m", m);
+  if (m.size() == 0)
+    return m;
   check_square("complex_schur_decompose_t", "m", m);
   using MatType = Eigen::Matrix<scalar_type_t<M>, -1, -1>;
   // copy because ComplexSchur requires Eigen::Matrix type

--- a/stan/math/prim/fun/complex_schur_decompose.hpp
+++ b/stan/math/prim/fun/complex_schur_decompose.hpp
@@ -4,8 +4,6 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
-#include <Eigen/Dense>
-#include <complex>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/fun/complex_schur_decompose.hpp
+++ b/stan/math/prim/fun/complex_schur_decompose.hpp
@@ -1,0 +1,66 @@
+#ifndef STAN_MATH_PRIM_FUN_COMPLEX_SCHUR_DECOMPOSE_HPP
+#define STAN_MATH_PRIM_FUN_COMPLEX_SCHUR_DECOMPOSE_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <Eigen/Dense>
+#include <complex>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the unitary matrix of the complex Schur decomposition of the
+ * specified square matrix.
+ *
+ * The complex Schur decomposition of a square matrix `A` produces a
+ * complex unitary matrix `U` and a complex upper-triangular Schur
+ * form matrix `T` such that `A = U * T * inv(U)`.  Further, the
+ * unitary matrix's inverse is equal to its conjugate transpose,
+ * `inv(U) = U*`, where `U*(i, j) = conj(U(j, i))`
+ *
+ * @tparam value type of matrix
+ * @param m real matrix to decompose
+ * @return complex unitary matrix of the complex Schur decomposition of the
+ * specified matrix
+ * @see complex_schur_decompose_t
+ */
+template <typename M, require_eigen_dense_dynamic_t<M>* = nullptr>
+inline Eigen::Matrix<complex_return_t<scalar_type_t<M>>, -1, -1>
+complex_schur_decompose_u(const M& m) {
+  check_nonzero_size("complex_schur_decompose_u", "m", m);
+  check_square("complex_schur_decompose_u", "m", m);
+  using MatType = Eigen::Matrix<scalar_type_t<M>, -1, -1>;
+  // copy because ComplexSchur requires Eigen::Matrix type
+  MatType mv = m;
+  Eigen::ComplexSchur<MatType> cs(mv);
+  return cs.matrixU();
+}
+
+/**
+ * Return the Schur form matrix of the complex Schur decomposition of the
+ * specified square matrix.
+ *
+ * @tparam value type of matrix
+ * @param m real matrix to decompose
+ * @return Schur form matrix of the complex Schur decomposition of the
+ * specified matrix
+ * @see complex_schur_decompose_u for a definition of the complex
+ * Schur decomposition
+ */
+template <typename M, require_eigen_dense_dynamic_t<M>* = nullptr>
+inline Eigen::Matrix<complex_return_t<scalar_type_t<M>>, -1, -1>
+complex_schur_decompose_t(const M& m) {
+  check_nonzero_size("complex_schur_decompose_t", "m", m);
+  check_square("complex_schur_decompose_t", "m", m);
+  using MatType = Eigen::Matrix<scalar_type_t<M>, -1, -1>;
+  // copy because ComplexSchur requires Eigen::Matrix type
+  MatType mv = m;
+  Eigen::ComplexSchur<MatType> cs(mv);
+  return cs.matrixT();
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/fun/complex_schur_decompose.hpp
+++ b/stan/math/prim/fun/complex_schur_decompose.hpp
@@ -18,7 +18,7 @@ namespace math {
  * unitary matrix's inverse is equal to its conjugate transpose,
  * `inv(U) = U*`, where `U*(i, j) = conj(U(j, i))`
  *
- * @tparam value type of matrix
+ * @tparam M type of matrix
  * @param m real matrix to decompose
  * @return complex unitary matrix of the complex Schur decomposition of the
  * specified matrix
@@ -40,7 +40,7 @@ complex_schur_decompose_u(const M& m) {
  * Return the Schur form matrix of the complex Schur decomposition of the
  * specified square matrix.
  *
- * @tparam value type of matrix
+ * @tparam M type of matrix
  * @param m real matrix to decompose
  * @return Schur form matrix of the complex Schur decomposition of the
  * specified matrix
@@ -55,7 +55,7 @@ complex_schur_decompose_t(const M& m) {
   using MatType = Eigen::Matrix<scalar_type_t<M>, -1, -1>;
   // copy because ComplexSchur requires Eigen::Matrix type
   MatType mv = m;
-  Eigen::ComplexSchur<MatType> cs(mv);
+  Eigen::ComplexSchur<MatType> cs(mv, false);
   return cs.matrixT();
 }
 

--- a/test/unit/math/mix/fun/complex_schur_decompose_test.cpp
+++ b/test/unit/math/mix/fun/complex_schur_decompose_test.cpp
@@ -66,7 +66,7 @@ TEST(mathMixFun, complexSchurDecompose) {
   using ffd_t = stan::math::fvar<fd_t>;
   using fv_t = stan::math::fvar<v_t>;
   using ffv_t = stan::math::fvar<fv_t>;
-  for (const auto& x : stan::test::square_test_matrices(1, 3)) {
+  for (const auto& x : stan::test::square_test_matrices(0, 3)) {
     test_complex_schur_decompose<d_t>(x);
     test_complex_schur_decompose<v_t>(x);
     test_complex_schur_decompose<fd_t>(x);
@@ -74,7 +74,7 @@ TEST(mathMixFun, complexSchurDecompose) {
     test_complex_schur_decompose<fv_t>(x);
     test_complex_schur_decompose<ffv_t>(x);
   }
-  for (const auto& x : stan::test::square_test_matrices(1, 3)) {
+  for (const auto& x : stan::test::square_test_matrices(0, 3)) {
     test_complex_schur_decompose_complex<d_t>(x);
     test_complex_schur_decompose_complex<v_t>(x);
     test_complex_schur_decompose_complex<fd_t>(x);

--- a/test/unit/math/mix/fun/complex_schur_decompose_test.cpp
+++ b/test/unit/math/mix/fun/complex_schur_decompose_test.cpp
@@ -1,0 +1,94 @@
+#include <test/unit/math/test_ad.hpp>
+#include <stdexcept>
+
+TEST(mathMixFun, complexSchurDecomposeT) {
+  auto f = [](const auto& x) {
+    using stan::math::complex_schur_decompose_t;
+    return complex_schur_decompose_t(x);
+  };
+  for (const auto& x : stan::test::square_test_matrices(0, 2)) {
+    stan::test::expect_ad(f, x);
+  }
+
+  Eigen::MatrixXd a32(3, 2);
+  a32 << 3, -5, 7, -7.2, 9.1, -6.3;
+  EXPECT_THROW(f(a32), std::invalid_argument);
+}
+
+TEST(mathMixFun, complexSchurDecomposeU) {
+  auto f = [](const auto& x) {
+    using stan::math::complex_schur_decompose_u;
+    return complex_schur_decompose_u(x);
+  };
+  for (const auto& x : stan::test::square_test_matrices(0, 2)) {
+    stan::test::expect_ad(f, x);
+  }
+
+  Eigen::MatrixXd a32(3, 2);
+  a32 << 3, -5, 7, -7.2, 9.1, -6.3;
+  EXPECT_THROW(f(a32), std::invalid_argument);
+}
+
+template <typename V>
+void test_complex_schur_decompose(const Eigen::MatrixXd& x) {
+  using stan::math::complex_schur_decompose_t;
+  using stan::math::complex_schur_decompose_u;
+  using stan::math::value_of_rec;
+  Eigen::Matrix<V, -1, -1> X(x.rows(), x.cols());
+  for (int i = 0; i < x.size(); ++i)
+    X(i) = x(i);
+  auto T = complex_schur_decompose_t(X);
+  auto U = complex_schur_decompose_u(X);
+  auto X2 = U * T * U.adjoint();
+  for (int j = 0; j < x.cols(); ++j) {
+    for (int i = 0; i < x.rows(); ++i) {
+      EXPECT_FLOAT_EQ(x(i, j), value_of_rec(X2(i, j).real()));
+    }
+  }
+}
+
+template <typename V>
+void test_complex_schur_decompose_complex(const Eigen::MatrixXd& x) {
+  using stan::math::complex_schur_decompose_t;
+  using stan::math::complex_schur_decompose_u;
+  using stan::math::value_of_rec;
+  Eigen::Matrix<std::complex<V>, -1, -1> X(x.rows(), x.cols());
+  for (int i = 0; i < x.size(); ++i)
+    X(i) = std::complex<double>(x(i), i);
+  auto T = complex_schur_decompose_t(X);
+  auto U = complex_schur_decompose_u(X);
+  auto X2 = U * T * U.adjoint();
+  for (int j = 0; j < x.cols(); ++j) {
+    for (int i = 0; i < x.rows(); ++i) {
+      EXPECT_NEAR(value_of_rec(X(i, j).real()), value_of_rec(X2(i, j).real()),
+                  1e-8);
+      EXPECT_NEAR(value_of_rec(X(i, j)).imag(), value_of_rec(X2(i, j).imag()),
+                  1e-8);
+    }
+  }
+}
+
+TEST(mathMixFun, complexSchurDecompose) {
+  using d_t = double;
+  using v_t = stan::math::var;
+  using fd_t = stan::math::fvar<d_t>;
+  using ffd_t = stan::math::fvar<fd_t>;
+  using fv_t = stan::math::fvar<v_t>;
+  using ffv_t = stan::math::fvar<fv_t>;
+  for (const auto& x : stan::test::square_test_matrices(1, 3)) {
+    test_complex_schur_decompose<d_t>(x);
+    test_complex_schur_decompose<v_t>(x);
+    test_complex_schur_decompose<fd_t>(x);
+    test_complex_schur_decompose<ffd_t>(x);
+    test_complex_schur_decompose<fv_t>(x);
+    test_complex_schur_decompose<ffv_t>(x);
+  }
+  for (const auto& x : stan::test::square_test_matrices(1, 3)) {
+    test_complex_schur_decompose_complex<d_t>(x);
+    test_complex_schur_decompose_complex<v_t>(x);
+    test_complex_schur_decompose_complex<fd_t>(x);
+    test_complex_schur_decompose_complex<ffd_t>(x);
+    test_complex_schur_decompose_complex<fv_t>(x);
+    test_complex_schur_decompose_complex<ffv_t>(x);
+  }
+}

--- a/test/unit/math/mix/fun/complex_schur_decompose_test.cpp
+++ b/test/unit/math/mix/fun/complex_schur_decompose_test.cpp
@@ -33,18 +33,15 @@ template <typename V>
 void test_complex_schur_decompose(const Eigen::MatrixXd& x) {
   using stan::math::complex_schur_decompose_t;
   using stan::math::complex_schur_decompose_u;
+  using stan::math::get_real;
   using stan::math::value_of_rec;
-  Eigen::Matrix<V, -1, -1> X(x.rows(), x.cols());
-  for (int i = 0; i < x.size(); ++i)
-    X(i) = x(i);
+  Eigen::Matrix<V, -1, -1> X = x;
+
   auto T = complex_schur_decompose_t(X);
   auto U = complex_schur_decompose_u(X);
   auto X2 = U * T * U.adjoint();
-  for (int j = 0; j < x.cols(); ++j) {
-    for (int i = 0; i < x.rows(); ++i) {
-      EXPECT_FLOAT_EQ(x(i, j), value_of_rec(X2(i, j).real()));
-    }
-  }
+
+  EXPECT_MATRIX_NEAR(x, value_of_rec(get_real(X2)), 1e-8);
 }
 
 template <typename V>
@@ -58,14 +55,8 @@ void test_complex_schur_decompose_complex(const Eigen::MatrixXd& x) {
   auto T = complex_schur_decompose_t(X);
   auto U = complex_schur_decompose_u(X);
   auto X2 = U * T * U.adjoint();
-  for (int j = 0; j < x.cols(); ++j) {
-    for (int i = 0; i < x.rows(); ++i) {
-      EXPECT_NEAR(value_of_rec(X(i, j).real()), value_of_rec(X2(i, j).real()),
-                  1e-8);
-      EXPECT_NEAR(value_of_rec(X(i, j)).imag(), value_of_rec(X2(i, j).imag()),
-                  1e-8);
-    }
-  }
+
+  EXPECT_MATRIX_COMPLEX_NEAR(value_of_rec(X), value_of_rec(X2), 1e-8);
 }
 
 TEST(mathMixFun, complexSchurDecompose) {

--- a/test/unit/math/prim/fun/complex_schur_decompose_test.cpp
+++ b/test/unit/math/prim/fun/complex_schur_decompose_test.cpp
@@ -2,18 +2,6 @@
 #include <test/unit/util.hpp>
 #include <gtest/gtest.h>
 
-template <typename T, typename U>
-void expect_complex_mat_eq(const T& x, const U& y, double tol = 1e-8) {
-  EXPECT_EQ(x.rows(), y.rows());
-  EXPECT_EQ(x.cols(), y.cols());
-  for (int j = 0; j < x.cols(); ++j) {
-    for (int i = 0; i < x.rows(); ++i) {
-      EXPECT_NEAR(real(x(i, j)), real(y(i, j)), tol);
-      EXPECT_NEAR(imag(x(i, j)), imag(y(i, j)), tol);
-    }
-  }
-}
-
 TEST(primFun, complex_schur_decompose) {
   using c_t = std::complex<double>;
   using stan::math::complex_schur_decompose_t;
@@ -26,7 +14,7 @@ TEST(primFun, complex_schur_decompose) {
   auto A_t = complex_schur_decompose_t(A);
   auto A_u = complex_schur_decompose_u(A);
   auto A_recovered = A_u * A_t * A_u.adjoint();
-  expect_complex_mat_eq(stan::math::to_complex(A, 0), A_recovered);
+  EXPECT_MATRIX_NEAR(A, stan::math::get_real(A_recovered), 1e-8);
 
   Eigen::MatrixXcd B(3, 3);
   B << 0, 2, 2, 0, c_t(0, 1), 2, 1, 0, 1;
@@ -35,6 +23,5 @@ TEST(primFun, complex_schur_decompose) {
   auto B_u = complex_schur_decompose_u(B);
 
   auto B_recovered = B_u * B_t * B_u.adjoint();
-
-  expect_complex_mat_eq(B, B_recovered);
+  EXPECT_MATRIX_COMPLEX_NEAR(B, B_recovered, 1e-8);
 }

--- a/test/unit/math/prim/fun/complex_schur_decompose_test.cpp
+++ b/test/unit/math/prim/fun/complex_schur_decompose_test.cpp
@@ -1,0 +1,37 @@
+#include <stan/math/prim.hpp>
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+#include <iostream>
+
+template <typename T, typename U>
+void expect_complex_mat_eq(const T& x, const U& y, double tol = 1e-8) {
+  EXPECT_EQ(x.rows(), y.rows());
+  EXPECT_EQ(x.cols(), y.cols());
+  for (int j = 0; j < x.cols(); ++j) {
+    for (int i = 0; i < x.rows(); ++i) {
+      EXPECT_FLOAT_EQ(real(x(i, j)), real(y(i, j)));
+      EXPECT_FLOAT_EQ(imag(x(i, j)), imag(y(i, j)));
+    }
+  }
+}
+
+TEST(primFun, complex_schur_decompose) {
+  using c_t = std::complex<double>;
+  using stan::math::complex_schur_decompose_t;
+  using stan::math::complex_schur_decompose_u;
+
+  // reference answers calculated using scipy.linalg.schur with output="complex"
+
+  Eigen::MatrixXd A(3, 3);
+  A << 0, 2, 2, 0, 1, 2, 1, 0, 1;
+
+  auto A_t = complex_schur_decompose_t(A);
+
+  Eigen::Matrix3cd A_t_expected;
+  A_t_expected << c_t(2.65896708, 0.), c_t(-1.22839825, 1.32378589),
+      c_t(0.42590094, 1.51937377), c_t(0., 0.), c_t(-0.32948354, 0.80225456),
+      c_t(-0.59877805, 0.56192148), c_t(0., 0.), c_t(0., 0.),
+      c_t(-0.32948354, -0.80225456);
+
+  expect_complex_mat_eq(A_t_expected, A_t);
+}

--- a/test/unit/math/prim/fun/complex_schur_decompose_test.cpp
+++ b/test/unit/math/prim/fun/complex_schur_decompose_test.cpp
@@ -1,7 +1,6 @@
 #include <stan/math/prim.hpp>
 #include <test/unit/util.hpp>
 #include <gtest/gtest.h>
-#include <iostream>
 
 template <typename T, typename U>
 void expect_complex_mat_eq(const T& x, const U& y, double tol = 1e-8) {
@@ -9,8 +8,8 @@ void expect_complex_mat_eq(const T& x, const U& y, double tol = 1e-8) {
   EXPECT_EQ(x.cols(), y.cols());
   for (int j = 0; j < x.cols(); ++j) {
     for (int i = 0; i < x.rows(); ++i) {
-      EXPECT_NEAR(real(x(i, j)), real(y(i, j)), 1e-6);
-      EXPECT_NEAR(imag(x(i, j)), imag(y(i, j)), 1e-6);
+      EXPECT_NEAR(real(x(i, j)), real(y(i, j)), tol);
+      EXPECT_NEAR(imag(x(i, j)), imag(y(i, j)), tol);
     }
   }
 }
@@ -27,11 +26,10 @@ TEST(primFun, complex_schur_decompose) {
   auto A_t = complex_schur_decompose_t(A);
   auto A_u = complex_schur_decompose_u(A);
   auto A_recovered = A_u * A_t * A_u.adjoint();
-  expect_complex_mat_eq(stan::math::to_complex(A,0), A_recovered);
-
+  expect_complex_mat_eq(stan::math::to_complex(A, 0), A_recovered);
 
   Eigen::MatrixXcd B(3, 3);
-  B << 0, 2, 2, 0, c_t(0,1), 2, 1, 0, 1;
+  B << 0, 2, 2, 0, c_t(0, 1), 2, 1, 0, 1;
 
   auto B_t = complex_schur_decompose_t(B);
   auto B_u = complex_schur_decompose_u(B);

--- a/test/unit/math/prim/fun/fft_test.cpp
+++ b/test/unit/math/prim/fun/fft_test.cpp
@@ -45,17 +45,6 @@ TEST(primFun, fft) {
   EXPECT_NEAR(imag(yb[2]), 2 * -6.53589838, 1e-6);
 }
 
-template <typename T, typename U>
-void expect_complex_mat_eq(const T& x, const U& y, double tol = 1e-8) {
-  EXPECT_EQ(x.rows(), y.rows());
-  EXPECT_EQ(x.cols(), y.cols());
-  for (int j = 0; j < x.cols(); ++j) {
-    for (int i = 0; i < x.rows(); ++i) {
-      EXPECT_FLOAT_EQ(real(x(i, j)), real(y(i, j)));
-      EXPECT_FLOAT_EQ(imag(x(i, j)), imag(y(i, j)));
-    }
-  }
-}
 
 TEST(primFun, inv_fft) {
   using c_t = std::complex<double>;
@@ -74,7 +63,7 @@ TEST(primFun, inv_fft) {
   cv_t x1 = inv_fft(y1);
   cv_t x1_expected(1);
   x1_expected << c_t(-3.247, 1.98555);
-  expect_complex_mat_eq(x1_expected, x1);
+  EXPECT_MATRIX_COMPLEX_NEAR(x1_expected, x1, 1e-8);
 
   EXPECT_EQ(1, x1.size());
   EXPECT_EQ(real(x1[0]), -3.247);
@@ -87,7 +76,7 @@ TEST(primFun, inv_fft) {
   EXPECT_EQ(3, y.size());
   Eigen::VectorXcd x_expected(3);
   x_expected << c_t(1, -2), c_t(-3, 5), c_t(-7, 11);
-  expect_complex_mat_eq(x_expected, x);
+  EXPECT_MATRIX_COMPLEX_NEAR(x_expected, x, 1e-8);
 }
 
 TEST(primFun, fft2) {
@@ -115,7 +104,7 @@ TEST(primFun, fft2) {
   cm_t y12 = fft2(x12);
   cm_t y12_expected(1, 2);
   y12_expected << c_t(-7.6, -3.7), c_t(9.6, -4.1);
-  expect_complex_mat_eq(y12_expected, y12);
+  EXPECT_MATRIX_COMPLEX_NEAR(y12_expected, y12, 1e-8);
 
   cm_t x33(3, 3);
   x33 << c_t(1, 2), c_t(3, -1.4), c_t(2, 1), c_t(3, -9), c_t(2, -1.3),
@@ -127,7 +116,7 @@ TEST(primFun, fft2) {
       c_t(-13.29326674, 20.88153533), c_t(-13.25262794, 15.82794549),
       c_t(4.160254038, 5.928718708), c_t(-11.34737206, -7.72794549),
       c_t(4.89326674, -1.98153533);
-  expect_complex_mat_eq(y33_expected, y33);
+  EXPECT_MATRIX_COMPLEX_NEAR(y33_expected, y33, 1e-8);
 }
 
 TEST(primFunFFT, invfft2) {
@@ -153,7 +142,7 @@ TEST(primFunFFT, invfft2) {
   x13 << c_t(-2.3, 1.82), c_t(1.18, 9.32), c_t(1.15, -14.1);
   cm_t y13 = inv_fft2(x13);
   cm_t y13copy = inv_fft(x13.row(0));
-  expect_complex_mat_eq(y13, y13copy.transpose());
+  EXPECT_MATRIX_COMPLEX_NEAR(y13, y13copy.transpose(), 1e-8);
 
   cm_t x33(3, 3);
   x33 << c_t(1, 2), c_t(3, -1.4), c_t(2, 1), c_t(3, -9), c_t(2, -1.3),
@@ -182,10 +171,10 @@ TEST(primFunFFT, invfft2) {
 
   // check round trips inv_fft(fft(x))
   cm_t x33copy = inv_fft2(y33);
-  expect_complex_mat_eq(x33, x33copy);
+  EXPECT_MATRIX_COMPLEX_NEAR(x33, x33copy, 1e-8);
 
   // check round trip fft(inv_fft(x))
   cm_t z33 = inv_fft2(x33);
   cm_t x33copy2 = fft2(z33);
-  expect_complex_mat_eq(x33, x33copy2);
+  EXPECT_MATRIX_COMPLEX_NEAR(x33, x33copy2, 1e-8);
 }

--- a/test/unit/math/prim/fun/fft_test.cpp
+++ b/test/unit/math/prim/fun/fft_test.cpp
@@ -45,7 +45,6 @@ TEST(primFun, fft) {
   EXPECT_NEAR(imag(yb[2]), 2 * -6.53589838, 1e-6);
 }
 
-
 TEST(primFun, inv_fft) {
   using c_t = std::complex<double>;
   using cv_t = Eigen::Matrix<std::complex<double>, -1, 1>;

--- a/test/unit/util.hpp
+++ b/test/unit/util.hpp
@@ -121,6 +121,26 @@
   }
 
 /**
+ * Tests for elementwise equality of the input matrices
+ * of std::complex<double>s with the EXPECT_FLOAT_EQ macro
+ * from GTest.
+ *
+ * @param A first input matrix to compare
+ * @param B second input matrix to compare
+ */
+#define EXPECT_MATRIX_COMPLEX_NEAR(A, B, DELTA)               \
+  {                                                           \
+    const Eigen::MatrixXcd& A_eval = A;                       \
+    const Eigen::MatrixXcd& B_eval = B;                       \
+    EXPECT_EQ(A_eval.rows(), B_eval.rows());                  \
+    EXPECT_EQ(A_eval.cols(), B_eval.cols());                  \
+    for (int i = 0; i < A_eval.size(); i++) {                 \
+      EXPECT_NEAR(A_eval(i).real(), B_eval(i).real(), DELTA); \
+      EXPECT_NEAR(A_eval(i).imag(), B_eval(i).imag(), DELTA); \
+    }                                                         \
+  }
+
+/**
  * Tests if given types are the same type.
  *
  * @param a first type


### PR DESCRIPTION
## Summary

Adds two new functions, `complex_schur_decompose_t` and `complex_schur_decompose_u`. These wrap Eigen and implement the [Schur Decomposition](https://en.wikipedia.org/wiki/Schur_decomposition) of a matrix. 

This is mostly an update of code @bob-carpenter wrote during the initial effort to add complex matrix types. 

## Tests

Tests added to /mix and /prim. The prim tests verify that `A = U T U*` where `*` indicates conjugate transpose. 

## Side Effects

None

## Release notes

Added two new functions, `complex_schur_decompose_t` and `complex_schur_decompose_u`.

## Checklist

- [x] Math issue: Closes #2704

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
