### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/header_checks.yml
+++ b/.github/workflows/header_checks.yml
@@ -13,6 +13,10 @@ on:
       - 'README.md'
       - 'RELEASE-NOTES.txt'
 
+permissions:
+  actions: write # to create & stop workflow runs (n1hility/cancel-previous-runs)
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   windows:
     name: Windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,15 @@ on:
       - 'LICENSE.md'
       - 'README.md'
       - 'RELEASE-NOTES.txt'
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   prim-rev:
+    permissions:
+      actions: write # to create & stop workflow runs (n1hility/cancel-previous-runs)
+      contents: read # to fetch code (actions/checkout)
+
     name: prim and rev tests
     runs-on: windows-latest
 


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.