### PR TITLE
Vectorize conj

### DIFF
--- a/stan/math/prim/fun/conj.hpp
+++ b/stan/math/prim/fun/conj.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_FUN_CONJ_HPP
 
 #include <complex>
+#include <stan/math/prim/meta.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/fun/conj.hpp
+++ b/stan/math/prim/fun/conj.hpp
@@ -6,16 +6,33 @@
 namespace stan {
 namespace math {
 
+
+
 /**
- * Return the complex conjugate the complex argument.
+ * Return the complex conjugate the Eigen object.
  *
- * @tparam V value type of argument
+ * @tparam Eig A type derived from `Eigen::EigenBase`
  * @param[in] z argument
  * @return complex conjugate of the argument
  */
-template <typename V>
-inline std::complex<V> conj(const std::complex<V>& z) {
-  return std::conj(z);
+template <typename Eig, require_eigen_vt<is_complex, Eig>* = nullptr>
+inline auto conj(const Eig& z) {
+  return z.conjugate();
+}
+
+/**
+ * Return the complex conjugate the vector with complex scalar components.
+ *
+ * @tparam StdVec A `std::vector` type with complex scalar type
+ * @param[in] z argument
+ * @return complex conjugate of the argument
+ */
+template <typename StdVec, require_std_vector_st<is_complex, StdVec>* = nullptr>
+inline auto conj(const StdVec& z) {
+  promote_scalar_t<base_type_t<StdVec>, StdVec> result(z.size());
+  std::transform(z.begin(), z.end(), result.begin(),
+                 [](auto&& x) { return conj(x); });
+  return result;
 }
 
 namespace internal {

--- a/stan/math/prim/fun/conj.hpp
+++ b/stan/math/prim/fun/conj.hpp
@@ -6,7 +6,17 @@
 namespace stan {
 namespace math {
 
-
+/**
+ * Return the complex conjugate the complex argument.
+ *
+ * @tparam V value type of argument
+ * @param[in] z argument
+ * @return complex conjugate of the argument
+ */
+template <typename V>
+inline std::complex<V> conj(const std::complex<V>& z) {
+  return std::conj(z);
+}
 
 /**
  * Return the complex conjugate the Eigen object.
@@ -29,9 +39,9 @@ inline auto conj(const Eig& z) {
  */
 template <typename StdVec, require_std_vector_st<is_complex, StdVec>* = nullptr>
 inline auto conj(const StdVec& z) {
-  promote_scalar_t<base_type_t<StdVec>, StdVec> result(z.size());
+  promote_scalar_t<scalar_type_t<StdVec>, StdVec> result(z.size());
   std::transform(z.begin(), z.end(), result.begin(),
-                 [](auto&& x) { return conj(x); });
+                 [](auto&& x) { return stan::math::conj(x); });
   return result;
 }
 

--- a/test/unit/math/mix/fun/acos_test.cpp
+++ b/test/unit/math/mix/fun/acos_test.cpp
@@ -12,7 +12,7 @@ TEST(mathMixMatFun, acos) {
   // can't autodiff acos through integers
   for (auto x : stan::test::internal::common_nonzero_args())
     stan::test::expect_unary_vectorized(f, x);
-  expect_unary_vectorized<stan::test::PromoteToComplex::No>(
+  expect_unary_vectorized<stan::test::ScalarSupport::Real>(
       f, -2.2, -0.8, 0.5, 1 + std::numeric_limits<double>::epsilon(), 1.5, 3,
       3.4, 4);
   for (double re : std::vector<double>{-0.2, 0, 0.3}) {

--- a/test/unit/math/mix/fun/acosh_test.cpp
+++ b/test/unit/math/mix/fun/acosh_test.cpp
@@ -8,8 +8,8 @@ TEST(mathMixMatFun, acosh) {
   };
   for (double x : stan::test::internal::common_args())
     stan::test::expect_unary_vectorized(f, x);
-  stan::test::expect_unary_vectorized<stan::test::PromoteToComplex::Yes>(
-      f, 1.5, 3.2, 5, 10, 12.9);
+  stan::test::expect_unary_vectorized<
+      stan::test::ScalarSupport::RealAndComplex>(f, 1.5, 3.2, 5, 10, 12.9);
   // avoid pole at complex zero that can't be autodiffed
   for (double re : std::vector<double>{-0.2, 0, 0.3}) {
     for (double im : std::vector<double>{-0.3, 0.2}) {

--- a/test/unit/math/mix/fun/atan_test.cpp
+++ b/test/unit/math/mix/fun/atan_test.cpp
@@ -8,7 +8,7 @@ TEST(mathMixMatFun, atan) {
     return atan(x);
   };
   stan::test::expect_common_nonzero_unary_vectorized<
-      stan::test::PromoteToComplex::No>(f);
+      stan::test::ScalarSupport::Real>(f);
   stan::test::expect_unary_vectorized(f, -2.6, -2, -0.2, 0.5, 1, 1.3, 1.5, 3);
   // avoid 0 imaginary component where autodiff doesn't work
   for (double re : std::vector<double>{-0.2, 0, 0.3}) {

--- a/test/unit/math/mix/fun/cbrt_test.cpp
+++ b/test/unit/math/mix/fun/cbrt_test.cpp
@@ -3,7 +3,7 @@
 TEST(mathMixMatFun, cbrt) {
   auto f = [](const auto& x1) { return stan::math::cbrt(x1); };
   stan::test::expect_common_nonzero_unary_vectorized<
-      stan::test::PromoteToComplex::No>(f);
+      stan::test::ScalarSupport::Real>(f);
   stan::test::expect_unary_vectorized(f, -2.6, -2, 1, 1.3, 3);
 }
 

--- a/test/unit/math/mix/fun/conj_test.cpp
+++ b/test/unit/math/mix/fun/conj_test.cpp
@@ -3,31 +3,60 @@
 #include <complex>
 #include <vector>
 
-TEST(mixScalFun, conj) {
-  auto f = [](const auto& x) {
-    using stan::math::conj;
-    return conj(x);
-  };
+namespace stan {
+namespace math {
+/**
+ *  Dummy overload to allow expect_unary_vectorized. It requires real-valued
+ * overloads.
+ */
+template <typename V, require_not_st_complex<V>* = nullptr>
+inline auto conj(const V& z) {
+  return z;
+}
+}  // namespace math
+}  // namespace stan
+
+TEST(mathMixMatFun, conj) {
+  auto f = [](const auto& x) { return stan::math::conj(x); };
   stan::test::expect_complex_common(f);
+  stan::test::expect_unary_vectorized<stan::test::PromoteToComplex::Yes>(f);
 }
 
 template <typename T>
 void test_vectorized_conj() {
+  using stan::math::value_of_rec;
   using complex_t = std::complex<T>;
-  using matrix_t = Eigen::Matrix<T, -1, -1>;
   using complex_matrix = Eigen::Matrix<complex_t, -1, -1>;
   complex_matrix A(2, 2);
   A << complex_t(T(0), T(1)), complex_t(T(2), T(3)), complex_t(T(4), T(5)),
       complex_t(T(6), T(7));
+  auto A_conj = stan::math::conj(A);
+  EXPECT_MATRIX_COMPLEX_FLOAT_EQ(value_of_rec(A_conj),
+                                 value_of_rec(A.conjugate()))
+  std::vector<complex_t> v{complex_t(T(0), T(1)), complex_t(T(2), T(3)),
+                           complex_t(T(4), T(5)), complex_t(T(6), T(7))};
 
-  auto f = [](const auto& x) {
-    using stan::math::conj;
-    return conj(x);
-  };
-  stan::test::expect_ad(f, A);
+  std::vector<complex_t> v_conj = stan::math::conj(v);
+  for (int i = 0; i < v.size(); ++i) {
+    std::complex<double> vi = value_of_rec(v_conj[i]);
+    std::complex<double> ci = value_of_rec(stan::math::conj(v[i]));
+    EXPECT_FLOAT_EQ(vi.real(), ci.real());
+    EXPECT_FLOAT_EQ(vi.imag(), ci.imag());
+  }
 }
 
-TEST(mixScalFun, conj_vectorized) {
-  test_vectorized_conj<double>();
-  test_vectorized_conj<stan::math::var>();
+TEST(mathMixMatFun, conj_vectorized) {
+  using d_t = double;
+  using v_t = stan::math::var;
+  using fd_t = stan::math::fvar<d_t>;
+  using ffd_t = stan::math::fvar<fd_t>;
+  using fv_t = stan::math::fvar<v_t>;
+  using ffv_t = stan::math::fvar<fv_t>;
+
+  test_vectorized_conj<d_t>();
+  test_vectorized_conj<v_t>();
+  test_vectorized_conj<fd_t>();
+  test_vectorized_conj<ffd_t>();
+  test_vectorized_conj<fv_t>();
+  test_vectorized_conj<ffv_t>();
 }

--- a/test/unit/math/mix/fun/conj_test.cpp
+++ b/test/unit/math/mix/fun/conj_test.cpp
@@ -3,23 +3,11 @@
 #include <complex>
 #include <vector>
 
-namespace stan {
-namespace math {
-/**
- *  Dummy overload to allow expect_unary_vectorized. It requires real-valued
- * overloads.
- */
-template <typename V, require_not_st_complex<V>* = nullptr>
-inline auto conj(const V& z) {
-  return z;
-}
-}  // namespace math
-}  // namespace stan
-
 TEST(mathMixMatFun, conj) {
   auto f = [](const auto& x) { return stan::math::conj(x); };
   stan::test::expect_complex_common(f);
-  stan::test::expect_unary_vectorized<stan::test::PromoteToComplex::Yes>(f);
+  stan::test::expect_unary_vectorized<stan::test::ScalarSupport::ComplexOnly>(
+      f);
 }
 
 template <typename T>

--- a/test/unit/math/mix/fun/conj_test.cpp
+++ b/test/unit/math/mix/fun/conj_test.cpp
@@ -1,8 +1,33 @@
+#include <stan/math/prim.hpp>
 #include <test/unit/math/test_ad.hpp>
 #include <complex>
 #include <vector>
 
 TEST(mixScalFun, conj) {
-  auto f = [](const auto& x) { return conj(x); };
+  auto f = [](const auto& x) {
+    using stan::math::conj;
+    return conj(x);
+  };
   stan::test::expect_complex_common(f);
+}
+
+template <typename T>
+void test_vectorized_conj() {
+  using complex_t = std::complex<T>;
+  using matrix_t = Eigen::Matrix<T, -1, -1>;
+  using complex_matrix = Eigen::Matrix<complex_t, -1, -1>;
+  complex_matrix A(2, 2);
+  A << complex_t(T(0), T(1)), complex_t(T(2), T(3)), complex_t(T(4), T(5)),
+      complex_t(T(6), T(7));
+
+  auto f = [](const auto& x) {
+    using stan::math::conj;
+    return conj(x);
+  };
+  stan::test::expect_ad(f, A);
+}
+
+TEST(mixScalFun, conj_vectorized) {
+  test_vectorized_conj<double>();
+  test_vectorized_conj<stan::math::var>();
 }

--- a/test/unit/math/mix/fun/cos_test.cpp
+++ b/test/unit/math/mix/fun/cos_test.cpp
@@ -6,8 +6,9 @@ TEST(mathMixMatFun, cos) {
     return cos(x);
   };
   stan::test::expect_common_nonzero_unary_vectorized(f);
-  stan::test::expect_unary_vectorized<stan::test::PromoteToComplex::Yes>(
-      f, -2.6, -2, -0.2, -0.5, 0, 1.5, 3, 5, 5.3);
+  stan::test::expect_unary_vectorized<
+      stan::test::ScalarSupport::RealAndComplex>(f, -2.6, -2, -0.2, -0.5, 0,
+                                                 1.5, 3, 5, 5.3);
   stan::test::expect_complex_common(f);
 }
 

--- a/test/unit/math/mix/fun/cosh_test.cpp
+++ b/test/unit/math/mix/fun/cosh_test.cpp
@@ -6,8 +6,9 @@ TEST(mathMixMatFun, cosh) {
     return cosh(x1);
   };
   stan::test::expect_common_unary_vectorized(f);
-  stan::test::expect_unary_vectorized<stan::test::PromoteToComplex::Yes>(
-      f, -2.6, -2, -1.2, -0.2, 0.5, 1, 1.3, 1.5);
+  stan::test::expect_unary_vectorized<
+      stan::test::ScalarSupport::RealAndComplex>(f, -2.6, -2, -1.2, -0.2, 0.5,
+                                                 1, 1.3, 1.5);
   stan::test::expect_complex_common(f);
 }
 

--- a/test/unit/math/mix/fun/digamma_test.cpp
+++ b/test/unit/math/mix/fun/digamma_test.cpp
@@ -3,7 +3,7 @@
 TEST(mathMixMatFun, digamma) {
   auto f = [](const auto& x1) { return stan::math::digamma(x1); };
   stan::test::expect_common_nonzero_unary_vectorized<
-      stan::test::PromoteToComplex::No>(f);
+      stan::test::ScalarSupport::Real>(f);
   stan::test::expect_unary_vectorized(f, -25, -10.2, -1.2, -1, 2.3, 5.7);
 }
 

--- a/test/unit/math/mix/fun/exp_test.cpp
+++ b/test/unit/math/mix/fun/exp_test.cpp
@@ -5,10 +5,11 @@ TEST(mathMixMatFun, exp) {
     using stan::math::exp;
     return exp(x);
   };
-  stan::test::expect_common_unary_vectorized<stan::test::PromoteToComplex::Yes>(
-      f);
-  stan::test::expect_unary_vectorized<stan::test::PromoteToComplex::Yes>(
-      f, -15.2, -10, -0.5, 0.5, 1, 1.0, 1.3, 5, 10);
+  stan::test::expect_common_unary_vectorized<
+      stan::test::ScalarSupport::RealAndComplex>(f);
+  stan::test::expect_unary_vectorized<
+      stan::test::ScalarSupport::RealAndComplex>(f, -15.2, -10, -0.5, 0.5, 1,
+                                                 1.0, 1.3, 5, 10);
   stan::test::expect_complex_common(f);
 
   std::vector<double> com_args = stan::test::internal::common_nonzero_args();

--- a/test/unit/math/mix/fun/log1m_exp_test.cpp
+++ b/test/unit/math/mix/fun/log1m_exp_test.cpp
@@ -3,7 +3,7 @@
 TEST(mathMixMatFun, log1m_exp) {
   auto f = [](const auto& x1) { return stan::math::log1m_exp(x1); };
   stan::test::expect_common_nonzero_unary_vectorized<
-      stan::test::PromoteToComplex::No>(f);
+      stan::test::ScalarSupport::Real>(f);
   stan::test::expect_unary_vectorized(f, -14, -12.6, -2, -1, -0.2, -0.5, 1.3,
                                       3);
 }

--- a/test/unit/math/mix/fun/log1m_inv_logit_test.cpp
+++ b/test/unit/math/mix/fun/log1m_inv_logit_test.cpp
@@ -3,7 +3,7 @@
 TEST(mathMixMatFun, log1mInvLogit) {
   auto f = [](const auto& x1) { return stan::math::log1m_inv_logit(x1); };
   stan::test::expect_common_nonzero_unary_vectorized<
-      stan::test::PromoteToComplex::No>(f);
+      stan::test::ScalarSupport::Real>(f);
   stan::test::expect_unary_vectorized(f, -2.6, -2, -1, -0.5, -0.2, 0.5, 1, 1.3,
                                       3, 5);
 }

--- a/test/unit/math/mix/fun/log1p_exp_test.cpp
+++ b/test/unit/math/mix/fun/log1p_exp_test.cpp
@@ -3,7 +3,7 @@
 TEST(mathMixMatFun, log1pExp) {
   auto f = [](const auto& x1) { return stan::math::log1p_exp(x1); };
   stan::test::expect_common_nonzero_unary_vectorized<
-      stan::test::PromoteToComplex::No>(f);
+      stan::test::ScalarSupport::Real>(f);
   stan::test::expect_unary_vectorized(f, -2.6, -2, -1, -0.5, -0.2, 0.5, 1.0,
                                       1.3, 2, 3);
 

--- a/test/unit/math/mix/fun/sin_test.cpp
+++ b/test/unit/math/mix/fun/sin_test.cpp
@@ -6,9 +6,9 @@ TEST(mathMixMatFun, sin) {
     return sin(x1);
   };
   stan::test::expect_common_nonzero_unary_vectorized<
-      stan::test::PromoteToComplex::No>(f);
-  stan::test::expect_unary_vectorized<stan::test::PromoteToComplex::Yes>(
-      f, -2.6, -2, -0.2, 3, 5, 5.3);
+      stan::test::ScalarSupport::Real>(f);
+  stan::test::expect_unary_vectorized<
+      stan::test::ScalarSupport::RealAndComplex>(f, -2.6, -2, -0.2, 3, 5, 5.3);
   stan::test::expect_complex_common(f);
 }
 

--- a/test/unit/math/mix/fun/sinh_test.cpp
+++ b/test/unit/math/mix/fun/sinh_test.cpp
@@ -6,9 +6,10 @@ TEST(mathMixMatFun, sinh) {
     return sinh(x);
   };
   stan::test::expect_common_nonzero_unary_vectorized<
-      stan::test::PromoteToComplex::No>(f);
-  stan::test::expect_unary_vectorized<stan::test::PromoteToComplex::Yes>(
-      f, -2, -1.2, -0.5, -0.2, 0.5, 1.3, 1.5, 3);
+      stan::test::ScalarSupport::Real>(f);
+  stan::test::expect_unary_vectorized<
+      stan::test::ScalarSupport::RealAndComplex>(f, -2, -1.2, -0.5, -0.2, 0.5,
+                                                 1.3, 1.5, 3);
   stan::test::expect_complex_common(f);
 }
 

--- a/test/unit/math/mix/fun/sqrt_test.cpp
+++ b/test/unit/math/mix/fun/sqrt_test.cpp
@@ -7,7 +7,7 @@ TEST(mathMixMatFun, sqrt) {
     return sqrt(x1);
   };
   stan::test::expect_common_nonzero_unary_vectorized<
-      stan::test::PromoteToComplex::No>(f);
+      stan::test::ScalarSupport::Real>(f);
   stan::test::expect_unary_vectorized(f, -6, -5.2, 1.3, 7, 10.7, 36, 1e6);
 
   // undefined with 0 in denominator

--- a/test/unit/math/mix/fun/tan_test.cpp
+++ b/test/unit/math/mix/fun/tan_test.cpp
@@ -6,9 +6,9 @@ TEST(mathMixMatFun, tan) {
     return tan(x);
   };
   stan::test::expect_common_nonzero_unary_vectorized<
-      stan::test::PromoteToComplex::No>(f);
-  stan::test::expect_unary_vectorized<stan::test::PromoteToComplex::Yes>(
-      f, -2, -0.5, 0.5, 1.5, 3, 4.4);
+      stan::test::ScalarSupport::Real>(f);
+  stan::test::expect_unary_vectorized<
+      stan::test::ScalarSupport::RealAndComplex>(f, -2, -0.5, 0.5, 1.5, 3, 4.4);
   stan::test::expect_complex_common(f);
 }
 

--- a/test/unit/math/mix/fun/tanh_test.cpp
+++ b/test/unit/math/mix/fun/tanh_test.cpp
@@ -6,9 +6,10 @@ TEST(mathMixMatFun, tanh) {
     return tanh(x1);
   };
   stan::test::expect_common_nonzero_unary_vectorized<
-      stan::test::PromoteToComplex::No>(f);
-  stan::test::expect_unary_vectorized<stan::test::PromoteToComplex::Yes>(
-      f, -2.6, -2, -1.2, -0.5, 0.5, 1.5);
+      stan::test::ScalarSupport::Real>(f);
+  stan::test::expect_unary_vectorized<
+      stan::test::ScalarSupport::RealAndComplex>(f, -2.6, -2, -1.2, -0.5, 0.5,
+                                                 1.5);
   stan::test::expect_complex_common(f);
 }
 

--- a/test/unit/math/mix/fun/trigamma_test.cpp
+++ b/test/unit/math/mix/fun/trigamma_test.cpp
@@ -15,7 +15,7 @@ TEST(mathMixMatFun, trigamma) {
   tols.grad_hessian_hessian_ = relative_tolerance(1e-3, 1e-2);
   tols.grad_hessian_grad_hessian_ = relative_tolerance(1e-2, 1e-1);
 
-  expect_unary_vectorized<stan::test::PromoteToComplex::No>(
+  expect_unary_vectorized<stan::test::ScalarSupport::Real>(
       tols, f, -103.52, -0.9, -0.5, 0, 0.5, 1.3, 5.1, 19.2);
 
   // reduce tol_min for first deriv tests one order, second derivs four orders,

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -1247,11 +1247,11 @@ void expect_ad(const F& f, const T1& x1, const T2& x2, const T3& x3) {
 /**
  * Promote to Complex is used by the `expect_ad_vectorized` framework
  *  to specify at compile time whether a function should check
- *  for complex support. By default the value is `No`, meaning that
+ *  for complex support. By default the value is `Real`, meaning that
  *  the test does not promote the input to a complex double when it is running
  *  the test suite.
  */
-enum class PromoteToComplex { No, Yes };
+enum class ScalarSupport { Real, RealAndComplex, ComplexOnly };
 
 /**
  * Test that the specified vectorized polymorphic unary function
@@ -1259,19 +1259,19 @@ enum class PromoteToComplex { No, Yes };
  * double and integer inputs and 1st-, 2nd-, and 3rd-order derivatives
  * consistent with finite differences of double inputs.
  *
- * @tparam PromoteToComplex whether the input should be promoted to a
- * complex<double> for the ad test suite to check whether complex is supported.
- *  This specialization is for when complex support is turned off.
+ * @tparam ScalarSupport whether the input supports real numbers, complex numbers,
+ *  or both.
+ *  This specialization is for real numbers only.
  * @tparam F type of polymorphic, vectorized functor to test
  * @tparam T1 type of first argument (integer or double)
  * @param tols tolerances for test
  * @param f functor to test
  * @param x1 value to test
  */
-template <PromoteToComplex ComplexSupport = PromoteToComplex::No, typename F,
-          typename T1,
-          stan::require_t<stan::bool_constant<
-              ComplexSupport == PromoteToComplex::No>>* = nullptr>
+template <
+    ScalarSupport ComplexSupport = ScalarSupport::Real, typename F, typename T1,
+    stan::require_t<
+        stan::bool_constant<ComplexSupport == ScalarSupport::Real>>* = nullptr>
 void expect_ad_vectorized(const ad_tolerances& tols, const F& f, const T1& x1) {
   using Scalar = std::conditional_t<std::is_integral<T1>::value, double, T1>;
   using matrix_t = Eigen::Matrix<Scalar, -1, -1>;
@@ -1312,18 +1312,18 @@ void expect_ad_vectorized(const ad_tolerances& tols, const F& f, const T1& x1) {
  * double and integer inputs and 1st-, 2nd-, and 3rd-order derivatives
  * consistent with finite differences of double inputs.
  *
- * @tparam PromoteToComplex whether the input should be promoted to a
- * complex<double> for the ad test suite to check whether complex is supported.
- *  This specialization is for when complex numbers are supported.
+ * @tparam ScalarSupport whether the input supports real numbers, complex numbers,
+ *  or both.
+ *  This specialization is for when complex and real numbers are supported.
  * @tparam F type of polymorphic, vectorized functor to test
  * @tparam T1 type of first argument (integer or double)
  * @param tols tolerances for test
  * @param f functor to test
  * @param x1 value to test
  */
-template <PromoteToComplex ComplexSupport, typename F, typename T1,
+template <ScalarSupport ComplexSupport, typename F, typename T1,
           stan::require_t<stan::bool_constant<
-              ComplexSupport == PromoteToComplex::Yes>>* = nullptr>
+              ComplexSupport == ScalarSupport::RealAndComplex>>* = nullptr>
 void expect_ad_vectorized(const ad_tolerances& tols, const F& f, const T1& x1) {
   using Scalar = std::conditional_t<std::is_integral<T1>::value, double, T1>;
   using matrix_t = Eigen::Matrix<Scalar, -1, -1>;
@@ -1392,18 +1392,84 @@ void expect_ad_vectorized(const ad_tolerances& tols, const F& f, const T1& x1) {
 }
 
 /**
+ * Test that the specified vectorized polymorphic unary function
+ * produces autodiff results consistent with values determined by
+ * double and integer inputs and 1st-, 2nd-, and 3rd-order derivatives
+ * consistent with finite differences of double inputs.
+ *
+ * @tparam ScalarSupport whether the input supports real numbers, complex numbers,
+ *  or both.
+ *  This specialization is for when only complex numbers are supported.
+ * @tparam F type of polymorphic, vectorized functor to test
+ * @tparam T1 type of first argument (integer or double)
+ * @param tols tolerances for test
+ * @param f functor to test
+ * @param x1 value to test
+ */
+template <ScalarSupport ComplexSupport, typename F, typename T1,
+          stan::require_t<stan::bool_constant<
+              ComplexSupport == ScalarSupport::ComplexOnly>>* = nullptr>
+void expect_ad_vectorized(const ad_tolerances& tols, const F& f, const T1& x1) {
+  using Scalar = std::conditional_t<std::is_integral<T1>::value, double, T1>;
+  using complex_t = std::complex<double>;
+  using complex_matrix_t = Eigen::Matrix<complex_t, -1, -1>;
+  using complex_vector_t = Eigen::Matrix<complex_t, -1, 1>;
+  using complex_row_vector_t = Eigen::Matrix<complex_t, 1, -1>;
+  using std::vector;
+  using vector_complex = vector<complex_t>;
+  using vector2_complex = vector<vector_complex>;
+  using vector3_complex = vector<vector2_complex>;
+
+  expect_ad(tols, f, std::complex<double>(static_cast<Scalar>(x1)));
+  for (int i = 0; i < 2; ++i) {
+    expect_ad(tols, f, complex_vector_t::Constant(i, x1).eval());
+  }
+  for (int i = 0; i < 2; ++i) {
+    expect_ad(tols, f, complex_row_vector_t::Constant(i, x1).eval());
+  }
+  for (int i = 0; i < 2; ++i) {
+    expect_ad(tols, f, complex_matrix_t::Constant(i, i, x1).eval());
+  }
+  for (size_t i = 0; i < 2; ++i) {
+    expect_ad(tols, f, vector_complex(i, x1));
+  }
+  for (size_t i = 0; i < 2; ++i) {
+    expect_ad(
+        tols, f,
+        vector<complex_vector_t>(i, complex_vector_t::Constant(i, x1).eval()));
+  }
+  for (size_t i = 0; i < 2; ++i) {
+    expect_ad(tols, f,
+              vector<complex_row_vector_t>(
+                  i, complex_row_vector_t::Constant(i, x1).eval()));
+  }
+  for (size_t i = 0; i < 2; ++i) {
+    expect_ad(tols, f,
+              vector<complex_matrix_t>(
+                  i, complex_matrix_t::Constant(i, i, x1).eval()));
+  }
+  for (int i = 0; i < 2; ++i) {
+    expect_ad(tols, f, vector2_complex(i, vector_complex(i, x1)));
+  }
+  for (int i = 0; i < 2; ++i) {
+    expect_ad(tols, f,
+              vector3_complex(i, vector2_complex(i, vector_complex(i, x1))));
+  }
+}
+
+/**
  * Test that the specified function has value and 1st-, 2nd-, and
  * 3rd-order derivatives consistent with primitive values and finite
  * differences using default tolerances.
  *
- * @tparam PromoteToComplex whether the input should be promoted to a
- * complex<double> for the ad test suite to check whether complex is supported.
+ * @tparam ScalarSupport whether the input supports real numbers, complex numbers,
+ *  or both.
  * @tparam F type of function
  * @tparam T type of argument
  * @param f function to test
  * @param x argument to test
  */
-template <PromoteToComplex ComplexSupport = PromoteToComplex::No, typename F,
+template <ScalarSupport ComplexSupport = ScalarSupport::Real, typename F,
           typename T>
 void expect_ad_vectorized(const F& f, const T& x) {
   ad_tolerances tols;
@@ -1801,15 +1867,15 @@ void expect_complex_common_comparison(const F& f) {
  * input type.  The value for containers must be the same as applying
  * the scalar function elementwise.
  *
- * @tparam PromoteToComplex whether the input should be promoted to a
- * complex<double> for the ad test suite to check whether complex is supported.
+ * @tparam ScalarSupport whether the input supports real numbers, complex numbers,
+ *  or both.
  *  This specialization is for whenever complex numbers are not supported.
  * @tparam F type of functor to test
  * @param f functor to test
  */
 template <
-    PromoteToComplex ComplexSupport = PromoteToComplex::No, typename F,
-    require_t<bool_constant<ComplexSupport == PromoteToComplex::No>>* = nullptr>
+    ScalarSupport ComplexSupport = ScalarSupport::Real, typename F,
+    require_t<bool_constant<ComplexSupport == ScalarSupport::Real>>* = nullptr>
 void expect_common_unary_vectorized(const F& f) {
   ad_tolerances tols;
   auto args = internal::common_args();
@@ -1832,15 +1898,15 @@ void expect_common_unary_vectorized(const F& f) {
  * input type.  The value for containers must be the same as applying
  * the scalar function elementwise.
  *
- * @tparam PromoteToComplex whether the input should be promoted to a
- * complex<double> for the ad test suite to check whether complex is supported.
- *  This specialization is for when complex numbers are supported.
+ * @tparam ScalarSupport whether the input supports real numbers, complex numbers,
+ *  or both.
+ *  This specialization is for when complex and real numbers are supported.
  * @tparam F type of functor to test
  * @param f functor to test
  */
-template <PromoteToComplex ComplexSupport, typename F,
+template <ScalarSupport ComplexSupport, typename F,
           require_t<bool_constant<ComplexSupport
-                                  == PromoteToComplex::Yes>>* = nullptr>
+                                  == ScalarSupport::RealAndComplex>>* = nullptr>
 void expect_common_unary_vectorized(const F& f) {
   ad_tolerances tols;
   auto args = internal::common_args();
@@ -1853,7 +1919,36 @@ void expect_common_unary_vectorized(const F& f) {
     stan::test::expect_ad_vectorized<ComplexSupport>(tols, f, x1);
 }
 
-template <PromoteToComplex ComplexSupport = PromoteToComplex::No, typename F>
+
+
+/**
+ * Test that the specified vectorized unary function produces the same
+ * results and exceptions, and has 1st-, 2nd-, and 3rd-order
+ * derivatives consistent with finite differences as returned by the
+ * primitive version of the function when applied to all common
+ * arguments.  Uses default tolerances.
+ *
+ * <p>The function must be defined from scalars to scalars and from
+ * containers to containers, always producing the same output type as
+ * input type.  The value for containers must be the same as applying
+ * the scalar function elementwise.
+ *
+ * @tparam ScalarSupport whether the input supports real numbers, complex numbers,
+ *  or both.
+ *  This specialization is for when only complex numbers are supported.
+ * @tparam F type of functor to test
+ * @param f functor to test
+ */
+template <ScalarSupport ComplexSupport, typename F,
+          require_t<bool_constant<ComplexSupport
+                                  == ScalarSupport::ComplexOnly>>* = nullptr>
+void expect_common_unary_vectorized(const F& f) {
+  ad_tolerances tols;
+  for (auto x1 : common_complex())
+    stan::test::expect_ad_vectorized<ComplexSupport>(tols, f, x1);
+}
+
+template <ScalarSupport ComplexSupport = ScalarSupport::Real, typename F>
 void expect_unary_vectorized(const ad_tolerances& tols, const F& f) {}
 
 /**
@@ -1862,16 +1957,15 @@ void expect_unary_vectorized(const ad_tolerances& tols, const F& f) {}
  * differences.  Tests both scalar and container behavior.  Integer
  * arguments will be preserved through to function calls.
  *
- * @tparam PromoteToComplex whether the input should be promoted to a
- * complex<double> for the ad test suite to check whether complex is supported.
- *  This specialization is for when complex numbers are supported.
+ * @tparam ScalarSupport whether the input supports real numbers, complex numbers,
+ *  or both.
  * @tparam F type of function
  * @tparam Ts types of arguments
  * @param tols test relative tolerances
  * @param f function to test
  * @param xs arguments to test
  */
-template <PromoteToComplex ComplexSupport = PromoteToComplex::No, typename F,
+template <ScalarSupport ComplexSupport = ScalarSupport::Real, typename F,
           typename T, typename... Ts>
 void expect_unary_vectorized(const ad_tolerances& tols, const F& f, T x,
                              Ts... xs) {
@@ -1884,14 +1978,14 @@ void expect_unary_vectorized(const ad_tolerances& tols, const F& f, T x,
  * values for the specified values that are consistent with primitive
  * values and finite differences.  Tests both scalars and containers.
  *
- * @tparam PromoteToComplex whether the input should be promoted to a
- * complex<double> for the ad test suite to check whether complex is supported.
+ * @tparam ScalarSupport whether the input supports real numbers, complex numbers,
+ *  or both.
  * @tparam F type of function to test
  * @tparam Ts type of remaining arguments to test
  * @param f function to test
  * @param xs arguments to test
  */
-template <PromoteToComplex ComplexSupport = PromoteToComplex::No, typename F,
+template <ScalarSupport ComplexSupport = ScalarSupport::Real, typename F,
           require_not_same_t<F, ad_tolerances>* = nullptr, typename... Ts>
 void expect_unary_vectorized(const F& f, Ts... xs) {
   ad_tolerances tols;  // default tolerances
@@ -1905,15 +1999,15 @@ void expect_unary_vectorized(const F& f, Ts... xs) {
  * when applied to all common non-zero integer and double arguments.
  * This includes tests for standard vector and Eigen vector containers.
  *
- * @tparam PromoteToComplex whether the input should be promoted to a
- * complex<double> for the ad test suite to check whether complex is supported.
+ * @tparam ScalarSupport whether the input supports real numbers, complex numbers,
+ *  or both.
  *  This specialization is for when complex numbers are not supported.
  * @tparam F type of functor to test
  * @param f functor to test
  */
-template <PromoteToComplex ComplexSupport = PromoteToComplex::No, typename F,
+template <ScalarSupport ComplexSupport = ScalarSupport::Real, typename F,
           stan::require_t<stan::bool_constant<
-              ComplexSupport == PromoteToComplex::No>>* = nullptr>
+              ComplexSupport == ScalarSupport::Real>>* = nullptr>
 void expect_common_nonzero_unary_vectorized(const F& f) {
   ad_tolerances tols;
   for (double x : internal::common_nonzero_args())
@@ -1929,21 +2023,44 @@ void expect_common_nonzero_unary_vectorized(const F& f) {
  * when applied to all common non-zero integer and double arguments.
  * This includes tests for standard vector and Eigen vector containers.
  *
- * @tparam PromoteToComplex whether the input should be promoted to a
- * complex<double> for the ad test suite to check whether complex is supported.
- *  This specialization is for when complex numbers are supported.
+ * @tparam ScalarSupport whether the input supports real numbers, complex numbers,
+ *  or both.
+ *  This specialization is for when complex and real numbers are supported.
  * @tparam F type of functor to test
  * @param f functor to test
  */
-template <PromoteToComplex ComplexSupport, typename F,
+template <ScalarSupport ComplexSupport, typename F,
           stan::require_t<stan::bool_constant<
-              ComplexSupport == PromoteToComplex::Yes>>* = nullptr>
+              ComplexSupport == ScalarSupport::RealAndComplex>>* = nullptr>
 void expect_common_nonzero_unary_vectorized(const F& f) {
   ad_tolerances tols;
   for (double x : internal::common_nonzero_args())
     stan::test::expect_unary_vectorized<ComplexSupport>(tols, f, x);
   for (int x : internal::common_nonzero_int_args())
     stan::test::expect_unary_vectorized<ComplexSupport>(tols, f, x);
+  for (auto x1 : common_complex())
+    stan::test::expect_ad_vectorized<ComplexSupport>(tols, f, x1);
+}
+
+
+/**
+ * Test that the specified vectorized unary function produces the same
+ * results and exceptions, and has derivatives consistent with finite
+ * differences as returned by the primitive version of the function
+ * when applied to all common non-zero integer and double arguments.
+ * This includes tests for standard vector and Eigen vector containers.
+ *
+ * @tparam ScalarSupport whether the input supports real numbers, complex numbers,
+ *  or both.
+ *  This specialization is for when only complex numbers are supported.
+ * @tparam F type of functor to test
+ * @param f functor to test
+ */
+template <ScalarSupport ComplexSupport, typename F,
+          stan::require_t<stan::bool_constant<
+              ComplexSupport == ScalarSupport::ComplexOnly>>* = nullptr>
+void expect_common_nonzero_unary_vectorized(const F& f) {
+  ad_tolerances tols;
   for (auto x1 : common_complex())
     stan::test::expect_ad_vectorized<ComplexSupport>(tols, f, x1);
 }

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -306,8 +306,8 @@ TEST(testAd, integerGetsPassedVectorized) {
   baz_double = 0;
   baz_var = 0;
   baz_fvar = 0;
-  stan::test::expect_common_unary_vectorized<stan::test::PromoteToComplex::Yes>(
-      h);
+  stan::test::expect_common_unary_vectorized<
+      stan::test::ScalarSupport::RealAndComplex>(h);
   EXPECT_GT(baz_int, 0);  // int version gets called
   EXPECT_GT(baz_double, 0);
   EXPECT_GT(baz_var, 0);


### PR DESCRIPTION
## Summary

This vectorizes the `conj` function.

## Tests

This did a minor re-write of the vectorization test framework to add the option for functions which _only_ support complex inputs. 
This changed the enum we use for settings accordingly:
```diff
-enum class PromoteToComplex { No, Yes };
+enum class ScalarSupport { Real, RealAndComplex, ComplexOnly };
```

## Side Effects

Many test files changed as part of that renaming, but none of them changed in meaning.

## Release notes

The `conj` function is vectorized for Eigen and std::vector types.

## Checklist

- [x] Math issue: Closes #2815 

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
