### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/header_checks.yml
+++ b/.github/workflows/header_checks.yml
@@ -13,8 +13,14 @@ on:
       - 'README.md'
       - 'RELEASE-NOTES.txt'
 
+permissions:
+  contents: read
+
 jobs:
   windows:
+    permissions:
+      actions: write  # for n1hility/cancel-previous-runs to create & stop workflow runs
+      contents: read  # for actions/checkout to fetch code
     name: Windows
     runs-on: windows-latest
 
@@ -47,6 +53,9 @@ jobs:
       run: make -j2 test-headers
 
   opencl:
+    permissions:
+      actions: write  # for n1hility/cancel-previous-runs to create & stop workflow runs
+      contents: read  # for actions/checkout to fetch code
     name: OpenCL
     runs-on: ubuntu-latest
 
@@ -64,6 +73,9 @@ jobs:
         echo "STAN_OPENCL=true" > make/local
         make -j2 test-headers
   no_range_checks:
+    permissions:
+      actions: write  # for n1hility/cancel-previous-runs to create & stop workflow runs
+      contents: read  # for actions/checkout to fetch code
     name: NoRange
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,14 @@ on:
       - 'LICENSE.md'
       - 'README.md'
       - 'RELEASE-NOTES.txt'
+permissions:
+  contents: read
+
 jobs:
   prim-rev:
+    permissions:
+      actions: write  # for n1hility/cancel-previous-runs to create & stop workflow runs
+      contents: read  # for actions/checkout to fetch code
     name: prim and rev tests
     runs-on: windows-latest
 


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using [secure-workflows](https://github.com/step-security/secure-workflows).

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes. Here is an example of the permissions in one of the workflow runs:
https://github.com/stan-dev/math/actions/runs/3153019054/jobs/5128975789#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- header_checks.yml
- main.yml


### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- [GitHub recommends](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) defining minimum GITHUB_TOKEN permissions.
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>