### PR TITLE
Patch Eigen to resolve FFT forward derivative issue

### DIFF
--- a/lib/eigen_3.3.9/unsupported/Eigen/src/FFT/ei_kissfft_impl.h
+++ b/lib/eigen_3.3.9/unsupported/Eigen/src/FFT/ei_kissfft_impl.h
@@ -31,7 +31,8 @@ struct kiss_cpx_fft
       using std::acos;
       m_inverse = inverse;
       m_twiddles.resize(nfft);
-      Scalar phinc =  (inverse?2:-2)* acos( (Scalar) -1)  / nfft;
+      // STAN CHANGE: The next line originally cast -1 to Scalar, which breaks derivatives
+      Scalar phinc =  (inverse?2:-2)* acos(-1.0)  / nfft;
       for (int i=0;i<nfft;++i)
         m_twiddles[i] = exp( Complex(0,i*phinc) );
     }

--- a/test/unit/math/ad_tolerances.hpp
+++ b/test/unit/math/ad_tolerances.hpp
@@ -69,34 +69,6 @@ struct ad_tolerances {
         grad_hessian_grad_hessian_(1e-2) {}
 };
 
-/**
- * Return tolerances that are infinite other than for the value
- * tolerance and gradient tolerance for reverse mode.
- *
- * @param val_tol value relative tolerance (default `1e-8`)
- * @param grad_tol gradient relative tolerance (default `1e-4`)
- */
-ad_tolerances reverse_only_ad_tolerances(double val_tol = 1e-8,
-                                         double grad_tol = 1e-4) {
-  ad_tolerances tols;
-  tols.gradient_val_ = val_tol;
-  tols.gradient_grad_ = grad_tol;
-  constexpr double inf = std::numeric_limits<double>::infinity();
-  tols.gradient_grad_varmat_matvar_ = inf;
-  tols.gradient_fvar_val_ = inf;
-  tols.gradient_fvar_grad_ = inf;
-  tols.hessian_val_ = inf;
-  tols.hessian_grad_ = inf;
-  tols.hessian_hessian_ = inf;
-  tols.hessian_fvar_val_ = inf;
-  tols.hessian_fvar_grad_ = inf;
-  tols.hessian_fvar_hessian_ = inf;
-  tols.grad_hessian_val_ = inf;
-  tols.grad_hessian_hessian_ = inf;
-  tols.grad_hessian_grad_hessian_ = inf;
-  return tols;
-}
-
 }  // namespace test
 }  // namespace stan
 #endif

--- a/test/unit/math/mix/fun/fft_test.cpp
+++ b/test/unit/math/mix/fun/fft_test.cpp
@@ -1,6 +1,5 @@
 #include <test/unit/math/test_ad.hpp>
 
-
 void expect_fft(const Eigen::VectorXcd& x) {
   for (int m = 0; m < x.rows(); ++m) {
     auto g = [m](const auto& x) {

--- a/test/unit/math/mix/fun/fft_test.cpp
+++ b/test/unit/math/mix/fun/fft_test.cpp
@@ -1,13 +1,13 @@
 #include <test/unit/math/test_ad.hpp>
 
+
 void expect_fft(const Eigen::VectorXcd& x) {
-  stan::test::ad_tolerances tols = stan::test::reverse_only_ad_tolerances();
   for (int m = 0; m < x.rows(); ++m) {
     auto g = [m](const auto& x) {
       using stan::math::fft;
       return fft(x)(m);
     };
-    stan::test::expect_ad(tols, g, x);
+    stan::test::expect_ad(g, x);
   }
 }
 
@@ -41,13 +41,12 @@ TEST(mathMixFun, fft) {
 }
 
 void expect_inv_fft(const Eigen::VectorXcd& x) {
-  stan::test::ad_tolerances tols = stan::test::reverse_only_ad_tolerances();
   for (int m = 0; m < x.rows(); ++m) {
     auto g = [m](const auto& x) {
       using stan::math::inv_fft;
       return inv_fft(x)(m);
     };
-    stan::test::expect_ad(tols, g, x);
+    stan::test::expect_ad(g, x);
   }
 }
 
@@ -81,14 +80,13 @@ TEST(mathMixFun, invFft) {
 }
 
 void expect_fft2(const Eigen::MatrixXcd& x) {
-  stan::test::ad_tolerances tols = stan::test::reverse_only_ad_tolerances();
   for (int n = 0; n < x.cols(); ++n) {
     for (int m = 0; m < x.rows(); ++m) {
       auto g = [m, n](const auto& x) {
         using stan::math::fft2;
         return fft2(x)(m, n);
       };
-      stan::test::expect_ad(tols, g, x);
+      stan::test::expect_ad(g, x);
     }
   }
 }
@@ -129,14 +127,13 @@ TEST(mathMixFun, fft2) {
 }
 
 void expect_inv_fft2(const Eigen::MatrixXcd& x) {
-  stan::test::ad_tolerances tols = stan::test::reverse_only_ad_tolerances();
   for (int n = 0; n < x.cols(); ++n) {
     for (int m = 0; m < x.rows(); ++m) {
       auto g = [m, n](const auto& x) {
         using stan::math::inv_fft2;
         return inv_fft2(x)(m, n);
       };
-      stan::test::expect_ad(tols, g, x);
+      stan::test::expect_ad(g, x);
     }
   }
 }

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -334,25 +334,12 @@ template <typename G>
 void expect_ad_derivatives(const ad_tolerances& tols, const G& g,
                            const Eigen::VectorXd& x) {
   double gx = g(x);
-  if (!tols.gradient_val_.is_inf() || !tols.gradient_grad_.is_inf()) {
-    test_gradient(tols, g, x, gx);
-  }
+  test_gradient(tols, g, x, gx);
 #ifndef STAN_MATH_TESTS_REV_ONLY
-  if (!tols.gradient_fvar_val_.is_inf() || !tols.gradient_fvar_grad_.is_inf()) {
-    test_gradient_fvar(tols, g, x, gx);
-  }
-  if (!tols.hessian_val_.is_inf() || !tols.hessian_grad_.is_inf()
-      || !tols.hessian_hessian_.is_inf()) {
-    test_hessian(tols, g, x, gx);
-  }
-  if (!tols.hessian_fvar_val_.is_inf() || !tols.hessian_fvar_grad_.is_inf()
-      || !tols.hessian_hessian_.is_inf()) {
-    test_hessian_fvar(tols, g, x, gx);
-  }
-  if (!tols.grad_hessian_val_.is_inf() || !tols.grad_hessian_hessian_.is_inf()
-      || !tols.grad_hessian_grad_hessian_.is_inf()) {
-    test_grad_hessian(tols, g, x, gx);
-  }
+  test_gradient_fvar(tols, g, x, gx);
+  test_hessian(tols, g, x, gx);
+  test_hessian_fvar(tols, g, x, gx);
+  test_grad_hessian(tols, g, x, gx);
 #endif
 }
 


### PR DESCRIPTION
## Summary

The FFT functions introduced in #2686 disabled forward-mode autodiff due to it failing. 

I was finally able to track down the issue, which stems from this one line in Eigen's main FFT implementation:
https://github.com/stan-dev/math/blob/cd60e75a4e63fa5c321ed6effcf825adfbde92c0/lib/eigen_3.3.9/unsupported/Eigen/src/FFT/ei_kissfft_impl.h#L34

The code above uses `acos(-1)` as a shorthand for $\pi$. But, it also casts -1 to the input scalar type, in our case, `fvar<T>`. The derivative of acos is only defined for `-1 < x < 1`, so this creates an NaN which eventually propagates everywhere. But, this number is really just a constant, so we don't need to autodiff it.

There are two options I think for fixing this:

1. What is currently done here, which is just patch the FFT module to remove that scalar cast. 
   ```diff
   --      Scalar phinc =  (inverse?2:-2)* acos( (Scalar) -1)  / nfft;
   ++      // STAN CHANGE: The next line originally cast -1 to Scalar, which breaks derivatives
   ++      Scalar phinc =  (inverse?2:-2)* acos(-1.0)  / nfft;
   ```
2. Use Eigen 3.4's FFT module or update Eigen (#2583). As part of improving the code of the function in question, they removed the offending call to `acos`. @andrjohns @SteveBronder - how close do you think an update is?

If we go with option 1, we won't need to maintain this into the future since the next Eigen update will fix this anyway.

## Tests

This enables forward mode testing for the FFT functions. It also deletes the code which was used to disable them, since it was not used elsewhere (and likely should not be in the future).

## Side Effects

None

## Release notes

Fixed forward mode autodiff for FFT functions.

## Checklist

- [ ] Math issue 

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
