### PR TITLE
Fix broken wiki links in documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,8 +2,7 @@
 
 Thanks for reading! We love contributions from everyone in the form of good discussion, issues, and pull requests.
 
-This is the short version. There's more information on the [wiki](https://github.com/stan-dev/math/wiki/Developer-Doc#contributing).
-
+This is the short version. There's more information on the [documentation site](https://mc-stan.org/math/developer_guide.html).
 ## Issues
 
 We reserve [issues](https://github.com/stan-dev/math/issues) for bugs and feature requests that are defined well enough for a developer to tackle. If you have general questions about the Math library, please see the [Discussion](#discussion) section.
@@ -31,22 +30,22 @@ Open feature requests should be the ones we want to implement in the Math librar
 
 ## Pull Requests
 
-All changes to the Math library are handled through [pull requests](https://github.com/stan-dev/math/pulls). Each pull request should correspond to an issue. We follow a [modified GitFlow branching model](https://github.com/stan-dev/stan/wiki/Dev:-Git-Process) for development.
+All changes to the Math library are handled through [pull requests](https://github.com/stan-dev/math/pulls). Each pull request should correspond to an issue. We follow a [modified GitFlow branching model](https://github.com/stan-dev/stan/wiki/Developer-process-overview#2-create-a-branch-for-the-issue) for development.
 
 When a contributor creates a pull request for inclusion to the Math library, here are some of the things we expect:
 
-1. the contribution maintains the Math library's open-source [license](https://github.com/stan-dev/math/wiki/Developer-Doc#licensing): 3-clause BSD
+1. the contribution maintains the Math library's open-source [license](https://github.com/stan-dev/stan/wiki/Stan-Licensing): 3-clause BSD
 2. the code base remains stable after merging the pull request; we expect the `develop` branch to always be in a good state
 3. the changes are maintainable. In code review, we look at the design of the proposed code. We also expect documentation. It should look like idiomatic C++.
 4. the changes are tested. For bugs, we expect at least one test that fails before the patch and is fixed after the patch. For new features, we expect at least one test that shows expected behavior and one test that shows the behavior when there's an error.
-5. the changes adhere to the Math library's [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality). Consistency really helps.
+5. the changes adhere to the Math library's [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms). Consistency really helps.
 
 Pull requests are code reviewed after they pass our continuous integration tests. We expect all the above before a pull request is merged. We are an open-source project and once code makes it into the repository, it's on the community to maintain.
 
 It is the responsibility of the contributor submitting the pull request that the code meets these requirements. We're open-source. Once the code gets into the code base, the community of developers take ownership of it.
 
 ### Code Reviews
-See the [Code Review Guidelines](https://github.com/stan-dev/math/wiki/Developer-Doc#code-review-guidelines) on the Math wiki.
+See the [Code Review Guidelines](https://github.com/stan-dev/stan/wiki/Developer-process-overview#code-review-guidelines) on the Math wiki.
 
 
 ## Discussion

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Thanks for submitting a pull request! Please remove this text when submitting.
 
-Start by filling in the Summary, Tests, and Side Effects sections of this pull request and then work through the handy checklist at the bottom. If anything significant is missing, the pull request may be closed until it's ready. The full guidebook on how pull requests are reviewed is here: [Code Review Guidelines](https://github.com/stan-dev/math/wiki/Developer-Doc#code-review-guidelines).
+Start by filling in the Summary, Tests, and Side Effects sections of this pull request and then work through the handy checklist at the bottom. If anything significant is missing, the pull request may be closed until it's ready. The full guidebook on how pull requests are reviewed is here: [Code Review Guidelines](https://github.com/stan-dev/stan/wiki/Developer-process-overview#code-review-guidelines).
 
 ## Summary
 
@@ -40,7 +40,7 @@ Replace this text with a short note on what will change if this pull request is 
     - header checks pass, (`make test-headers`)
     - dependencies checks pass, (`make test-math-dependencies`)
     - docs build, (`make doxygen`)
-    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)
+    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)
 
 - [ ] the code is written in idiomatic C++ and changes are documented in the doxygen
 

--- a/doxygen/contributor_help_pages/developer_doc.md
+++ b/doxygen/contributor_help_pages/developer_doc.md
@@ -43,11 +43,7 @@ We're committed to having a permissive open-source license. The Math library is 
 
 # Contributing {#contribution}
 
-Thanks for reading! We love contributions from everyone in the form of discussions, issues, and pull requests.
-
-This is the short version. There's more information on the [wiki](https://github.com/stan-dev/math/wiki/Developer-Doc#contributing).
-
-It is the responsibility of the contributor submitting the pull request that the code meets these requirements. We're open-source. Once the code gets into the code base, the community of developers take ownership of it.
+Thanks for reading! We love contributions from everyone in the form of good discussion, issues, and pull requests.
 
 ## Issues
 
@@ -76,29 +72,30 @@ Open feature requests should be the ones we want to implement in the Math librar
 
 ## Pull Requests
 
-All changes to the Math library are handled through [pull requests](https://github.com/stan-dev/math/pulls). Each pull request should correspond to an issue. We follow a [modified GitFlow branching model](https://github.com/stan-dev/stan/wiki/Dev:-Git-Process) for development.
+All changes to the Math library are handled through [pull requests](https://github.com/stan-dev/math/pulls). Each pull request should correspond to an issue. We follow a [modified GitFlow branching model](https://github.com/stan-dev/stan/wiki/Developer-process-overview#2-create-a-branch-for-the-issue) for development.
 
 When a contributor creates a pull request for inclusion to the Math library, here are some of the things we expect:
 
-1. the contribution maintains the Math library's open-source [license](https://github.com/stan-dev/math/wiki/Developer-Doc#licensing): 3-clause BSD
+1. the contribution maintains the Math library's open-source [license](https://github.com/stan-dev/stan/wiki/Stan-Licensing): 3-clause BSD
 2. the code base remains stable after merging the pull request; we expect the `develop` branch to always be in a good state
-3. the changes are maintainable. In code review, we look at the design of the proposed code. We also expect documentation.
+3. the changes are maintainable. In code review, we look at the design of the proposed code. We also expect documentation. It should look like idiomatic C++.
 4. the changes are tested. For bugs, we expect at least one test that fails before the patch and is fixed after the patch. For new features, we expect at least one test that shows expected behavior and one test that shows the behavior when there's an error.
-5. the changes adhere to the Math library's [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality). Consistency really helps.
+5. the changes adhere to the Math library's [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms). Consistency really helps.
 
 Pull requests are code reviewed after they pass our continuous integration tests. We expect all the above before a pull request is merged. We are an open-source project and once code makes it into the repository, it's on the community to maintain.
 
-### Code Reviews
-See the [Code Review Guidelines](https://github.com/stan-dev/math/wiki/Developer-Doc#code-review-guidelines) on the Math wiki.
+It is the responsibility of the contributor submitting the pull request that the code meets these requirements. We're open-source. Once the code gets into the code base, the community of developers take ownership of it.
 
 
-## Discussion {#discussion}
+## Discussion
 
-For general questions, please ask on the forums with the ["Developers" tag](https://discourse.mc-stan.org/c/stan-dev).
-
+For general questions, please ask on the forums with the ["Developers" tag](http://discourse.mc-stan.org/c/stan-dev).
 
 
 # Code Review Guidelines {#code-review-guidelines}
+
+(These are also listed on the
+[wiki](https://github.com/stan-dev/stan/wiki/Developer-process-overview#code-review-guidelines))
 
 All pull requests must have these things:
 
@@ -109,7 +106,7 @@ All pull requests must have these things:
     - code design. It should either be designed with well-known C++ patterns or there should be a good reason it isn't.
     - documentation. The documentation that goes with the changes should go in this pull request.
 4. the changes are tested. Please verify that there's at least one new test that forces the code to execute. Please also verify there's at least one test that shows how to handle errors in the code. Having just these two tests (without full coverage) is usually enough to trap errors in the future. It is also enough to use these to refactor the code when the time comes.
-5. the changes adhere to the Math library's [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality). This is a large code base. We want the quality to be consistent so it's easy to navigate and understand other parts of the code base.
+5. the changes adhere to the Math library's [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms). This is a large code base. We want the quality to be consistent so it's easy to navigate and understand other parts of the code base.
 
 Most of the above is subjective, so please use your best judgement.
 
@@ -280,14 +277,20 @@ The easiest way to build and run tests is to use the `runTests.py` python script
 
 ## Misc: Stan Testing
 
-The [Stan testing](https://github.com/stan-dev/stan/wiki/Testing-Stan-using-Gnu-Make-and-Python) process depends on the makefiles in Math.
+The [Stan testing](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms#unit-testing) process depends on the makefiles in Math.
 
 
 
 # Where do I create a new issue
 
-Stan's development is across multiple repositories. See this page for details on where to put new issues:
-https://github.com/stan-dev/stan/wiki/Where-do-I-create-a-new-issue
+Stan's development is across multiple repositories. When in doubt of which one
+to open an issue in, we ask that you make your best guess. We can always move it for you.
+
+Language or compiler issues: stanc3
+
+Algorithm issues: stan
+
+Function or derivative issues: math
 
 # Running tests from the math library
 

--- a/doxygen/parallelism_support/threading_tbb.md
+++ b/doxygen/parallelism_support/threading_tbb.md
@@ -33,7 +33,7 @@ Threading support requires a fully C++11 compliant compiler which has a working 
 The compiler support for the C++11 `thread_local` keyword for the major open-source compilers is available since these versions:
 
 - GNU g++ 4.8.1, [see here](https://gcc.gnu.org/projects/cxx-status.html); please also add `-pthread` to the `CXXFLAGS` variable
-- clang++ 3.3, [see here](https://clang.llvm.org/cxx_status.html)  
+- clang++ 3.3, [see here](https://clang.llvm.org/cxx_status.html)
   Note: clang + linux long had issues with `thread_local` which should be fixed with clang >=4.0
 
 ## Mac OS X
@@ -58,4 +58,4 @@ With `clang` on linux there are issues during the linking step of programs which
 
 Known to work:
 - RTools 3.5 for Windows which uses mingw g++ 4.9.1 (since stan-math 2.20.0)
-- RTools 4.0 for Windows with a port of GNU g++ 8.2 see [here](https://github.com/stan-dev/rstan/wiki/Using-RStan-with-the-R-3.6.0-Prerelease-on-Windows) but that compiler can also be used with CmdStan
+- RTools 4.0 for Windows with a port of GNU g++ 8.2, that compiler can also be used with CmdStan

--- a/doxygen/pretty_stuff/layout.xml
+++ b/doxygen/pretty_stuff/layout.xml
@@ -2,11 +2,11 @@
 <navindex>
   <tab type="user" url="index.html" title="Overview" />
   <tab type="usergroup" visible="yes" title="Contributor Guides" url="@ref contributing" intro="">
+      <tab type="usergroup" visible="yes" title="Developer Guide" url="@ref developer_guide" intro=""/>
       <tab type="usergroup" visible="yes" title="Adding New Functions" url="@ref getting_started" intro=""/>
       <tab type="usergroup" visible="yes" title="Adding New Distributions" url="@ref new_distribution" intro=""/>
-      <tab type="usergroup" visible="yes" title="Using requires for general overloads" url="@ref require_meta_doc" intro=""/>
       <tab type="usergroup" visible="yes" title="Common Pitfalls" url="@ref common_pitfalls" intro=""/>
-      <tab type="usergroup" visible="yes" title="Developer Guide" url="@ref developer_guide" intro=""/>
+      <tab type="usergroup" visible="yes" title="Using requires for general overloads" url="@ref require_meta_doc" intro=""/>
       <tab type="usergroup" visible="yes" title="Reverse Mode Types" url="@ref reverse_mode_types" intro=""/>
       <tab type="usergroup" visible="yes" title="Testing Automatic Differentiation Functions" url="@ref autodiff_test_guide" intro=""/>
       <tab type="usergroup" visible="yes" title="Testing New Distributions" url="@ref dist_tests" intro=""/>

--- a/makefile
+++ b/makefile
@@ -25,9 +25,7 @@ include make/clang-tidy
 help:
 	@echo '--------------------------------------------------------------------------------'
 	@echo 'Note: testing of Math is typically done with the `runTests.py` python script.'
-	@echo '  See https://github.com/stan-dev/math/wiki/Developer-Doc#building-and-running-tests'
-	@echo '  for more detail on testing.'
-	@echo  ''
+	@echo ''
 	@echo 'Stan Math makefile:'
 	@$(MAKE) print-compiler-flags
 	@echo 'Tests:'

--- a/runTests.py
+++ b/runTests.py
@@ -236,8 +236,7 @@ def runTest(name, run_all=False, mpi=False, j=1):
     if mpi:
         if not commandExists("mpirun"):
             stopErr(
-                "Error: need to have mpi (and mpirun) installed to run mpi tests"
-                + "\nCheck https://github.com/stan-dev/stan/wiki/Parallelism-using-MPI-in-Stan for more details.",
+                "Error: need to have mpi (and mpirun) installed to run mpi tests",
                 -1,
             )
         if "mpi_" in name:


### PR DESCRIPTION

## Summary

This is a follow on to #2805 which deletes or updates links in the Math repo. Many of the existing links are to wiki pages which no longer exist.

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
