### PR TITLE
Add std_normal_qf to ignored expression tests

### DIFF
--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -146,14 +146,9 @@ special_arg_values = {
 # list of functions we do not test. These are mainly functions implemented in compiler
 # (not in Stan Math).
 ignored = [
-    "lchoose",
-    "lmultiply",
-    "assign_add",
-    "assign_divide",
-    "assign_elt_divide",
-    "assign_elt_times",
-    "assign_multiply",
-    "assign_subtract",
+    "lchoose", # synonym for binomial_coefficient_log
+    "lmultiply", # synonym for multiply_log
+    "std_normal_qf", # synonym for inv_Phi
     "if_else",
 ]
 


### PR DESCRIPTION
Required for https://github.com/stan-dev/stanc3/pull/1258, which adds a function to stanc (`std_normal_qf`) which is just a synonym for an existing function (`inv_Phi`).

I also deleted some no-longer-necessary functions from this list. 

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder:  Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
