### PR TITLE
Expression tests: std_normal_log_qf requires non-positive argument

### DIFF
--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -124,6 +124,7 @@ special_arg_values = {
     "ordered_free": [1.0],
     "simplex_constrain": [None, scalar_return_type],
     "simplex_free": [simplex],
+    "std_normal_log_qf": [-0.1],
     "student_t_cdf": [0.8, None, 0.4, None],
     "student_t_cdf_log": [0.8, None, 0.4, None],
     "student_t_ccdf_log": [0.8, None, 0.4, None],


### PR DESCRIPTION
Follow on to #2824, the new function from #2744 requires an argument <=0. 

I have run the expression tests for this locally and confirmed they passed after this change, so this will unblock https://github.com/stan-dev/stanc3/pull/1258

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
