### PR TITLE
Log sum exp signed

### DIFF
--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -197,6 +197,7 @@
 #include <stan/math/prim/fun/log_rising_factorial.hpp>
 #include <stan/math/prim/fun/log_softmax.hpp>
 #include <stan/math/prim/fun/log_sum_exp.hpp>
+#include <stan/math/prim/fun/log_sum_exp_signed.hpp>
 #include <stan/math/prim/fun/logical_and.hpp>
 #include <stan/math/prim/fun/logical_eq.hpp>
 #include <stan/math/prim/fun/logical_gt.hpp>

--- a/stan/math/prim/fun/log_sum_exp_signed.hpp
+++ b/stan/math/prim/fun/log_sum_exp_signed.hpp
@@ -24,15 +24,16 @@ namespace math {
  */
 template <typename T1, typename T2,
           require_all_stan_scalar_t<T1, T2>* = nullptr>
-inline std::tuple<return_type_t<T1, T2>, int>
-  log_sum_exp_signed(const T1& a, int a_sign, const T2& b, int b_sign) {
+inline std::tuple<return_type_t<T1, T2>, int> log_sum_exp_signed(const T1& a,
+                                                                 int a_sign,
+                                                                 const T2& b,
+                                                                 int b_sign) {
   if (a_sign == b_sign) {
     return std::make_tuple(log_sum_exp(a, b), a_sign);
   }
   bool a_larger = (a > b);
-  return std::make_tuple(
-    a_larger ? log_diff_exp(a, b) : log_diff_exp(b, a),
-    a_larger ? a_sign : b_sign);
+  return std::make_tuple(a_larger ? log_diff_exp(a, b) : log_diff_exp(b, a),
+                         a_larger ? a_sign : b_sign);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_sum_exp_signed.hpp
+++ b/stan/math/prim/fun/log_sum_exp_signed.hpp
@@ -11,6 +11,17 @@
 namespace stan {
 namespace math {
 
+/**
+ * Calculates the log sum of exponentials without overflow,
+ * accounting for the signs of the inputs
+ *
+ * @tparam T1 type of the first variable
+ * @tparam T2 type of the second variable
+ * @param a the first variable
+ * @param a_sign sign of the first variable
+ * @param b the second variable
+ * @param b_sign sign of the second variable
+ */
 template <typename T1, typename T2,
           require_all_stan_scalar_t<T1, T2>* = nullptr>
 inline std::tuple<return_type_t<T1, T2>, int>
@@ -18,7 +29,7 @@ inline std::tuple<return_type_t<T1, T2>, int>
   if (a_sign == b_sign) {
     return std::make_tuple(log_sum_exp(a, b), a_sign);
   }
-  bool a_larger = (value_of_rec(a) > value_of_rec(b));
+  bool a_larger = (a > b);
   return std::make_tuple(
     a_larger ? log_diff_exp(a, b) : log_diff_exp(b, a),
     a_larger ? a_sign : b_sign);

--- a/stan/math/prim/fun/log_sum_exp_signed.hpp
+++ b/stan/math/prim/fun/log_sum_exp_signed.hpp
@@ -18,7 +18,7 @@ inline std::tuple<return_type_t<T1, T2>, int>
   if (a_sign == b_sign) {
     return std::make_tuple(log_sum_exp(a, b), a_sign);
   }
-  bool a_larger = (a > b);
+  bool a_larger = (value_of_rec(a) > value_of_rec(b));
   return std::make_tuple(
     a_larger ? log_diff_exp(a, b) : log_diff_exp(b, a),
     a_larger ? a_sign : b_sign);

--- a/stan/math/prim/fun/log_sum_exp_signed.hpp
+++ b/stan/math/prim/fun/log_sum_exp_signed.hpp
@@ -1,0 +1,30 @@
+#ifndef STAN_MATH_PRIM_FUN_LOG_SUM_EXP_SIGNED_HPP
+#define STAN_MATH_PRIM_FUN_LOG_SUM_EXP_SIGNED_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/log1p_exp.hpp>
+#include <cmath>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+template <typename T1, typename T2,
+          require_all_stan_scalar_t<T1, T2>* = nullptr>
+inline std::tuple<return_type_t<T1, T2>, int>
+  log_sum_exp_signed(const T1& a, int a_sign, const T2& b, int b_sign) {
+  if (a_sign == b_sign) {
+    return std::make_tuple(log_sum_exp(a, b), a_sign);
+  }
+  bool a_larger = (a > b);
+  return std::make_tuple(
+    a_larger ? log_diff_exp(a, b) : log_diff_exp(b, a),
+    a_larger ? a_sign : b_sign);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/test/unit/math/mix/fun/log_sum_exp_signed_test.cpp
+++ b/test/unit/math/mix/fun/log_sum_exp_signed_test.cpp
@@ -4,14 +4,13 @@
 
 TEST(mathMixScalFun, logSumExp_signed) {
   auto f = [](const int x1_sign, const int x2_sign) {
-    return
-        [=](const auto& x1, const auto& x2) {
-          stan::return_type_t<decltype(x1), decltype(x2)> ret_val;
-          int ret_val_sign;
-          std::forward_as_tuple(ret_val, ret_val_sign)
-            = stan::math::log_sum_exp_signed(x1, x1_sign, x2, x2_sign);
-          return ret_val_sign * stan::math::exp(ret_val);
-        };
+    return [=](const auto& x1, const auto& x2) {
+      stan::return_type_t<decltype(x1), decltype(x2)> ret_val;
+      int ret_val_sign;
+      std::forward_as_tuple(ret_val, ret_val_sign)
+          = stan::math::log_sum_exp_signed(x1, x1_sign, x2, x2_sign);
+      return ret_val_sign * stan::math::exp(ret_val);
+    };
   };
   std::vector<double> a{0.15, 0.35, 0.51, 0.65, 0.89, 1.0};
   std::vector<double> b{1.4, 1.2, 2.0, 3.0, 3.21, 3.4};

--- a/test/unit/math/mix/fun/log_sum_exp_signed_test.cpp
+++ b/test/unit/math/mix/fun/log_sum_exp_signed_test.cpp
@@ -1,0 +1,27 @@
+#include <test/unit/math/test_ad.hpp>
+#include <limits>
+#include <vector>
+
+TEST(mathMixScalFun, logSumExp_signed) {
+  auto f = [](const int x1_sign, const int x2_sign) {
+    return
+        [=](const auto& x1, const auto& x2) {
+          stan::return_type_t<decltype(x1), decltype(x2)> ret_val;
+          int ret_val_sign;
+          std::forward_as_tuple(ret_val, ret_val_sign)
+            = stan::math::log_sum_exp_signed(x1, x1_sign, x2, x2_sign);
+          return ret_val_sign * stan::math::exp(ret_val);
+        };
+  };
+  std::vector<double> a{0.15, 0.35, 0.51, 0.65, 0.89, 1.0};
+  std::vector<double> b{1.4, 1.2, 2.0, 3.0, 3.21, 3.4};
+
+  for (auto&& a_val : a) {
+    for (auto&& b_val : b) {
+      stan::test::expect_ad(f(1, 1), a_val, b_val);
+      stan::test::expect_ad(f(1, -1), a_val, b_val);
+      stan::test::expect_ad(f(-1, 1), a_val, b_val);
+      stan::test::expect_ad(f(-1, -1), a_val, b_val);
+    }
+  }
+}

--- a/test/unit/math/prim/fun/log_sum_exp_signed_test.cpp
+++ b/test/unit/math/prim/fun/log_sum_exp_signed_test.cpp
@@ -5,11 +5,11 @@
 #include <vector>
 
 TEST(MathFunctions, log_sum_exp_signed) {
-  using stan::math::log_sum_exp_signed;
-  using stan::math::log_sum_exp;
-  using stan::math::log_diff_exp;
-  using stan::math::sign;
   using stan::math::exp;
+  using stan::math::log_diff_exp;
+  using stan::math::log_sum_exp;
+  using stan::math::log_sum_exp_signed;
+  using stan::math::sign;
 
   double a = 2.5;
   double b = 76.2;
@@ -19,23 +19,19 @@ TEST(MathFunctions, log_sum_exp_signed) {
   double val;
   int val_sign;
 
-  std::forward_as_tuple(val, val_sign)
-    = log_sum_exp_signed(a, 1, b, 1);
+  std::forward_as_tuple(val, val_sign) = log_sum_exp_signed(a, 1, b, 1);
 
   EXPECT_FLOAT_EQ(exp_a + exp_b, val_sign * exp(val));
 
-  std::forward_as_tuple(val, val_sign)
-    = log_sum_exp_signed(a, 1, b, -1);
+  std::forward_as_tuple(val, val_sign) = log_sum_exp_signed(a, 1, b, -1);
 
   EXPECT_FLOAT_EQ(exp_a - exp_b, val_sign * exp(val));
 
-  std::forward_as_tuple(val, val_sign)
-    = log_sum_exp_signed(a, -1, b, 1);
+  std::forward_as_tuple(val, val_sign) = log_sum_exp_signed(a, -1, b, 1);
 
   EXPECT_FLOAT_EQ(-exp_a + exp_b, val_sign * exp(val));
 
-  std::forward_as_tuple(val, val_sign)
-    = log_sum_exp_signed(a, -1, b, -1);
+  std::forward_as_tuple(val, val_sign) = log_sum_exp_signed(a, -1, b, -1);
 
   EXPECT_FLOAT_EQ(-exp_a - exp_b, val_sign * exp(val));
 }

--- a/test/unit/math/prim/fun/log_sum_exp_signed_test.cpp
+++ b/test/unit/math/prim/fun/log_sum_exp_signed_test.cpp
@@ -1,0 +1,41 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <tuple>
+#include <vector>
+
+TEST(MathFunctions, log_sum_exp_signed) {
+  using stan::math::log_sum_exp_signed;
+  using stan::math::log_sum_exp;
+  using stan::math::log_diff_exp;
+  using stan::math::sign;
+  using stan::math::exp;
+
+  double a = 2.5;
+  double b = 76.2;
+  double exp_a = exp(a);
+  double exp_b = exp(b);
+
+  double val;
+  int val_sign;
+
+  std::forward_as_tuple(val, val_sign)
+    = log_sum_exp_signed(a, 1, b, 1);
+
+  EXPECT_FLOAT_EQ(exp_a + exp_b, val_sign * exp(val));
+
+  std::forward_as_tuple(val, val_sign)
+    = log_sum_exp_signed(a, 1, b, -1);
+
+  EXPECT_FLOAT_EQ(exp_a - exp_b, val_sign * exp(val));
+
+  std::forward_as_tuple(val, val_sign)
+    = log_sum_exp_signed(a, -1, b, 1);
+
+  EXPECT_FLOAT_EQ(-exp_a + exp_b, val_sign * exp(val));
+
+  std::forward_as_tuple(val, val_sign)
+    = log_sum_exp_signed(a, -1, b, -1);
+
+  EXPECT_FLOAT_EQ(-exp_a - exp_b, val_sign * exp(val));
+}


### PR DESCRIPTION
## Summary

This PR introduces a function for performing `log_sum_exp` while respecting the signs of the input variables and tracking the sign of the returned sum. The function returns a two-element tuple, where the first element is the sum (on the log-scale) and the second is the sign. This isn't intended to be exposed to users, so I think the `tuple` return is fine.

We currently have to exponentiate and apply the signs to each argument (so that the values are correctly added or subtracted) and then extract the sign of the result and return the `log(fabs())` of the sum:
```cpp
double a = 2.1;
double b = 54.21;
int a_sign = 1;
int b_sign = -1;

double sum_exp_scale = a_sign * exp(a) + b_sign * exp(b);
double sum_log_scale = log(fabs(sum_exp_scale));
int sum_log_scale_sign = sign(sum_exp_scale);
```

However, this means that we lose the over-/under-flow robustness of the `log_sum_exp` and `log_diff_exp` functions. The `log_sum_exp_signed` function uses the provided signs to determine whether a `log_sum_exp` or `log_diff_exp` should be applied and also what the returned sign should be:

```cpp
std::tuple<double, int> sum_new = log_sum_exp_signed(a, a_sign, b, b_sign);
```

This will be used in the `hypergeometric_*` functions and their derivatives which accumulate an infinite sum on the log-scale while tracking the input and output signs.

## Tests

`prim` tests are added to ensure that different combinations of positive and negative arguments, as well as different magnitudes of arguments (i.e., `a > b` vs `b > a`) are correctly handled, as well as `mix` tests for the gradients

## Side Effects

N/A

## Release notes

Added `log_sum_exp_signed` function for computing `log_sum_exp` while respecting signs of arguments and tracking the sign of the result

## Checklist

- [x] Math issue #2592 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
