### PR TITLE
Testing: Prioritize changed unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,25 +177,62 @@ pipeline {
             }
         }
 
-        stage('Headers check') {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu-cpp17'
-                    label 'linux'
-                }
-            }
+        stage('Quick tests') {
             when {
                 expression {
                     !skipRemainingStages
                 }
             }
-            steps {
-                unstash 'MathSetup'
-                sh "echo CXX=${CLANG_CXX} -Werror > make/local"
-                sh "echo O=0 >> make/local"
-                sh "make -j${PARALLEL} test-headers"
+            failFast true
+            parallel {
+                stage('Headers check') {
+                    when {
+                        expression {
+                            !skipRemainingStages
+                        }
+                    }
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu-cpp17'
+                            label 'linux'
+                        }
+                    }
+
+                    steps {
+                        unstash 'MathSetup'
+                        sh "echo CXX=${CLANG_CXX} -Werror > make/local"
+                        sh "make -j${PARALLEL} test-headers"
+                    }
+                    post { always { deleteDir() } }
+                }
+                stage('Run changed unit tests') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu-cpp17'
+                            label 'linux'
+                            args '--cap-add SYS_PTRACE'
+                        }
+                    }
+                    when {
+                        allOf {
+                            expression {
+                                env.BRANCH_NAME ==~ /PR-\d+/
+                            }
+                            expression {
+                                !skipRemainingStages
+                            }
+                        }
+                    }
+                    steps {
+                        unstash 'MathSetup'
+
+                        sh "echo CXXFLAGS += -fsanitize=address >> make/local"
+                        sh "./runTests.py -j${PARALLEL} --changed --debug"
+
+                    }
+                    post { always { retry(3) { deleteDir() } } }
+                }
             }
-            post { always { deleteDir() } }
         }
 
         stage('Full Unit Tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,7 +224,7 @@ pipeline {
                         }
                     }
                     steps {
-                        unstash 'MathSetup'
+                        retry(3) { checkout scm }
 
                         sh "echo CXXFLAGS += -fsanitize=address >> make/local"
                         sh "./runTests.py -j${PARALLEL} --changed --debug"

--- a/runTests.py
+++ b/runTests.py
@@ -399,34 +399,34 @@ def main():
 
     jumboFiles = []
 
-    try:
-        if inputs.changed:
-            tests = findChangedTests(inputs.debug)
-        else:
-            # pass 0: generate all auto-generated tests
-            if any("test/prob" in arg for arg in inputs.tests):
-                generateTests(inputs.j)
+    if inputs.changed:
+        tests = findChangedTests(inputs.debug)
+    else:
+        # pass 0: generate all auto-generated tests
+        if any("test/prob" in arg for arg in inputs.tests):
+            generateTests(inputs.j)
 
-            if inputs.do_jumbo:
-                jumboFiles = generateJumboTests(inputs.tests)
-            if inputs.e == -1:
-                if inputs.j == 1:
-                    num_expr_test_files = 1
-                else:
-                    num_expr_test_files = inputs.j * 4
+        if inputs.do_jumbo:
+            jumboFiles = generateJumboTests(inputs.tests)
+        if inputs.e == -1:
+            if inputs.j == 1:
+                num_expr_test_files = 1
             else:
-                num_expr_test_files = inputs.e
-            handleExpressionTests(inputs.tests, inputs.only_functions, num_expr_test_files)
+                num_expr_test_files = inputs.j * 4
+        else:
+            num_expr_test_files = inputs.e
+        handleExpressionTests(inputs.tests, inputs.only_functions, num_expr_test_files)
 
-            tests = findTests(inputs.tests, inputs.f, inputs.do_jumbo)
+        tests = findTests(inputs.tests, inputs.f, inputs.do_jumbo)
 
-        if not tests:
-            if inputs.changed:
-                stopErr("No changed tests were found!", 0)
-            stopErr(
-                "No matching tests found. Check the path passed on the command line", -1
-            )
+    if not tests:
+        if inputs.changed:
+            stopErr("No changed tests were found!", 0)
+        stopErr(
+            "No matching tests found. Check the path passed on the command line", -1
+        )
 
+    try:
         # pass 1: make test executables
         for batch in batched(tests):
             if inputs.debug:

--- a/runTests.py
+++ b/runTests.py
@@ -87,13 +87,13 @@ def processCLIArgs():
         default=-1,
         help="number of files to split expressions tests in",
     )
-    tests_help_msg = "The path(s) to the test case(s) to run.\n"
-    tests_help_msg += "Example: 'test/unit', 'test/prob', and/or\n"
-    tests_help_msg += "         'test/unit/math/prim/fun/abs_test.cpp'"
-    parser.add_argument("tests", nargs="+", type=str, help=tests_help_msg)
     f_help_msg = "Only tests with file names matching these will be executed.\n"
     f_help_msg += "Example: '-f chol', '-f opencl', '-f prim'"
     parser.add_argument("-f", type=str, default=[], action="append", help=f_help_msg)
+    changed_help = (
+        "Use git to determine which tests may have changed, and run only those"
+    )
+    parser.add_argument("--changed", action="store_true", help=changed_help)
     parser.add_argument(
         "-d",
         "--debug",
@@ -127,6 +127,11 @@ def processCLIArgs():
         action="store_true",
         help="Build/run jumbo tests.",
     )
+
+    tests_help_msg = "The path(s) to the test case(s) to run.\n"
+    tests_help_msg += "Example: 'test/unit', 'test/prob', and/or\n"
+    tests_help_msg += "         'test/unit/math/prim/fun/abs_test.cpp'"
+    parser.add_argument("tests", nargs="*", type=str, help=tests_help_msg)
     # And parse the command line against those rules
     return parser.parse_args()
 
@@ -146,6 +151,8 @@ def isWin():
 
 batchSize = 20 if isWin() else 200
 jumboSize = 5 if isWin() else 12
+maxChangedTests = 20
+
 
 def mungeName(name):
     """Set up the makefile target name"""
@@ -306,6 +313,38 @@ def findTests(base_path, filter_names, do_jumbo=False):
     return tests
 
 
+def findChangedTests(debug):
+    import subprocess
+
+    changed_files = subprocess.run(
+        ["git", "diff", "--name-only", "origin/develop...HEAD"], text=True, capture_output=True
+    ).stdout.splitlines()
+    if debug:
+        print("Changed files:", changed_files)
+
+    # changes in prim should also test other non-prim signatures
+    test_deps = {"prim/": ["prim/", "rev/", "mix/", "fwd/"], "rev/": ["rev/", "mix/"], "fwd/": ["fwd/", "mix/"]}
+
+    changed_tests = set()
+    for f in changed_files:
+        if 'stan/' in f and f.endswith('.hpp') and 'opencl' not in f: # changed fn
+            maybe_test = f.replace('stan/', 'test/unit/').replace('.hpp', testsfx)
+            for (path, replacements) in test_deps.items():
+                if path in maybe_test:
+                    for rep in replacements:
+                        maybe_test = maybe_test.replace(path, rep)
+                        if os.path.exists(maybe_test):
+                            changed_tests.add(maybe_test)
+
+        if f.endswith(testsfx) and 'opencl' not in f:
+            changed_tests.add(f)
+
+    if len(changed_tests) > maxChangedTests:
+        stopErr("Number of changed tests excluded maximum, not running priority tests", 0)
+
+    return list(map(mungeName, changed_tests))
+
+
 def batched(tests):
     return [tests[i : i + batchSize] for i in range(0, len(tests), batchSize)]
 
@@ -357,30 +396,37 @@ def main():
             stan_mpi = "STAN_MPI" in f.read()
     except IOError:
         stan_mpi = False
-    # pass 0: generate all auto-generated tests
-    if any("test/prob" in arg for arg in inputs.tests):
-        generateTests(inputs.j)
-    tests = inputs.tests
 
     jumboFiles = []
-    if inputs.do_jumbo:
-        jumboFiles = generateJumboTests(tests, debug=inputs.debug)
-    try:
-        if inputs.e == -1:
-            if inputs.j == 1:
-                num_expr_test_files = 1
-            else:
-                num_expr_test_files = inputs.j * 4
-        else:
-            num_expr_test_files = inputs.e
-        handleExpressionTests(tests, inputs.only_functions, num_expr_test_files)
 
-        tests = findTests(inputs.tests, inputs.f, inputs.do_jumbo)
+    try:
+        if inputs.changed:
+            tests = findChangedTests(inputs.debug)
+        else:
+            # pass 0: generate all auto-generated tests
+            if any("test/prob" in arg for arg in inputs.tests):
+                generateTests(inputs.j)
+
+            if inputs.do_jumbo:
+                jumboFiles = generateJumboTests(inputs.tests)
+            if inputs.e == -1:
+                if inputs.j == 1:
+                    num_expr_test_files = 1
+                else:
+                    num_expr_test_files = inputs.j * 4
+            else:
+                num_expr_test_files = inputs.e
+            handleExpressionTests(inputs.tests, inputs.only_functions, num_expr_test_files)
+
+            tests = findTests(inputs.tests, inputs.f, inputs.do_jumbo)
 
         if not tests:
-            stopErr("No matching tests found.", -1)
-        if inputs.debug:
-            print("Collected the following tests:\n", tests)
+            if inputs.changed:
+                stopErr("No changed tests were found!", 0)
+            stopErr(
+                "No matching tests found. Check the path passed on the command line", -1
+            )
+
         # pass 1: make test executables
         for batch in batched(tests):
             if inputs.debug:
@@ -398,6 +444,7 @@ def main():
     finally:
         cleanupJumboTests(jumboFiles)
         pass
+
 
 if __name__ == "__main__":
     main()

--- a/stan/math/prim/fun/asinh.hpp
+++ b/stan/math/prim/fun/asinh.hpp
@@ -65,7 +65,6 @@ inline std::complex<V> complex_asinh(const std::complex<V>& z) {
   return copysign(y, y_d);
 }
 }  // namespace internal
-
 }  // namespace math
 }  // namespace stan
 

--- a/test/unit/math/mix/fun/abs_test.cpp
+++ b/test/unit/math/mix/fun/abs_test.cpp
@@ -14,6 +14,7 @@ TEST(mixFun, absBasics) {
   x << 1, 2, 3, 4, 5, 6;
   Eigen::Matrix<double, -1, -1> y = abs(x);
 
+  // test int -> int vectorization
   std::vector<int> u{1, 2, 3, 4};
   std::vector<int> v = abs(u);
 }


### PR DESCRIPTION
## Summary

This adds a short round of testing which is run in parallel with the header checks. It sees what files are changed relative to `develop` and runs only the tests which either changed, or the tests of the functions which changed, if it can determine them. 

The goal here is to make the math CI pipeline fail faster and with a more localized error for simple PRs. Obviously if you change a function which other functions depend on it might still fail in later stages, but this should help with iteration.

Note that these tests do get re-run later during the stage they normally would.

Other notes: OpenCL tests are excluded, and if more than 20 tests have changed we skip this to avoid it slowing down the whole CI pipeline - at that point, you probably want to move on to the later full stages anyway.

Thanks to @SteveBronder for the idea

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
