### PR TITLE
Allow printing of tuples

### DIFF
--- a/test/unit/math/prim/fun/stan_print_test.cpp
+++ b/test/unit/math/prim/fun/stan_print_test.cpp
@@ -9,6 +9,8 @@ TEST(MathPrim, basic_print) {
   Eigen::MatrixXd m = Eigen::MatrixXd::Ones(1, 1);
   std::vector<double> a(1, 1);
 
+  std::tuple<Eigen::VectorXd, int, std::vector<double>> tup(v, i, a);
+
   {
     std::stringstream s;
     stan::math::stan_print(&s, i);
@@ -43,6 +45,12 @@ TEST(MathPrim, basic_print) {
     std::stringstream s;
     stan::math::stan_print(&s, a);
     EXPECT_TRUE(s.str().find("[1]") != std::string::npos);
+  }
+
+  {
+    std::stringstream s;
+    stan::math::stan_print(&s, tup);
+    EXPECT_TRUE(s.str().find("([1],1,[1])") != std::string::npos);
   }
 }
 


### PR DESCRIPTION
## Summary

Extends `stan_print` to work on tuples

## Tests

Added a test to the existing test file

## Side Effects

None

## Release notes

`stan_print` can now print std::tuple types

## Checklist

- [x] Math issue: Closes #2709 

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
