### PR TITLE
Tests: Fix sporadic failures to find `docker`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -421,6 +421,7 @@ pipeline {
                     for (f in files.toList().collate(8)) {
                         def names = f.join(" ")
                         tests["Distribution Tests: ${names}"] = { node {
+                            label "linux"
                             docker.image('stanorg/ci:gpu-cpp17').inside {
                                 unstash 'MathSetup'
                                 sh """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,13 +137,13 @@ pipeline {
                     stash 'MathSetup'
                     sh "echo CXX=${CLANG_CXX} > make/local"
                     sh "echo BOOST_PARALLEL_JOBS=${PARALLEL} >> make/local"
-                    parallel(
-                        CppLint: { sh "make cpplint" },
-                        Dependencies: { sh """#!/bin/bash
-                            set -o pipefail
-                            make test-math-dependencies 2>&1 | tee dependencies.log""" } ,
-                        Documentation: { sh "make doxygen" },
-                    )
+                    // parallel(
+                    //     CppLint: { sh "make cpplint" },
+                    //     Dependencies: { sh """#!/bin/bash
+                    //         set -o pipefail
+                    //         make test-math-dependencies 2>&1 | tee dependencies.log""" } ,
+                    //     Documentation: { sh "make doxygen" },
+                    // )
                 }
             }
             post {
@@ -157,25 +157,25 @@ pipeline {
             }
         }
 
-        stage('Verify changes') {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu-cpp17'
-                    label 'linux'
-                }
-            }
-            steps {
-                script {
+        // stage('Verify changes') {
+        //     agent {
+        //         docker {
+        //             image 'stanorg/ci:gpu-cpp17'
+        //             label 'linux'
+        //         }
+        //     }
+        //     steps {
+        //         script {
 
-                    retry(3) { checkout scm }
-                    sh 'git clean -xffd'
+        //             retry(3) { checkout scm }
+        //             sh 'git clean -xffd'
 
-                    def paths = ['stan', 'make', 'lib', 'test', 'runTests.py', 'runChecks.py', 'makefile', 'Jenkinsfile', '.clang-format'].join(" ")
-                    skipRemainingStages = utils.verifyChanges(paths)
+        //             def paths = ['stan', 'make', 'lib', 'test', 'runTests.py', 'runChecks.py', 'makefile', 'Jenkinsfile', '.clang-format'].join(" ")
+        //             skipRemainingStages = utils.verifyChanges(paths)
 
-                }
-            }
-        }
+        //         }
+        //     }
+        // }
 
         // stage('Headers check') {
         //     agent {
@@ -421,7 +421,7 @@ pipeline {
                     for (f in files.toList().collate(8)) {
                         def names = f.join(" ")
                         tests["Distribution Tests: ${names}"] = { node {
-                            label "linux"
+                            label "docker"
                             docker.image('stanorg/ci:gpu-cpp17').inside {
                                 unstash 'MathSetup'
                                 sh """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,234 +177,234 @@ pipeline {
             }
         }
 
-        stage('Headers check') {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu-cpp17'
-                    label 'linux'
-                }
-            }
-            when {
-                expression {
-                    !skipRemainingStages
-                }
-            }
-            steps {
-                unstash 'MathSetup'
-                sh "echo CXX=${CLANG_CXX} -Werror > make/local"
-                sh "echo O=0 >> make/local"
-                sh "make -j${PARALLEL} test-headers"
-            }
-            post { always { deleteDir() } }
-        }
+        // stage('Headers check') {
+        //     agent {
+        //         docker {
+        //             image 'stanorg/ci:gpu-cpp17'
+        //             label 'linux'
+        //         }
+        //     }
+        //     when {
+        //         expression {
+        //             !skipRemainingStages
+        //         }
+        //     }
+        //     steps {
+        //         unstash 'MathSetup'
+        //         sh "echo CXX=${CLANG_CXX} -Werror > make/local"
+        //         sh "echo O=0 >> make/local"
+        //         sh "make -j${PARALLEL} test-headers"
+        //     }
+        //     post { always { deleteDir() } }
+        // }
 
-        stage('Full Unit Tests') {
-            when {
-                expression {
-                    !skipRemainingStages
-                }
-            }
-            failFast true
-            parallel {
-                stage('Rev/Fwd Unit Tests') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:gpu-cpp17'
-                            label 'linux'
-                            args '--cap-add SYS_PTRACE'
-                        }
-                    }
-                    when {
-                        expression {
-                            !skipRemainingStages
-                        }
-                    }
-                    steps {
-                        unstash 'MathSetup'
-                        sh "echo CXXFLAGS += -fsanitize=address >> make/local"
+        // stage('Full Unit Tests') {
+        //     when {
+        //         expression {
+        //             !skipRemainingStages
+        //         }
+        //     }
+        //     failFast true
+        //     parallel {
+        //         stage('Rev/Fwd Unit Tests') {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:gpu-cpp17'
+        //                     label 'linux'
+        //                     args '--cap-add SYS_PTRACE'
+        //                 }
+        //             }
+        //             when {
+        //                 expression {
+        //                     !skipRemainingStages
+        //                 }
+        //             }
+        //             steps {
+        //                 unstash 'MathSetup'
+        //                 sh "echo CXXFLAGS += -fsanitize=address >> make/local"
 
-                        script {
-                            if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
-                                sh "echo O=0 >> make/local"
-                            }
+        //                 script {
+        //                     if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
+        //                         sh "echo O=0 >> make/local"
+        //                     }
 
-                            runTests("test/unit/math/rev")
-                            runTests("test/unit/math/fwd")
-                        }
-                    }
-                    post { always { retry(3) { deleteDir() } } }
-                }
-                stage('Mix Unit Tests') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:gpu-cpp17'
-                            label 'linux'
-                            args '--cap-add SYS_PTRACE'
-                        }
-                    }
-                    when {
-                        expression {
-                            !skipRemainingStages
-                        }
-                    }
-                    steps {
-                        unstash 'MathSetup'
-                        sh "echo CXXFLAGS += -fsanitize=address >> make/local"
-                        script {
-                            if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
-                                sh "echo O=1 >> make/local"
-                            }
-                            runTests("test/unit/math/mix", true)
-                        }
-                    }
-                    post { always { retry(3) { deleteDir() } } }
-                }
-                stage('Prim Unit Tests') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:gpu-cpp17'
-                            label 'linux'
-                            args '--cap-add SYS_PTRACE'
-                        }
-                    }
-                    when {
-                        expression {
-                            !skipRemainingStages
-                        }
-                    }
-                    steps {
-                        unstash 'MathSetup'
-                        sh "echo CXXFLAGS += -fsanitize=address >> make/local"
-                        script {
-                            if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
-                                sh "echo O=0 >> make/local"
-                            }
-                            runTests("test/unit/*_test.cpp", false)
-                            runTests("test/unit/math/*_test.cpp", false)
-                            runTests("test/unit/math/prim", true)
-                            runTests("test/unit/math/memory", false)
-                        }
-                    }
-                    post { always { retry(3) { deleteDir() } } }
-                }
-                stage('OpenCL GPU tests') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:gpu-cpp17'
-                            label 'v100'
-                            args '--gpus 1'
-                        }
-                    }
-                    steps {
-                        script {
-                            unstash 'MathSetup'
-                            sh """
-                                echo CXX=${CLANG_CXX} -Werror > make/local
-                                echo STAN_OPENCL=true >> make/local
-                                echo OPENCL_PLATFORM_ID=${OPENCL_PLATFORM_ID_GPU} >> make/local
-                                echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID_GPU} >> make/local
-                            """
-                            if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
-                                sh "echo O=1 >> make/local"
-                            }
-                            runTests("test/unit/math/opencl", false) // TODO(bward): try to enable
-                            runTests("test/unit/multiple_translation_units_test.cpp")
-                        }
-                    }
-                }
-            }
-        }
-        stage('Always-run tests') {
-            when {
-                expression {
-                    !skipRemainingStages
-                }
-            }
-            failFast true
-            parallel {
-                stage('MPI tests') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:gpu-cpp17'
-                            label 'linux'
-                        }
-                    }
-                    steps {
-                        unstash 'MathSetup'
-                        sh """
-                            echo CXX=${MPICXX} > make/local
-                            echo CXX_TYPE=gcc >> make/local
-                            echo STAN_MPI=true >> make/local
-                        """
-                        runTests("test/unit/math/prim/functor")
-                        runTests("test/unit/math/rev/functor")
-                    }
-                    post { always { retry(3) { deleteDir() } } }
-                }
-                stage('Expressions test') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:gpu-cpp17'
-                            label 'linux'
-                        }
-                    }
-                    steps {
-                        unstash 'MathSetup'
-                        script {
-                            sh "echo O=0 > make/local"
-                            sh "echo CXX=${CLANG_CXX} -Werror >> make/local"
-                            sh "python ./test/code_generator_test.py"
-                            sh "python ./test/signature_parser_test.py"
-                            sh "python ./test/statement_types_test.py"
-                            sh "python ./test/varmat_compatibility_summary_test.py"
-                            sh "python ./test/varmat_compatibility_test.py"
-                            withEnv(['PATH+TBB=./lib/tbb']) {
-                                sh "python ./test/expressions/test_expression_testing_framework.py"
-                                try { sh "./runTests.py -j${PARALLEL} test/expressions" }
-                                finally { junit 'test/**/*.xml' }
-                            }
-                            sh "make clean-all"
-                            sh "echo STAN_THREADS=true >> make/local"
-                            withEnv(['PATH+TBB=./lib/tbb']) {
-                                try {
-                                    sh "./runTests.py -j${PARALLEL} test/expressions --only-functions reduce_sum map_rect"
-				                }
-                                finally { junit 'test/**/*.xml' }
-                            }
-                        }
-                    }
-                    post { always { deleteDir() } }
-                }
+        //                     runTests("test/unit/math/rev")
+        //                     runTests("test/unit/math/fwd")
+        //                 }
+        //             }
+        //             post { always { retry(3) { deleteDir() } } }
+        //         }
+        //         stage('Mix Unit Tests') {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:gpu-cpp17'
+        //                     label 'linux'
+        //                     args '--cap-add SYS_PTRACE'
+        //                 }
+        //             }
+        //             when {
+        //                 expression {
+        //                     !skipRemainingStages
+        //                 }
+        //             }
+        //             steps {
+        //                 unstash 'MathSetup'
+        //                 sh "echo CXXFLAGS += -fsanitize=address >> make/local"
+        //                 script {
+        //                     if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
+        //                         sh "echo O=1 >> make/local"
+        //                     }
+        //                     runTests("test/unit/math/mix", true)
+        //                 }
+        //             }
+        //             post { always { retry(3) { deleteDir() } } }
+        //         }
+        //         stage('Prim Unit Tests') {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:gpu-cpp17'
+        //                     label 'linux'
+        //                     args '--cap-add SYS_PTRACE'
+        //                 }
+        //             }
+        //             when {
+        //                 expression {
+        //                     !skipRemainingStages
+        //                 }
+        //             }
+        //             steps {
+        //                 unstash 'MathSetup'
+        //                 sh "echo CXXFLAGS += -fsanitize=address >> make/local"
+        //                 script {
+        //                     if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
+        //                         sh "echo O=0 >> make/local"
+        //                     }
+        //                     runTests("test/unit/*_test.cpp", false)
+        //                     runTests("test/unit/math/*_test.cpp", false)
+        //                     runTests("test/unit/math/prim", true)
+        //                     runTests("test/unit/math/memory", false)
+        //                 }
+        //             }
+        //             post { always { retry(3) { deleteDir() } } }
+        //         }
+        //         stage('OpenCL GPU tests') {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:gpu-cpp17'
+        //                     label 'v100'
+        //                     args '--gpus 1'
+        //                 }
+        //             }
+        //             steps {
+        //                 script {
+        //                     unstash 'MathSetup'
+        //                     sh """
+        //                         echo CXX=${CLANG_CXX} -Werror > make/local
+        //                         echo STAN_OPENCL=true >> make/local
+        //                         echo OPENCL_PLATFORM_ID=${OPENCL_PLATFORM_ID_GPU} >> make/local
+        //                         echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID_GPU} >> make/local
+        //                     """
+        //                     if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
+        //                         sh "echo O=1 >> make/local"
+        //                     }
+        //                     runTests("test/unit/math/opencl", false) // TODO(bward): try to enable
+        //                     runTests("test/unit/multiple_translation_units_test.cpp")
+        //                 }
+        //             }
+        //         }
+        //     }
+        // }
+        // stage('Always-run tests') {
+        //     when {
+        //         expression {
+        //             !skipRemainingStages
+        //         }
+        //     }
+        //     failFast true
+        //     parallel {
+        //         stage('MPI tests') {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:gpu-cpp17'
+        //                     label 'linux'
+        //                 }
+        //             }
+        //             steps {
+        //                 unstash 'MathSetup'
+        //                 sh """
+        //                     echo CXX=${MPICXX} > make/local
+        //                     echo CXX_TYPE=gcc >> make/local
+        //                     echo STAN_MPI=true >> make/local
+        //                 """
+        //                 runTests("test/unit/math/prim/functor")
+        //                 runTests("test/unit/math/rev/functor")
+        //             }
+        //             post { always { retry(3) { deleteDir() } } }
+        //         }
+        //         stage('Expressions test') {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:gpu-cpp17'
+        //                     label 'linux'
+        //                 }
+        //             }
+        //             steps {
+        //                 unstash 'MathSetup'
+        //                 script {
+        //                     sh "echo O=0 > make/local"
+        //                     sh "echo CXX=${CLANG_CXX} -Werror >> make/local"
+        //                     sh "python ./test/code_generator_test.py"
+        //                     sh "python ./test/signature_parser_test.py"
+        //                     sh "python ./test/statement_types_test.py"
+        //                     sh "python ./test/varmat_compatibility_summary_test.py"
+        //                     sh "python ./test/varmat_compatibility_test.py"
+        //                     withEnv(['PATH+TBB=./lib/tbb']) {
+        //                         sh "python ./test/expressions/test_expression_testing_framework.py"
+        //                         try { sh "./runTests.py -j${PARALLEL} test/expressions" }
+        //                         finally { junit 'test/**/*.xml' }
+        //                     }
+        //                     sh "make clean-all"
+        //                     sh "echo STAN_THREADS=true >> make/local"
+        //                     withEnv(['PATH+TBB=./lib/tbb']) {
+        //                         try {
+        //                             sh "./runTests.py -j${PARALLEL} test/expressions --only-functions reduce_sum map_rect"
+		// 		                }
+        //                         finally { junit 'test/**/*.xml' }
+        //                     }
+        //                 }
+        //             }
+        //             post { always { deleteDir() } }
+        //         }
 
-                stage('Threading tests') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:gpu-cpp17'
-                            label 'linux'
-                        }
-                    }
-                    steps {
-                        script {
-                            unstash 'MathSetup'
-                            sh "echo CXX=${CLANG_CXX} -Werror > make/local"
-                            sh "echo STAN_THREADS=true >> make/local"
-                            sh "export STAN_NUM_THREADS=4"
-                            if (isBranch('develop') || isBranch('master')) {
-                                runTests("test/unit")
-                                sh "find . -name *_test.xml | xargs rm"
-                            } else {
-                                runTests("test/unit -f thread")
-                                sh "find . -name *_test.xml | xargs rm"
-                                runTests("test/unit -f map_rect")
-                                sh "find . -name *_test.xml | xargs rm"
-                                runTests("test/unit -f reduce_sum")
-                            }
-                        }
-                    }
-                    post { always { retry(3) { deleteDir() } } }
-                }
-            }
-        }
+        //         stage('Threading tests') {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:gpu-cpp17'
+        //                     label 'linux'
+        //                 }
+        //             }
+        //             steps {
+        //                 script {
+        //                     unstash 'MathSetup'
+        //                     sh "echo CXX=${CLANG_CXX} -Werror > make/local"
+        //                     sh "echo STAN_THREADS=true >> make/local"
+        //                     sh "export STAN_NUM_THREADS=4"
+        //                     if (isBranch('develop') || isBranch('master')) {
+        //                         runTests("test/unit")
+        //                         sh "find . -name *_test.xml | xargs rm"
+        //                     } else {
+        //                         runTests("test/unit -f thread")
+        //                         sh "find . -name *_test.xml | xargs rm"
+        //                         runTests("test/unit -f map_rect")
+        //                         sh "find . -name *_test.xml | xargs rm"
+        //                         runTests("test/unit -f reduce_sum")
+        //                     }
+        //                 }
+        //             }
+        //             post { always { retry(3) { deleteDir() } } }
+        //         }
+        //     }
+        // }
 
         stage ('Distribution tests') {
             when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -412,7 +412,7 @@ pipeline {
                     !skipRemainingStages
                 }
             }
-            agent { label 'linux' }
+            agent { label 'linux && docker' }
             steps {
                 script {
                     unstash 'MathSetup'
@@ -420,8 +420,7 @@ pipeline {
                     def files = sh(script:"find test/prob/* -type d", returnStdout:true).trim().split('\n')
                     for (f in files.toList().collate(8)) {
                         def names = f.join(" ")
-                        tests["Distribution Tests: ${names}"] = { node {
-                            label "docker"
+                        tests["Distribution Tests: ${names}"] = { node ("linux && docker") {
                             docker.image('stanorg/ci:gpu-cpp17').inside {
                                 unstash 'MathSetup'
                                 sh """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,13 +137,13 @@ pipeline {
                     stash 'MathSetup'
                     sh "echo CXX=${CLANG_CXX} > make/local"
                     sh "echo BOOST_PARALLEL_JOBS=${PARALLEL} >> make/local"
-                    // parallel(
-                    //     CppLint: { sh "make cpplint" },
-                    //     Dependencies: { sh """#!/bin/bash
-                    //         set -o pipefail
-                    //         make test-math-dependencies 2>&1 | tee dependencies.log""" } ,
-                    //     Documentation: { sh "make doxygen" },
-                    // )
+                    parallel(
+                        CppLint: { sh "make cpplint" },
+                        Dependencies: { sh """#!/bin/bash
+                            set -o pipefail
+                            make test-math-dependencies 2>&1 | tee dependencies.log""" } ,
+                        Documentation: { sh "make doxygen" },
+                    )
                 }
             }
             post {
@@ -157,254 +157,254 @@ pipeline {
             }
         }
 
-        // stage('Verify changes') {
-        //     agent {
-        //         docker {
-        //             image 'stanorg/ci:gpu-cpp17'
-        //             label 'linux'
-        //         }
-        //     }
-        //     steps {
-        //         script {
+        stage('Verify changes') {
+            agent {
+                docker {
+                    image 'stanorg/ci:gpu-cpp17'
+                    label 'linux'
+                }
+            }
+            steps {
+                script {
 
-        //             retry(3) { checkout scm }
-        //             sh 'git clean -xffd'
+                    retry(3) { checkout scm }
+                    sh 'git clean -xffd'
 
-        //             def paths = ['stan', 'make', 'lib', 'test', 'runTests.py', 'runChecks.py', 'makefile', 'Jenkinsfile', '.clang-format'].join(" ")
-        //             skipRemainingStages = utils.verifyChanges(paths)
+                    def paths = ['stan', 'make', 'lib', 'test', 'runTests.py', 'runChecks.py', 'makefile', 'Jenkinsfile', '.clang-format'].join(" ")
+                    skipRemainingStages = utils.verifyChanges(paths)
 
-        //         }
-        //     }
-        // }
+                }
+            }
+        }
 
-        // stage('Headers check') {
-        //     agent {
-        //         docker {
-        //             image 'stanorg/ci:gpu-cpp17'
-        //             label 'linux'
-        //         }
-        //     }
-        //     when {
-        //         expression {
-        //             !skipRemainingStages
-        //         }
-        //     }
-        //     steps {
-        //         unstash 'MathSetup'
-        //         sh "echo CXX=${CLANG_CXX} -Werror > make/local"
-        //         sh "echo O=0 >> make/local"
-        //         sh "make -j${PARALLEL} test-headers"
-        //     }
-        //     post { always { deleteDir() } }
-        // }
+        stage('Headers check') {
+            agent {
+                docker {
+                    image 'stanorg/ci:gpu-cpp17'
+                    label 'linux'
+                }
+            }
+            when {
+                expression {
+                    !skipRemainingStages
+                }
+            }
+            steps {
+                unstash 'MathSetup'
+                sh "echo CXX=${CLANG_CXX} -Werror > make/local"
+                sh "echo O=0 >> make/local"
+                sh "make -j${PARALLEL} test-headers"
+            }
+            post { always { deleteDir() } }
+        }
 
-        // stage('Full Unit Tests') {
-        //     when {
-        //         expression {
-        //             !skipRemainingStages
-        //         }
-        //     }
-        //     failFast true
-        //     parallel {
-        //         stage('Rev/Fwd Unit Tests') {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:gpu-cpp17'
-        //                     label 'linux'
-        //                     args '--cap-add SYS_PTRACE'
-        //                 }
-        //             }
-        //             when {
-        //                 expression {
-        //                     !skipRemainingStages
-        //                 }
-        //             }
-        //             steps {
-        //                 unstash 'MathSetup'
-        //                 sh "echo CXXFLAGS += -fsanitize=address >> make/local"
+        stage('Full Unit Tests') {
+            when {
+                expression {
+                    !skipRemainingStages
+                }
+            }
+            failFast true
+            parallel {
+                stage('Rev/Fwd Unit Tests') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu-cpp17'
+                            label 'linux'
+                            args '--cap-add SYS_PTRACE'
+                        }
+                    }
+                    when {
+                        expression {
+                            !skipRemainingStages
+                        }
+                    }
+                    steps {
+                        unstash 'MathSetup'
+                        sh "echo CXXFLAGS += -fsanitize=address >> make/local"
 
-        //                 script {
-        //                     if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
-        //                         sh "echo O=0 >> make/local"
-        //                     }
+                        script {
+                            if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
+                                sh "echo O=0 >> make/local"
+                            }
 
-        //                     runTests("test/unit/math/rev")
-        //                     runTests("test/unit/math/fwd")
-        //                 }
-        //             }
-        //             post { always { retry(3) { deleteDir() } } }
-        //         }
-        //         stage('Mix Unit Tests') {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:gpu-cpp17'
-        //                     label 'linux'
-        //                     args '--cap-add SYS_PTRACE'
-        //                 }
-        //             }
-        //             when {
-        //                 expression {
-        //                     !skipRemainingStages
-        //                 }
-        //             }
-        //             steps {
-        //                 unstash 'MathSetup'
-        //                 sh "echo CXXFLAGS += -fsanitize=address >> make/local"
-        //                 script {
-        //                     if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
-        //                         sh "echo O=1 >> make/local"
-        //                     }
-        //                     runTests("test/unit/math/mix", true)
-        //                 }
-        //             }
-        //             post { always { retry(3) { deleteDir() } } }
-        //         }
-        //         stage('Prim Unit Tests') {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:gpu-cpp17'
-        //                     label 'linux'
-        //                     args '--cap-add SYS_PTRACE'
-        //                 }
-        //             }
-        //             when {
-        //                 expression {
-        //                     !skipRemainingStages
-        //                 }
-        //             }
-        //             steps {
-        //                 unstash 'MathSetup'
-        //                 sh "echo CXXFLAGS += -fsanitize=address >> make/local"
-        //                 script {
-        //                     if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
-        //                         sh "echo O=0 >> make/local"
-        //                     }
-        //                     runTests("test/unit/*_test.cpp", false)
-        //                     runTests("test/unit/math/*_test.cpp", false)
-        //                     runTests("test/unit/math/prim", true)
-        //                     runTests("test/unit/math/memory", false)
-        //                 }
-        //             }
-        //             post { always { retry(3) { deleteDir() } } }
-        //         }
-        //         stage('OpenCL GPU tests') {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:gpu-cpp17'
-        //                     label 'v100'
-        //                     args '--gpus 1'
-        //                 }
-        //             }
-        //             steps {
-        //                 script {
-        //                     unstash 'MathSetup'
-        //                     sh """
-        //                         echo CXX=${CLANG_CXX} -Werror > make/local
-        //                         echo STAN_OPENCL=true >> make/local
-        //                         echo OPENCL_PLATFORM_ID=${OPENCL_PLATFORM_ID_GPU} >> make/local
-        //                         echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID_GPU} >> make/local
-        //                     """
-        //                     if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
-        //                         sh "echo O=1 >> make/local"
-        //                     }
-        //                     runTests("test/unit/math/opencl", false) // TODO(bward): try to enable
-        //                     runTests("test/unit/multiple_translation_units_test.cpp")
-        //                 }
-        //             }
-        //         }
-        //     }
-        // }
-        // stage('Always-run tests') {
-        //     when {
-        //         expression {
-        //             !skipRemainingStages
-        //         }
-        //     }
-        //     failFast true
-        //     parallel {
-        //         stage('MPI tests') {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:gpu-cpp17'
-        //                     label 'linux'
-        //                 }
-        //             }
-        //             steps {
-        //                 unstash 'MathSetup'
-        //                 sh """
-        //                     echo CXX=${MPICXX} > make/local
-        //                     echo CXX_TYPE=gcc >> make/local
-        //                     echo STAN_MPI=true >> make/local
-        //                 """
-        //                 runTests("test/unit/math/prim/functor")
-        //                 runTests("test/unit/math/rev/functor")
-        //             }
-        //             post { always { retry(3) { deleteDir() } } }
-        //         }
-        //         stage('Expressions test') {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:gpu-cpp17'
-        //                     label 'linux'
-        //                 }
-        //             }
-        //             steps {
-        //                 unstash 'MathSetup'
-        //                 script {
-        //                     sh "echo O=0 > make/local"
-        //                     sh "echo CXX=${CLANG_CXX} -Werror >> make/local"
-        //                     sh "python ./test/code_generator_test.py"
-        //                     sh "python ./test/signature_parser_test.py"
-        //                     sh "python ./test/statement_types_test.py"
-        //                     sh "python ./test/varmat_compatibility_summary_test.py"
-        //                     sh "python ./test/varmat_compatibility_test.py"
-        //                     withEnv(['PATH+TBB=./lib/tbb']) {
-        //                         sh "python ./test/expressions/test_expression_testing_framework.py"
-        //                         try { sh "./runTests.py -j${PARALLEL} test/expressions" }
-        //                         finally { junit 'test/**/*.xml' }
-        //                     }
-        //                     sh "make clean-all"
-        //                     sh "echo STAN_THREADS=true >> make/local"
-        //                     withEnv(['PATH+TBB=./lib/tbb']) {
-        //                         try {
-        //                             sh "./runTests.py -j${PARALLEL} test/expressions --only-functions reduce_sum map_rect"
-		// 		                }
-        //                         finally { junit 'test/**/*.xml' }
-        //                     }
-        //                 }
-        //             }
-        //             post { always { deleteDir() } }
-        //         }
+                            runTests("test/unit/math/rev")
+                            runTests("test/unit/math/fwd")
+                        }
+                    }
+                    post { always { retry(3) { deleteDir() } } }
+                }
+                stage('Mix Unit Tests') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu-cpp17'
+                            label 'linux'
+                            args '--cap-add SYS_PTRACE'
+                        }
+                    }
+                    when {
+                        expression {
+                            !skipRemainingStages
+                        }
+                    }
+                    steps {
+                        unstash 'MathSetup'
+                        sh "echo CXXFLAGS += -fsanitize=address >> make/local"
+                        script {
+                            if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
+                                sh "echo O=1 >> make/local"
+                            }
+                            runTests("test/unit/math/mix", true)
+                        }
+                    }
+                    post { always { retry(3) { deleteDir() } } }
+                }
+                stage('Prim Unit Tests') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu-cpp17'
+                            label 'linux'
+                            args '--cap-add SYS_PTRACE'
+                        }
+                    }
+                    when {
+                        expression {
+                            !skipRemainingStages
+                        }
+                    }
+                    steps {
+                        unstash 'MathSetup'
+                        sh "echo CXXFLAGS += -fsanitize=address >> make/local"
+                        script {
+                            if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
+                                sh "echo O=0 >> make/local"
+                            }
+                            runTests("test/unit/*_test.cpp", false)
+                            runTests("test/unit/math/*_test.cpp", false)
+                            runTests("test/unit/math/prim", true)
+                            runTests("test/unit/math/memory", false)
+                        }
+                    }
+                    post { always { retry(3) { deleteDir() } } }
+                }
+                stage('OpenCL GPU tests') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu-cpp17'
+                            label 'v100'
+                            args '--gpus 1'
+                        }
+                    }
+                    steps {
+                        script {
+                            unstash 'MathSetup'
+                            sh """
+                                echo CXX=${CLANG_CXX} -Werror > make/local
+                                echo STAN_OPENCL=true >> make/local
+                                echo OPENCL_PLATFORM_ID=${OPENCL_PLATFORM_ID_GPU} >> make/local
+                                echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID_GPU} >> make/local
+                            """
+                            if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
+                                sh "echo O=1 >> make/local"
+                            }
+                            runTests("test/unit/math/opencl", false) // TODO(bward): try to enable
+                            runTests("test/unit/multiple_translation_units_test.cpp")
+                        }
+                    }
+                }
+            }
+        }
+        stage('Always-run tests') {
+            when {
+                expression {
+                    !skipRemainingStages
+                }
+            }
+            failFast true
+            parallel {
+                stage('MPI tests') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu-cpp17'
+                            label 'linux'
+                        }
+                    }
+                    steps {
+                        unstash 'MathSetup'
+                        sh """
+                            echo CXX=${MPICXX} > make/local
+                            echo CXX_TYPE=gcc >> make/local
+                            echo STAN_MPI=true >> make/local
+                        """
+                        runTests("test/unit/math/prim/functor")
+                        runTests("test/unit/math/rev/functor")
+                    }
+                    post { always { retry(3) { deleteDir() } } }
+                }
+                stage('Expressions test') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu-cpp17'
+                            label 'linux'
+                        }
+                    }
+                    steps {
+                        unstash 'MathSetup'
+                        script {
+                            sh "echo O=0 > make/local"
+                            sh "echo CXX=${CLANG_CXX} -Werror >> make/local"
+                            sh "python ./test/code_generator_test.py"
+                            sh "python ./test/signature_parser_test.py"
+                            sh "python ./test/statement_types_test.py"
+                            sh "python ./test/varmat_compatibility_summary_test.py"
+                            sh "python ./test/varmat_compatibility_test.py"
+                            withEnv(['PATH+TBB=./lib/tbb']) {
+                                sh "python ./test/expressions/test_expression_testing_framework.py"
+                                try { sh "./runTests.py -j${PARALLEL} test/expressions" }
+                                finally { junit 'test/**/*.xml' }
+                            }
+                            sh "make clean-all"
+                            sh "echo STAN_THREADS=true >> make/local"
+                            withEnv(['PATH+TBB=./lib/tbb']) {
+                                try {
+                                    sh "./runTests.py -j${PARALLEL} test/expressions --only-functions reduce_sum map_rect"
+				                }
+                                finally { junit 'test/**/*.xml' }
+                            }
+                        }
+                    }
+                    post { always { deleteDir() } }
+                }
 
-        //         stage('Threading tests') {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:gpu-cpp17'
-        //                     label 'linux'
-        //                 }
-        //             }
-        //             steps {
-        //                 script {
-        //                     unstash 'MathSetup'
-        //                     sh "echo CXX=${CLANG_CXX} -Werror > make/local"
-        //                     sh "echo STAN_THREADS=true >> make/local"
-        //                     sh "export STAN_NUM_THREADS=4"
-        //                     if (isBranch('develop') || isBranch('master')) {
-        //                         runTests("test/unit")
-        //                         sh "find . -name *_test.xml | xargs rm"
-        //                     } else {
-        //                         runTests("test/unit -f thread")
-        //                         sh "find . -name *_test.xml | xargs rm"
-        //                         runTests("test/unit -f map_rect")
-        //                         sh "find . -name *_test.xml | xargs rm"
-        //                         runTests("test/unit -f reduce_sum")
-        //                     }
-        //                 }
-        //             }
-        //             post { always { retry(3) { deleteDir() } } }
-        //         }
-        //     }
-        // }
+                stage('Threading tests') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu-cpp17'
+                            label 'linux'
+                        }
+                    }
+                    steps {
+                        script {
+                            unstash 'MathSetup'
+                            sh "echo CXX=${CLANG_CXX} -Werror > make/local"
+                            sh "echo STAN_THREADS=true >> make/local"
+                            sh "export STAN_NUM_THREADS=4"
+                            if (isBranch('develop') || isBranch('master')) {
+                                runTests("test/unit")
+                                sh "find . -name *_test.xml | xargs rm"
+                            } else {
+                                runTests("test/unit -f thread")
+                                sh "find . -name *_test.xml | xargs rm"
+                                runTests("test/unit -f map_rect")
+                                sh "find . -name *_test.xml | xargs rm"
+                                runTests("test/unit -f reduce_sum")
+                            }
+                        }
+                    }
+                    post { always { retry(3) { deleteDir() } } }
+                }
+            }
+        }
 
         stage ('Distribution tests') {
             when {


### PR DESCRIPTION
## Summary

See runs like https://jenkins.flatironinstitute.org/blue/organizations/jenkins/Stan%2FMath/detail/PR-2832/20/pipeline

This started after #2826. I believe it's a simple fix to request that the nodes are only linux ones.


## Checklist

- [x] Math issue #(issue number)

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
