### PR TITLE
[BUGFIX] grad_2f1: Add minimum number of iterations and early stopping test

### DIFF
--- a/stan/math/prim/fun/grad_2F1.hpp
+++ b/stan/math/prim/fun/grad_2F1.hpp
@@ -76,7 +76,7 @@ TupleT grad_2F1_impl_ab(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
   ScalarT inner_diff = 1;
   ScalarArrayT g_current = ScalarArrayT::Zero(3);
 
-  while (inner_diff > precision && k < max_steps) {
+  while ((inner_diff > precision || k < 5) && k < max_steps) {
     ScalarT p = ((a1 + k) * (a2 + k) / ((b1 + k) * (1.0 + k)));
     if (p == 0) {
       return grad_tuple;

--- a/stan/math/prim/fun/grad_2F1.hpp
+++ b/stan/math/prim/fun/grad_2F1.hpp
@@ -73,10 +73,11 @@ TupleT grad_2F1_impl_ab(const T1& a1, const T2& a2, const T3& b1, const T_z& z,
 
   int sign_zk = sign_z;
   int k = 0;
+  const int min_steps = 5;
   ScalarT inner_diff = 1;
   ScalarArrayT g_current = ScalarArrayT::Zero(3);
 
-  while ((inner_diff > precision || k < 5) && k < max_steps) {
+  while ((inner_diff > precision || k < min_steps) && k < max_steps) {
     ScalarT p = ((a1 + k) * (a2 + k) / ((b1 + k) * (1.0 + k)));
     if (p == 0) {
       return grad_tuple;

--- a/test/unit/math/prim/fun/grad_2F1_test.cpp
+++ b/test/unit/math/prim/fun/grad_2F1_test.cpp
@@ -156,3 +156,17 @@ TEST(MathPrimScalFun, grad2F1_11) {
   EXPECT_NEAR(-30843032.10697079073015067426929807, std::get<2>(grad_tuple),
               1e-1);  // reference: discrete diff in mathematica
 }
+
+TEST(MathPrimScalFun, grad2F1_early_stop) {
+  using stan::math::internal::grad_2F1_impl;
+  double a1 = -0.5;
+  double a2 = -4.5;
+  double b1 = 11.0;
+  double z = 0.3;
+
+  // Algorithm will falsely converge early when only calculating w.r.t a1
+  // with these inputs. The minimum number of iterations (5) will take effect
+  auto grad_tuple = grad_2F1_impl<true, false, false, false>(a1, a2, b1, z);
+
+  EXPECT_NEAR(-0.1227022810085707, std::get<0>(grad_tuple), 1e-8);
+}


### PR DESCRIPTION
## Summary

As mentioned in #2857, the `grad_2f1` function can falsely converge early when only calculating gradients w.r.t. a subset of parameters. This PR introduces a minimum number of iterations (5) to avoid this and a test to verify

## Tests

Test-case from #2857 added

## Side Effects

N/A

## Release notes

Added a minimum number of iterations (5) to the `grad_2f1` function to avoid early convergence

## Checklist

- [x] Math issue #2857 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
