### PR TITLE
Revert "Change label from v100 to k40 for OpenCL GPU tests"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -330,7 +330,7 @@ pipeline {
                     agent {
                         docker {
                             image 'stanorg/ci:gpu-cpp17'
-                            label 'k40'
+                            label 'v100'
                             args '--gpus 1'
                         }
                     }


### PR DESCRIPTION
Reverts stan-dev/math#2862

The k40s are much older machines and have been causing their own test failures. 