### PR TITLE
Comment out OpenCL GPU tests stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -326,31 +326,33 @@ pipeline {
                     }
                     post { always { retry(3) { deleteDir() } } }
                 }
-                stage('OpenCL GPU tests') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:gpu-cpp17'
-                            label 'v100'
-                            args '--gpus 1'
-                        }
-                    }
-                    steps {
-                        script {
-                            unstash 'MathSetup'
-                            sh """
-                                echo CXX=${CLANG_CXX} -Werror > make/local
-                                echo STAN_OPENCL=true >> make/local
-                                echo OPENCL_PLATFORM_ID=${OPENCL_PLATFORM_ID_GPU} >> make/local
-                                echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID_GPU} >> make/local
-                            """
-                            if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
-                                sh "echo O=1 >> make/local"
-                            }
-                            runTests("test/unit/math/opencl", false) // TODO(bward): try to enable
-                            runTests("test/unit/multiple_translation_units_test.cpp")
-                        }
-                    }
-                }
+                // We have commented out the GPU tests as there's a bug in CUDA12 & Docker
+                // As soon as that's sorted out we should un-comment this stage
+                // stage('OpenCL GPU tests') {
+                //     agent {
+                //         docker {
+                //             image 'stanorg/ci:gpu-cpp17'
+                //             label 'v100'
+                //             args '--gpus 1'
+                //         }
+                //     }
+                //     steps {
+                //         script {
+                //             unstash 'MathSetup'
+                //             sh """
+                //                 echo CXX=${CLANG_CXX} -Werror > make/local
+                //                 echo STAN_OPENCL=true >> make/local
+                //                 echo OPENCL_PLATFORM_ID=${OPENCL_PLATFORM_ID_GPU} >> make/local
+                //                 echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID_GPU} >> make/local
+                //             """
+                //             if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
+                //                 sh "echo O=1 >> make/local"
+                //             }
+                //             runTests("test/unit/math/opencl", false) // TODO(bward): try to enable
+                //             runTests("test/unit/multiple_translation_units_test.cpp")
+                //         }
+                //     }
+                // }
             }
         }
         stage('Always-run tests') {


### PR DESCRIPTION
## Summary

There's currently a bug with CUDA12 and Docker, the Flatiron IT team is working on sorting this out.
Until the problem is fixed, we are disabling the OpenCL GPU tests to un-stuck the CI/PRs.

## Tests

-

## Side Effects

Temporarily disable OpenCL GPU tests in CI.

## Release notes

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
