### PR TITLE
Re-enable OpenCL tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -326,33 +326,31 @@ pipeline {
                     }
                     post { always { retry(3) { deleteDir() } } }
                 }
-                // We have commented out the GPU tests as there's a bug in CUDA12 & Docker
-                // As soon as that's sorted out we should un-comment this stage
-                // stage('OpenCL GPU tests') {
-                //     agent {
-                //         docker {
-                //             image 'stanorg/ci:gpu-cpp17'
-                //             label 'v100'
-                //             args '--gpus 1'
-                //         }
-                //     }
-                //     steps {
-                //         script {
-                //             unstash 'MathSetup'
-                //             sh """
-                //                 echo CXX=${CLANG_CXX} -Werror > make/local
-                //                 echo STAN_OPENCL=true >> make/local
-                //                 echo OPENCL_PLATFORM_ID=${OPENCL_PLATFORM_ID_GPU} >> make/local
-                //                 echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID_GPU} >> make/local
-                //             """
-                //             if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
-                //                 sh "echo O=1 >> make/local"
-                //             }
-                //             runTests("test/unit/math/opencl", false) // TODO(bward): try to enable
-                //             runTests("test/unit/multiple_translation_units_test.cpp")
-                //         }
-                //     }
-                // }
+                stage('OpenCL GPU tests') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu-cpp17'
+                            label 'v100'
+                            args '--gpus 1'
+                        }
+                    }
+                    steps {
+                        script {
+                            unstash 'MathSetup'
+                            sh """
+                                echo CXX=${CLANG_CXX} -Werror > make/local
+                                echo STAN_OPENCL=true >> make/local
+                                echo OPENCL_PLATFORM_ID=${OPENCL_PLATFORM_ID_GPU} >> make/local
+                                echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID_GPU} >> make/local
+                            """
+                            if (!(params.optimizeUnitTests || isBranch('develop') || isBranch('master'))) {
+                                sh "echo O=1 >> make/local"
+                            }
+                            runTests("test/unit/math/opencl", false) // TODO(bward): try to enable
+                            runTests("test/unit/multiple_translation_units_test.cpp")
+                        }
+                    }
+                }
             }
         }
         stage('Always-run tests') {

--- a/test/unit/math/opencl/mrrr_test.cpp
+++ b/test/unit/math/opencl/mrrr_test.cpp
@@ -149,7 +149,8 @@ TEST(MathMatrix, tridiag_eigensolver_large_fixed) {
 //   stan::math::matrix_cl<double> eigenvecs_cl;
 
 //   stan::math::internal::tridiagonal_eigensolver_cl(diag_cl, subdiag_cl,
-//                                                    eigenvals_cl, eigenvecs_cl);
+//                                                    eigenvals_cl,
+//                                                    eigenvecs_cl);
 
 //   Eigen::VectorXd eigenvals
 //       = stan::math::from_matrix_cl<Eigen::VectorXd>(eigenvals_cl);
@@ -162,7 +163,8 @@ TEST(MathMatrix, tridiag_eigensolver_large_fixed) {
 //   EXPECT_NEAR_REL(diag.sum(), eigenvals.sum());
 //   EXPECT_MATRIX_NEAR(eigenvecs * eigenvecs.transpose(),
 //                      Eigen::MatrixXd::Identity(size, size), 1e-11);
-//   EXPECT_MATRIX_NEAR(t * eigenvecs, eigenvecs * eigenvals.asDiagonal(), 1e-12);
+//   EXPECT_MATRIX_NEAR(t * eigenvecs, eigenvecs * eigenvals.asDiagonal(),
+//   1e-12);
 // }
 
 #endif

--- a/test/unit/math/opencl/mrrr_test.cpp
+++ b/test/unit/math/opencl/mrrr_test.cpp
@@ -103,65 +103,66 @@ TEST(MathMatrix, tridiag_eigensolver_large_fixed) {
   EXPECT_MATRIX_NEAR(t * eigenvecs, eigenvecs * eigenvals.asDiagonal(), 1e-12);
 }
 
-/**
- * Generates a glued Wilkinson matrix - a known hard case for MRRR.
- * @param m each Wilkinson matrix is of size `2*m+1`
- * @param n number of Wilkinson matrices to use
- * @param glue amount og glue
- * @param[out] diag diagonal of the resulting matrix
- * @param[out] subdiag subdiagonal of the resulting matrix
- */
-void get_glued_wilkinson(int m, int n, double glue, Eigen::VectorXd& diag,
-                         Eigen::VectorXd& subdiag) {
-  int w_size = 2 * m + 1;
-  int size = w_size * n;
-  diag.resize(size);
-  subdiag.resize(size - 1);
-  for (int start = 0; start < size; start += w_size) {
-    for (int i = 0; i < m; i++) {
-      int value = m - i;
-      diag[start + i] = value;
-      diag[start + w_size - i - 1] = value;
-    }
-    diag[start + m] = 0;
-    subdiag.segment(start, w_size - 1)
-        = Eigen::VectorXd::Constant(w_size - 1, 1);
-    if (start > 0) {
-      subdiag[start - 1] = glue;
-      diag[start] += glue;
-      diag[start - 1] += glue;
-    }
-  }
-}
+// COMMENTED OUT DUE TO INFINITE LOOP BEHAVIOR WITH CUDA 12
+// /**
+//  * Generates a glued Wilkinson matrix - a known hard case for MRRR.
+//  * @param m each Wilkinson matrix is of size `2*m+1`
+//  * @param n number of Wilkinson matrices to use
+//  * @param glue amount og glue
+//  * @param[out] diag diagonal of the resulting matrix
+//  * @param[out] subdiag subdiagonal of the resulting matrix
+//  */
+// void get_glued_wilkinson(int m, int n, double glue, Eigen::VectorXd& diag,
+//                          Eigen::VectorXd& subdiag) {
+//   int w_size = 2 * m + 1;
+//   int size = w_size * n;
+//   diag.resize(size);
+//   subdiag.resize(size - 1);
+//   for (int start = 0; start < size; start += w_size) {
+//     for (int i = 0; i < m; i++) {
+//       int value = m - i;
+//       diag[start + i] = value;
+//       diag[start + w_size - i - 1] = value;
+//     }
+//     diag[start + m] = 0;
+//     subdiag.segment(start, w_size - 1)
+//         = Eigen::VectorXd::Constant(w_size - 1, 1);
+//     if (start > 0) {
+//       subdiag[start - 1] = glue;
+//       diag[start] += glue;
+//       diag[start - 1] += glue;
+//     }
+//   }
+// }
 
-TEST(MathMatrix, tridiag_eigensolver_large_wilkinson) {
-  int n = 5;
-  int m = 100;
-  int size = (2 * m + 1) * n;
-  Eigen::VectorXd diag;
-  Eigen::VectorXd subdiag;
-  get_glued_wilkinson(m, n, 1e-13, diag, subdiag);
+// TEST(MathMatrix, tridiag_eigensolver_large_wilkinson) {
+//   int n = 5;
+//   int m = 100;
+//   int size = (2 * m + 1) * n;
+//   Eigen::VectorXd diag;
+//   Eigen::VectorXd subdiag;
+//   get_glued_wilkinson(m, n, 1e-13, diag, subdiag);
 
-  stan::math::matrix_cl<double> diag_cl(diag);
-  stan::math::matrix_cl<double> subdiag_cl(subdiag);
-  stan::math::matrix_cl<double> eigenvals_cl;
-  stan::math::matrix_cl<double> eigenvecs_cl;
+//   stan::math::matrix_cl<double> diag_cl(diag);
+//   stan::math::matrix_cl<double> subdiag_cl(subdiag);
+//   stan::math::matrix_cl<double> eigenvals_cl;
+//   stan::math::matrix_cl<double> eigenvecs_cl;
 
-  stan::math::internal::tridiagonal_eigensolver_cl(diag_cl, subdiag_cl,
-                                                   eigenvals_cl, eigenvecs_cl);
+//   stan::math::internal::tridiagonal_eigensolver_cl(diag_cl, subdiag_cl,
+//                                                    eigenvals_cl, eigenvecs_cl);
 
-  Eigen::VectorXd eigenvals
-      = stan::math::from_matrix_cl<Eigen::VectorXd>(eigenvals_cl);
-  Eigen::MatrixXd eigenvecs = stan::math::from_matrix_cl(eigenvecs_cl);
+//   Eigen::VectorXd eigenvals
+//       = stan::math::from_matrix_cl<Eigen::VectorXd>(eigenvals_cl);
+//   Eigen::MatrixXd eigenvecs = stan::math::from_matrix_cl(eigenvecs_cl);
 
-  Eigen::MatrixXd t = Eigen::MatrixXd::Constant(size, size, 0);
-  t.diagonal() = diag;
-  t.diagonal(1) = subdiag;
-  t.diagonal(-1) = subdiag;
-  EXPECT_NEAR_REL(diag.sum(), eigenvals.sum());
-  EXPECT_MATRIX_NEAR(eigenvecs * eigenvecs.transpose(),
-                     Eigen::MatrixXd::Identity(size, size), 1e-11);
-  EXPECT_MATRIX_NEAR(t * eigenvecs, eigenvecs * eigenvals.asDiagonal(), 1e-12);
-}
+//   Eigen::MatrixXd t = Eigen::MatrixXd::Constant(size, size, 0);
+//   t.diagonal() = diag;
+//   t.diagonal(1) = subdiag;
+//   t.diagonal(-1) = subdiag;
+//   EXPECT_NEAR_REL(diag.sum(), eigenvals.sum());
+//   EXPECT_MATRIX_NEAR(eigenvecs * eigenvecs.transpose(),
+//                      Eigen::MatrixXd::Identity(size, size), 1e-11);
+//   EXPECT_MATRIX_NEAR(t * eigenvecs, eigenvecs * eigenvals.asDiagonal(), 1e-12);
+// }
 
 #endif


### PR DESCRIPTION
## Summary

Re-enables OpenCL tests (see #2867). Thanks to @blackwer and @dylex for identifying and patching the issue on the CI machines.

The test `tridiag_eigensolver_large_wilkinson`, is still disabled, since it currently loops forever on this line:
https://github.com/stan-dev/math/blob/03f68a6187de08b9f4fb4beebc356000ec9a7c1c/stan/math/opencl/mrrr.hpp#L356


## Tests

Enables existing tests

## Side Effects

None

## Release notes

## Checklist

- [x] Math issue: Closes #2860

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
