### PR TITLE
Specialize `is_nan` for ints

### DIFF
--- a/stan/math/prim/fun/is_nan.hpp
+++ b/stan/math/prim/fun/is_nan.hpp
@@ -8,19 +8,34 @@ namespace stan {
 namespace math {
 
 /**
- * Returns true if the input is NaN and false otherwise.
+ * Tests if the input is Not a Number (NaN)
+ *
+ * Integer specialization, always return false.
+ *
+ * @tparam T Integer type.
+ * @param x Value to test.
+ * @return <code>false</code>.
+ */
+template <typename T, require_integral_t<T>* = nullptr>
+inline bool is_nan(T x) {
+  return false;
+}
+
+/**
+ * Tests if the input is Not a Number (NaN)
  *
  * Delegates to <code>std::isnan</code>.
  *
+ * @tparam T Floating point type.
  * @param x Value to test.
  * @return <code>true</code> if the value is NaN.
  */
-template <typename T, typename = require_arithmetic_t<T>>
+template <typename T, require_floating_point_t<T>* = nullptr>
 inline bool is_nan(T x) {
   return std::isnan(x);
 }
 
-template <typename T, typename = require_eigen_t<T>>
+template <typename T, require_eigen_t<T>* = nullptr>
 inline bool is_nan(const T& x) {
   return x.hasNan();
 }


### PR DESCRIPTION
## Summary

This is a bit of an odd PR. Basically, I have been (very successfully! it's quite encouraging) trying to compile Stan Math and downstream CmdStan programs using Microsoft Visual Studio on Windows. 

The only  actual error I've encountered has been with `is_nan`. We have some code (I believe in acosh) which ends up instantiating `std::isnan<int>`. This is not accepted by MSVC. Luckily, there is an easy answer - an `int` is never `NaN`! So this PR makes the very small change to just always return false for ints. 

## Tests

No new tests

## Side Effects

None

## Release notes


## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
