### PR TITLE
Fix csr_to_dense_matrix first row indexing check bug

### DIFF
--- a/stan/math/prim/fun/csr_to_dense_matrix.hpp
+++ b/stan/math/prim/fun/csr_to_dense_matrix.hpp
@@ -50,13 +50,17 @@ csr_to_dense_matrix(int m, int n, const T& w, const std::vector<int>& v,
   Matrix<value_type_t<T>, Dynamic, Dynamic> result(m, n);
   result.setZero();
   for (int row = 0; row < m; ++row) {
-    int row_end_in_w = (u[row] - stan::error_index::value) + csr_u_to_z(u, row);
-    check_range("csr_to_dense_matrix", "w", w.size(), row_end_in_w);
-    for (int nze = u[row] - stan::error_index::value; nze < row_end_in_w;
-         ++nze) {
-      // row is row index, v[nze] is column index. w[nze] is entry value.
-      check_range("csr_to_dense_matrix", "j", n, v[nze]);
-      result(row, v[nze] - stan::error_index::value) = w_ref.coeff(nze);
+    int row_nnz = csr_u_to_z(u, row);
+
+    if (row_nnz > 0) {
+      int row_end_in_w = (u[row] - stan::error_index::value) + row_nnz;
+      check_range("csr_to_dense_matrix", "w", w.size(), row_end_in_w);
+      for (int nze = u[row] - stan::error_index::value; nze < row_end_in_w;
+           ++nze) {
+        // row is row index, v[nze] is column index. w[nze] is entry value.
+        check_range("csr_to_dense_matrix", "j", n, v[nze]);
+        result(row, v[nze] - stan::error_index::value) = w_ref.coeff(nze);
+      }
     }
   }
   return result;

--- a/test/unit/math/prim/fun/csr_to_dense_matrix_test.cpp
+++ b/test/unit/math/prim/fun/csr_to_dense_matrix_test.cpp
@@ -115,3 +115,16 @@ TEST(SparseStuff, csr_to_dense_matrix_v_short) {
   EXPECT_THROW(stan::math::csr_to_dense_matrix(2, 3, X_w, X_v, X_u),
                std::invalid_argument);
 }
+
+// Test that valid sparse matrix with empty first row does not throw (CSR).
+TEST(SparseStuff, csr_to_dense_matrix_empty_row) {
+  stan::math::matrix_d m(3, 2);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 0.0, 0.0, 1.0, 0.0, 0.0, 0.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  EXPECT_NO_THROW(stan::math::csr_to_dense_matrix(3, 2, X_w, X_v, X_u));
+}


### PR DESCRIPTION
## Summary

Fix #2876 by skipping `check_range` and iteration for empty rows.

## Tests

New test with a sparse matrix with first row of zeros (adapted from failing case in #2030).

## Side Effects

N/A

## Release notes

Fix `csr_to_dense_matrix` to work in case of matrix with empty first row.

## Checklist

- [x] Math issue #2876 (duplicate of #2030)

- [x] Copyright holder: (Torsti Schulz)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
