### PR TITLE
Delete object files after test executable is built

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -24,9 +24,9 @@ test/% : CXXFLAGS += $(CXXFLAGS_GTEST)
 test/% : CPPFLAGS += $(CPPFLAGS_GTEST)
 test/% : INC += $(INC_GTEST)
 
-test/%_test$(EXE) : test/%_test.cpp $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(MPI_TARGETS) $(TBB_TARGETS)
+test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(MPI_TARGETS) $(TBB_TARGETS)
 	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
-
+	$(RM) test/$(subst  \,/,$*).o
 
 ##
 # Include dependency files for tests

--- a/make/tests
+++ b/make/tests
@@ -26,13 +26,15 @@ test/% : INC += $(INC_GTEST)
 
 test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(MPI_TARGETS) $(TBB_TARGETS)
 	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
-	$(RM) test/$(subst  \,/,$*).o
 
 ##
 # Include dependency files for tests
+# This has the side-effect of making the object files non-intermediates,
+# so we need to explicitly tell make we don't want to keep them
 ##
 ifneq ($(filter test/%,$(MAKECMDGOALS)),)
 -include $(patsubst %$(EXE),%.d,$(filter test/%,$(MAKECMDGOALS)))
+.INTERMEDIATE: $(patsubst %$(EXE),%.o,$(filter test/%,$(MAKECMDGOALS)))
 endif
 
 ##

--- a/make/tests
+++ b/make/tests
@@ -34,7 +34,7 @@ test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(MP
 ##
 ifneq ($(filter test/%,$(MAKECMDGOALS)),)
 -include $(patsubst %$(EXE),%.d,$(filter test/%,$(MAKECMDGOALS)))
-.INTERMEDIATE: $(patsubst %$(EXE),%.o,$(filter-out test/%.d test/%.o,$(filter test/%,$(MAKECMDGOALS))))
+.INTERMEDIATE: $(patsubst test/%_test$(EXE),test/%_test.o,$(filter test/%_test$(EXE),$(MAKECMDGOALS)))
 endif
 
 ##

--- a/make/tests
+++ b/make/tests
@@ -34,7 +34,7 @@ test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(MP
 ##
 ifneq ($(filter test/%,$(MAKECMDGOALS)),)
 -include $(patsubst %$(EXE),%.d,$(filter test/%,$(MAKECMDGOALS)))
-.INTERMEDIATE: $(patsubst %$(EXE),%.o,$(filter-out test/%.o,$(filter test/%,$(MAKECMDGOALS))))
+.INTERMEDIATE: $(patsubst %$(EXE),%.o,$(filter-out test/%.d test/%.o,$(filter test/%,$(MAKECMDGOALS))))
 endif
 
 ##

--- a/make/tests
+++ b/make/tests
@@ -26,6 +26,7 @@ test/% : INC += $(INC_GTEST)
 
 test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(MPI_TARGETS) $(TBB_TARGETS)
 	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
+	$(RM) test/$(subst  \,/,$*).o
 
 ##
 # Include dependency files for tests

--- a/make/tests
+++ b/make/tests
@@ -24,9 +24,9 @@ test/% : CXXFLAGS += $(CXXFLAGS_GTEST)
 test/% : CPPFLAGS += $(CPPFLAGS_GTEST)
 test/% : INC += $(INC_GTEST)
 
-test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(MPI_TARGETS) $(TBB_TARGETS)
+test/%_test$(EXE) : test/%_test.cpp $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(MPI_TARGETS) $(TBB_TARGETS)
 	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
-	$(RM) test/$(subst  \,/,$*).o
+
 
 ##
 # Include dependency files for tests

--- a/make/tests
+++ b/make/tests
@@ -34,7 +34,7 @@ test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(MP
 ##
 ifneq ($(filter test/%,$(MAKECMDGOALS)),)
 -include $(patsubst %$(EXE),%.d,$(filter test/%,$(MAKECMDGOALS)))
-.INTERMEDIATE: $(patsubst %$(EXE),%.o,$(filter test/%,$(MAKECMDGOALS)))
+.INTERMEDIATE: $(patsubst %$(EXE),%.o,$(filter-out test/%.o,$(filter test/%,$(MAKECMDGOALS))))
 endif
 
 ##

--- a/test/varmat_compatibility.py
+++ b/test/varmat_compatibility.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import threading
 
-from sig_utils import make, exe_extension,handle_function_list, get_signatures
+from sig_utils import make, handle_function_list, get_signatures
 from signature_parser import SignatureParser
 from code_generator import CodeGenerator
 
@@ -33,7 +33,7 @@ def run_command(command):
     """
     proc = subprocess.Popen(command, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
     stdout, stderr = proc.communicate()
-
+    
     if proc.poll() == 0:
         return (True, stdout, stderr)
     else:
@@ -56,12 +56,12 @@ def build_signature(prefix, cpp_code, debug):
 
     cpp_path = os.path.join(WORKING_FOLDER, os.path.basename(f.name))
 
-    executable_path = cpp_path.replace(".cpp", exe_extension)
+    object_path = cpp_path.replace(".cpp", ".o")
     dependency_path = cpp_path.replace(".cpp", ".d")
     stdout_path = cpp_path.replace(".cpp", ".stdout")
     stderr_path = cpp_path.replace(".cpp", ".stderr")
 
-    successful, stdout, stderr = run_command([make, executable_path])
+    successful, stdout, stderr = run_command([make, object_path])
 
     if successful or not debug:
         try:
@@ -75,7 +75,7 @@ def build_signature(prefix, cpp_code, debug):
             pass
 
         try:
-            os.remove(executable_path)
+            os.remove(object_path)
         except OSError:
             pass
     else:
@@ -85,7 +85,7 @@ def build_signature(prefix, cpp_code, debug):
 
             with open(stderr_path, "w") as stderr_f:
                 stderr_f.write(stderr.decode("utf-8"))
-
+        
     return successful
 
 def main(functions_or_sigs, results_file, cores, debug):
@@ -127,7 +127,7 @@ def main(functions_or_sigs, results_file, cores, debug):
 
         if len(requested_functions) > 0 and sp.function_name not in requested_functions:
             continue
-
+        
         signatures_to_check.add(signature)
 
     work_queue = Queue.Queue()
@@ -142,7 +142,7 @@ def main(functions_or_sigs, results_file, cores, debug):
 
         cpp_code = ""
         any_overload_uses_varmat = False
-
+        
         for m, overloads in enumerate(itertools.product(("Prim", "Rev", "RevVarmat"), repeat = sp.number_arguments())):
             cg = CodeGenerator()
 
@@ -153,7 +153,7 @@ def main(functions_or_sigs, results_file, cores, debug):
                 if arg.is_reverse_mode() and arg.is_varmat_compatible() and overload.endswith("Varmat"):
                     any_overload_uses_varmat = True
                     arg = cg.to_var_value(arg)
-
+                
                 arg_list.append(arg)
 
             cg.function_call_assign("stan::math::" + sp.function_name, *arg_list)


### PR DESCRIPTION
## Summary

Update the `make` rule for the test executables such that the `.o` files are deleted after they're done being used for linking.

This should help with #2872 

## Tests

None

## Side Effects

Hopefully none. The `.o` files would be re-built anyway of the executable needed to be updated, so these were truly only used once.

## Release notes

## Checklist

- [x] Math issue #2872 

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
