### PR TITLE
Fix eigenvalues_sym return type

### DIFF
--- a/stan/math/prim/fun/eigenvalues_sym.hpp
+++ b/stan/math/prim/fun/eigenvalues_sym.hpp
@@ -21,8 +21,7 @@ namespace math {
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
           require_not_st_var<EigMat>* = nullptr>
-Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, 1> eigenvalues_sym(
-    const EigMat& m) {
+Eigen::Vector<value_type_t<EigMat>, -1> eigenvalues_sym(const EigMat& m) {
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
   check_nonzero_size("eigenvalues_sym", "m", m_eval);

--- a/stan/math/rev/fun/eigenvalues_sym.hpp
+++ b/stan/math/rev/fun/eigenvalues_sym.hpp
@@ -23,10 +23,8 @@ namespace math {
  */
 template <typename T, require_rev_matrix_t<T>* = nullptr>
 inline auto eigenvalues_sym(const T& m) {
-  using return_t = return_var_matrix_t<T>;
-  if (unlikely(m.size() == 0)) {
-    return return_t(m);
-  }
+  using return_t = return_var_matrix_t<Eigen::VectorXd, T>;
+  check_nonzero_size("eigenvalues_sym", "m", m);
   check_symmetric("eigenvalues_sym", "m", m);
 
   auto arena_m = to_arena(m);

--- a/test/unit/math/rev/fun/eigenvalues_sym_test.cpp
+++ b/test/unit/math/rev/fun/eigenvalues_sym_test.cpp
@@ -17,7 +17,7 @@ TEST(AgradRev, eigenvaluesSymLogDet) {
   stan::math::matrix_d a_inv = stan::math::inverse(a);
 
   stan::math::matrix_v a_v(a);
-  auto w = eigenvalues_sym(a_v);
+  stan::math::matrix_v w = eigenvalues_sym(a_v);
   auto logdet = stan::math::sum(stan::math::log(w));
 
   stan::math::set_zero_all_adjoints();


### PR DESCRIPTION
## Summary

The reverse-mode specialization for eigenvalues_sym currently returns a matrix, rather than a vector. 

## Tests

Replaced an `auto` in existing tests with an explicit vector type to force compilation to verify this change.

## Side Effects

The reverse-mode specialization had different behavior than the prim version for size 0 matrices. These have been unified, as the old behavior fails to compile with the new return type. 

## Release notes
Fixed a bug where `eigenvalues_sym` would return a matrix with a dynamic number of rows  equal to 1, rather than a vector.

## Checklist

- [x] Math issue: Closes #2883

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
