### PR TITLE
make: remove unused LIBSUNDIALS

### DIFF
--- a/make/libraries
+++ b/make/libraries
@@ -81,9 +81,6 @@ $(SUNDIALS)/lib/libsundials_nvecserial.a: $(SUNDIALS_NVECSERIAL)
 
 SUNDIALS_TARGETS ?= $(SUNDIALS)/lib/libsundials_nvecserial.a $(SUNDIALS)/lib/libsundials_cvodes.a $(SUNDIALS)/lib/libsundials_idas.a $(SUNDIALS)/lib/libsundials_kinsol.a
 
-# FIXME(dl, 02/2023): remove LIBSUNDIALS variable after replacing use in Stan and CmdStan with SUNDIALS_TARGETS
-LIBSUNDIALS = $(SUNDIALS_TARGETS)
-
 STAN_SUNDIALS_HEADERS :=  $(call findfiles,$(MATH)stan,*cvodes*.hpp) $(call findfiles,$(MATH)stan,*idas*.hpp) $(call findfiles,$(MATH)stan,*kinsol*.hpp)
 $(STAN_SUNDIALS_HEADERS) : $(SUNDIALS_TARGETS)
 


### PR DESCRIPTION
## Summary

Following https://github.com/stan-dev/cmdstan/pull/1151, all our makefiles now use SUNDIALS_TARGET instead of LIBSUNDIALS.

This completes the checklist @syclik made here: https://github.com/stan-dev/math/pull/2861#issuecomment-1419182607

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
