### PR TITLE
Minor return type update for Eigen backwards compatibility

### DIFF
--- a/stan/math/prim/fun/eigenvalues_sym.hpp
+++ b/stan/math/prim/fun/eigenvalues_sym.hpp
@@ -21,7 +21,7 @@ namespace math {
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
           require_not_st_var<EigMat>* = nullptr>
-Eigen::Vector<value_type_t<EigMat>, -1> eigenvalues_sym(const EigMat& m) {
+Eigen::Matrix<value_type_t<EigMat>, -1, 1> eigenvalues_sym(const EigMat& m) {
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
   check_nonzero_size("eigenvalues_sym", "m", m_eval);


### PR DESCRIPTION
## Summary

The `eigenvalues_sym` return type currently uses `Eigen::Vector<>`, which was introduced in Eigen 3.4. This breaks compatibility with RcppEigen, which is currently only up to 3.3.9

## Tests

N/A

## Side Effects

N/A

## Release notes

`eigenvalues_sym` return type updated for RcppEigen compatibility

## Checklist

- [x] Math issue #2886

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
