### PR TITLE
StanHeaders 2.26 - Backport Eigen 3.4 Compatibility

### DIFF
--- a/stan/math/prim/fun/mdivide_left_tri.hpp
+++ b/stan/math/prim/fun/mdivide_left_tri.hpp
@@ -26,20 +26,19 @@ namespace math {
 template <Eigen::UpLoType TriView, typename T1, typename T2,
           require_all_eigen_t<T1, T2> * = nullptr,
           require_all_not_eigen_vt<is_var, T1, T2> * = nullptr>
-inline Eigen::Matrix<return_type_t<T1, T2>, T1::RowsAtCompileTime,
-                     T2::ColsAtCompileTime>
-mdivide_left_tri(const T1 &A, const T2 &b) {
+inline auto mdivide_left_tri(const T1 &A, const T2 &b) {
   using T_return = return_type_t<T1, T2>;
+  using ret_type = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
   if (A.rows() == 0) {
-    return {0, b.cols()};
+    return ret_type(0, b.cols());
   }
 
-  return A.template cast<T_return>()
-      .eval()
+  return ret_type(A)
       .template triangularView<TriView>()
-      .solve(b.template cast<T_return>().eval());
+      .solve(ret_type(b))
+      .eval();
 }
 
 /**

--- a/stan/math/prim/fun/mdivide_right.hpp
+++ b/stan/math/prim/fun/mdivide_right.hpp
@@ -37,8 +37,7 @@ mdivide_right(const EigMat1& b, const EigMat2& A) {
                        EigMat2::ColsAtCompileTime>(A)
       .transpose()
       .lu()
-      .solve(Eigen::Matrix<T_return, EigMat1::RowsAtCompileTime,
-                           EigMat1::ColsAtCompileTime>(b)
+      .solve(Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>(b)
                  .transpose())
       .transpose();
 }

--- a/stan/math/prim/fun/mdivide_right_tri.hpp
+++ b/stan/math/prim/fun/mdivide_right_tri.hpp
@@ -26,9 +26,7 @@ namespace math {
  */
 template <Eigen::UpLoType TriView, typename EigMat1, typename EigMat2,
           require_all_eigen_t<EigMat1, EigMat2>* = nullptr>
-inline Eigen::Matrix<return_type_t<EigMat1, EigMat2>,
-                     EigMat1::RowsAtCompileTime, EigMat2::ColsAtCompileTime>
-mdivide_right_tri(const EigMat1& b, const EigMat2& A) {
+inline auto mdivide_right_tri(const EigMat1& b, const EigMat2& A) {
   check_square("mdivide_right_tri", "A", A);
   check_multiplicable("mdivide_right_tri", "b", b, "A", A);
   if (TriView != Eigen::Lower && TriView != Eigen::Upper) {
@@ -36,21 +34,18 @@ mdivide_right_tri(const EigMat1& b, const EigMat2& A) {
                        "triangular view must be Eigen::Lower or Eigen::Upper",
                        "", "");
   }
+  using T_return = return_type_t<EigMat1, EigMat2>;
+  using ret_type = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
   if (A.rows() == 0) {
-    return {b.rows(), 0};
+    return ret_type(b.rows(), 0);
   }
 
-  return Eigen::Matrix<return_type_t<EigMat1, EigMat2>,
-                       EigMat2::RowsAtCompileTime, EigMat2::ColsAtCompileTime>(
-             A)
+  return ret_type(A)
       .template triangularView<TriView>()
       .transpose()
-      .solve(
-          Eigen::Matrix<return_type_t<EigMat1, EigMat2>,
-                        EigMat1::RowsAtCompileTime, EigMat1::ColsAtCompileTime>(
-              b)
-              .transpose())
-      .transpose();
+      .solve(ret_type(b).transpose())
+      .transpose()
+      .eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/meta/plain_type.hpp
+++ b/stan/math/prim/meta/plain_type.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta/is_eigen.hpp>
 #include <stan/math/prim/meta/is_detected.hpp>
+#include <stan/math/prim/meta/is_var_matrix.hpp>
 #include <type_traits>
 
 namespace stan {
@@ -40,13 +41,43 @@ struct eval_return_type {
 template <typename T>
 using eval_return_type_t = typename eval_return_type<T>::type;
 
+namespace internal {
+// primary template handles types that have no nested ::type member:
+template <class, class = void>
+struct has_plain_object : std::false_type {};
+
+// specialization recognizes types that do have a nested ::type member:
+template <class T>
+struct has_plain_object<T, void_t<typename std::decay_t<T>::PlainObject>>
+    : std::true_type {};
+
+// primary template handles types that have no nested ::type member:
+template <class, class = void>
+struct has_eval : std::false_type {};
+
+// specialization recognizes types that do have a nested ::type member:
+template <class T>
+struct has_eval<T, void_t<decltype(std::declval<std::decay_t<T>&>().eval())>>
+    : std::true_type {};
+
+}  // namespace internal
+
 /**
  * Determines plain (non expression) type associated with \c T. For \c Eigen
  * expression it is a type the expression can be evaluated into.
  * @tparam T type to determine plain type of
  */
 template <typename T>
-struct plain_type<T, require_eigen_t<T>> {
+struct plain_type<T, require_t<bool_constant<internal::has_eval<T>::value
+                                             && is_eigen<T>::value>>> {
+  using type = std::decay_t<decltype(std::declval<T&>().eval())>;
+};
+
+template <typename T>
+struct plain_type<
+    T, require_t<bool_constant<!internal::has_eval<T>::value
+                               && internal::has_plain_object<T>::value
+                               && is_eigen<T>::value>>> {
   using type = typename std::decay_t<T>::PlainObject;
 };
 


### PR DESCRIPTION
@hsbadr This PR backports the [Math header changes](https://github.com/stan-dev/math/pull/2583/files?file-filters%5B%5D=.hpp&show-deleted-files=true&show-viewed-files=true) from the Eigen 3.4 compatibility PR to StanHeaders 2.26

With this PR and #2887, both StanHeaders 2.26 and 2.31 will be compatible with both RcppEigen 3.3.9 and 3.4.0. This also resolves the ctsem error from the [update issue](https://github.com/RcppCore/RcppEigen/issues/103), and means that all rstan-based packages will be compatible with RcppEigen 3.4.0 once StanHeaders 2.26 is on CRAN