### PR TITLE
Backport tbb fix for building on gcc 13

### DIFF
--- a/lib/tbb_2020.3/STAN_CHANGES
+++ b/lib/tbb_2020.3/STAN_CHANGES
@@ -1,3 +1,4 @@
 This file documents changes done for the stan-math project
 
 - drop -g flag from makefiles for release mode builds to decrease size of binaries
+- Add `tbb::` to line 252 of `task.h` to fix a build failure with gcc 13. This was done upstream in https://github.com/oneapi-src/oneTBB/pull/833

--- a/lib/tbb_2020.3/include/tbb/task.h
+++ b/lib/tbb_2020.3/include/tbb/task.h
@@ -249,7 +249,7 @@ namespace internal {
 #if __TBB_TASK_PRIORITY
         //! Pointer to the next offloaded lower priority task.
         /** Used to maintain a list of offloaded tasks inside the scheduler. **/
-        task* next_offloaded;
+        tbb::task* next_offloaded;
 #endif
 
 #if __TBB_PREVIEW_RESUMABLE_TASKS


### PR DESCRIPTION
## Summary

Closes #2889. This takes the most conservative approach of simply copying the changes in https://github.com/oneapi-src/oneTBB/pull/833 into our vendored copy, rather than updating TBB.

## Tests

## Side Effects


## Release notes

Fixed and issue with building TBB with gcc 13.

## Checklist

- [x] Math issue #2889

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
