### PR TITLE
Add tuple-returning QR decomposition

### DIFF
--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -272,6 +272,7 @@
 #include <stan/math/prim/fun/promote_scalar.hpp>
 #include <stan/math/prim/fun/pseudo_eigenvalues.hpp>
 #include <stan/math/prim/fun/pseudo_eigenvectors.hpp>
+#include <stan/math/prim/fun/qr.hpp>
 #include <stan/math/prim/fun/qr_Q.hpp>
 #include <stan/math/prim/fun/qr_R.hpp>
 #include <stan/math/prim/fun/qr_thin_Q.hpp>

--- a/stan/math/prim/fun/qr.hpp
+++ b/stan/math/prim/fun/qr.hpp
@@ -1,0 +1,56 @@
+#ifndef STAN_MATH_PRIM_FUN_QR_HPP
+#define STAN_MATH_PRIM_FUN_QR_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <algorithm>
+#include <tuple>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the fat QR decomposition
+ *
+ * @tparam EigMat type of the matrix
+ * @param m Matrix.
+ * @return A tuple containing (Q,R):
+ * 1. Orthogonal matrix with maximal columns
+ * 2. Upper triangular matrix with maximal rows
+ */
+template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
+std::tuple<Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>,
+           Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>>
+qr(const EigMat& m) {
+  using matrix_t
+      = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
+  check_nonzero_size("qr", "m", m);
+  Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
+  qr.compute(m);
+  matrix_t Q = qr.householderQ();
+  const int min_size = std::min(m.rows(), m.cols());
+  for (int i = 0; i < min_size; i++) {
+    if (qr.matrixQR().coeff(i, i) < 0) {
+      Q.col(i) *= -1.0;
+    }
+  }
+  matrix_t R = qr.matrixQR();
+  if (m.rows() > m.cols()) {
+    R.bottomRows(m.rows() - m.cols()).setZero();
+  }
+  for (int i = 0; i < min_size; i++) {
+    for (int j = 0; j < i; j++) {
+      R.coeffRef(i, j) = 0.0;
+    }
+    if (R(i, i) < 0) {
+      R.row(i) *= -1.0;
+    }
+  }
+  return std::make_tuple(std::move(Q), std::move(R));
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/test/unit/math/mix/fun/qr_test.cpp
+++ b/test/unit/math/mix/fun/qr_test.cpp
@@ -1,0 +1,30 @@
+#include <test/unit/math/test_ad.hpp>
+#include <limits>
+
+TEST(MathMixMatFun, qr) {
+  auto f = [](const auto& x) { return std::get<0>(stan::math::qr(x)); };
+  auto g = [](const auto& x) { return std::get<1>(stan::math::qr(x)); };
+
+  Eigen::MatrixXd a(0, 0);
+  stan::test::expect_ad(f, a);
+  stan::test::expect_ad(g, a);
+
+  Eigen::MatrixXd b(1, 1);
+  b << 1.5;
+  stan::test::expect_ad(f, b);
+  stan::test::expect_ad(g, b);
+
+  stan::test::ad_tolerances tols;
+  tols.hessian_hessian_ = 1e-2;
+  tols.hessian_fvar_hessian_ = 1e-2;
+
+  Eigen::MatrixXd c(3, 2);
+  c << 1, 2, 3, 4, 5, 6;
+  stan::test::expect_ad(tols, f, c);
+  stan::test::expect_ad(tols, g, c);
+
+  // cols > rows case
+  Eigen::MatrixXd b_tr = b.transpose();
+  stan::test::expect_ad(f, b_tr);
+  stan::test::expect_ad(g, b_tr);
+}

--- a/test/unit/math/prim/fun/qr_test.cpp
+++ b/test/unit/math/prim/fun/qr_test.cpp
@@ -1,0 +1,36 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathMatrixPrimMat, qr) {
+  stan::math::matrix_d m0(0, 0);
+  stan::math::matrix_d m1(4, 2);
+  m1 << 1, 2, 3, 4, 5, 6, 7, 8;
+
+  using stan::math::qr;
+  using stan::math::transpose;
+  EXPECT_THROW(qr(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr(m1));
+
+  stan::math::matrix_d m2(4, 2);
+  stan::math::matrix_d Q(4, 4);
+  stan::math::matrix_d R(4, 2);
+  std::tie(Q, R) = qr(m1);
+  m2 = Q * R;
+  for (unsigned int i = 0; i < m1.rows(); i++) {
+    for (unsigned int j = 0; j < m1.cols(); j++) {
+      EXPECT_NEAR(m1(i, j), m2(i, j), 1e-12);
+    }
+  }
+  for (unsigned int j = 0; j < m1.cols(); j++)
+    EXPECT_TRUE(R(j, j) >= 0.0);
+  stan::math::matrix_d m3(2, 4);
+
+  auto m1_T = transpose(m1);
+  std::tie(Q, R) = qr(m1_T);
+  m3 = Q * R;
+  for (unsigned int i = 0; i < m1.rows(); i++) {
+    for (unsigned int j = 0; j < m1.cols(); j++) {
+      EXPECT_NEAR(m1(i, j), m3(j, i), 1e-12);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This is the first example of the kind of thing #2845 is requesting. 

This adds a function `qr(m)` which returns the equivalent of `std::tuple(qr_Q(m), qr_R(m))` but with reduced computation due to the shared work. 

QR was selected because it was short and did not have any rev/fwd specializations to worry about, so it seemed like a nice minimal example.

## Tests

The existing tests for `qr_R` and `qr_Q` were adapted

## Side Effects


## Release notes

Added a new function `qr` which returns the `qr_Q` and `qr_R` matrices as a tuple.


## Checklist

- [x] Math issue #2845

- [x] Copyright holder: Simons Foundation
    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
