### PR TITLE
Use built-in concurrency feature in Github Actions

### DIFF
--- a/.github/workflows/header_checks.yml
+++ b/.github/workflows/header_checks.yml
@@ -16,21 +16,16 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   windows:
-    permissions:
-      actions: write  # for n1hility/cancel-previous-runs to create & stop workflow runs
-      contents: read  # for actions/checkout to fetch code
     name: Windows
     runs-on: windows-latest
 
     steps:
-    - uses: n1hility/cancel-previous-runs@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        workflow: c-cpp.yml
-      if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
-
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
@@ -53,19 +48,10 @@ jobs:
       run: make -j2 test-headers
 
   opencl:
-    permissions:
-      actions: write  # for n1hility/cancel-previous-runs to create & stop workflow runs
-      contents: read  # for actions/checkout to fetch code
     name: OpenCL
     runs-on: ubuntu-latest
 
     steps:
-    - uses: n1hility/cancel-previous-runs@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        workflow: c-cpp.yml
-      if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
-
     - uses: actions/checkout@v3
 
     - name: Run header tests
@@ -73,19 +59,10 @@ jobs:
         echo "STAN_OPENCL=true" > make/local
         make -j2 test-headers
   no_range_checks:
-    permissions:
-      actions: write  # for n1hility/cancel-previous-runs to create & stop workflow runs
-      contents: read  # for actions/checkout to fetch code
     name: NoRange
     runs-on: ubuntu-latest
 
     steps:
-    - uses: n1hility/cancel-previous-runs@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        workflow: c-cpp.yml
-      if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
-
     - uses: actions/checkout@v3
 
     - name: Run header tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
       with:
         name: gtest_outputs_xml
         path: '**/*_test.xml'
+
   fwd-non-fun-mix:
     name: fwd tests and non-fun mix tests
     runs-on: windows-latest
@@ -121,6 +122,7 @@ jobs:
       with:
         name: gtest_outputs_xml
         path: '**/*_test.xml'
+
   mix-fun-1:
     name: mix/fun tests 1
     runs-on: windows-latest
@@ -169,6 +171,7 @@ jobs:
       with:
         name: gtest_outputs_xml
         path: '**/*_test.xml'
+        
   mix-fun-2:
     name: mix/fun tests 2
     runs-on: windows-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,21 +14,16 @@ on:
       - 'RELEASE-NOTES.txt'
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   prim-rev:
-    permissions:
-      actions: write  # for n1hility/cancel-previous-runs to create & stop workflow runs
-      contents: read  # for actions/checkout to fetch code
     name: prim and rev tests
     runs-on: windows-latest
 
     steps:
-    - uses: n1hility/cancel-previous-runs@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
-
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
This uses [GitHub's `concurrency` feature](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) rather than the `n1hility/cancel-previous-runs` third-party step we were using before

## Summary

This will make it so only one workflow per "group" is allowed to run. Groups are defined by a key given as `${{ github.workflow }}-${{ github.head_ref || github.run_id }}`. The [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value-1) provide more information, but the end result is that this will only let one copy of this workflow run in PRs (the key will be something like `main.yml-PR####`), but will not cancel runs on branches (where instead the key will be something like `main.yml-SomeUniqueNumber`)

## Tests

## Side Effects

## Release notes

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
