### PR TITLE
Add necessary overloads for Tuple return types in expression tests

### DIFF
--- a/test/expressions/expression_test_helpers.hpp
+++ b/test/expressions/expression_test_helpers.hpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 #include <stan/math/prim.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/functor/for_each.hpp>
 #include <stan/math/rev.hpp>
 #include <stan/math/fwd.hpp>
 #include <vector>
@@ -18,7 +20,8 @@ struct counterOp {
   }
 };
 
-template <typename T>
+
+template <typename T, stan::math::require_not_tuple_t<T>* = nullptr>
 auto recursive_sum(const T& a) {
   return math::sum(a);
 }
@@ -30,6 +33,13 @@ auto recursive_sum(const std::vector<T>& a) {
     res += recursive_sum(a[i]);
   }
   return res;
+}
+
+template <typename T, stan::math::require_tuple_t<T>* = nullptr>
+auto recursive_sum(const T& t1) {
+  stan::value_type_t<decltype(std::get<0>(t1))> val = 0;
+  stan::math::for_each([&val](auto&& elt1) { val += recursive_sum(elt1); }, t1);
+  return val;
 }
 
 template <typename T, require_integral_t<T>* = nullptr>
@@ -158,6 +168,12 @@ void expect_eq(const std::vector<T>& a, const std::vector<T>& b,
   for (int i = 0; i < a.size(); i++) {
     expect_eq(a[i], b[i], msg);
   }
+}
+
+template <typename T, stan::math::require_tuple_t<T>* = nullptr>
+void expect_eq(const T& t1, const T& t2, const char* msg) {
+  stan::math::for_each(
+      [&msg](auto&& elt1, auto&& elt2) { expect_eq(elt1, elt2, msg); }, t1, t2);
 }
 
 template <typename T, require_not_st_var<T>* = nullptr>

--- a/test/expressions/expression_test_helpers.hpp
+++ b/test/expressions/expression_test_helpers.hpp
@@ -20,7 +20,6 @@ struct counterOp {
   }
 };
 
-
 template <typename T, stan::math::require_not_tuple_t<T>* = nullptr>
 auto recursive_sum(const T& a) {
   return math::sum(a);


### PR DESCRIPTION
## Summary

Updates the expression test framework with the necessary overloads to test functions such as `qr(matrix) => tuple(matrix, matrix)` from #2896 

## Tests

## Side Effects


## Release notes


## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
