### PR TITLE
Ensure proper cleanup during CI stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,6 +178,7 @@ pipeline {
 
                 }
             }
+            post { always { retry(3) { deleteDir() } } }
         }
 
         stage('Quick tests') {


### PR DESCRIPTION
## Summary

Because we do not clean after `VerifyChanges` master is keeping an older state on disk, this PR fixes this behavior.


## Tests

## Side Effects

## Release notes

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
