### PR TITLE
Feature/threadsafe matrixcl

### DIFF
--- a/stan/math/opencl/copy.hpp
+++ b/stan/math/opencl/copy.hpp
@@ -98,9 +98,10 @@ inline auto from_matrix_cl(const T& src) {
     try {
       cl::Event copy_event;
       const cl::CommandQueue queue = opencl_context.queue();
+      std::vector<cl::Event> copy_write_events(src.write_events().begin(), src.write_events().end());
       queue.enqueueReadBuffer(src.buffer(), opencl_context.in_order(), 0,
                               sizeof(T_val) * dst.size(), dst.data(),
-                              &src.write_events(), &copy_event);
+                              &copy_write_events, &copy_event);
       copy_event.wait();
       src.clear_write_events();
     } catch (const cl::Error& e) {
@@ -151,8 +152,9 @@ inline T_dst from_matrix_cl(const matrix_cl<T>& src) {
   try {
     cl::Event copy_event;
     const cl::CommandQueue queue = opencl_context.queue();
+      std::vector<cl::Event> copy_write_events(src.write_events().begin(), src.write_events().end());
     queue.enqueueReadBuffer(src.buffer(), opencl_context.in_order(), 0,
-                            sizeof(T), &dst, &src.write_events(), &copy_event);
+                            sizeof(T), &dst, &copy_write_events, &copy_event);
     copy_event.wait();
     src.clear_write_events();
   } catch (const cl::Error& e) {
@@ -183,9 +185,10 @@ inline T_dst from_matrix_cl(const matrix_cl<T>& src) {
   try {
     cl::Event copy_event;
     const cl::CommandQueue queue = opencl_context.queue();
+    std::vector<cl::Event> copy_write_events(src.write_events().begin(), src.write_events().end());
     queue.enqueueReadBuffer(src.buffer(), opencl_context.in_order(), 0,
                             sizeof(T) * src.rows(), dst.data(),
-                            &src.write_events(), &copy_event);
+                            &copy_write_events, &copy_event);
     copy_event.wait();
     src.clear_write_events();
   } catch (const cl::Error& e) {
@@ -257,7 +260,7 @@ inline auto packed_copy(const T& src) {
                                      packed, src, src.rows(), src.rows(),
                                      src.view());
     const std::vector<cl::Event> mat_events
-        = vec_concat(packed.read_write_events(), src.write_events());
+        = vec_concat(std::vector<cl::Event>{}, packed.read_write_events(), src.write_events());
     cl::Event copy_event;
     queue.enqueueReadBuffer(packed.buffer(), opencl_context.in_order(), 0,
                             sizeof(T_val) * packed_size, dst.data(),

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -12,6 +12,7 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/vec_concat.hpp>
 #include <CL/opencl.hpp>
+#include <tbb/concurrent_vector.h>
 #include <algorithm>
 #include <iostream>
 #include <string>
@@ -50,8 +51,8 @@ class matrix_cl : public matrix_cl_base {
   int cols_{0};           // Number of columns.
   // Holds info on if matrix is a special type
   matrix_cl_view view_{matrix_cl_view::Entire};
-  mutable std::vector<cl::Event> write_events_;  // Tracks write jobs
-  mutable std::vector<cl::Event> read_events_;   // Tracks reads
+  mutable tbb::concurrent_vector<cl::Event> write_events_;  // Tracks write jobs
+  mutable tbb::concurrent_vector<cl::Event> read_events_;   // Tracks reads
 
  public:
   using Scalar = T;  // Underlying type of the matrix
@@ -99,7 +100,7 @@ class matrix_cl : public matrix_cl_base {
    * Get the events from the event stacks.
    * @return The write event stack.
    */
-  inline const std::vector<cl::Event>& write_events() const {
+  inline const tbb::concurrent_vector<cl::Event>& write_events() const {
     return write_events_;
   }
 
@@ -107,7 +108,7 @@ class matrix_cl : public matrix_cl_base {
    * Get the events from the event stacks.
    * @return The read/write event stack.
    */
-  inline const std::vector<cl::Event>& read_events() const {
+  inline const tbb::concurrent_vector<cl::Event>& read_events() const {
     return read_events_;
   }
 
@@ -115,7 +116,7 @@ class matrix_cl : public matrix_cl_base {
    * Get the events from the event stacks.
    * @return The read/write event stack.
    */
-  inline const std::vector<cl::Event> read_write_events() const {
+  inline const tbb::concurrent_vector<cl::Event> read_write_events() const {
     return vec_concat(this->read_events(), this->write_events());
   }
 
@@ -615,15 +616,29 @@ class matrix_cl : public matrix_cl_base {
    * @param A matrix_cl
    */
   void initialize_buffer_cl(const matrix_cl<T>& A) {
+    cl::Event cstr_event;
+    std::vector<cl::Event>* dep_events = 
+      new std::vector<cl::Event>(A.write_events().begin(), 
+      A.write_events().end()); 
     try {
-      cl::Event cstr_event;
       opencl_context.queue().enqueueCopyBuffer(A.buffer(), this->buffer(), 0, 0,
                                                A.size() * sizeof(T),
-                                               &A.write_events(), &cstr_event);
+                                               dep_events, &cstr_event);
+      if (opencl_context.device()[0].getInfo<CL_DEVICE_HOST_UNIFIED_MEMORY>()) {
+        buffer_cl_.setDestructorCallback(
+          &delete_it_destructor<std::vector<cl::Event>>, dep_events);
+      } else {
+        cstr_event.setCallback(CL_COMPLETE, 
+          &delete_it_event<std::vector<cl::Event>>, dep_events);
+      }
       this->add_write_event(cstr_event);
       A.add_read_event(cstr_event);
     } catch (const cl::Error& e) {
+      delete dep_events;
       check_opencl_error("copy (OpenCL)->(OpenCL)", e);
+    } catch (...) {
+      delete dep_events;
+      throw;
     }
   }
 

--- a/stan/math/opencl/prim/normal_lccdf.hpp
+++ b/stan/math/opencl/prim/normal_lccdf.hpp
@@ -64,12 +64,12 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> normal_lccdf(
   auto sigma_positive_expr = 0 < sigma_val;
 
   auto scaled_diff = elt_divide(y_val - mu_val, sigma_val * SQRT_TWO);
-  auto one_m_erf = select(
+  matrix_cl<double> one_m_erf = select(
       scaled_diff < -37.5 * INV_SQRT_TWO, 2.0,
       select(scaled_diff < -5.0 * INV_SQRT_TWO, 2.0 - erfc(-scaled_diff),
              select(scaled_diff > 8.25 * INV_SQRT_TWO, 0.0,
                     1.0 - erf(scaled_diff))));
-  auto lccdf_expr = colwise_sum(log(one_m_erf));
+  auto lccdf_expr = log(one_m_erf);
   auto mu_deriv = select(scaled_diff > 8.25 * INV_SQRT_TWO, INFTY,
                          SQRT_TWO_OVER_SQRT_PI
                              * elt_divide(exp(-square(scaled_diff)),
@@ -89,7 +89,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> normal_lccdf(
                     calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
                     calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
 
-  T_partials_return lccdf = LOG_HALF + sum(from_matrix_cl(lccdf_cl));
+  T_partials_return lccdf = LOG_HALF * lccdf_cl.size() + sum(from_matrix_cl(lccdf_cl));
 
   auto ops_partials = make_partials_propagator(y_col, mu_col, sigma_col);
 

--- a/stan/math/prim/fun/vec_concat.hpp
+++ b/stan/math/prim/fun/vec_concat.hpp
@@ -37,7 +37,9 @@ inline void append_vectors(VecInOut& x) {}
 template <typename VecInOut, typename VecIn, typename... VecArgs>
 inline void append_vectors(VecInOut& x, const VecIn& y,
                            const VecArgs&... args) {
-  x.insert(x.end(), y.begin(), y.end());
+  for (auto& yy : y) {
+    x.push_back(yy);
+  }
   append_vectors(x, args...);
 }
 }  // namespace internal
@@ -53,7 +55,7 @@ inline void append_vectors(VecInOut& x, const VecIn& y,
  */
 template <typename Vec, typename... Args>
 inline auto vec_concat(const Vec& v1, const Args&... args) {
-  std::vector<value_type_t<Vec>> vec;
+  Vec vec;
   vec.reserve(internal::sum_vector_sizes(v1, args...));
   internal::append_vectors(vec, v1, args...);
   return vec;

--- a/test/unit/math/opencl/rev/normal_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/normal_lccdf_test.cpp
@@ -5,35 +5,186 @@
 #include <test/unit/math/opencl/util.hpp>
 #include <vector>
 
+namespace exp_mod_normal_lccdf_test {
 
-auto normal_lccdf_functor
-    = [](const auto& y, const auto& mu, const auto& sigma) {
-        return stan::math::normal_lccdf(y, mu, sigma);
+TEST(ProbDistributionsDoubleExpModNormalLccdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  Eigen::VectorXd lambda(N);
+  lambda << 0.4, 0.4, 1.4;
+  Eigen::VectorXd lambda_size(N - 1);
+  lambda_size << 0.3, 0.8;
+  Eigen::VectorXd lambda_value(N);
+  lambda_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+  stan::math::matrix_cl<double> lambda_cl(lambda);
+  stan::math::matrix_cl<double> lambda_size_cl(lambda_size);
+  stan::math::matrix_cl<double> lambda_value_cl(lambda_value);
+
+  EXPECT_NO_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_cl, sigma_cl, lambda_cl));
+
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_size_cl, mu_cl, sigma_cl, lambda_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_size_cl, sigma_cl, lambda_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_cl, sigma_size_cl, lambda_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_cl, sigma_cl, lambda_size_cl),
+      std::invalid_argument);
+
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_value_cl, mu_cl, sigma_cl, lambda_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_value_cl, sigma_cl, lambda_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_cl, sigma_value_cl, lambda_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_cl, sigma_cl, lambda_value_cl),
+      std::domain_error);
+}
+
+auto exp_mod_normal_lccdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& lambda) {
+        return stan::math::exp_mod_normal_lccdf(y, mu, sigma, lambda);
       };
 
+TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
 
+  Eigen::VectorXd y(N);
+  y << -0.3, 1.8, 1.4;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
 
-TEST(ProbDistributionsNormalLccdf, opencl_matches_cpu_big) {
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lccdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf,
+     opencl_matches_cpu_small_y_pos_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << -0.3, 1.8, INFINITY;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lccdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf,
+     opencl_matches_cpu_small_y_neg_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << -0.3, 1.8, -INFINITY;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lccdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      exp_mod_normal_lccdf_functor, y_scal, mu, sigma, lambda);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      exp_mod_normal_lccdf_functor, y_scal, mu.transpose().eval(), sigma,
+      lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_matches_cpu_big) {
   int N = 153;
 
-std::srand(123);
-for (int i = 0; i < 10; ++i) {
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
   Eigen::Matrix<double, Eigen::Dynamic, 1> mu
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1) + 1.0;
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs() + 0.01;
-  Eigen::Matrix<double, Eigen::Dynamic, 1> y = (mu.array() * sigma.array()).matrix();
-  std::cout << "Iter: " << i << " mu, sigma, y" << std::endl;
-  for (int j = 0; j < N; j++) {
-    std::cout << mu(j) << ", " << sigma(j) << ", " << y(j) << std::endl;
-  }
-  std::cout << "-----------compare_cpu_opencl_prim_rev" << std::endl;
-  stan::math::test::compare_cpu_opencl_prim_rev(normal_lccdf_functor, y, mu,
-                                                sigma);
-  std::cout << "-----------compare_cpu_opencl_prim_rev transpose" << std::endl;
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array()
+        + 0.1;
+  Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lccdf_functor, y,
+                                                mu, sigma, lambda);
   stan::math::test::compare_cpu_opencl_prim_rev(
-      normal_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
-      sigma.transpose().eval());
+      exp_mod_normal_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
 }
-}
+}  // namespace exp_mod_normal_lccdf_test
+
 #endif

--- a/test/unit/math/opencl/rev/normal_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/normal_lccdf_test.cpp
@@ -5,139 +5,35 @@
 #include <test/unit/math/opencl/util.hpp>
 #include <vector>
 
-TEST(ProbDistributionsNormalLccdf, error_checking) {
-  int N = 3;
-
-  Eigen::VectorXd y(N);
-  y << 0.3, 0.8, 1.0;
-  Eigen::VectorXd y_size(N - 1);
-  y_size << 0.3, 0.8;
-  Eigen::VectorXd y_value(N);
-  y_value << 0.3, NAN, 0.5;
-
-  Eigen::VectorXd mu(N);
-  mu << 0.3, 0.8, 1.0;
-  Eigen::VectorXd mu_size(N - 1);
-  mu_size << 0.3, 0.8;
-  Eigen::VectorXd mu_value(N);
-  mu_value << 0.3, -INFINITY, 0.5;
-
-  Eigen::VectorXd sigma(N);
-  sigma << 0.3, 0.8, 1.0;
-  Eigen::VectorXd sigma_size(N - 1);
-  sigma_size << 0.3, 0.8;
-  Eigen::VectorXd sigma_value(N);
-  sigma_value << 0.3, 0, 0.5;
-
-  stan::math::matrix_cl<double> y_cl(y);
-  stan::math::matrix_cl<double> y_size_cl(y_size);
-  stan::math::matrix_cl<double> y_value_cl(y_value);
-  stan::math::matrix_cl<double> mu_cl(mu);
-  stan::math::matrix_cl<double> mu_size_cl(mu_size);
-  stan::math::matrix_cl<double> mu_value_cl(mu_value);
-  stan::math::matrix_cl<double> sigma_cl(sigma);
-  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
-  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
-
-  EXPECT_NO_THROW(stan::math::normal_lccdf(y_cl, mu_cl, sigma_cl));
-
-  EXPECT_THROW(stan::math::normal_lccdf(y_size_cl, mu_cl, sigma_cl),
-               std::invalid_argument);
-  EXPECT_THROW(stan::math::normal_lccdf(y_cl, mu_size_cl, sigma_cl),
-               std::invalid_argument);
-  EXPECT_THROW(stan::math::normal_lccdf(y_cl, mu_cl, sigma_size_cl),
-               std::invalid_argument);
-
-  EXPECT_THROW(stan::math::normal_lccdf(y_value_cl, mu_cl, sigma_cl),
-               std::domain_error);
-  EXPECT_THROW(stan::math::normal_lccdf(y_cl, mu_value_cl, sigma_cl),
-               std::domain_error);
-  EXPECT_THROW(stan::math::normal_lccdf(y_cl, mu_cl, sigma_value_cl),
-               std::domain_error);
-}
 
 auto normal_lccdf_functor
     = [](const auto& y, const auto& mu, const auto& sigma) {
         return stan::math::normal_lccdf(y, mu, sigma);
       };
 
-TEST(ProbDistributionsNormalLccdf, opencl_matches_cpu_small) {
-  int N = 3;
-  int M = 2;
 
-  Eigen::VectorXd y(N);
-  y << 0.3, 0.8, 1.0;
-  Eigen::VectorXd mu(N);
-  mu << -0.3, -0.8, 1.01;
-  Eigen::VectorXd sigma(N);
-  sigma << 0.3, 0.1, 1.0;
-
-  stan::math::test::compare_cpu_opencl_prim_rev(normal_lccdf_functor, y, mu,
-                                                sigma);
-  stan::math::test::compare_cpu_opencl_prim_rev(
-      normal_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
-      sigma.transpose().eval());
-}
-
-TEST(ProbDistributionsNormalLccdf, opencl_broadcast_y) {
-  int N = 3;
-
-  double y_scal = 12.3;
-  Eigen::VectorXd mu(N);
-  mu << 0.5, 1.2, 1.0;
-  Eigen::VectorXd sigma(N);
-  sigma << 0.3, 0.8, 1.0;
-
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(normal_lccdf_functor,
-                                                         y_scal, mu, sigma);
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
-      normal_lccdf_functor, y_scal, mu.transpose().eval(), sigma);
-}
-
-TEST(ProbDistributionsNormalLccdf, opencl_broadcast_mu) {
-  int N = 3;
-
-  Eigen::VectorXd y(N);
-  y << 0.3, 0.8, 1.0;
-  double mu_scal = 12.3;
-  Eigen::VectorXd sigma(N);
-  sigma << 0.3, 0.8, 1.0;
-
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(normal_lccdf_functor,
-                                                         y, mu_scal, sigma);
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
-      normal_lccdf_functor, y.transpose().eval(), mu_scal, sigma);
-}
-
-TEST(ProbDistributionsNormalLccdf, opencl_broadcast_sigma) {
-  int N = 3;
-
-  Eigen::VectorXd y(N);
-  y << 0.3, 0.8, 1.0;
-  Eigen::VectorXd mu(N);
-  mu << 0.3, 0.8, 1.0;
-  double sigma_scal = 12.3;
-
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(normal_lccdf_functor,
-                                                         y, mu, sigma_scal);
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
-      normal_lccdf_functor, y.transpose().eval(), mu, sigma_scal);
-}
 
 TEST(ProbDistributionsNormalLccdf, opencl_matches_cpu_big) {
   int N = 153;
 
-  Eigen::Matrix<double, Eigen::Dynamic, 1> y
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+std::srand(123);
+for (int i = 0; i < 10; ++i) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> mu
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1) + 1.0;
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs() + 0.01;
-
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y = (mu.array() * sigma.array()).matrix();
+  std::cout << "Iter: " << i << " mu, sigma, y" << std::endl;
+  for (int j = 0; j < N; j++) {
+    std::cout << mu(j) << ", " << sigma(j) << ", " << y(j) << std::endl;
+  }
+  std::cout << "-----------compare_cpu_opencl_prim_rev" << std::endl;
   stan::math::test::compare_cpu_opencl_prim_rev(normal_lccdf_functor, y, mu,
                                                 sigma);
+  std::cout << "-----------compare_cpu_opencl_prim_rev transpose" << std::endl;
   stan::math::test::compare_cpu_opencl_prim_rev(
       normal_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
       sigma.transpose().eval());
+}
 }
 #endif


### PR DESCRIPTION
## Summary

This makes `matrix_cl`'s  event vectors thread safe by using `tbb::concurrent_vector` instead of a `std::vector`.


In Stan a `matrix_cl` can be in a model class and shared across multiple threads. When using multiple threads we can have a race condition where two operations attempt to push to the vector of read/write events.

I think the simplest fix for this is the below where we replace `std::vector` with `tbb::concurrent_vector`. This has some issues though, notably that `tbb::concurrent_vector` is not a contiguous block of memory. Some functions like `clenqueueReadBuffer` expect a pointer to memory and the size of the block of memory so I end up doing is making a hard copy of the `tbb::concurrent_vector` into an `std::vector`. This is not optimal for performance. 

If we wanted to I could write something based on rigtorp's [`ring_buffer`](https://rigtorp.se/ringbuffer.cpp) but for just a vector of data. The only odd part of it would be when we have to resize the vector we would have to make a hard copy of the events into a new slice of memory and keep the old memory around until either the buffer falls out of scope or the last event is done. I'm fine with doing that as well.

## Tests

I'm also not sure how to write a test for this? The current tests all pass (in fact I found a small bug in normal_lccdf where the results didn't match and fixed that).

## Side Effects

The bad thing to note here is the copy every time we need a contiguous block of memory for queuing the events for read/write ops. This is not great, though it will be fine for now if we keep it this way and then later I can write a faster scheme.

## Release notes

Replace the `std::vector`s  for read/write events in `matrix_cl` with `tbb::concurrent_vectors`

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
