### PR TITLE
Doxygen: patch to address dead links

### DIFF
--- a/doxygen/contributor_help_pages/developer_doc.md
+++ b/doxygen/contributor_help_pages/developer_doc.md
@@ -1,4 +1,4 @@
-# Developers Guide {#developer_guide}
+# Developer Guide {#developer_guide}
 
 Thanks for checking out these docs. This is where you'll find information on contributing to the [Math library](https://github.com/stan-dev/math), how the source code is laid out, and other technical details that could help. This wiki focuses on things relevant to the Math library. There's also a separate [Stan wiki](https://github.com/stan-dev/stan/wiki) for things related to the language, services, algorithms.
 
@@ -41,7 +41,7 @@ For implementation details of the Math library's automatic differentiation, plea
 
 We're committed to having a permissive open-source license. The Math library is [licensed with the BSD 3-Clause License](https://github.com/stan-dev/math/blob/develop/LICENSE%2Emd) and we only accept changes to the code base that compatible with this license.
 
-# Contributing {#contribution}
+# Contributing {#contributing}
 
 Thanks for reading! We love contributions from everyone in the form of good discussion, issues, and pull requests.
 

--- a/doxygen/pretty_stuff/layout.xml
+++ b/doxygen/pretty_stuff/layout.xml
@@ -1,24 +1,46 @@
 <doxygenlayout version="1.0">
 <navindex>
   <tab type="user" url="index.html" title="Overview" />
+  <!-- Note: @ref doesn't work in doxygen v1.9.7. Perhaps this could come back in the future.
   <tab type="usergroup" visible="yes" title="Contributor Guides" url="@ref contributing" intro="">
-      <tab type="usergroup" visible="yes" title="Developer Guide" url="@ref developer_guide" intro=""/>
-      <tab type="usergroup" visible="yes" title="Adding New Functions" url="@ref getting_started" intro=""/>
-      <tab type="usergroup" visible="yes" title="Adding New Distributions" url="@ref new_distribution" intro=""/>
-      <tab type="usergroup" visible="yes" title="Common Pitfalls" url="@ref common_pitfalls" intro=""/>
-      <tab type="usergroup" visible="yes" title="Using requires for general overloads" url="@ref require_meta_doc" intro=""/>
-      <tab type="usergroup" visible="yes" title="Reverse Mode Types" url="@ref reverse_mode_types" intro=""/>
-      <tab type="usergroup" visible="yes" title="Testing Automatic Differentiation Functions" url="@ref autodiff_test_guide" intro=""/>
-      <tab type="usergroup" visible="yes" title="Testing New Distributions" url="@ref dist_tests" intro=""/>
-      <tab type="usergroup" visible="yes" title="Add New Functions With Known Gradients" url="@ref new_grad" intro=""/>
-      <tab type="usergroup" visible="yes" title="Adding New OpenCL Functions" url="@ref opencl_guide" intro=""/>
-      <tab type="usergroup" visible="yes" title="Windows Development Tips" url="@ref windows_tips" intro=""/>
-  </tab>
+      <tab type="user" visible="yes" title="Developer Guide" url="@ref developer_guide" intro=""/>
+      <tab type="user" visible="yes" title="Adding New Functions" url="@ref getting_started" intro=""/>
+      <tab type="user" visible="yes" title="Adding New Distributions" url="@ref new_distribution" intro=""/>
+      <tab type="user" visible="yes" title="Common Pitfalls" url="@ref common_pitfalls" intro=""/>
+      <tab type="user" visible="yes" title="Using requires for general overloads" url="@ref require_meta_doc" intro=""/>
+      <tab type="user" visible="yes" title="Reverse Mode Types" url="@ref reverse_mode_types" intro=""/>
+      <tab type="user" visible="yes" title="Testing Automatic Differentiation Functions" url="@ref autodiff_test_guide" intro=""/>
+      <tab type="user" visible="yes" title="Testing New Distributions" url="@ref dist_tests" intro=""/>
+      <tab type="user" visible="yes" title="Add New Functions With Known Gradients" url="@ref new_grad" intro=""/>
+      <tab type="user" visible="yes" title="Adding New OpenCL Functions" url="@ref opencl_guide" intro=""/>
+      <tab type="user" visible="yes" title="Windows Development Tips" url="@ref windows_tips" intro=""/>
+  </tab> 
+  -->
+  <tab type="usergroup" visible="yes" title="Contributor Guides" url="md__8github_2_c_o_n_t_r_i_b_u_t_i_n_g.html" intro="">
+      <tab type="user" visible="yes" title="Developer Guide" url="md_doxygen_2contributor__help__pages_2developer__doc.html" intro=""/>
+      <tab type="user" visible="yes" title="Adding New Functions" url="md_doxygen_2contributor__help__pages_2getting__started.html" intro=""/>
+      <tab type="user" visible="yes" title="Adding New Distributions" url="md_doxygen_2contributor__help__pages_2adding__new__distributions.html" intro=""/>
+      <tab type="user" visible="yes" title="Common Pitfalls" url="md_doxygen_2contributor__help__pages_2common__pitfalls.html" intro=""/>
+      <tab type="user" visible="yes" title="Using requires for general overloads" url="md_doxygen_2contributor__help__pages_2require__meta.html" intro=""/>
+      <tab type="user" visible="yes" title="Reverse Mode Types" url="md_doxygen_2contributor__help__pages_2reverse__mode__types.html" intro=""/>
+      <tab type="user" visible="yes" title="Testing Automatic Differentiation Functions" url="md_doxygen_2contributor__help__pages_2autodiff__test__guide.html" intro=""/>
+      <tab type="user" visible="yes" title="Testing New Distributions" url="md_doxygen_2contributor__help__pages_2distribution__tests.html" intro=""/>
+      <tab type="user" visible="yes" title="Add New Functions With Known Gradients" url="md_doxygen_2contributor__help__pages_2new__gradients.html" intro=""/>
+      <tab type="user" visible="yes" title="Adding New OpenCL Functions" url="md_doxygen_2contributor__help__pages_2add__new__opencl__kernel.html" intro=""/>
+      <tab type="user" visible="yes" title="Windows Development Tips" url="md_doxygen_2contributor__help__pages_2windows__devnotes.html" intro=""/>
+  </tab> 
   <tab type="modules" visible="yes" title="Internal Docs" intro=""/>
+  <!-- Note: @ref doesn't work in doxygen v1.9.7. Perhaps this could come back in the future.
   <tab type="usergroup" visible="yes" title="Parallelism" intro="">
-    <tab type="usergroup" visible="yes" title="Threading" url="@ref tbb_threading" intro=""/>
-    <tab type="usergroup" visible="yes" title="OpenCL for GPU Computing" url="@ref opencl_support" intro=""/>
-    <tab type="usergroup" visible="yes" title="MPI Support" url="@ref mpi" intro=""/>
+    <tab type="user" visible="yes" title="Threading" url="@ref tbb_threading" intro=""/>
+    <tab type="user" visible="yes" title="OpenCL for GPU Computing" url="@ref opencl_support" intro=""/>
+    <tab type="user" visible="yes" title="MPI Support" url="@ref mpi" intro=""/>
+  </tab>
+  -->
+  <tab type="usergroup" visible="yes" title="Parallelism" intro="">
+    <tab type="user" visible="yes" title="Threading" url="md_doxygen_2parallelism__support_2threading__tbb.html" intro=""/>
+    <tab type="user" visible="yes" title="OpenCL for GPU Computing" url="md_doxygen_2parallelism__support_2opencl__support.html" intro=""/>
+    <tab type="user" visible="yes" title="MPI Support" url="md_doxygen_2parallelism__support_2mpi__parallelism.html" intro=""/>
   </tab>
   <tab type="usergroup" visible="yes" title="(External Link) Stan Language Docs" url="https://mc-stan.org/users/documentation/" intro=""/>
   <tab type="usergroup" visible="yes" title="(External Link) Stan Discourse" url="https://discourse.mc-stan.org/" intro=""/>


### PR DESCRIPTION
## Summary

The current built doxygen has dead links. It looks like there's some issue with the latest version of doxygen (v1.9.7) and our layout.xml. 

I haven't found a good way to replicate the original behavior. This PR patches the dead links by directly linking to the files. 

## Tests

I walked through all the places where there were dead links locally. We'll see this pushed to the web after merge.

## Side Effects

In `layout.xml` you'll see the old stuff commented out. It was originally implemented with `@ref` with a named section. The current patch uses the generated html filename directly.

There's no guarantee that the naming convention by doxygen stays the same. That said, I don't envision this changing very quickly. 

## Release notes

Fixing doxygen.

## Checklist

- [x] Math issue #(issue number)

- [x] Copyright holder: Daniel Lee

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
