### PR TITLE
inv_wishart_cholesky_test: make type of NaN argument double

### DIFF
--- a/test/unit/math/prim/prob/inv_wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/inv_wishart_cholesky_test.cpp
@@ -80,7 +80,7 @@ TEST(ProbDistributionsInvWishartCholesky, dof_0) {
   MatrixXd L_Y = Y.llt().matrixL();
   MatrixXd L_S = Sigma.llt().matrixL();
 
-  unsigned int dof = std::numeric_limits<double>::quiet_NaN();
+  double dof = std::numeric_limits<double>::quiet_NaN();
   EXPECT_THROW(stan::math::inv_wishart_cholesky_lpdf(L_Y, dof, L_S),
                std::domain_error);
 }


### PR DESCRIPTION
## Summary

The inverse-Wishart (cholesky parameterization) tests currently have a test which tries the `dof` argument with `NaN`, but cast to an unsigned int. This is, I believe, a simple typo, and it causes the tests to fail when compiled with clang 16.0.6 (see https://github.com/stan-dev/ci-scripts/pull/27)

## Tests

## Side Effects

None. The same test does not exist for the non-Cholesky version of the function.

## Release notes

Fixed a type issue in the tests for inv_wishart_cholesky.

## Checklist

- [x] Math issue #(issue number)

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
