### PR TITLE
Allow constraint tolerance to be adjusted with a compile-time define

### DIFF
--- a/stan/math/prim/err/constraint_tolerance.hpp
+++ b/stan/math/prim/err/constraint_tolerance.hpp
@@ -1,6 +1,10 @@
 #ifndef STAN_MATH_PRIM_ERR_CONSTRAINT_TOLERANCE_HPP
 #define STAN_MATH_PRIM_ERR_CONSTRAINT_TOLERANCE_HPP
 
+#ifndef STAN_MATH_CONSTRAINT_TOLERANCE
+#define STAN_MATH_CONSTRAINT_TOLERANCE 1E-8
+#endif
+
 #include <stan/math/prim/meta.hpp>
 namespace stan {
 namespace math {
@@ -8,8 +12,10 @@ namespace math {
 /**
  * The tolerance for checking arithmetic bounds in rank and in
  * simplexes.  The default value is <code>1E-8</code>.
+ * This can changed by defining <code>STAN_MATH_CONSTRAINT_TOLERANCE</code>
+ * at compile time.
  */
-const double CONSTRAINT_TOLERANCE = 1E-8;
+const double CONSTRAINT_TOLERANCE = STAN_MATH_CONSTRAINT_TOLERANCE;
 
 }  // namespace math
 }  // namespace stan


### PR DESCRIPTION
## Summary

Certain advanced usages of the Math library require the tolerance for constraints such a simplex unconstraining to be looser than we normally allow in Stan. This lets those users pass `-DSTAN_MATH_CONSTRAINT_TOLERANCE=1e-4`, for example, to set the value of the tolerance at compile time.

As an aside, this also allows these checks to essentially be disabled by setting it to some arbitrarily large value.

## Tests

None

## Side Effects

None for normal users.

## Release notes

The constraint tolerance can now be adjusted by defining the `STAN_MATH_CONSTRAINT_TOLERANCE` macro before including Stan headers. The default value remains `1E-8`.

## Checklist

- [x] Math issue: Closes #2911 

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
