### PR TITLE
Use -dumpfullversion if available in makefiles

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -58,7 +58,7 @@ ifneq (,$(findstring g++,$(CXX)))
   CXX_TYPE ?= gcc
 endif
 CXX_TYPE ?= other
-CXX_VERSION :=  $(shell $(CXX) -dumpversion 2>&1)
+CXX_VERSION :=  $(shell $(CXX) -dumpfullversion -dumpversion 2>&1)
 CXX_MAJOR := $(word 1,$(subst ., ,$(CXX_VERSION)))
 CXX_MINOR := $(word 2,$(subst ., ,$(CXX_VERSION)))
 


### PR DESCRIPTION
## Summary

We use `-dumpversion` to get the version of our C++ compiler, but this only reports the major version for newer GCCs. 

See: https://stackoverflow.com/questions/45168516/gcc-7-1-1-on-fedora-26-dumpversion-now-only-includes-major-version-by-default

This works because gcc (and clang, from testing) ignore unknown `-dump*` flags

## Tests

None

## Side Effects

CXX_MINOR should be more consistently populated, making downstream usages better

## Release notes


## Checklist

- [x] Math issue #(issue number)

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
