### PR TITLE
Add forward declaration to stan_print.hpp

### DIFF
--- a/stan/math/prim/fun/stan_print.hpp
+++ b/stan/math/prim/fun/stan_print.hpp
@@ -52,6 +52,10 @@ void stan_print(std::ostream* o, const EigMat& x) {
   *o << ']';
 }
 
+// forward decl to allow the next two overloads to call each other
+template <typename T, require_tuple_t<T>* = nullptr>
+void stan_print(std::ostream* o, const T& x);
+
 template <typename T, require_std_vector_t<T>* = nullptr>
 void stan_print(std::ostream* o, const T& x) {
   *o << '[';

--- a/test/unit/math/prim/fun/stan_print_test.cpp
+++ b/test/unit/math/prim/fun/stan_print_test.cpp
@@ -11,6 +11,9 @@ TEST(MathPrim, basic_print) {
 
   std::tuple<Eigen::VectorXd, int, std::vector<double>> tup(v, i, a);
 
+  std::vector<std::tuple<Eigen::VectorXd, int, std::vector<double>>> arr_tup{
+      tup, tup};
+
   {
     std::stringstream s;
     stan::math::stan_print(&s, i);
@@ -51,6 +54,11 @@ TEST(MathPrim, basic_print) {
     std::stringstream s;
     stan::math::stan_print(&s, tup);
     EXPECT_TRUE(s.str().find("([1],1,[1])") != std::string::npos);
+  }
+  {
+    std::stringstream s;
+    stan::math::stan_print(&s, arr_tup);
+    EXPECT_TRUE(s.str().find("[([1],1,[1])") != std::string::npos);
   }
 }
 


### PR DESCRIPTION

## Summary

Fixes printing arrays-of-tuples

## Tests

Added test (which would fail to compile before this patch)

## Side Effects


## Release notes

## Checklist

- [x] Math issue #(issue number)

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
