### PR TITLE
Fix: promote_scalar ambiguous tuple overload

### DIFF
--- a/stan/math/prim/fun/promote_scalar.hpp
+++ b/stan/math/prim/fun/promote_scalar.hpp
@@ -59,9 +59,11 @@ inline auto promote_scalar(UnPromotedType&& x) {
 
 // Forward decl for iterating over tuples used in std::vector<tuple>
 template <typename PromotionScalars, typename UnPromotedTypes,
-          require_all_tuple_t<PromotionScalars, UnPromotedTypes>* = nullptr>
+          require_all_tuple_t<PromotionScalars, UnPromotedTypes>* = nullptr,
+          require_not_same_t<PromotionScalars, UnPromotedTypes>* = nullptr>
 inline constexpr promote_scalar_t<PromotionScalars, UnPromotedTypes>
 promote_scalar(UnPromotedTypes&& x);
+
 /**
  * Promote the scalar type of an standard vector to the requested type.
  *
@@ -93,7 +95,8 @@ inline auto promote_scalar(UnPromotedType&& x) {
  * @param x input
  */
 template <typename PromotionScalars, typename UnPromotedTypes,
-          require_all_tuple_t<PromotionScalars, UnPromotedTypes>*>
+          require_all_tuple_t<PromotionScalars, UnPromotedTypes>*,
+          require_not_same_t<PromotionScalars, UnPromotedTypes>*>
 inline constexpr promote_scalar_t<PromotionScalars, UnPromotedTypes>
 promote_scalar(UnPromotedTypes&& x) {
   return index_apply<std::tuple_size<std::decay_t<UnPromotedTypes>>::value>(


### PR DESCRIPTION
## Summary

The current code fails to compile when promoting a tuple with the same type it already is.

## Tests

Oddly, it looks like there is a test for this already in /mix

## Side Effects


## Release notes


## Checklist

- [x] Math issue #(issue number)

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
