### PR TITLE
Add tuple-returning special functions

### DIFF
--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -62,6 +62,7 @@
 #include <stan/math/prim/fun/cov_matrix_free.hpp>
 #include <stan/math/prim/fun/cov_matrix_free_lkj.hpp>
 #include <stan/math/prim/fun/crossprod.hpp>
+#include <stan/math/prim/fun/csr_extract.hpp>
 #include <stan/math/prim/fun/csr_extract_u.hpp>
 #include <stan/math/prim/fun/csr_extract_v.hpp>
 #include <stan/math/prim/fun/csr_extract_w.hpp>

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -82,6 +82,7 @@
 #include <stan/math/prim/fun/dot_product.hpp>
 #include <stan/math/prim/fun/dot_self.hpp>
 #include <stan/math/prim/fun/eigen_comparisons.hpp>
+#include <stan/math/prim/fun/eigendecompose_sym.hpp>
 #include <stan/math/prim/fun/eigenvalues.hpp>
 #include <stan/math/prim/fun/eigenvalues_sym.hpp>
 #include <stan/math/prim/fun/eigenvectors.hpp>

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -333,6 +333,7 @@
 #include <stan/math/prim/fun/sub_row.hpp>
 #include <stan/math/prim/fun/subtract.hpp>
 #include <stan/math/prim/fun/sum.hpp>
+#include <stan/math/prim/fun/svd.hpp>
 #include <stan/math/prim/fun/svd_U.hpp>
 #include <stan/math/prim/fun/svd_V.hpp>
 #include <stan/math/prim/fun/symmetrize_from_lower_tri.hpp>

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -275,6 +275,7 @@
 #include <stan/math/prim/fun/qr.hpp>
 #include <stan/math/prim/fun/qr_Q.hpp>
 #include <stan/math/prim/fun/qr_R.hpp>
+#include <stan/math/prim/fun/qr_thin.hpp>
 #include <stan/math/prim/fun/qr_thin_Q.hpp>
 #include <stan/math/prim/fun/qr_thin_R.hpp>
 #include <stan/math/prim/fun/quad_form.hpp>

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -82,6 +82,7 @@
 #include <stan/math/prim/fun/dot_product.hpp>
 #include <stan/math/prim/fun/dot_self.hpp>
 #include <stan/math/prim/fun/eigen_comparisons.hpp>
+#include <stan/math/prim/fun/eigendecompose.hpp>
 #include <stan/math/prim/fun/eigendecompose_sym.hpp>
 #include <stan/math/prim/fun/eigenvalues.hpp>
 #include <stan/math/prim/fun/eigenvalues_sym.hpp>

--- a/stan/math/prim/fun/complex_schur_decompose.hpp
+++ b/stan/math/prim/fun/complex_schur_decompose.hpp
@@ -82,7 +82,7 @@ inline std::tuple<Eigen::Matrix<complex_return_t<scalar_type_t<M>>, -1, -1>,
                   Eigen::Matrix<complex_return_t<scalar_type_t<M>>, -1, -1>>
 complex_schur_decompose(const M& m) {
   if (m.size() == 0)
-    return std::make_tuple(m,m);
+    return std::make_tuple(m, m);
   check_square("complex_schur_decompose", "m", m);
   using MatType = Eigen::Matrix<scalar_type_t<M>, -1, -1>;
   // copy because ComplexSchur requires Eigen::Matrix type

--- a/stan/math/prim/fun/complex_schur_decompose.hpp
+++ b/stan/math/prim/fun/complex_schur_decompose.hpp
@@ -61,6 +61,36 @@ complex_schur_decompose_t(const M& m) {
   return cs.matrixT();
 }
 
+/**
+ * Return the complex Schur decomposition of the
+ * specified square matrix.
+ *
+ * The complex Schur decomposition of a square matrix `A` produces a
+ * complex unitary matrix `U` and a complex upper-triangular Schur
+ * form matrix `T` such that `A = U * T * inv(U)`.  Further, the
+ * unitary matrix's inverse is equal to its conjugate transpose,
+ * `inv(U) = U*`, where `U*(i, j) = conj(U(j, i))`
+ *
+ * @tparam M type of matrix
+ * @param m real matrix to decompose
+ * @return a tuple (U,T) where U is the complex unitary matrix of the complex
+ * Schur decomposition of `m` and T is the Schur form matrix of
+ * the complex Schur decomposition of `m`
+ */
+template <typename M, require_eigen_dense_dynamic_t<M>* = nullptr>
+inline std::tuple<Eigen::Matrix<complex_return_t<scalar_type_t<M>>, -1, -1>,
+                  Eigen::Matrix<complex_return_t<scalar_type_t<M>>, -1, -1>>
+complex_schur_decompose(const M& m) {
+  if (m.size() == 0)
+    return std::make_tuple(m,m);
+  check_square("complex_schur_decompose", "m", m);
+  using MatType = Eigen::Matrix<scalar_type_t<M>, -1, -1>;
+  // copy because ComplexSchur requires Eigen::Matrix type
+  MatType mv = m;
+  Eigen::ComplexSchur<MatType> cs(mv);
+  return std::make_tuple(std::move(cs.matrixU()), std::move(cs.matrixT()));
+}
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/fun/complex_schur_decompose.hpp
+++ b/stan/math/prim/fun/complex_schur_decompose.hpp
@@ -27,13 +27,13 @@ namespace math {
 template <typename M, require_eigen_dense_dynamic_t<M>* = nullptr>
 inline Eigen::Matrix<complex_return_t<scalar_type_t<M>>, -1, -1>
 complex_schur_decompose_u(const M& m) {
-  if (m.size() == 0)
+  if (unlikely(m.size() == 0)) {
     return m;
+  }
   check_square("complex_schur_decompose_u", "m", m);
   using MatType = Eigen::Matrix<scalar_type_t<M>, -1, -1>;
   // copy because ComplexSchur requires Eigen::Matrix type
-  MatType mv = m;
-  Eigen::ComplexSchur<MatType> cs(mv);
+  Eigen::ComplexSchur<MatType> cs{MatType(m)};
   return cs.matrixU();
 }
 
@@ -51,13 +51,13 @@ complex_schur_decompose_u(const M& m) {
 template <typename M, require_eigen_dense_dynamic_t<M>* = nullptr>
 inline Eigen::Matrix<complex_return_t<scalar_type_t<M>>, -1, -1>
 complex_schur_decompose_t(const M& m) {
-  if (m.size() == 0)
+  if (unlikely(m.size() == 0)) {
     return m;
+  }
   check_square("complex_schur_decompose_t", "m", m);
   using MatType = Eigen::Matrix<scalar_type_t<M>, -1, -1>;
   // copy because ComplexSchur requires Eigen::Matrix type
-  MatType mv = m;
-  Eigen::ComplexSchur<MatType> cs(mv, false);
+  Eigen::ComplexSchur<MatType> cs{MatType(m), false};
   return cs.matrixT();
 }
 
@@ -81,13 +81,13 @@ template <typename M, require_eigen_dense_dynamic_t<M>* = nullptr>
 inline std::tuple<Eigen::Matrix<complex_return_t<scalar_type_t<M>>, -1, -1>,
                   Eigen::Matrix<complex_return_t<scalar_type_t<M>>, -1, -1>>
 complex_schur_decompose(const M& m) {
-  if (m.size() == 0)
+  if (unlikely(m.size() == 0)) {
     return std::make_tuple(m, m);
+  }
   check_square("complex_schur_decompose", "m", m);
   using MatType = Eigen::Matrix<scalar_type_t<M>, -1, -1>;
   // copy because ComplexSchur requires Eigen::Matrix type
-  MatType mv = m;
-  Eigen::ComplexSchur<MatType> cs(mv);
+  Eigen::ComplexSchur<MatType> cs{MatType(m)};
   return std::make_tuple(std::move(cs.matrixU()), std::move(cs.matrixT()));
 }
 

--- a/stan/math/prim/fun/csr_extract.hpp
+++ b/stan/math/prim/fun/csr_extract.hpp
@@ -11,7 +11,8 @@ namespace math {
  *  @{
  */
 
-/* Extract the non-zero values, column indexes for non-zero values, and
+/**
+ * Extract the non-zero values, column indexes for non-zero values, and
  * the NZE index for each entry from a sparse matrix.
  *
  * @tparam T type of elements in the matrix
@@ -22,10 +23,11 @@ template <typename T>
 const std::tuple<Eigen::Matrix<T, Eigen::Dynamic, 1>, std::vector<int>,
                  std::vector<int>>
 csr_extract(const Eigen::SparseMatrix<T, Eigen::RowMajor>& A) {
-  Eigen::Matrix<T, Eigen::Dynamic, 1> w(A.nonZeros());
-  w.setZero();
-  std::vector<int> v(A.nonZeros());
-  for (int nze = 0; nze < A.nonZeros(); ++nze) {
+  auto a_nonzeros = A.nonZeros();
+  Eigen::Matrix<T, Eigen::Dynamic, 1> w
+      = Eigen::Matrix<T, Eigen::Dynamic, 1>::Zero(a_nonzeros);
+  std::vector<int> v(a_nonzeros);
+  for (int nze = 0; nze < a_nonzeros; ++nze) {
     w[nze] = *(A.valuePtr() + nze);
     v[nze] = *(A.innerIndexPtr() + nze) + stan::error_index::value;
   }

--- a/stan/math/prim/fun/csr_extract.hpp
+++ b/stan/math/prim/fun/csr_extract.hpp
@@ -1,0 +1,64 @@
+#ifndef STAN_MATH_PRIM_FUN_CSR_EXTRACT_HPP
+#define STAN_MATH_PRIM_FUN_CSR_EXTRACT_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+
+namespace stan {
+namespace math {
+
+/** \addtogroup csr_format
+ *  @{
+ */
+
+/* Extract the non-zero values, column indexes for non-zero values, and
+ * the NZE index for each entry from a sparse matrix.
+ *
+ * @tparam T type of elements in the matrix
+ * @param[in] A sparse matrix.
+ * @return a tuple W,V,U.
+ */
+template <typename T>
+const std::tuple<Eigen::Matrix<T, Eigen::Dynamic, 1>, std::vector<int>,
+                 std::vector<int>>
+csr_extract(const Eigen::SparseMatrix<T, Eigen::RowMajor>& A) {
+  Eigen::Matrix<T, Eigen::Dynamic, 1> w(A.nonZeros());
+  w.setZero();
+  std::vector<int> v(A.nonZeros());
+  for (int nze = 0; nze < A.nonZeros(); ++nze) {
+    w[nze] = *(A.valuePtr() + nze);
+    v[nze] = *(A.innerIndexPtr() + nze) + stan::error_index::value;
+  }
+  std::vector<int> u(A.outerSize() + 1);  // last entry is garbage.
+  for (int nze = 0; nze <= A.outerSize(); ++nze) {
+    u[nze] = *(A.outerIndexPtr() + nze) + stan::error_index::value;
+  }
+  return std::make_tuple(std::move(w), std::move(v), std::move(u));
+}
+
+/* Extract the non-zero values from a dense matrix by converting
+ * to sparse and calling the sparse matrix extractor.
+ *
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
+ * @param[in] A dense matrix.
+ * @return a tuple W,V,U.
+ */
+template <typename T, require_eigen_dense_base_t<T>* = nullptr>
+const std::tuple<Eigen::Matrix<scalar_type_t<T>, Eigen::Dynamic, 1>,
+                 std::vector<int>, std::vector<int>>
+csr_extract(const T& A) {
+  // conversion to sparse seems to touch data twice, so we need to call to_ref
+  Eigen::SparseMatrix<scalar_type_t<T>, Eigen::RowMajor> B
+      = to_ref(A).sparseView();
+  return csr_extract(B);
+}
+
+/** @} */  // end of csr_format group
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/csr_extract_w.hpp
+++ b/stan/math/prim/fun/csr_extract_w.hpp
@@ -20,9 +20,10 @@ namespace math {
 template <typename T>
 const Eigen::Matrix<T, Eigen::Dynamic, 1> csr_extract_w(
     const Eigen::SparseMatrix<T, Eigen::RowMajor>& A) {
-  Eigen::Matrix<T, Eigen::Dynamic, 1> w(A.nonZeros());
-  w.setZero();
-  for (int nze = 0; nze < A.nonZeros(); ++nze) {
+  auto a_nonzeros = A.nonZeros();
+  Eigen::Matrix<T, Eigen::Dynamic, 1> w
+      = Eigen::Matrix<T, Eigen::Dynamic, 1>::Zero(a_nonzeros);
+  for (int nze = 0; nze < a_nonzeros; ++nze) {
     w[nze] = *(A.valuePtr() + nze);
   }
   return w;

--- a/stan/math/prim/fun/eigendecompose.hpp
+++ b/stan/math/prim/fun/eigendecompose.hpp
@@ -22,10 +22,15 @@ template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
 inline std::tuple<Eigen::Matrix<complex_return_t<value_type_t<EigMat>>, -1, -1>,
                   Eigen::Matrix<complex_return_t<value_type_t<EigMat>>, -1, 1>>
 eigendecompose(const EigMat& m) {
+  if (unlikely(m.size() == 0)) {
+    return std::make_tuple(
+        Eigen::Matrix<complex_return_t<value_type_t<EigMat>>, -1, -1>(0, 0),
+        Eigen::Matrix<complex_return_t<value_type_t<EigMat>>, -1, 1>(0, 1));
+  }
+  check_square("eigendecompose", "m", m);
+
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
-  check_nonzero_size("eigendecompose", "m", m_eval);
-  check_square("eigendecompose", "m", m_eval);
 
   Eigen::EigenSolver<PlainMat> solver(m_eval);
   return std::make_tuple(std::move(solver.eigenvectors()),
@@ -43,16 +48,20 @@ eigendecompose(const EigMat& m) {
  * with entries the eigenvectors of `m`
  */
 template <typename EigCplxMat,
-          require_eigen_matrix_dynamic_t<EigCplxMat>* = nullptr,
-          require_vt_complex<EigCplxMat>* = nullptr>
+          require_eigen_matrix_dynamic_vt<is_complex, EigCplxMat>* = nullptr>
 inline std::tuple<
     Eigen::Matrix<complex_return_t<value_type_t<EigCplxMat>>, -1, -1>,
     Eigen::Matrix<complex_return_t<value_type_t<EigCplxMat>>, -1, 1>>
 eigendecompose(const EigCplxMat& m) {
+  if (unlikely(m.size() == 0)) {
+    return std::make_tuple(
+        Eigen::Matrix<complex_return_t<value_type_t<EigCplxMat>>, -1, -1>(0, 0),
+        Eigen::Matrix<complex_return_t<value_type_t<EigCplxMat>>, -1, 1>(0, 1));
+  }
+  check_square("eigendecompose", "m", m);
+
   using PlainMat = Eigen::Matrix<scalar_type_t<EigCplxMat>, -1, -1>;
   const PlainMat& m_eval = m;
-  check_nonzero_size("eigendecompose", "m", m_eval);
-  check_square("eigendecompose", "m", m_eval);
 
   Eigen::ComplexEigenSolver<PlainMat> solver(m_eval);
 

--- a/stan/math/prim/fun/eigendecompose.hpp
+++ b/stan/math/prim/fun/eigendecompose.hpp
@@ -1,0 +1,65 @@
+#ifndef STAN_MATH_PRIM_FUN_EIGENDECOMPOSE_HPP
+#define STAN_MATH_PRIM_FUN_EIGENDECOMPOSE_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/err.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the eigendecomposition of a (real-valued) matrix
+ *
+ * @tparam EigMat type of real matrix argument
+ * @param[in] m matrix to find the eigendecomposition of. Must be square and
+ * have a non-zero size.
+ * @return A tuple V,D where V is a matrix where the columns are the
+ * complex-valued eigenvectors of `m` and D is a complex-valued column vector
+ * with entries the eigenvectors of `m`
+ */
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
+          require_not_vt_complex<EigMat>* = nullptr>
+inline std::tuple<Eigen::Matrix<complex_return_t<value_type_t<EigMat>>, -1, -1>,
+                  Eigen::Matrix<complex_return_t<value_type_t<EigMat>>, -1, 1>>
+eigendecompose(const EigMat& m) {
+  using PlainMat = plain_type_t<EigMat>;
+  const PlainMat& m_eval = m;
+  check_nonzero_size("eigendecompose", "m", m_eval);
+  check_square("eigendecompose", "m", m_eval);
+
+  Eigen::EigenSolver<PlainMat> solver(m_eval);
+  return std::make_tuple(std::move(solver.eigenvectors()),
+                         std::move(solver.eigenvalues()));
+}
+
+/**
+ * Return the eigendecomposition of a (complex-valued) matrix
+ *
+ * @tparam EigCplxMat type of complex matrix argument
+ * @param[in] m matrix to find the eigendecomposition of. Must be square and
+ * have a non-zero size.
+ * @return A tuple V,D where V is a matrix where the columns are the
+ * complex-valued eigenvectors of `m` and D is a complex-valued column vector
+ * with entries the eigenvectors of `m`
+ */
+template <typename EigCplxMat,
+          require_eigen_matrix_dynamic_t<EigCplxMat>* = nullptr,
+          require_vt_complex<EigCplxMat>* = nullptr>
+inline std::tuple<
+    Eigen::Matrix<complex_return_t<value_type_t<EigCplxMat>>, -1, -1>,
+    Eigen::Matrix<complex_return_t<value_type_t<EigCplxMat>>, -1, 1>>
+eigendecompose(const EigCplxMat& m) {
+  using PlainMat = Eigen::Matrix<scalar_type_t<EigCplxMat>, -1, -1>;
+  const PlainMat& m_eval = m;
+  check_nonzero_size("eigendecompose", "m", m_eval);
+  check_square("eigendecompose", "m", m_eval);
+
+  Eigen::ComplexEigenSolver<PlainMat> solver(m_eval);
+
+  return std::make_tuple(std::move(solver.eigenvectors()),
+                         std::move(solver.eigenvalues()));
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/fun/eigendecompose_sym.hpp
+++ b/stan/math/prim/fun/eigendecompose_sym.hpp
@@ -9,9 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Return the eigendecomposition of the specified symmetric matrix.  This
- * function is more efficient than the general eigendecomposition function for
- * symmetric matrices.
+ * Return the eigendecomposition of the specified symmetric matrix.
  *
  * @tparam EigMat type of the matrix
  * @param m Specified matrix.
@@ -25,10 +23,13 @@ template <typename EigMat, require_eigen_t<EigMat>* = nullptr,
 std::tuple<Eigen::Matrix<value_type_t<EigMat>, -1, -1>,
            Eigen::Matrix<value_type_t<EigMat>, -1, 1>>
 eigendecompose_sym(const EigMat& m) {
+  if (unlikely(m.size() == 0)) {
+    return std::make_tuple(Eigen::Matrix<value_type_t<EigMat>, -1, -1>(0, 0),
+                           Eigen::Matrix<value_type_t<EigMat>, -1, 1>(0, 1));
+  }
+  check_symmetric("eigendecompose_sym", "m", m);
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
-  check_nonzero_size("eigendecompose_sym", "m", m_eval);
-  check_symmetric("eigendecompose_sym", "m", m_eval);
 
   Eigen::SelfAdjointEigenSolver<PlainMat> solver(m_eval);
   return std::make_tuple(std::move(solver.eigenvectors()),

--- a/stan/math/prim/fun/eigendecompose_sym.hpp
+++ b/stan/math/prim/fun/eigendecompose_sym.hpp
@@ -27,9 +27,9 @@ eigendecompose_sym(const EigMat& m) {
     return std::make_tuple(Eigen::Matrix<value_type_t<EigMat>, -1, -1>(0, 0),
                            Eigen::Matrix<value_type_t<EigMat>, -1, 1>(0, 1));
   }
-  check_symmetric("eigendecompose_sym", "m", m);
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
+  check_symmetric("eigendecompose_sym", "m", m_eval);
 
   Eigen::SelfAdjointEigenSolver<PlainMat> solver(m_eval);
   return std::make_tuple(std::move(solver.eigenvectors()),

--- a/stan/math/prim/fun/eigendecompose_sym.hpp
+++ b/stan/math/prim/fun/eigendecompose_sym.hpp
@@ -1,0 +1,40 @@
+#ifndef STAN_MATH_PRIM_FUN_EIGENDECOMPOSE_SYM_HPP
+#define STAN_MATH_PRIM_FUN_EIGENDECOMPOSE_SYM_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the eigendecomposition of the specified symmetric matrix.  This
+ * function is more efficient than the general eigendecomposition function for
+ * symmetric matrices.
+ *
+ * @tparam EigMat type of the matrix
+ * @param m Specified matrix.
+ * @return A tuple V,D where V is a matrix where the columns are the
+ * eigenvectors of m, and D is a column vector of the eigenvalues of m.
+ * The eigenvalues are in ascending order of magnitude, with the eigenvectors
+ * provided in the same order.
+ */
+template <typename EigMat, require_eigen_t<EigMat>* = nullptr,
+          require_not_st_var<EigMat>* = nullptr>
+std::tuple<Eigen::Matrix<value_type_t<EigMat>, -1, -1>,
+           Eigen::Matrix<value_type_t<EigMat>, -1, 1>>
+eigendecompose_sym(const EigMat& m) {
+  using PlainMat = plain_type_t<EigMat>;
+  const PlainMat& m_eval = m;
+  check_nonzero_size("eigendecompose_sym", "m", m_eval);
+  check_symmetric("eigendecompose_sym", "m", m_eval);
+
+  Eigen::SelfAdjointEigenSolver<PlainMat> solver(m_eval);
+  return std::make_tuple(std::move(solver.eigenvectors()),
+                         std::move(solver.eigenvalues()));
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/fun/eigenvalues.hpp
+++ b/stan/math/prim/fun/eigenvalues.hpp
@@ -19,10 +19,12 @@ template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
           require_not_vt_complex<EigMat>* = nullptr>
 inline Eigen::Matrix<complex_return_t<value_type_t<EigMat>>, -1, 1> eigenvalues(
     const EigMat& m) {
+  if (unlikely(m.size() == 0)) {
+    return Eigen::Matrix<complex_return_t<value_type_t<EigMat>>, -1, 1>(0, 1);
+  }
+  check_square("eigenvalues", "m", m);
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
-  check_nonzero_size("eigenvalues", "m", m_eval);
-  check_square("eigenvalues", "m", m_eval);
 
   Eigen::EigenSolver<PlainMat> solver(m_eval, false);
   return solver.eigenvalues();
@@ -37,14 +39,16 @@ inline Eigen::Matrix<complex_return_t<value_type_t<EigMat>>, -1, 1> eigenvalues(
  * @return a complex-valued column vector with entries the eigenvectors of `m`
  */
 template <typename EigCplxMat,
-          require_eigen_matrix_dynamic_t<EigCplxMat>* = nullptr,
-          require_vt_complex<EigCplxMat>* = nullptr>
+          require_eigen_matrix_dynamic_vt<is_complex, EigCplxMat>* = nullptr>
 inline Eigen::Matrix<complex_return_t<value_type_t<EigCplxMat>>, -1, 1>
 eigenvalues(const EigCplxMat& m) {
+  if (unlikely(m.size() == 0)) {
+    return Eigen::Matrix<complex_return_t<value_type_t<EigCplxMat>>, -1, 1>(0,
+                                                                            1);
+  }
+  check_square("eigenvalues", "m", m);
   using PlainMat = Eigen::Matrix<scalar_type_t<EigCplxMat>, -1, -1>;
   const PlainMat& m_eval = m;
-  check_nonzero_size("eigenvalues", "m", m_eval);
-  check_square("eigenvalues", "m", m_eval);
 
   Eigen::ComplexEigenSolver<PlainMat> solver(m_eval, false);
 

--- a/stan/math/prim/fun/eigenvalues_sym.hpp
+++ b/stan/math/prim/fun/eigenvalues_sym.hpp
@@ -21,10 +21,12 @@ namespace math {
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
           require_not_st_var<EigMat>* = nullptr>
 Eigen::Matrix<value_type_t<EigMat>, -1, 1> eigenvalues_sym(const EigMat& m) {
+  if (unlikely(m.size() == 0)) {
+    return Eigen::Matrix<value_type_t<EigMat>, -1, 1>(0, 1);
+  }
+  check_symmetric("eigenvalues_sym", "m", m);
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
-  check_nonzero_size("eigenvalues_sym", "m", m_eval);
-  check_symmetric("eigenvalues_sym", "m", m_eval);
 
   Eigen::SelfAdjointEigenSolver<PlainMat> solver(m_eval,
                                                  Eigen::EigenvaluesOnly);

--- a/stan/math/prim/fun/eigenvalues_sym.hpp
+++ b/stan/math/prim/fun/eigenvalues_sym.hpp
@@ -24,9 +24,9 @@ Eigen::Matrix<value_type_t<EigMat>, -1, 1> eigenvalues_sym(const EigMat& m) {
   if (unlikely(m.size() == 0)) {
     return Eigen::Matrix<value_type_t<EigMat>, -1, 1>(0, 1);
   }
-  check_symmetric("eigenvalues_sym", "m", m);
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
+  check_symmetric("eigenvalues_sym", "m", m_eval);
 
   Eigen::SelfAdjointEigenSolver<PlainMat> solver(m_eval,
                                                  Eigen::EigenvaluesOnly);

--- a/stan/math/prim/fun/eigenvalues_sym.hpp
+++ b/stan/math/prim/fun/eigenvalues_sym.hpp
@@ -10,10 +10,9 @@ namespace math {
 
 /**
  * Return the eigenvalues of the specified symmetric matrix
- * in descending order of magnitude.  This function is more
+ * in ascending order of magnitude.  This function is more
  * efficient than the general eigenvalues function for symmetric
  * matrices.
- * <p>See <code>eigen_decompose()</code> for more information.
  *
  * @tparam EigMat type of the matrix
  * @param m Specified matrix.

--- a/stan/math/prim/fun/eigenvectors.hpp
+++ b/stan/math/prim/fun/eigenvectors.hpp
@@ -20,10 +20,12 @@ template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
           require_not_vt_complex<EigMat>* = nullptr>
 inline Eigen::Matrix<complex_return_t<value_type_t<EigMat>>, -1, -1>
 eigenvectors(const EigMat& m) {
+  if (unlikely(m.size() == 0)) {
+    return Eigen::Matrix<complex_return_t<value_type_t<EigMat>>, -1, -1>(0, 0);
+  }
+  check_square("eigenvectors", "m", m);
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
-  check_nonzero_size("eigenvectors", "m", m_eval);
-  check_square("eigenvectors", "m", m_eval);
 
   Eigen::EigenSolver<PlainMat> solver(m_eval);
   return solver.eigenvectors();
@@ -39,14 +41,16 @@ eigenvectors(const EigMat& m) {
  * `m`
  */
 template <typename EigCplxMat,
-          require_eigen_matrix_dynamic_t<EigCplxMat>* = nullptr,
-          require_vt_complex<EigCplxMat>* = nullptr>
+          require_eigen_matrix_dynamic_vt<is_complex, EigCplxMat>* = nullptr>
 inline Eigen::Matrix<complex_return_t<value_type_t<EigCplxMat>>, -1, -1>
 eigenvectors(const EigCplxMat& m) {
+  if (unlikely(m.size() == 0)) {
+    return Eigen::Matrix<complex_return_t<value_type_t<EigCplxMat>>, -1, -1>(0,
+                                                                             0);
+  }
+  check_square("eigenvectors", "m", m);
   using PlainMat = Eigen::Matrix<scalar_type_t<EigCplxMat>, -1, -1>;
   const PlainMat& m_eval = m;
-  check_nonzero_size("eigenvectors", "m", m_eval);
-  check_square("eigenvectors", "m", m_eval);
 
   Eigen::ComplexEigenSolver<PlainMat> solver(m_eval);
   return solver.eigenvectors();

--- a/stan/math/prim/fun/eigenvectors_sym.hpp
+++ b/stan/math/prim/fun/eigenvectors_sym.hpp
@@ -12,10 +12,13 @@ template <typename EigMat, require_eigen_t<EigMat>* = nullptr,
           require_not_st_var<EigMat>* = nullptr>
 Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>
 eigenvectors_sym(const EigMat& m) {
+  if (unlikely(m.size() == 0)) {
+    return Eigen::Matrix<value_type_t<EigMat>, -1, -1>(0, 0);
+  }
+  check_symmetric("eigenvalues_sym", "m", m);
+
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
-  check_nonzero_size("eigenvectors_sym", "m", m_eval);
-  check_symmetric("eigenvalues_sym", "m", m_eval);
 
   Eigen::SelfAdjointEigenSolver<PlainMat> solver(m_eval);
   return solver.eigenvectors();

--- a/stan/math/prim/fun/eigenvectors_sym.hpp
+++ b/stan/math/prim/fun/eigenvectors_sym.hpp
@@ -15,10 +15,10 @@ eigenvectors_sym(const EigMat& m) {
   if (unlikely(m.size() == 0)) {
     return Eigen::Matrix<value_type_t<EigMat>, -1, -1>(0, 0);
   }
-  check_symmetric("eigenvalues_sym", "m", m);
-
   using PlainMat = plain_type_t<EigMat>;
   const PlainMat& m_eval = m;
+  check_symmetric("eigenvalues_sym", "m", m_eval);
+
 
   Eigen::SelfAdjointEigenSolver<PlainMat> solver(m_eval);
   return solver.eigenvectors();

--- a/stan/math/prim/fun/eigenvectors_sym.hpp
+++ b/stan/math/prim/fun/eigenvectors_sym.hpp
@@ -19,7 +19,6 @@ eigenvectors_sym(const EigMat& m) {
   const PlainMat& m_eval = m;
   check_symmetric("eigenvalues_sym", "m", m_eval);
 
-
   Eigen::SelfAdjointEigenSolver<PlainMat> solver(m_eval);
   return solver.eigenvectors();
 }

--- a/stan/math/prim/fun/qr.hpp
+++ b/stan/math/prim/fun/qr.hpp
@@ -25,7 +25,10 @@ std::tuple<Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>,
 qr(const EigMat& m) {
   using matrix_t
       = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
-  check_nonzero_size("qr", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return std::make_tuple(matrix_t(0, 0), matrix_t(0, 0));
+  }
+
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);
   matrix_t Q = qr.householderQ();

--- a/stan/math/prim/fun/qr_Q.hpp
+++ b/stan/math/prim/fun/qr_Q.hpp
@@ -21,7 +21,10 @@ Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_Q(
     const EigMat& m) {
   using matrix_t
       = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
-  check_nonzero_size("qr_Q", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return matrix_t(0, 0);
+  }
+  
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);
   matrix_t Q = qr.householderQ();

--- a/stan/math/prim/fun/qr_Q.hpp
+++ b/stan/math/prim/fun/qr_Q.hpp
@@ -24,7 +24,7 @@ Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_Q(
   if (unlikely(m.size() == 0)) {
     return matrix_t(0, 0);
   }
-  
+
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);
   matrix_t Q = qr.householderQ();

--- a/stan/math/prim/fun/qr_R.hpp
+++ b/stan/math/prim/fun/qr_R.hpp
@@ -20,7 +20,9 @@ Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_R(
     const EigMat& m) {
   using matrix_t
       = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
-  check_nonzero_size("qr_R", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return matrix_t(0, 0);
+  }
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);
   matrix_t R = qr.matrixQR();

--- a/stan/math/prim/fun/qr_thin.hpp
+++ b/stan/math/prim/fun/qr_thin.hpp
@@ -1,0 +1,53 @@
+#ifndef STAN_MATH_PRIM_FUN_QR_THIN_HPP
+#define STAN_MATH_PRIM_FUN_QR_THIN_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <algorithm>
+#include <tuple>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the thin QR decomposition
+ *
+ * @tparam EigMat type of the matrix
+ * @param m Matrix.
+ * @return A tuple containing (Q,R):
+ * 1. Orthogonal matrix with minimal columns
+ * 2. Upper triangular matrix with minimal rows
+ */
+template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
+std::tuple<Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>,
+           Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>>
+qr_thin(const EigMat& m) {
+  using matrix_t
+      = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
+  check_nonzero_size("qr_thin", "m", m);
+  Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
+  qr.compute(m);
+  const int min_size = std::min(m.rows(), m.cols());
+  matrix_t Q = qr.householderQ() * matrix_t::Identity(m.rows(), min_size);
+  for (int i = 0; i < min_size; i++) {
+    if (qr.matrixQR().coeff(i, i) < 0) {
+      Q.col(i) *= -1.0;
+    }
+  }
+  matrix_t R = qr.matrixQR().topLeftCorner(min_size, m.cols());
+  for (int i = 0; i < min_size; i++) {
+    for (int j = 0; j < i; j++) {
+      R.coeffRef(i, j) = 0.0;
+    }
+    if (R(i, i) < 0) {
+      R.row(i) *= -1.0;
+    }
+  }
+  return std::make_tuple(std::move(Q), std::move(R));
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/qr_thin.hpp
+++ b/stan/math/prim/fun/qr_thin.hpp
@@ -25,7 +25,10 @@ std::tuple<Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>,
 qr_thin(const EigMat& m) {
   using matrix_t
       = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
-  check_nonzero_size("qr_thin", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return std::make_tuple(matrix_t(0, 0), matrix_t(0, 0));
+  }
+
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);
   const int min_size = std::min(m.rows(), m.cols());

--- a/stan/math/prim/fun/qr_thin.hpp
+++ b/stan/math/prim/fun/qr_thin.hpp
@@ -36,10 +36,8 @@ qr_thin(const EigMat& m) {
     }
   }
   matrix_t R = qr.matrixQR().topLeftCorner(min_size, m.cols());
-  for (int i = 0; i < min_size; i++) {
-    for (int j = 0; j < i; j++) {
-      R.coeffRef(i, j) = 0.0;
-    }
+  R.template triangularView<Eigen::StrictlyLower>().setZero();
+  for (int i = 0; i < min_size; ++i) {
     if (R(i, i) < 0) {
       R.row(i) *= -1.0;
     }

--- a/stan/math/prim/fun/qr_thin_Q.hpp
+++ b/stan/math/prim/fun/qr_thin_Q.hpp
@@ -20,7 +20,9 @@ Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_thin_Q(
     const EigMat& m) {
   using matrix_t
       = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
-  check_nonzero_size("qr_thin_Q", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return matrix_t(0, 0);
+  }
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);
   const int min_size = std::min(m.rows(), m.cols());

--- a/stan/math/prim/fun/qr_thin_R.hpp
+++ b/stan/math/prim/fun/qr_thin_R.hpp
@@ -25,10 +25,8 @@ Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_thin_R(
   qr.compute(m);
   const int min_size = std::min(m.rows(), m.cols());
   matrix_t R = qr.matrixQR().topLeftCorner(min_size, m.cols());
-  for (int i = 0; i < min_size; i++) {
-    for (int j = 0; j < i; j++) {
-      R.coeffRef(i, j) = 0.0;
-    }
+  R.template triangularView<Eigen::StrictlyLower>().setZero();
+  for (int i = 0; i < min_size; ++i) {
     if (R(i, i) < 0) {
       R.row(i) *= -1.0;
     }

--- a/stan/math/prim/fun/qr_thin_R.hpp
+++ b/stan/math/prim/fun/qr_thin_R.hpp
@@ -20,7 +20,9 @@ Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_thin_R(
     const EigMat& m) {
   using matrix_t
       = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
-  check_nonzero_size("qr_thin_R", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return matrix_t(0, 0);
+  }
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);
   const int min_size = std::min(m.rows(), m.cols());

--- a/stan/math/prim/fun/singular_values.hpp
+++ b/stan/math/prim/fun/singular_values.hpp
@@ -21,8 +21,9 @@ namespace math {
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
           require_not_st_var<EigMat>* = nullptr>
 auto singular_values(const EigMat& m) {
-  check_nonzero_size("singular_values", "m", m);
-
+  if (unlikely(m.size() == 0)) {
+    return Eigen::Matrix<base_type_t<EigMat>, Eigen::Dynamic, 1>(0, 1);
+  }
   return Eigen::JacobiSVD<Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic,
                                         Eigen::Dynamic> >(m)
       .singularValues();

--- a/stan/math/prim/fun/svd.hpp
+++ b/stan/math/prim/fun/svd.hpp
@@ -1,0 +1,37 @@
+#ifndef STAN_MATH_PRIM_FUN_SVD_HPP
+#define STAN_MATH_PRIM_FUN_SVD_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Given input matrix m, return the singular value decomposition (U,D,V)
+ * such that `m = U*diag(D)*V^{T}`
+ *
+ * @tparam EigMat type of the matrix
+ * @param m MxN input matrix
+ * @return a tuple (U,D,V) where U is an orthogonal matrix, D a vector of
+ * singular values (in decreasing order), and V an orthogonal matrix
+ */
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
+          require_not_st_var<EigMat>* = nullptr>
+std::tuple<Eigen::Matrix<value_type_t<EigMat>, -1, -1>,
+           Eigen::Matrix<base_type_t<EigMat>, -1, 1>,
+           Eigen::Matrix<value_type_t<EigMat>, -1, -1>>
+svd(const EigMat& m) {
+  check_nonzero_size("svd", "m", m);
+
+  Eigen::JacobiSVD<Eigen::Matrix<value_type_t<EigMat>, -1, -1>> svd(
+      m, Eigen::ComputeThinU | Eigen::ComputeThinV);
+  return std::make_tuple(std::move(svd.matrixU()),
+                         std::move(svd.singularValues()),
+                         std::move(svd.matrixV()));
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/svd.hpp
+++ b/stan/math/prim/fun/svd.hpp
@@ -22,7 +22,11 @@ std::tuple<Eigen::Matrix<value_type_t<EigMat>, -1, -1>,
            Eigen::Matrix<base_type_t<EigMat>, -1, 1>,
            Eigen::Matrix<value_type_t<EigMat>, -1, -1>>
 svd(const EigMat& m) {
-  check_nonzero_size("svd", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return std::make_tuple(Eigen::Matrix<value_type_t<EigMat>, -1, -1>(0, 0),
+                           Eigen::Matrix<base_type_t<EigMat>, -1, 1>(0, 1),
+                           Eigen::Matrix<value_type_t<EigMat>, -1, -1>(0, 0));
+  }
 
   Eigen::JacobiSVD<Eigen::Matrix<value_type_t<EigMat>, -1, -1>> svd(
       m, Eigen::ComputeThinU | Eigen::ComputeThinV);

--- a/stan/math/prim/fun/svd_U.hpp
+++ b/stan/math/prim/fun/svd_U.hpp
@@ -23,7 +23,7 @@ Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> svd_U(
   if (unlikely(m.size() == 0)) {
     return MatType(0, 0);
   }
-  return Eigen::JacobiSVD<MatType> (m, Eigen::ComputeThinU).matrixU();
+  return Eigen::JacobiSVD<MatType>(m, Eigen::ComputeThinU).matrixU();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/svd_U.hpp
+++ b/stan/math/prim/fun/svd_U.hpp
@@ -18,12 +18,12 @@ template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
           require_not_st_var<EigMat>* = nullptr>
 Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> svd_U(
     const EigMat& m) {
-  check_nonzero_size("svd_U", "m", m);
-
-  return Eigen::JacobiSVD<Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic,
-                                        Eigen::Dynamic> >(m,
-                                                          Eigen::ComputeThinU)
-      .matrixU();
+  using MatType
+      = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
+  if (unlikely(m.size() == 0)) {
+    return MatType(0, 0);
+  }
+  return Eigen::JacobiSVD<MatType> (m, Eigen::ComputeThinU).matrixU();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/svd_V.hpp
+++ b/stan/math/prim/fun/svd_V.hpp
@@ -18,12 +18,12 @@ template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
           require_not_st_var<EigMat>* = nullptr>
 Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> svd_V(
     const EigMat& m) {
-  check_nonzero_size("svd_V", "m", m);
-
-  return Eigen::JacobiSVD<Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic,
-                                        Eigen::Dynamic> >(m,
-                                                          Eigen::ComputeThinV)
-      .matrixV();
+  using MatType
+      = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
+  if (unlikely(m.size() == 0)) {
+    return MatType(0, 0);
+  }
+  return Eigen::JacobiSVD<MatType>(m, Eigen::ComputeThinV).matrixV();
 }
 
 }  // namespace math

--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -163,6 +163,7 @@
 #include <stan/math/rev/fun/simplex_constrain.hpp>
 #include <stan/math/rev/fun/sin.hpp>
 #include <stan/math/rev/fun/singular_values.hpp>
+#include <stan/math/rev/fun/svd.hpp>
 #include <stan/math/rev/fun/svd_U.hpp>
 #include <stan/math/rev/fun/svd_V.hpp>
 #include <stan/math/rev/fun/sinh.hpp>

--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -49,6 +49,7 @@
 #include <stan/math/rev/fun/divide.hpp>
 #include <stan/math/rev/fun/dot_product.hpp>
 #include <stan/math/rev/fun/dot_self.hpp>
+#include <stan/math/rev/fun/eigendecompose_sym.hpp>
 #include <stan/math/rev/fun/eigenvalues_sym.hpp>
 #include <stan/math/rev/fun/eigenvectors_sym.hpp>
 #include <stan/math/rev/fun/elt_divide.hpp>

--- a/stan/math/rev/fun/eigendecompose_sym.hpp
+++ b/stan/math/rev/fun/eigendecompose_sym.hpp
@@ -1,0 +1,63 @@
+#ifndef STAN_MATH_REV_FUN_EIGENDECOMPOSE_HPP
+#define STAN_MATH_REV_FUN_EIGENDECOMPOSE_HPP
+
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/fun/value_of_rec.hpp>
+#include <stan/math/rev/core/typedefs.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/err/check_symmetric.hpp>
+#include <stan/math/prim/err/check_nonzero_size.hpp>
+#include <stan/math/prim/fun/typedefs.hpp>
+#include <stan/math/prim/fun/value_of_rec.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the decomposition of the specified symmetric matrix.
+ *
+ * @tparam T type of input matrix.
+ * @param m Specified matrix.
+ * @return A tuple V,D where V is a matrix where the columns are the
+ * eigenvectors of m, and D is a column vector of the eigenvalues of m.
+ * The eigenvalues are in ascending order of magnitude, with the eigenvectors
+ * provided in the same order.
+ */
+template <typename T, require_rev_matrix_t<T>* = nullptr>
+inline auto eigendecompose_sym(const T& m) {
+  using eigval_return_t = return_var_matrix_t<Eigen::VectorXd, T>;
+  using eigvec_return_t = return_var_matrix_t<T>;
+
+  check_nonzero_size("eigendecompose_sym", "m", m);
+  check_symmetric("eigendecompose_sym", "m", m);
+
+  auto arena_m = to_arena(m);
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> solver(arena_m.val());
+  arena_t<eigval_return_t> eigenvals = solver.eigenvalues();
+  arena_t<eigvec_return_t> eigenvecs = solver.eigenvectors();
+
+  reverse_pass_callback([eigenvals, arena_m, eigenvecs]() mutable {
+    // eigenvalue reverse calculation
+    arena_m.adj()
+        += eigenvecs.val_op() * eigenvals.adj().asDiagonal() * eigenvecs.val_op().transpose();
+    // eigenvector reverse calculation
+    const int p = arena_m.val().cols();
+    Eigen::MatrixXd f = (1
+                         / (eigenvals.val_op().rowwise().replicate(p).transpose()
+                            - eigenvals.val_op().rowwise().replicate(p))
+                               .array());
+    f.diagonal().setZero();
+    arena_m.adj()
+        += eigenvecs.val_op()
+           * f.cwiseProduct(eigenvecs.val_op().transpose() * eigenvecs.adj_op())
+           * eigenvecs.val_op().transpose();
+  });
+
+  return std::make_tuple(std::move(eigvec_return_t(eigenvecs)),
+                         std::move(eigval_return_t(eigenvals)));
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/fun/eigendecompose_sym.hpp
+++ b/stan/math/rev/fun/eigendecompose_sym.hpp
@@ -39,14 +39,15 @@ inline auto eigendecompose_sym(const T& m) {
 
   reverse_pass_callback([eigenvals, arena_m, eigenvecs]() mutable {
     // eigenvalue reverse calculation
-    arena_m.adj()
-        += eigenvecs.val_op() * eigenvals.adj().asDiagonal() * eigenvecs.val_op().transpose();
+    arena_m.adj() += eigenvecs.val_op() * eigenvals.adj().asDiagonal()
+                     * eigenvecs.val_op().transpose();
     // eigenvector reverse calculation
     const int p = arena_m.val().cols();
-    Eigen::MatrixXd f = (1
-                         / (eigenvals.val_op().rowwise().replicate(p).transpose()
-                            - eigenvals.val_op().rowwise().replicate(p))
-                               .array());
+    Eigen::MatrixXd f
+        = (1
+           / (eigenvals.val_op().rowwise().replicate(p).transpose()
+              - eigenvals.val_op().rowwise().replicate(p))
+                 .array());
     f.diagonal().setZero();
     arena_m.adj()
         += eigenvecs.val_op()

--- a/stan/math/rev/fun/eigenvalues_sym.hpp
+++ b/stan/math/rev/fun/eigenvalues_sym.hpp
@@ -16,7 +16,6 @@ namespace math {
 
 /**
  * Return the eigenvalues of the specified symmetric matrix.
- * <p>See <code>eigen_decompose()</code> for more information.
  * @tparam T type of input matrix.
  * @param m Specified matrix.
  * @return Eigenvalues of matrix.

--- a/stan/math/rev/fun/eigenvalues_sym.hpp
+++ b/stan/math/rev/fun/eigenvalues_sym.hpp
@@ -23,7 +23,9 @@ namespace math {
 template <typename T, require_rev_matrix_t<T>* = nullptr>
 inline auto eigenvalues_sym(const T& m) {
   using return_t = return_var_matrix_t<Eigen::VectorXd, T>;
-  check_nonzero_size("eigenvalues_sym", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return return_t(Eigen::VectorXd(0));
+  }
   check_symmetric("eigenvalues_sym", "m", m);
 
   auto arena_m = to_arena(m);

--- a/stan/math/rev/fun/eigenvectors_sym.hpp
+++ b/stan/math/rev/fun/eigenvectors_sym.hpp
@@ -16,7 +16,7 @@ namespace math {
 
 /**
  * Return the eigenvectors of the specified symmetric matrix.
- * <p>See <code>eigen_decompose()</code> for more information.
+ *
  * @tparam T type of input matrix.
  * @param m Specified matrix.
  * @return Eigenvectors of matrix.
@@ -24,9 +24,7 @@ namespace math {
 template <typename T, require_rev_matrix_t<T>* = nullptr>
 inline auto eigenvectors_sym(const T& m) {
   using return_t = return_var_matrix_t<T>;
-  if (unlikely(m.size() == 0)) {
-    return return_t(m);
-  }
+  check_nonzero_size("eigenvectors_sym", "m", m);
   check_symmetric("eigenvectors_sym", "m", m);
 
   auto arena_m = to_arena(m);

--- a/stan/math/rev/fun/eigenvectors_sym.hpp
+++ b/stan/math/rev/fun/eigenvectors_sym.hpp
@@ -24,7 +24,9 @@ namespace math {
 template <typename T, require_rev_matrix_t<T>* = nullptr>
 inline auto eigenvectors_sym(const T& m) {
   using return_t = return_var_matrix_t<T>;
-  check_nonzero_size("eigenvectors_sym", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return return_t(Eigen::MatrixXd(0, 0));
+  }
   check_symmetric("eigenvectors_sym", "m", m);
 
   auto arena_m = to_arena(m);
@@ -33,7 +35,7 @@ inline auto eigenvectors_sym(const T& m) {
   auto eigenvals = to_arena(solver.eigenvalues());
 
   reverse_pass_callback([arena_m, eigenvals, eigenvecs]() mutable {
-    const int p = arena_m.val().cols();
+    const auto p = arena_m.val().cols();
     Eigen::MatrixXd f = (1
                          / (eigenvals.rowwise().replicate(p).transpose()
                             - eigenvals.rowwise().replicate(p))

--- a/stan/math/rev/fun/singular_values.hpp
+++ b/stan/math/rev/fun/singular_values.hpp
@@ -22,7 +22,9 @@ namespace math {
 template <typename EigMat, require_rev_matrix_t<EigMat>* = nullptr>
 inline auto singular_values(const EigMat& m) {
   using ret_type = return_var_matrix_t<Eigen::VectorXd, EigMat>;
-  check_nonzero_size("singular_values", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return ret_type(Eigen::VectorXd(0));
+  }
 
   auto arena_m = to_arena(m);
 

--- a/stan/math/rev/fun/svd.hpp
+++ b/stan/math/rev/fun/svd.hpp
@@ -28,7 +28,11 @@ inline auto svd(const EigMat& m) {
   using mat_ret_type = return_var_matrix_t<Eigen::MatrixXd, EigMat>;
   using vec_ret_type = return_var_matrix_t<Eigen::VectorXd, EigMat>;
 
-  check_nonzero_size("svd", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return std::make_tuple(mat_ret_type(Eigen::MatrixXd(0, 0)),
+                           vec_ret_type(Eigen::VectorXd(0, 1)),
+                           mat_ret_type(Eigen::MatrixXd(0, 0)));
+  }
 
   const int M = std::min(m.rows(), m.cols());
   auto arena_m = to_arena(m);

--- a/stan/math/rev/fun/svd.hpp
+++ b/stan/math/rev/fun/svd.hpp
@@ -1,0 +1,96 @@
+#ifndef STAN_MATH_REV_FUN_SVD_HPP
+#define STAN_MATH_REV_FUN_SVD_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/err/check_nonzero_size.hpp>
+#include <stan/math/prim/fun/typedefs.hpp>
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/fun/value_of.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Given input matrix m, return the singular value decomposition (U,D,V)
+ * such that `m = U*diag(D)*V^{T}`
+ *
+ * Adjoint update equation comes from Equation (4) in Differentiable Programming
+ * Tensor Networks(H. Liao, J. Liu, et al., arXiv:1903.09650).
+ *
+ * @tparam EigMat type of input matrix
+ * @param m MxN input matrix
+ * @return a tuple (U,D,V) where U is an orthogonal matrix, D a vector of
+ * singular values (in decreasing order), and V an orthogonal matrix
+ */
+template <typename EigMat, require_rev_matrix_t<EigMat>* = nullptr>
+inline auto svd(const EigMat& m) {
+  using mat_ret_type = return_var_matrix_t<Eigen::MatrixXd, EigMat>;
+  using vec_ret_type = return_var_matrix_t<Eigen::VectorXd, EigMat>;
+
+  check_nonzero_size("svd", "m", m);
+
+  const int M = std::min(m.rows(), m.cols());
+  auto arena_m = to_arena(m);
+
+  Eigen::JacobiSVD<Eigen::MatrixXd> svd(
+      arena_m.val(), Eigen::ComputeThinU | Eigen::ComputeThinV);
+
+  auto singular_values_d = svd.singularValues();
+
+  arena_t<Eigen::MatrixXd> arena_Fp(M, M);
+  arena_t<Eigen::MatrixXd> arena_Fm(M, M);
+
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < M; j++) {
+      double a = 1.0 / (singular_values_d[j] - singular_values_d[i]);
+      double b = 1.0 / (singular_values_d[i] + singular_values_d[j]);
+      arena_Fp(i, j) = a + b;
+      arena_Fm(i, j) = a - b;
+    }
+  }
+  arena_Fp.diagonal().setZero();
+  arena_Fm.diagonal().setZero();
+
+  arena_t<vec_ret_type> singular_values = singular_values_d;
+  arena_t<mat_ret_type> arena_U = svd.matrixU();
+  arena_t<mat_ret_type> arena_V = svd.matrixV();
+
+  reverse_pass_callback([arena_m, arena_U, singular_values, arena_V, arena_Fp,
+                         arena_Fm, M]() mutable {
+    // SVD-U reverse mode
+    Eigen::MatrixXd UUadjT = arena_U.val_op().transpose() * arena_U.adj_op();
+    arena_m.adj()
+        += .5 * arena_U.val_op()
+               * (arena_Fp.array() * (UUadjT - UUadjT.transpose()).array())
+                     .matrix()
+               * arena_V.val_op().transpose()
+           + (Eigen::MatrixXd::Identity(arena_m.rows(), arena_m.rows())
+              - arena_U.val_op() * arena_U.val_op().transpose())
+                 * arena_U.adj_op()
+                 * singular_values.val_op().asDiagonal().inverse()
+                 * arena_V.val_op().transpose();
+    // Singular values reverse mode
+    arena_m.adj() += arena_U.val_op() * singular_values.adj().asDiagonal()
+                     * arena_V.val_op().transpose();
+    // SVD-V reverse mode
+    Eigen::MatrixXd VTVadj = arena_V.val_op().transpose() * arena_V.adj_op();
+    arena_m.adj()
+        += 0.5 * arena_U.val_op()
+               * (arena_Fm.array() * (VTVadj - VTVadj.transpose()).array())
+                     .matrix()
+               * arena_V.val_op().transpose()
+           + arena_U.val_op() * singular_values.val_op().asDiagonal().inverse()
+                 * arena_V.adj_op().transpose()
+                 * (Eigen::MatrixXd::Identity(arena_m.cols(), arena_m.cols())
+                    - arena_V.val_op() * arena_V.val_op().transpose());
+  });
+
+  return std::make_tuple(mat_ret_type(arena_U), vec_ret_type(singular_values),
+                         mat_ret_type(arena_V));
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/rev/fun/svd_U.hpp
+++ b/stan/math/rev/fun/svd_U.hpp
@@ -24,7 +24,9 @@ namespace math {
 template <typename EigMat, require_rev_matrix_t<EigMat>* = nullptr>
 inline auto svd_U(const EigMat& m) {
   using ret_type = return_var_matrix_t<Eigen::MatrixXd, EigMat>;
-  check_nonzero_size("svd_U", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return ret_type(Eigen::MatrixXd(0, 0));
+  }
 
   const int M = std::min(m.rows(), m.cols());
   auto arena_m = to_arena(m);

--- a/stan/math/rev/fun/svd_V.hpp
+++ b/stan/math/rev/fun/svd_V.hpp
@@ -24,7 +24,9 @@ namespace math {
 template <typename EigMat, require_rev_matrix_t<EigMat>* = nullptr>
 inline auto svd_V(const EigMat& m) {
   using ret_type = return_var_matrix_t<Eigen::MatrixXd, EigMat>;
-  check_nonzero_size("svd_V", "m", m);
+  if (unlikely(m.size() == 0)) {
+    return ret_type(Eigen::MatrixXd(0, 0));
+  }
 
   const int M = std::min(m.rows(), m.cols());
   auto arena_m = to_arena(m);

--- a/test/unit/math/mix/fun/complex_schur_decompose_test.cpp
+++ b/test/unit/math/mix/fun/complex_schur_decompose_test.cpp
@@ -51,9 +51,9 @@ TEST(mathMixFun, complexSchurDecompose) {
 
 template <typename V>
 void test_complex_schur_decompose(const Eigen::MatrixXd& x) {
+  using stan::math::complex_schur_decompose;
   using stan::math::complex_schur_decompose_t;
   using stan::math::complex_schur_decompose_u;
-  using stan::math::complex_schur_decompose;
   using stan::math::get_real;
   using stan::math::value_of_rec;
   Eigen::Matrix<V, -1, -1> X = x;
@@ -67,14 +67,13 @@ void test_complex_schur_decompose(const Eigen::MatrixXd& x) {
   std::tie(U, T) = complex_schur_decompose(X);
   auto X3 = U * T * U.adjoint();
   EXPECT_MATRIX_NEAR(x, value_of_rec(get_real(X3)), 1e-8);
-
 }
 
 template <typename V>
 void test_complex_schur_decompose_complex(const Eigen::MatrixXd& x) {
+  using stan::math::complex_schur_decompose;
   using stan::math::complex_schur_decompose_t;
   using stan::math::complex_schur_decompose_u;
-  using stan::math::complex_schur_decompose;
   using stan::math::value_of_rec;
   Eigen::Matrix<std::complex<V>, -1, -1> X(x.rows(), x.cols());
   for (int i = 0; i < x.size(); ++i)

--- a/test/unit/math/mix/fun/complex_schur_decompose_test.cpp
+++ b/test/unit/math/mix/fun/complex_schur_decompose_test.cpp
@@ -29,10 +29,31 @@ TEST(mathMixFun, complexSchurDecomposeU) {
   EXPECT_THROW(f(a32), std::invalid_argument);
 }
 
+TEST(mathMixFun, complexSchurDecompose) {
+  auto f = [](const auto& x) {
+    using stan::math::complex_schur_decompose;
+    return std::get<0>(complex_schur_decompose(x));
+  };
+  auto g = [](const auto& x) {
+    using stan::math::complex_schur_decompose;
+    return std::get<1>(complex_schur_decompose(x));
+  };
+  for (const auto& x : stan::test::square_test_matrices(0, 2)) {
+    stan::test::expect_ad(f, x);
+    stan::test::expect_ad(g, x);
+  }
+
+  Eigen::MatrixXd a32(3, 2);
+  a32 << 3, -5, 7, -7.2, 9.1, -6.3;
+  EXPECT_THROW(f(a32), std::invalid_argument);
+  EXPECT_THROW(g(a32), std::invalid_argument);
+}
+
 template <typename V>
 void test_complex_schur_decompose(const Eigen::MatrixXd& x) {
   using stan::math::complex_schur_decompose_t;
   using stan::math::complex_schur_decompose_u;
+  using stan::math::complex_schur_decompose;
   using stan::math::get_real;
   using stan::math::value_of_rec;
   Eigen::Matrix<V, -1, -1> X = x;
@@ -42,12 +63,18 @@ void test_complex_schur_decompose(const Eigen::MatrixXd& x) {
   auto X2 = U * T * U.adjoint();
 
   EXPECT_MATRIX_NEAR(x, value_of_rec(get_real(X2)), 1e-8);
+
+  std::tie(U, T) = complex_schur_decompose(X);
+  auto X3 = U * T * U.adjoint();
+  EXPECT_MATRIX_NEAR(x, value_of_rec(get_real(X3)), 1e-8);
+
 }
 
 template <typename V>
 void test_complex_schur_decompose_complex(const Eigen::MatrixXd& x) {
   using stan::math::complex_schur_decompose_t;
   using stan::math::complex_schur_decompose_u;
+  using stan::math::complex_schur_decompose;
   using stan::math::value_of_rec;
   Eigen::Matrix<std::complex<V>, -1, -1> X(x.rows(), x.cols());
   for (int i = 0; i < x.size(); ++i)
@@ -57,9 +84,13 @@ void test_complex_schur_decompose_complex(const Eigen::MatrixXd& x) {
   auto X2 = U * T * U.adjoint();
 
   EXPECT_MATRIX_COMPLEX_NEAR(value_of_rec(X), value_of_rec(X2), 1e-8);
+
+  std::tie(U, T) = complex_schur_decompose(X);
+  auto X3 = U * T * U.adjoint();
+  EXPECT_MATRIX_COMPLEX_NEAR(value_of_rec(X), value_of_rec(X3), 1e-8);
 }
 
-TEST(mathMixFun, complexSchurDecompose) {
+TEST(mathMixFun, complexSchurDecomposeIdent) {
   using d_t = double;
   using v_t = stan::math::var;
   using fd_t = stan::math::fvar<d_t>;

--- a/test/unit/math/mix/fun/eigendecompose_identity_complex_test.cpp
+++ b/test/unit/math/mix/fun/eigendecompose_identity_complex_test.cpp
@@ -27,7 +27,7 @@ void expectComplexEigenvectorsId() {
 
   std::tie(eigenvectors, eigenvalues) = stan::math::eigendecompose(c22);
   auto I2 = (eigenvectors.inverse() * c22 * eigenvectors
-       * eigenvalues.asDiagonal().inverse());
+             * eigenvalues.asDiagonal().inverse());
 
   expect_identity_matrix_complex(I2);
 }

--- a/test/unit/math/mix/fun/eigendecompose_identity_complex_test.cpp
+++ b/test/unit/math/mix/fun/eigendecompose_identity_complex_test.cpp
@@ -24,6 +24,12 @@ void expectComplexEigenvectorsId() {
             * eigenvalues.asDiagonal().inverse());
 
   expect_identity_matrix_complex(I);
+
+  std::tie(eigenvectors, eigenvalues) = stan::math::eigendecompose(c22);
+  auto I2 = (eigenvectors.inverse() * c22 * eigenvectors
+       * eigenvalues.asDiagonal().inverse());
+
+  expect_identity_matrix_complex(I2);
 }
 
 TEST(mathMixFun, eigenvectorsIdComplex) {

--- a/test/unit/math/mix/fun/eigendecompose_identity_test.cpp
+++ b/test/unit/math/mix/fun/eigendecompose_identity_test.cpp
@@ -18,6 +18,10 @@ void expectEigenvectorsId() {
     auto vals = eigenvalues(m).eval();
     auto I = (vecs.inverse() * m * vecs * vals.asDiagonal().inverse()).real();
     expect_identity_matrix(I);
+
+    std::tie(vecs,vals) = eigendecompose(m);
+    auto I2 = (vecs.inverse() * m * vecs * vals.asDiagonal().inverse()).real();
+    expect_identity_matrix(I2);
   }
 }
 

--- a/test/unit/math/mix/fun/eigendecompose_identity_test.cpp
+++ b/test/unit/math/mix/fun/eigendecompose_identity_test.cpp
@@ -19,7 +19,7 @@ void expectEigenvectorsId() {
     auto I = (vecs.inverse() * m * vecs * vals.asDiagonal().inverse()).real();
     expect_identity_matrix(I);
 
-    std::tie(vecs,vals) = eigendecompose(m);
+    std::tie(vecs, vals) = eigendecompose(m);
     auto I2 = (vecs.inverse() * m * vecs * vals.asDiagonal().inverse()).real();
     expect_identity_matrix(I2);
   }

--- a/test/unit/math/mix/fun/eigendecompose_sym_test.cpp
+++ b/test/unit/math/mix/fun/eigendecompose_sym_test.cpp
@@ -1,0 +1,106 @@
+#include <test/unit/math/test_ad.hpp>
+
+TEST(MathMixMatFun, eigendecomposeSym) {
+  auto g = [](const auto& y) {
+    // eigenvectors
+    // maintain symmetry for finite diffs; ignore if not square
+    if (y.rows() != y.cols()) {
+      return std::get<0>(stan::math::eigendecompose_sym(y));
+    }
+    auto a = ((y + y.transpose()) * 0.5).eval();
+    return std::get<0>(stan::math::eigendecompose_sym(a));
+  };
+
+  auto f = [](const auto& y) {
+    // eigenvalues
+    if (y.rows() != y.cols()) {
+      return std::get<1>(stan::math::eigendecompose_sym(y));
+    }
+    auto a = ((y + y.transpose()) * 0.5).eval();
+    return std::get<1>(stan::math::eigendecompose_sym(a));
+  };
+
+  stan::test::ad_tolerances values_tols;
+  values_tols.hessian_hessian_ = 5e-2;
+  values_tols.hessian_fvar_hessian_ = 5e-2;
+
+  // 1 x 1
+  Eigen::MatrixXd a11(1, 1);
+  a11 << 2.3;
+  stan::test::expect_ad(values_tols, f, a11);
+  stan::test::expect_ad(g, a11);
+
+  Eigen::MatrixXd a23(2, 3);
+  a23 << 1, 2, 3, 4, 5, 6;
+  stan::test::expect_ad(values_tols, f, a23);
+  stan::test::expect_ad(g, a23);
+
+  Eigen::MatrixXd m22(2, 2);
+  m22 << 1, 2, 3, 4;
+  stan::test::expect_ad(values_tols, f, m22);
+  stan::test::expect_ad(g, m22);
+
+  Eigen::MatrixXd a33(3, 3);
+  a33 << 1, 2, 3, 2, 5, 7.9, 3, 7.9, 1.08;
+  stan::test::expect_ad(values_tols, f, a33);
+  stan::test::expect_ad(g, a33);
+}
+
+TEST(MathMixMatFun, eigendecomposeSym_varmat) {
+  auto g = [](const auto& y) {
+    // eigenvectors
+    // maintain symmetry for finite diffs; ignore if not square
+    if (y.rows() != y.cols()) {
+      return std::get<0>(stan::math::eigendecompose_sym(y));
+    }
+    auto a = ((y + y.transpose()) * 0.5).eval();
+    return std::get<0>(stan::math::eigendecompose_sym(a));
+  };
+
+  auto f = [](const auto& y) {
+    // eigenvalues
+    if (y.rows() != y.cols()) {
+      return std::get<1>(stan::math::eigendecompose_sym(y));
+    }
+    auto a = ((y + y.transpose()) * 0.5).eval();
+    return std::get<1>(stan::math::eigendecompose_sym(a));
+  };
+
+  stan::test::ad_tolerances values_tols;
+  values_tols.hessian_hessian_ = 5e-2;
+  values_tols.hessian_fvar_hessian_ = 5e-2;
+
+  stan::test::ad_tolerances vec_tols;
+  vec_tols.hessian_hessian_ = 5e-2;
+  vec_tols.hessian_fvar_hessian_ = 5e-2;
+
+  Eigen::MatrixXd a11(1, 1);
+  a11 << 2.3;
+  stan::test::expect_ad(values_tols, f, a11);
+  stan::test::expect_ad_matvar(values_tols, f, a11);
+  stan::test::expect_ad(g, a11);
+  stan::test::expect_ad_matvar(vec_tols, g, a11);
+
+  Eigen::MatrixXd m22(2, 2);
+  m22 << 1, 2, 3, 4;
+  stan::test::expect_ad(values_tols, f, m22);
+  stan::test::expect_ad_matvar(values_tols, f, m22);
+  stan::test::expect_ad(g, m22);
+  stan::test::expect_ad_matvar(vec_tols, g, m22);
+
+  Eigen::MatrixXd a23(2, 3);
+  a23 << 1, 2, 3, 4, 5, 6;
+  stan::test::expect_ad(values_tols, f, a23);
+  stan::test::expect_ad_matvar(values_tols, f, a23);
+  stan::test::expect_ad(g, a23);
+  stan::test::expect_ad_matvar(vec_tols, g, a23);
+
+  Eigen::MatrixXd a33(3, 3);
+  a33 << 1, 2, 3, 2, 5, 7.9, 3, 7.9, 1.08;
+  stan::test::expect_ad(values_tols, f, a33);
+  stan::test::expect_ad_matvar(values_tols, f, a33);
+  stan::test::expect_ad(g, a33);
+  vec_tols.hessian_fvar_hessian_ = 1e-2;
+  vec_tols.hessian_hessian_ = 1e-2;
+  stan::test::expect_ad_matvar(vec_tols, g, a33);
+}

--- a/test/unit/math/mix/fun/eigendecompose_test.cpp
+++ b/test/unit/math/mix/fun/eigendecompose_test.cpp
@@ -1,0 +1,42 @@
+#include <test/unit/math/test_ad.hpp>
+#include <stdexcept>
+
+TEST(mathMixFun, eigendecompose) {
+  auto f = [](const auto& x) {
+    using stan::math::eigendecompose;
+    return std::get<0>(eigendecompose(x));
+  };
+  auto g = [](const auto& x) {
+    using stan::math::eigendecompose;
+    return std::get<1>(eigendecompose(x));
+  };
+  for (const auto& x : stan::test::square_test_matrices(0, 2)) {
+    stan::test::expect_ad(f, x);
+    stan::test::expect_ad(g, x);
+  }
+
+  Eigen::MatrixXd a32(3, 2);
+  a32 << 3, -5, 7, -7.2, 9.1, -6.3;
+  EXPECT_THROW(f(a32), std::invalid_argument);
+  EXPECT_THROW(g(a32), std::invalid_argument);
+}
+
+TEST(mathMixFun, eigendecomposeComplex) {
+  auto f = [](const auto& x) {
+    using stan::math::eigendecompose;
+    return std::get<0>(eigendecompose(stan::math::to_complex(x, 0)));
+  };
+  auto g = [](const auto& x) {
+    using stan::math::eigendecompose;
+    return std::get<1>(eigendecompose(stan::math::to_complex(x, 0)));
+  };
+  for (const auto& x : stan::test::square_test_matrices(0, 2)) {
+    stan::test::expect_ad(f, x);
+    stan::test::expect_ad(g, x);
+  }
+
+  Eigen::MatrixXd a32(3, 2);
+  a32 << 3, -5, 7, -7.2, 9.1, -6.3;
+  EXPECT_THROW(f(a32), std::invalid_argument);
+  EXPECT_THROW(g(a32), std::invalid_argument);
+}

--- a/test/unit/math/mix/fun/qr_thin_test.cpp
+++ b/test/unit/math/mix/fun/qr_thin_test.cpp
@@ -1,0 +1,30 @@
+#include <test/unit/math/test_ad.hpp>
+#include <limits>
+
+TEST(MathMixMatFun, qr_thin) {
+  auto f = [](const auto& x) { return std::get<0>(stan::math::qr_thin(x)); };
+  auto g = [](const auto& x) { return std::get<1>(stan::math::qr_thin(x)); };
+
+  Eigen::MatrixXd a(0, 0);
+  stan::test::expect_ad(f, a);
+  stan::test::expect_ad(g, a);
+
+  Eigen::MatrixXd b(1, 1);
+  b << 1.5;
+  stan::test::expect_ad(f, b);
+  stan::test::expect_ad(g, b);
+
+  stan::test::ad_tolerances tols;
+  tols.hessian_hessian_ = 1e-2;
+  tols.hessian_fvar_hessian_ = 1e-2;
+
+  Eigen::MatrixXd c(3, 2);
+  c << 1, 2, 3, 4, 5, 6;
+  stan::test::expect_ad(tols, f, c);
+  stan::test::expect_ad(tols, g, c);
+
+  // cols > rows case
+  Eigen::MatrixXd b_tr = b.transpose();
+  stan::test::expect_ad(f, b_tr);
+  stan::test::expect_ad(g, b_tr);
+}

--- a/test/unit/math/mix/fun/singular_values_test.cpp
+++ b/test/unit/math/mix/fun/singular_values_test.cpp
@@ -5,7 +5,7 @@ TEST(MathMixMatFun, singularValues) {
   auto f = [](const auto& x) { return stan::math::singular_values(x); };
 
   Eigen::MatrixXd m00(0, 0);
-  EXPECT_THROW(f(m00), std::invalid_argument);
+  EXPECT_NO_THROW(f(m00));
 
   Eigen::MatrixXd m11(1, 1);
   m11 << 1.1;

--- a/test/unit/math/mix/fun/svd_U_test.cpp
+++ b/test/unit/math/mix/fun/svd_U_test.cpp
@@ -5,7 +5,7 @@ TEST(MathMixMatFun, svd_U) {
   auto f = [](const auto& x) { return stan::math::svd_U(x); };
 
   Eigen::MatrixXd m00(0, 0);
-  EXPECT_THROW(f(m00), std::invalid_argument);
+  EXPECT_NO_THROW(f(m00));
 
   Eigen::MatrixXd m11(1, 1);
   m11 << 1.1;

--- a/test/unit/math/mix/fun/svd_V_test.cpp
+++ b/test/unit/math/mix/fun/svd_V_test.cpp
@@ -5,7 +5,7 @@ TEST(MathMixMatFun, svd_V) {
   auto f = [](const auto& x) { return stan::math::svd_V(x); };
 
   Eigen::MatrixXd m00(0, 0);
-  EXPECT_THROW(f(m00), std::invalid_argument);
+  EXPECT_NO_THROW(f(m00));
 
   Eigen::MatrixXd m11(1, 1);
   m11 << 1.1;

--- a/test/unit/math/mix/fun/svd_test.cpp
+++ b/test/unit/math/mix/fun/svd_test.cpp
@@ -1,0 +1,67 @@
+#include <test/unit/math/test_ad.hpp>
+#include <stdexcept>
+
+TEST(MathMixMatFun, svd) {
+  auto f = [](const auto& x) { return std::get<0>(stan::math::svd(x)); };
+  auto g = [](const auto& x) { return std::get<1>(stan::math::svd(x)); };
+  auto h = [](const auto& x) { return std::get<2>(stan::math::svd(x)); };
+
+  Eigen::MatrixXd m00(0, 0);
+  EXPECT_THROW(f(m00), std::invalid_argument);
+  EXPECT_THROW(g(m00), std::invalid_argument);
+  EXPECT_THROW(h(m00), std::invalid_argument);
+
+  Eigen::MatrixXd m11(1, 1);
+  m11 << 1.1;
+  stan::test::expect_ad(f, m11);
+  stan::test::expect_ad_matvar(f, m11);
+  stan::test::expect_ad(g, m11);
+  stan::test::expect_ad_matvar(g, m11);
+  stan::test::expect_ad(h, m11);
+  stan::test::expect_ad_matvar(h, m11);
+
+  Eigen::MatrixXd m22(2, 2);
+  m22 << 3, -5, 7, 11;
+  stan::test::expect_ad(f, m22);
+  stan::test::expect_ad_matvar(f, m22);
+  stan::test::expect_ad(g, m22);
+  stan::test::expect_ad_matvar(g, m22);
+  stan::test::expect_ad(h, m22);
+  stan::test::expect_ad_matvar(h, m22);
+
+  Eigen::MatrixXd m23(2, 3);
+  m23 << 3, 5, -7, -11, 13, -17;
+  stan::test::expect_ad(f, m23);
+  stan::test::expect_ad_matvar(f, m23);
+  stan::test::expect_ad(g, m23);
+  stan::test::expect_ad_matvar(g, m23);
+  stan::test::expect_ad(h, m23);
+  stan::test::expect_ad_matvar(h, m23);
+
+  Eigen::MatrixXd m32(3, 2);
+  m32 << 1, 3, -5, 7, 9, -11;
+  stan::test::expect_ad(f, m32);
+  stan::test::expect_ad_matvar(f, m32);
+  stan::test::expect_ad(g, m32);
+  stan::test::expect_ad_matvar(g, m32);
+  stan::test::expect_ad(h, m32);
+  stan::test::expect_ad_matvar(h, m32);
+
+  Eigen::MatrixXd a22(2, 2);
+  a22 << 1, 2, 3, 4;
+  stan::test::expect_ad(f, a22);
+  stan::test::expect_ad_matvar(f, a22);
+  stan::test::expect_ad(g, a22);
+  stan::test::expect_ad_matvar(g, a22);
+  stan::test::expect_ad(h, a22);
+  stan::test::expect_ad_matvar(h, a22);
+
+  Eigen::MatrixXcd c22(2, 2);
+  a22 << 1, 2, 3, 4;
+  stan::test::expect_ad(f, a22);
+  stan::test::expect_ad_matvar(f, a22);
+  stan::test::expect_ad(g, a22);
+  stan::test::expect_ad_matvar(g, a22);
+  stan::test::expect_ad(h, a22);
+  stan::test::expect_ad_matvar(h, a22);
+}

--- a/test/unit/math/mix/fun/svd_test.cpp
+++ b/test/unit/math/mix/fun/svd_test.cpp
@@ -7,9 +7,9 @@ TEST(MathMixMatFun, svd) {
   auto h = [](const auto& x) { return std::get<2>(stan::math::svd(x)); };
 
   Eigen::MatrixXd m00(0, 0);
-  EXPECT_THROW(f(m00), std::invalid_argument);
-  EXPECT_THROW(g(m00), std::invalid_argument);
-  EXPECT_THROW(h(m00), std::invalid_argument);
+  EXPECT_NO_THROW(f(m00));
+  EXPECT_NO_THROW(g(m00));
+  EXPECT_NO_THROW(h(m00));
 
   Eigen::MatrixXd m11(1, 1);
   m11 << 1.1;

--- a/test/unit/math/prim/fun/complex_schur_decompose_test.cpp
+++ b/test/unit/math/prim/fun/complex_schur_decompose_test.cpp
@@ -26,8 +26,6 @@ TEST(primFun, complex_schur_decompose_ut) {
   EXPECT_MATRIX_COMPLEX_NEAR(B, B_recovered, 1e-8);
 }
 
-
-
 TEST(primFun, complex_schur_decompose) {
   using c_t = std::complex<double>;
   using stan::math::complex_schur_decompose;

--- a/test/unit/math/prim/fun/complex_schur_decompose_test.cpp
+++ b/test/unit/math/prim/fun/complex_schur_decompose_test.cpp
@@ -2,7 +2,7 @@
 #include <test/unit/util.hpp>
 #include <gtest/gtest.h>
 
-TEST(primFun, complex_schur_decompose) {
+TEST(primFun, complex_schur_decompose_ut) {
   using c_t = std::complex<double>;
   using stan::math::complex_schur_decompose_t;
   using stan::math::complex_schur_decompose_u;
@@ -21,6 +21,31 @@ TEST(primFun, complex_schur_decompose) {
 
   auto B_t = complex_schur_decompose_t(B);
   auto B_u = complex_schur_decompose_u(B);
+
+  auto B_recovered = B_u * B_t * B_u.adjoint();
+  EXPECT_MATRIX_COMPLEX_NEAR(B, B_recovered, 1e-8);
+}
+
+
+
+TEST(primFun, complex_schur_decompose) {
+  using c_t = std::complex<double>;
+  using stan::math::complex_schur_decompose;
+
+  // verify that A = U T U*
+
+  Eigen::MatrixXd A(3, 3);
+  A << 0, 2, 2, 0, 0, 2, 1, 0, 1;
+  Eigen::MatrixXcd A_t, A_u;
+  std::tie(A_u, A_t) = complex_schur_decompose(A);
+  auto A_recovered = A_u * A_t * A_u.adjoint();
+  EXPECT_MATRIX_NEAR(A, stan::math::get_real(A_recovered), 1e-8);
+
+  Eigen::MatrixXcd B(3, 3);
+  B << 0, 2, 2, 0, c_t(0, 1), 2, 1, 0, 1;
+
+  Eigen::MatrixXcd B_t, B_u;
+  std::tie(B_u, B_t) = complex_schur_decompose(B);
 
   auto B_recovered = B_u * B_t * B_u.adjoint();
   EXPECT_MATRIX_COMPLEX_NEAR(B, B_recovered, 1e-8);

--- a/test/unit/math/prim/fun/csr_extract_test.cpp
+++ b/test/unit/math/prim/fun/csr_extract_test.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 // Test that values from a dense matrix in sparse format are extracted.
-TEST(SparseStuff, csr_extract_w_dense) {
+TEST(SparseStuff, csr_extract_dense) {
   stan::math::matrix_d m(2, 3);
   Eigen::SparseMatrix<double, Eigen::RowMajor> a;
   m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
@@ -33,7 +33,7 @@ TEST(SparseStuff, csr_extract_w_dense) {
 }
 
 // Test that values from a dense matrix are extracted.
-TEST(SparseStuff, csr_extract_w_dense_dense) {
+TEST(SparseStuff, csr_extract_dense_dense) {
   stan::math::matrix_d m(2, 3);
   m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
   stan::math::vector_d w;
@@ -61,7 +61,7 @@ TEST(SparseStuff, csr_extract_w_dense_dense) {
 
 // Test that values from a dense matrix in sparse format are extracted
 // after A.makeCompressed();
-TEST(SparseStuff, csr_extract_w_dense_compressed) {
+TEST(SparseStuff, csr_extract_dense_compressed) {
   stan::math::matrix_d m(2, 3);
   Eigen::SparseMatrix<double, Eigen::RowMajor> a;
   m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
@@ -91,7 +91,7 @@ TEST(SparseStuff, csr_extract_w_dense_compressed) {
 }
 
 // Test that values from a sparse matrix in sparse format are extracted
-TEST(SparseStuff, csr_extract_w_sparse) {
+TEST(SparseStuff, csr_extract_sparse) {
   stan::math::matrix_d m(2, 3);
   Eigen::SparseMatrix<double, Eigen::RowMajor> a;
   m << 2.0, 4.0, 6.0, 0.0, 0.0, 0.0;
@@ -117,7 +117,7 @@ TEST(SparseStuff, csr_extract_w_sparse) {
 
 // Test that values from a sparse matrix in sparse format are extracted
 // after A.makeCompressed()
-TEST(SparseStuff, csr_extract_w_sparse_compressed) {
+TEST(SparseStuff, csr_extract_sparse_compressed) {
   stan::math::matrix_d m(2, 3);
   Eigen::SparseMatrix<double, Eigen::RowMajor> a;
   m << 2.0, 4.0, 6.0, 0.0, 0.0, 0.0;

--- a/test/unit/math/prim/fun/csr_extract_test.cpp
+++ b/test/unit/math/prim/fun/csr_extract_test.cpp
@@ -1,0 +1,141 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+// Test that values from a dense matrix in sparse format are extracted.
+TEST(SparseStuff, csr_extract_w_dense) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d w;
+  std::vector<int> v, u;
+  std::tie(w, v, u) = stan::math::csr_extract(a);
+
+  EXPECT_FLOAT_EQ(2.0, w(0));
+  EXPECT_FLOAT_EQ(4.0, w(1));
+  EXPECT_FLOAT_EQ(6.0, w(2));
+  EXPECT_FLOAT_EQ(8.0, w(3));
+  EXPECT_FLOAT_EQ(10.0, w(4));
+  EXPECT_FLOAT_EQ(12.0, w(5));
+
+  EXPECT_EQ(1, v[0]);
+  EXPECT_EQ(2, v[1]);
+  EXPECT_EQ(3, v[2]);
+  EXPECT_EQ(1, v[3]);
+  EXPECT_EQ(2, v[4]);
+  EXPECT_EQ(3, v[5]);
+
+  EXPECT_EQ(1, u[0]);
+  EXPECT_EQ(4, u[1]);
+  EXPECT_EQ(7, u[2]);
+}
+
+// Test that values from a dense matrix are extracted.
+TEST(SparseStuff, csr_extract_w_dense_dense) {
+  stan::math::matrix_d m(2, 3);
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  stan::math::vector_d w;
+  std::vector<int> v, u;
+  std::tie(w, v, u) = stan::math::csr_extract(m);
+
+  EXPECT_FLOAT_EQ(2.0, w(0));
+  EXPECT_FLOAT_EQ(4.0, w(1));
+  EXPECT_FLOAT_EQ(6.0, w(2));
+  EXPECT_FLOAT_EQ(8.0, w(3));
+  EXPECT_FLOAT_EQ(10.0, w(4));
+  EXPECT_FLOAT_EQ(12.0, w(5));
+
+  EXPECT_EQ(1, v[0]);
+  EXPECT_EQ(2, v[1]);
+  EXPECT_EQ(3, v[2]);
+  EXPECT_EQ(1, v[3]);
+  EXPECT_EQ(2, v[4]);
+  EXPECT_EQ(3, v[5]);
+
+  EXPECT_EQ(1, u[0]);
+  EXPECT_EQ(4, u[1]);
+  EXPECT_EQ(7, u[2]);
+}
+
+// Test that values from a dense matrix in sparse format are extracted
+// after A.makeCompressed();
+TEST(SparseStuff, csr_extract_w_dense_compressed) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+  a.makeCompressed();
+  stan::math::vector_d w;
+  std::vector<int> v, u;
+  std::tie(w, v, u) = stan::math::csr_extract(a);
+
+  EXPECT_FLOAT_EQ(2.0, w(0));
+  EXPECT_FLOAT_EQ(4.0, w(1));
+  EXPECT_FLOAT_EQ(6.0, w(2));
+  EXPECT_FLOAT_EQ(8.0, w(3));
+  EXPECT_FLOAT_EQ(10.0, w(4));
+  EXPECT_FLOAT_EQ(12.0, w(5));
+
+  EXPECT_EQ(1, v[0]);
+  EXPECT_EQ(2, v[1]);
+  EXPECT_EQ(3, v[2]);
+  EXPECT_EQ(1, v[3]);
+  EXPECT_EQ(2, v[4]);
+  EXPECT_EQ(3, v[5]);
+
+  EXPECT_EQ(1, u[0]);
+  EXPECT_EQ(4, u[1]);
+  EXPECT_EQ(7, u[2]);
+}
+
+// Test that values from a sparse matrix in sparse format are extracted
+TEST(SparseStuff, csr_extract_w_sparse) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 0.0, 0.0, 0.0;
+  a = m.sparseView();
+  stan::math::vector_d w;
+  std::vector<int> v, u;
+  std::tie(w, v, u) = stan::math::csr_extract(a);
+
+  EXPECT_FLOAT_EQ(2.0, w(0));
+  EXPECT_FLOAT_EQ(4.0, w(1));
+  EXPECT_FLOAT_EQ(6.0, w(2));
+
+  EXPECT_EQ(1, v[0]);
+  EXPECT_EQ(2, v[1]);
+  EXPECT_EQ(3, v[2]);
+  EXPECT_EQ(3, v.size());
+
+  EXPECT_EQ(1, u[0]);
+  EXPECT_EQ(4, u[1]);
+  EXPECT_EQ(4, u[2]);
+  EXPECT_EQ(3, u.size());
+}
+
+// Test that values from a sparse matrix in sparse format are extracted
+// after A.makeCompressed()
+TEST(SparseStuff, csr_extract_w_sparse_compressed) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 0.0, 0.0, 0.0;
+  a = m.sparseView();
+  stan::math::vector_d w;
+  std::vector<int> v, u;
+  std::tie(w, v, u) = stan::math::csr_extract(a);
+  EXPECT_FLOAT_EQ(2.0, w(0));
+  EXPECT_FLOAT_EQ(4.0, w(1));
+  EXPECT_FLOAT_EQ(6.0, w(2));
+
+  EXPECT_EQ(1, v[0]);
+  EXPECT_EQ(2, v[1]);
+  EXPECT_EQ(3, v[2]);
+  EXPECT_EQ(3, v.size());
+
+  EXPECT_EQ(1, u[0]);
+  EXPECT_EQ(4, u[1]);
+  EXPECT_EQ(4, u[2]);
+  EXPECT_EQ(3, u.size());
+}

--- a/test/unit/math/prim/fun/eigendecompose_sym_test.cpp
+++ b/test/unit/math/prim/fun/eigendecompose_sym_test.cpp
@@ -1,0 +1,15 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathMatrixPrimMat, eigendecompose_sym) {
+  stan::math::matrix_d m0;
+  stan::math::matrix_d m1(2, 3);
+  m1 << 1, 2, 3, 4, 5, 6;
+  stan::math::matrix_d ev_m1(1, 1);
+  ev_m1 << 2.0;
+
+  using stan::math::eigendecompose_sym;
+  EXPECT_THROW(eigendecompose_sym(m0), std::invalid_argument);
+  EXPECT_NO_THROW(eigendecompose_sym(ev_m1));
+  EXPECT_THROW(eigendecompose_sym(m1), std::invalid_argument);
+}

--- a/test/unit/math/prim/fun/eigendecompose_sym_test.cpp
+++ b/test/unit/math/prim/fun/eigendecompose_sym_test.cpp
@@ -9,7 +9,7 @@ TEST(MathMatrixPrimMat, eigendecompose_sym) {
   ev_m1 << 2.0;
 
   using stan::math::eigendecompose_sym;
-  EXPECT_THROW(eigendecompose_sym(m0), std::invalid_argument);
+  EXPECT_NO_THROW(eigendecompose_sym(m0));
   EXPECT_NO_THROW(eigendecompose_sym(ev_m1));
   EXPECT_THROW(eigendecompose_sym(m1), std::invalid_argument);
 }

--- a/test/unit/math/prim/fun/eigenvalues_sym_test.cpp
+++ b/test/unit/math/prim/fun/eigenvalues_sym_test.cpp
@@ -7,6 +7,6 @@ TEST(MathMatrixPrimMat, eigenvalues_sym) {
   m1 << 1, 2, 3, 4, 5, 6;
 
   using stan::math::eigenvalues_sym;
-  EXPECT_THROW(eigenvalues_sym(m0), std::invalid_argument);
+  EXPECT_NO_THROW(eigenvalues_sym(m0));
   EXPECT_THROW(eigenvalues_sym(m1), std::invalid_argument);
 }

--- a/test/unit/math/prim/fun/eigenvectors_sym_test.cpp
+++ b/test/unit/math/prim/fun/eigenvectors_sym_test.cpp
@@ -9,7 +9,7 @@ TEST(MathMatrixPrimMat, eigenvectors_sym) {
   ev_m1 << 2.0;
 
   using stan::math::eigenvectors_sym;
-  EXPECT_THROW(eigenvectors_sym(m0), std::invalid_argument);
+  EXPECT_NO_THROW(eigenvectors_sym(m0));
   EXPECT_NO_THROW(eigenvectors_sym(ev_m1));
   EXPECT_THROW(eigenvectors_sym(m1), std::invalid_argument);
 }

--- a/test/unit/math/prim/fun/qr_Q_test.cpp
+++ b/test/unit/math/prim/fun/qr_Q_test.cpp
@@ -8,7 +8,7 @@ TEST(MathMatrixPrimMat, qr_Q) {
 
   using stan::math::qr_Q;
   using stan::math::transpose;
-  EXPECT_THROW(qr_Q(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_Q(m0));
   EXPECT_NO_THROW(qr_Q(m1));
   EXPECT_NO_THROW(qr_Q(transpose(m1)));
 }

--- a/test/unit/math/prim/fun/qr_R_test.cpp
+++ b/test/unit/math/prim/fun/qr_R_test.cpp
@@ -9,7 +9,7 @@ TEST(MathMatrixPrimMat, qr_R) {
   using stan::math::qr_Q;
   using stan::math::qr_R;
   using stan::math::transpose;
-  EXPECT_THROW(qr_R(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_R(m0));
   EXPECT_NO_THROW(qr_R(m1));
 
   stan::math::matrix_d m2(4, 2);

--- a/test/unit/math/prim/fun/qr_test.cpp
+++ b/test/unit/math/prim/fun/qr_test.cpp
@@ -8,7 +8,7 @@ TEST(MathMatrixPrimMat, qr) {
 
   using stan::math::qr;
   using stan::math::transpose;
-  EXPECT_THROW(qr(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr(m0));
   EXPECT_NO_THROW(qr(m1));
 
   stan::math::matrix_d m2(4, 2);

--- a/test/unit/math/prim/fun/qr_thin_Q_test.cpp
+++ b/test/unit/math/prim/fun/qr_thin_Q_test.cpp
@@ -8,7 +8,7 @@ TEST(MathMatrixPrimMat, qr_thin_Q) {
 
   using stan::math::qr_thin_Q;
   using stan::math::transpose;
-  EXPECT_THROW(qr_thin_Q(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_thin_Q(m0));
   EXPECT_NO_THROW(qr_thin_Q(m1));
   EXPECT_NO_THROW(qr_thin_Q(transpose(m1)));
 }

--- a/test/unit/math/prim/fun/qr_thin_R_test.cpp
+++ b/test/unit/math/prim/fun/qr_thin_R_test.cpp
@@ -9,7 +9,7 @@ TEST(MathMatrixPrimMat, qr_thin_R) {
   using stan::math::qr_thin_Q;
   using stan::math::qr_thin_R;
   using stan::math::transpose;
-  EXPECT_THROW(qr_thin_R(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_thin_R(m0));
   EXPECT_NO_THROW(qr_thin_R(m1));
 
   stan::math::matrix_d m2(4, 2);

--- a/test/unit/math/prim/fun/qr_thin_test.cpp
+++ b/test/unit/math/prim/fun/qr_thin_test.cpp
@@ -8,7 +8,7 @@ TEST(MathMatrixPrimMat, qr_thin) {
 
   using stan::math::qr_thin;
   using stan::math::transpose;
-  EXPECT_THROW(qr_thin(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_thin(m0));
   EXPECT_NO_THROW(qr_thin(m1));
 
   stan::math::matrix_d m2(4, 2);

--- a/test/unit/math/prim/fun/qr_thin_test.cpp
+++ b/test/unit/math/prim/fun/qr_thin_test.cpp
@@ -34,5 +34,4 @@ TEST(MathMatrixPrimMat, qr_thin) {
       EXPECT_NEAR(m1(i, j), m3(j, i), 1e-12);
     }
   }
-
 }

--- a/test/unit/math/prim/fun/qr_thin_test.cpp
+++ b/test/unit/math/prim/fun/qr_thin_test.cpp
@@ -1,0 +1,38 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathMatrixPrimMat, qr_thin) {
+  stan::math::matrix_d m0(0, 0);
+  stan::math::matrix_d m1(4, 2);
+  m1 << 1, 2, 3, 4, 5, 6, 7, 8;
+
+  using stan::math::qr_thin;
+  using stan::math::transpose;
+  EXPECT_THROW(qr_thin(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_thin(m1));
+
+  stan::math::matrix_d m2(4, 2);
+  stan::math::matrix_d Q(4, 2);
+  stan::math::matrix_d R(2, 2);
+  std::tie(Q, R) = qr_thin(m1);
+  m2 = Q * R;
+  for (unsigned int i = 0; i < m1.rows(); i++) {
+    for (unsigned int j = 0; j < m1.cols(); j++) {
+      EXPECT_NEAR(m1(i, j), m2(i, j), 1e-12);
+    }
+  }
+  for (unsigned int j = 0; j < m1.cols(); j++)
+    EXPECT_TRUE(R(j, j) >= 0.0);
+
+  auto m1_T = transpose(m1);
+
+  std::tie(Q, R) = qr_thin(m1_T);
+  stan::math::matrix_d m3(2, 4);
+  m3 = Q * R;
+  for (unsigned int i = 0; i < m1.rows(); i++) {
+    for (unsigned int j = 0; j < m1.cols(); j++) {
+      EXPECT_NEAR(m1(i, j), m3(j, i), 1e-12);
+    }
+  }
+
+}

--- a/test/unit/math/prim/fun/singular_values_test.cpp
+++ b/test/unit/math/prim/fun/singular_values_test.cpp
@@ -13,7 +13,7 @@ TEST(MathMatrixPrimMat, singular_values) {
   using matrix_c = Eigen::Matrix<compl_t, Eigen::Dynamic, Eigen::Dynamic>;
 
   matrix_d m0(0, 0);
-  EXPECT_THROW(singular_values(m0), std::invalid_argument);
+  EXPECT_NO_THROW(singular_values(m0));
 
   matrix_d m1(1, 1);
   m1 << 1.0;

--- a/test/unit/math/prim/fun/svd_U_test.cpp
+++ b/test/unit/math/prim/fun/svd_U_test.cpp
@@ -14,7 +14,7 @@ TEST(MathMatrixPrimMat, svd_U) {
   // Values generated using R base::svd
 
   matrix_d m00(0, 0);
-  EXPECT_THROW(svd_U(m00), std::invalid_argument);
+  EXPECT_NO_THROW(svd_U(m00));
 
   matrix_d m11(1, 1);
   m11 << 5;

--- a/test/unit/math/prim/fun/svd_V_test.cpp
+++ b/test/unit/math/prim/fun/svd_V_test.cpp
@@ -14,7 +14,7 @@ TEST(MathMatrixPrimMat, svd_V) {
   // Values generated using R base::svd
 
   matrix_d m00(0, 0);
-  EXPECT_THROW(svd_V(m00), std::invalid_argument);
+  EXPECT_NO_THROW(svd_V(m00));
 
   matrix_d m11(1, 1);
   m11 << 5;

--- a/test/unit/math/prim/fun/svd_test.cpp
+++ b/test/unit/math/prim/fun/svd_test.cpp
@@ -1,0 +1,108 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <stdexcept>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <complex>
+
+TEST(MathMatrixPrimMat, svd) {
+  using stan::math::matrix_d;
+  using stan::math::svd;
+  using stan::math::vector_d;
+  using compl_t = std::complex<double>;
+  using matrix_c = Eigen::Matrix<compl_t, Eigen::Dynamic, Eigen::Dynamic>;
+
+  // Values generated using R base::svd
+
+  matrix_d m00(0, 0);
+
+  EXPECT_THROW(svd(m00), std::invalid_argument);
+
+  matrix_d m11(1, 1);
+  m11 << 5;
+  matrix_d m11_U(1, 1);
+  m11_U << 1;
+  matrix_d m11_V(1, 1);
+  m11_V << 1;
+
+  matrix_d m11_U_out, m11_V_out;
+  std::tie(m11_U_out, std::ignore, m11_V_out) = svd(m11);
+  EXPECT_MATRIX_FLOAT_EQ(m11_U, m11_U_out);
+  EXPECT_MATRIX_FLOAT_EQ(m11_V, m11_V_out);
+
+  matrix_d m22(2, 2);
+  m22 << 1, 9, -4, 2;
+  matrix_d m22_U(2, 2);
+  m22_U << 0.97759158130035961, 0.21051057021124275, 0.21051057021124264,
+      -0.97759158130035972;
+  matrix_d m22_V(2, 2);
+  m22_V << 0.014701114509569043, 0.999891932776825976, 0.999891932776825976,
+      -0.014701114509569043;
+  vector_d m22_D(2);
+  m22_D << 9.220341788859560, 4.121322275266775;
+
+  matrix_d m22_U_out, m22_V_out;
+  vector_d m22_D_out;
+  std::tie(m22_U_out, m22_D_out, m22_V_out) = svd(m22);
+
+  EXPECT_MATRIX_FLOAT_EQ(m22_U, m22_U_out);
+  EXPECT_MATRIX_FLOAT_EQ(m22_V, m22_V_out);
+  EXPECT_MATRIX_FLOAT_EQ(m22_D, m22_D_out);
+
+  matrix_d m23(2, 3);
+  m23 << 1, 3, -5, 7, 9, -11;
+  matrix_d m23_U(2, 2);
+  m23_U << -0.33784321032557019, -0.94120240396894062, -0.94120240396894039,
+      0.33784321032557019;
+  matrix_d m23_V(3, 2);
+  m23_V << -0.41176240532160857, 0.81473005032163681, -0.56383954240865775,
+      0.12417046246885260, 0.71591667949570703, 0.56638912538393127;
+  vector_d m23_D(2);
+  m23_D << 16.821011215675149, 1.747450051398016;
+
+  matrix_d m23_U_out, m23_V_out;
+  vector_d m23_D_out;
+  std::tie(m23_U_out, m23_D_out, m23_V_out) = svd(m23);
+
+  EXPECT_MATRIX_FLOAT_EQ(m23_U, m23_U_out);
+  EXPECT_MATRIX_FLOAT_EQ(m23_V, m23_V_out);
+  EXPECT_MATRIX_FLOAT_EQ(m23_D, m23_D_out);
+
+  matrix_d m32(3, 2);
+  m32 << 1, 3, -5, 7, 9, -11;
+  matrix_d m32_U(3, 2);
+  m32_U << 0.10657276921942949, 0.978015199679778457, 0.51489182605641137,
+      0.099934023569151917, -0.85060487438128174, 0.183028577355020677;
+  matrix_d m32_V(2, 2);
+  m32_V << -0.60622380392317887, 0.79529409626685355, 0.79529409626685355,
+      0.60622380392317887;
+  vector_d m32_D(2);
+  m32_D << 16.698998232964481, 2.672724829728879;
+
+  matrix_d m32_U_out, m32_V_out;
+  vector_d m32_D_out;
+  std::tie(m32_U_out, m32_D_out, m32_V_out) = svd(m32);
+  // R's SVD returns different signs than Eigen.
+  EXPECT_MATRIX_FLOAT_EQ(m32_U, m32_U_out);
+  EXPECT_MATRIX_FLOAT_EQ(m32_V, m32_V_out);
+  EXPECT_MATRIX_FLOAT_EQ(m32_D, m32_D_out);
+
+  matrix_c c32(3, 2);
+  c32 << compl_t(0.86636546, 0.34306449), compl_t(0.28267243, 0.52462912),
+      compl_t(0.12104914, 0.2533793), compl_t(0.66889264, 0.39276455),
+      compl_t(0.02184348, 0.0614428), compl_t(0.96599692, 0.16180684);
+  matrix_c c32_U(3, 2);
+  c32_U << compl_t(0.50789057, 0.35782384), compl_t(0.74507868, 0.14261495),
+      compl_t(0.4823205, 0.19300139), compl_t(-0.29600299, 0.17466116),
+      compl_t(0.58489862, -0.04494745), compl_t(-0.53765935, 0.13159357);
+  matrix_c c32_V(2, 2);
+  c32_V << compl_t(0.45315061, 0.), compl_t(0.89143395, 0.),
+      compl_t(0.85785925, -0.2423469), compl_t(-0.43608328, 0.12319437);
+  vector_d c32_D(2);
+  c32_D << 1.50077492, 0.78435681;
+
+  matrix_c c32_U_out, c32_V_out;
+  vector_d c32_D_out;
+  std::tie(c32_U_out, c32_D_out, c32_V_out) = svd(c32);
+  EXPECT_MATRIX_COMPLEX_FLOAT_EQ(c32_U, c32_U_out);
+}

--- a/test/unit/math/prim/fun/svd_test.cpp
+++ b/test/unit/math/prim/fun/svd_test.cpp
@@ -16,7 +16,7 @@ TEST(MathMatrixPrimMat, svd) {
 
   matrix_d m00(0, 0);
 
-  EXPECT_THROW(svd(m00), std::invalid_argument);
+  EXPECT_NO_THROW(svd(m00));
 
   matrix_d m11(1, 1);
   m11 << 5;


### PR DESCRIPTION
## Summary

This adds the following functions which return tuples. Each is already implemented piecewise, these versions just reduce computation:

- `qr_thin`
- `eigendecompose_sym`
- `eigendecompose`
- `complex_schur_decompose`
- `svd`
- `csr_extract`

## Tests

Existing tests for the base functions were copied and applied to these tuple-returning variants.

## Side Effects

## Release notes

Added new functions `qr_thin`,  `eigendecompose_sym`, `eigendecompose`, `complex_schur_decompose`, `svd`, and `csr_extract`.
Each of these is equivalent to calling several existing functions, but should be more efficient due to sharing work. For example, `svd(m)` is equivalent to `(svd_U(m), singular_values(m), svd_V(m))`.

## Checklist

- [x] Math issue: Closes #2845 

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
