### PR TITLE
Disable fp-contract on arm64

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -174,6 +174,9 @@ ifeq ($(OS),Darwin)
   ifeq (clang,$(CXX_TYPE))
     CXXFLAGS_OS ?= -Wno-unknown-warning-option -Wno-tautological-compare -Wno-sign-compare
   endif
+	ifeq (arm64, $(shell uname -m))
+		CXXFLAGS_OS += -ffp-contract=off
+	endif
 endif
 
 ifeq ($(OS),Linux)
@@ -190,6 +193,9 @@ ifeq ($(OS),Linux)
   ifeq (clang,$(CXX_TYPE))
     LDLIBS_OS ?= -lpthread
   endif
+	ifeq (aarch64, $(shell uname -m))
+		CXXFLAGS_OS += -ffp-contract=off
+	endif
 endif
 
 ## makes reentrant version lgamma_r available from cmath

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -174,9 +174,9 @@ ifeq ($(OS),Darwin)
   ifeq (clang,$(CXX_TYPE))
     CXXFLAGS_OS ?= -Wno-unknown-warning-option -Wno-tautological-compare -Wno-sign-compare
   endif
-	ifeq (arm64, $(shell uname -m))
-		CXXFLAGS_OS += -ffp-contract=off
-	endif
+  ifeq (arm64, $(shell uname -m))
+    CXXFLAGS_OS += -ffp-contract=off
+  endif
 endif
 
 ifeq ($(OS),Linux)
@@ -193,9 +193,9 @@ ifeq ($(OS),Linux)
   ifeq (clang,$(CXX_TYPE))
     LDLIBS_OS ?= -lpthread
   endif
-	ifeq (aarch64, $(shell uname -m))
-		CXXFLAGS_OS += -ffp-contract=off
-	endif
+  ifeq (aarch64, $(shell uname -m))
+    CXXFLAGS_OS += -ffp-contract=off
+  endif
 endif
 
 ## makes reentrant version lgamma_r available from cmath


### PR DESCRIPTION
## Summary

Resolves floating-point precision errors on arm64 seen in #2935 by disabling the contraction of expressions via the `-ffp-contract=off` flag

## Tests

N/A

## Side Effects

Increased precision on arm64

## Release notes

Fixed floating-point precision loss on arm64 in some expressions

## Checklist

- [x] Math issue #2935 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
