### PR TITLE
Improve numerical stability of binomial_logit_lpmf

### DIFF
--- a/test/unit/math/mix/prob/binomial_logit_lpmf_test.cpp
+++ b/test/unit/math/mix/prob/binomial_logit_lpmf_test.cpp
@@ -19,4 +19,5 @@ TEST(mathMixScalFun, binomial_logit_lpmf) {
   stan::test::expect_ad(f(n_arr, 10), 2.11);
   stan::test::expect_ad(f(n_arr, N_arr), 2.11);
   stan::test::expect_ad(f(5, N_arr), 2.11);
+  stan::test::expect_ad(f(5, N_arr), alpha);
 }

--- a/test/unit/math/mix/prob/binomial_logit_lpmf_test.cpp
+++ b/test/unit/math/mix/prob/binomial_logit_lpmf_test.cpp
@@ -1,0 +1,22 @@
+#include <stan/math/mix.hpp>
+#include <test/unit/math/test_ad.hpp>
+
+TEST(mathMixScalFun, binomial_logit_lpmf) {
+  auto f = [](const auto n, const auto N) {
+    return [=](const auto& alpha) {
+      return stan::math::binomial_logit_lpmf(n, N, alpha);
+    };
+  };
+
+  Eigen::VectorXd alpha = Eigen::VectorXd::Random(3);
+  std::vector<int> n_arr{1, 4, 5};
+  std::vector<int> N_arr{10, 45, 25};
+
+  stan::test::expect_ad(f(5, 25), 2.11);
+  stan::test::expect_ad(f(5, 25), alpha);
+  stan::test::expect_ad(f(n_arr, 25), alpha);
+  stan::test::expect_ad(f(n_arr, N_arr), alpha);
+  stan::test::expect_ad(f(n_arr, 10), 2.11);
+  stan::test::expect_ad(f(n_arr, N_arr), 2.11);
+  stan::test::expect_ad(f(5, N_arr), 2.11);
+}


### PR DESCRIPTION
## Summary

This PR improves the numerical stability of the `binomial_logit` distribution through more efficient usage of compound `log_*` functions and simplified construction of gradients

## Tests

New `mix` tests for all scalar/container combinations have been added

## Side Effects

N/A

## Release notes

Improve numerical stability of `binomial_logit` distribution

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
