### PR TITLE
Add binomial_logit_glm distribution

### DIFF
--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -46,6 +46,7 @@
 #include <stan/math/prim/prob/binomial_log.hpp>
 #include <stan/math/prim/prob/binomial_logit_log.hpp>
 #include <stan/math/prim/prob/binomial_logit_lpmf.hpp>
+#include <stan/math/prim/prob/binomial_logit_glm_lpmf.hpp>
 #include <stan/math/prim/prob/binomial_lpmf.hpp>
 #include <stan/math/prim/prob/binomial_rng.hpp>
 #include <stan/math/prim/prob/categorical_log.hpp>

--- a/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
@@ -1,0 +1,174 @@
+#ifndef STAN_MATH_PRIM_PROB_BINOMIAL_LOGIT_GLM_LPMF_HPP
+#define STAN_MATH_PRIM_PROB_BINOMIAL_LOGIT_GLM_LPMF_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/isfinite.hpp>
+#include <stan/math/prim/fun/size.hpp>
+#include <stan/math/prim/fun/size_zero.hpp>
+#include <stan/math/prim/fun/max_size.hpp>
+#include <stan/math/prim/fun/max.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/fun/as_value_column_array_or_scalar.hpp>
+#include <stan/math/prim/fun/as_value_column_vector_or_scalar.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup multivar_dists
+ * Returns the log PMF of the Generalized Linear Model (GLM)
+ * with Binomial distribution and logit link function.
+ * The idea is that binomial_logit_glm_lpmf(n | N, x, alpha, beta) should
+ * compute a more efficient version of
+ * binomial_logit_lpmf(y | N, alpha + x * beta) by using analytically
+ * simplified gradients.
+ * If containers are supplied, returns the log sum of the probabilities.
+ *
+ * @tparam T_y type of binary vector of successes variables;
+ * this can also be a single binary value;
+ * @tparam T_y type of binary vector of population size variables;
+ * this can also be a single binary value;
+ * @tparam T_x type of the matrix of independent variables (features)
+ * @tparam T_alpha type of the intercept(s);
+ * this can be a vector (of the same length as y) of intercepts or a single
+ * value (for models with constant intercept);
+ * @tparam T_beta type of the weight vector
+ *
+ * @param n binary scalar or vector parameter. If it is a scalar it will be
+ * broadcast - used for all instances.
+ * @param N binary scalar or vector parameter. If it is a scalar it will be
+ * broadcast - used for all instances.
+ * @param x design matrix or row vector. If it is a row vector it will be
+ * broadcast - used for all instances.
+ * @param alpha intercept (in log odds)
+ * @param beta weight vector
+ * @return log probability or log sum of probabilities
+ * @throw std::domain_error if x, beta or alpha is infinite.
+ * @throw std::domain_error if n is negative or greater than N
+ * @throw std::domain_error if N is negative
+ * @throw std::invalid_argument if container sizes mismatch.
+ */
+template <bool propto, typename T_n, typename T_N, typename T_x,
+          typename T_alpha, typename T_beta, require_matrix_t<T_x>* = nullptr>
+return_type_t<T_x, T_alpha, T_beta> binomial_logit_glm_lpmf(
+    const T_n& n, const T_N& N, const T_x& x,
+    const T_alpha& alpha, const T_beta& beta) {
+  constexpr int T_x_rows = T_x::RowsAtCompileTime;
+  using T_xbeta_partials = partials_return_t<T_x, T_beta>;
+  using T_partials_return = partials_return_t<T_x, T_alpha, T_beta>;
+  using T_theta_tmp =
+      typename std::conditional_t<T_x_rows == 1, T_partials_return,
+                                  Eigen::Array<T_partials_return, -1, 1>>;
+  using T_xbeta_tmp =
+      typename std::conditional_t<T_x_rows == 1, T_xbeta_partials,
+                                  Eigen::Array<T_xbeta_partials, -1, 1>>;
+  using T_n_ref = ref_type_if_t<!is_constant<T_n>::value, T_n>;
+  using T_N_ref = ref_type_if_t<!is_constant<T_N>::value, T_N>;
+  using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
+  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
+  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
+
+  T_n_ref n_ref = n;
+  T_N_ref N_ref = N;
+  T_x_ref x_ref = x;
+  T_alpha_ref alpha_ref = alpha;
+  T_beta_ref beta_ref = beta;
+
+  if (size_zero(n, N, alpha, beta, x)) {
+    return 0;
+  }
+
+  if (!include_summand<propto, T_x, T_alpha, T_beta>::value) {
+    return 0;
+  }
+
+  const size_t N_instances = max_size(n, N, x.col(0), alpha);
+  const size_t N_attributes = x.cols();
+
+  static const char* function = "binomial_logit_glm_lpmf";
+  check_consistent_sizes(function, "Successes variable", n,
+                         "Population size parameter", N);
+  check_consistent_size(function, "Successes variable", n, N_instances);
+  check_consistent_size(function, "Population size parameter", N, N_instances);
+  check_consistent_size(function, "Weight vector", beta, N_attributes);
+  check_consistent_size(function, "Vector of intercepts", alpha, N_instances);
+
+  const auto& n_val = as_value_column_array_or_scalar(n_ref);
+  const auto& N_val = as_value_column_array_or_scalar(N_ref);
+
+  check_bounded(function, "Successes variable", n_val, 0, N_val);
+  check_nonnegative(function, "Population size parameter", N_val);
+
+  const auto& alpha_val = as_value_column_array_or_scalar(alpha_ref);
+  const auto& beta_val = as_value_column_vector_or_scalar(beta_ref);
+  const auto& x_val = value_of(x_ref);
+  Eigen::Array<T_partials_return, -1, 1> theta(N_instances);
+  if (T_x_rows == 1) {
+    theta = forward_as<T_xbeta_tmp>((x_val * beta_val)(0, 0)) + alpha_val;
+  } else {
+    theta = (x_val * beta_val).array() + alpha_val;
+  }
+
+  const auto& log_inv_logit_theta = log_inv_logit(theta);
+  const auto& log1m_inv_logit_theta = log1m_inv_logit(theta);
+
+  T_partials_return logp = sum(n_val * log_inv_logit_theta
+                               + (N_val - n_val) * log1m_inv_logit_theta);
+
+  using std::isfinite;
+  if (!isfinite(logp)) {
+    check_finite(function, "Weight vector", beta);
+    check_finite(function, "Intercept", alpha);
+    check_finite(function, "Matrix of independent variables", x);
+  }
+
+  if (include_summand<propto, T_n, T_N>::value) {
+    size_t broadcast_n = max_size(N, n) == N_instances ? 1 : N_instances;
+    logp += sum(binomial_coefficient_log(N_val, n_val)) * broadcast_n;
+  }
+
+  auto ops_partials = make_partials_propagator(x_ref, alpha_ref, beta_ref);
+
+  if (!is_constant_all<T_beta, T_x, T_alpha>::value) {
+    Eigen::Matrix<T_partials_return, -1, 1> theta_derivative
+        = n_val - N_val * exp(log_inv_logit_theta);
+
+    if (!is_constant_all<T_beta>::value) {
+      if (T_x_rows == 1) {
+        edge<2>(ops_partials).partials_
+            = forward_as<Eigen::Matrix<T_partials_return, 1, -1>>(
+                theta_derivative.sum() * x_val);
+      } else {
+        partials<2>(ops_partials) = x_val.transpose() * theta_derivative;
+      }
+    }
+
+    if (!is_constant_all<T_x>::value) {
+      if (T_x_rows == 1) {
+        edge<0>(ops_partials).partials_
+            = forward_as<Eigen::Array<T_partials_return, -1, T_x_rows>>(
+                beta_val * theta_derivative.sum());
+      } else {
+        edge<0>(ops_partials).partials_
+            = (beta_val * theta_derivative.transpose()).transpose();
+      }
+    }
+    if (!is_constant_all<T_alpha>::value) {
+      partials<1>(ops_partials) = theta_derivative;
+    }
+  }
+  return ops_partials.build(logp);
+}
+
+template <typename T_n, typename T_N, typename T_x, typename T_alpha,
+          typename T_beta>
+inline return_type_t<T_x, T_beta, T_alpha> binomial_logit_glm_lpmf(
+    const T_n& n, const T_N& N, const T_x& x,
+    const T_alpha& alpha, const T_beta& beta) {
+  return binomial_logit_glm_lpmf<false>(n, N, x, alpha, beta);
+}
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
@@ -53,8 +53,8 @@ namespace math {
 template <bool propto, typename T_n, typename T_N, typename T_x,
           typename T_alpha, typename T_beta, require_matrix_t<T_x>* = nullptr>
 return_type_t<T_x, T_alpha, T_beta> binomial_logit_glm_lpmf(
-    const T_n& n, const T_N& N, const T_x& x,
-    const T_alpha& alpha, const T_beta& beta) {
+    const T_n& n, const T_N& N, const T_x& x, const T_alpha& alpha,
+    const T_beta& beta) {
   constexpr int T_x_rows = T_x::RowsAtCompileTime;
   using T_xbeta_partials = partials_return_t<T_x, T_beta>;
   using T_partials_return = partials_return_t<T_x, T_alpha, T_beta>;
@@ -165,8 +165,8 @@ return_type_t<T_x, T_alpha, T_beta> binomial_logit_glm_lpmf(
 template <typename T_n, typename T_N, typename T_x, typename T_alpha,
           typename T_beta>
 inline return_type_t<T_x, T_beta, T_alpha> binomial_logit_glm_lpmf(
-    const T_n& n, const T_N& N, const T_x& x,
-    const T_alpha& alpha, const T_beta& beta) {
+    const T_n& n, const T_N& N, const T_x& x, const T_alpha& alpha,
+    const T_beta& beta) {
   return binomial_logit_glm_lpmf<false>(n, N, x, alpha, beta);
 }
 }  // namespace math

--- a/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
@@ -13,6 +13,7 @@
 #include <stan/math/prim/fun/value_of.hpp>
 #include <stan/math/prim/fun/as_value_column_array_or_scalar.hpp>
 #include <stan/math/prim/fun/as_value_column_vector_or_scalar.hpp>
+#include <stan/math/prim/functor/partials_propagator.hpp>
 
 namespace stan {
 namespace math {
@@ -58,9 +59,6 @@ return_type_t<T_x, T_alpha, T_beta> binomial_logit_glm_lpmf(
   constexpr int T_x_rows = T_x::RowsAtCompileTime;
   using T_xbeta_partials = partials_return_t<T_x, T_beta>;
   using T_partials_return = partials_return_t<T_x, T_alpha, T_beta>;
-  using T_theta_tmp =
-      typename std::conditional_t<T_x_rows == 1, T_partials_return,
-                                  Eigen::Array<T_partials_return, -1, 1>>;
   using T_xbeta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_xbeta_partials,
                                   Eigen::Array<T_xbeta_partials, -1, 1>>;

--- a/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
@@ -26,9 +26,9 @@ namespace math {
  * simplified gradients.
  * If containers are supplied, returns the log sum of the probabilities.
  *
- * @tparam T_y type of binary vector of successes variables;
+ * @tparam T_n type of binary vector of successes variables;
  * this can also be a single binary value;
- * @tparam T_y type of binary vector of population size variables;
+ * @tparam T_N type of binary vector of population size variables;
  * this can also be a single binary value;
  * @tparam T_x type of the matrix of independent variables (features)
  * @tparam T_alpha type of the intercept(s);
@@ -42,7 +42,7 @@ namespace math {
  * broadcast - used for all instances.
  * @param x design matrix or row vector. If it is a row vector it will be
  * broadcast - used for all instances.
- * @param alpha intercept (in log odds)
+ * @param alpha intercept
  * @param beta weight vector
  * @return log probability or log sum of probabilities
  * @throw std::domain_error if x, beta or alpha is infinite.

--- a/test/unit/math/mix/prob/binomial_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/mix/prob/binomial_logit_glm_lpmf_test.cpp
@@ -1,0 +1,35 @@
+#include <stan/math/mix.hpp>
+#include <test/unit/math/test_ad.hpp>
+
+TEST(mathMixScalFun, binomial_logit_glm_lpmf) {
+  auto f = [](const auto n, const auto N) {
+    return [=](const auto& x, const auto& alpha, const auto& beta) {
+      return stan::math::binomial_logit_glm_lpmf(n, N, x, alpha, beta);
+    };
+  };
+
+  std::vector<int> n_arr{1, 4};
+  std::vector<int> N_arr{10, 45};
+  Eigen::MatrixXd x = Eigen::MatrixXd::Random(2, 2);
+  Eigen::RowVectorXd x_rowvec = x.row(0);
+  Eigen::VectorXd alpha = Eigen::VectorXd::Random(2);
+  Eigen::VectorXd beta = Eigen::VectorXd::Random(2);
+
+  stan::test::expect_ad(f(n_arr[0], N_arr[0]), x, alpha, beta);
+  stan::test::expect_ad(f(n_arr[0], N_arr), x, alpha, beta);
+  stan::test::expect_ad(f(n_arr, N_arr[0]), x, alpha, beta);
+  stan::test::expect_ad(f(n_arr, N_arr), x, alpha, beta);
+  stan::test::expect_ad(f(n_arr[0], N_arr[0]), x, alpha[0], beta);
+  stan::test::expect_ad(f(n_arr[0], N_arr), x, alpha[0], beta);
+  stan::test::expect_ad(f(n_arr, N_arr[0]), x, alpha[0], beta);
+  stan::test::expect_ad(f(n_arr, N_arr), x, alpha[0], beta);
+  stan::test::expect_ad(f(n_arr[0], N_arr[0]), x_rowvec, alpha, beta);
+  stan::test::expect_ad(f(n_arr[0], N_arr), x_rowvec, alpha, beta);
+  stan::test::expect_ad(f(n_arr, N_arr[0]), x_rowvec, alpha, beta);
+  stan::test::expect_ad(f(n_arr, N_arr), x_rowvec, alpha, beta);
+  stan::test::expect_ad(f(n_arr[0], N_arr[0]), x_rowvec, alpha[0], beta);
+  stan::test::expect_ad(f(n_arr[0], N_arr), x_rowvec, alpha[0], beta);
+  stan::test::expect_ad(f(n_arr, N_arr[0]), x_rowvec, alpha[0], beta);
+  stan::test::expect_ad(f(n_arr, N_arr), x_rowvec, alpha[0], beta);
+
+}

--- a/test/unit/math/mix/prob/binomial_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/mix/prob/binomial_logit_glm_lpmf_test.cpp
@@ -31,5 +31,4 @@ TEST(mathMixScalFun, binomial_logit_glm_lpmf) {
   stan::test::expect_ad(f(n_arr[0], N_arr), x_rowvec, alpha[0], beta);
   stan::test::expect_ad(f(n_arr, N_arr[0]), x_rowvec, alpha[0], beta);
   stan::test::expect_ad(f(n_arr, N_arr), x_rowvec, alpha[0], beta);
-
 }

--- a/test/unit/math/prim/prob/binomial_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/prim/prob/binomial_logit_glm_lpmf_test.cpp
@@ -2,8 +2,8 @@
 #include <gtest/gtest.h>
 
 TEST(ProbBinomialLogitGLM, matchesNonGLM) {
-  using stan::math::binomial_logit_lpmf;
   using stan::math::binomial_logit_glm_lpmf;
+  using stan::math::binomial_logit_lpmf;
 
   std::vector<int> n{1, 2};
   std::vector<int> N{5, 4};
@@ -58,13 +58,13 @@ TEST(ProbBinomialLogitGLM, throwsCorrectly) {
 
   std::vector<int> N_mismatch_size{5, 4, 10};
   EXPECT_THROW(binomial_logit_glm_lpmf(n, N_mismatch_size, x, alpha, beta),
-                std::invalid_argument);
+               std::invalid_argument);
   EXPECT_THROW(binomial_logit_glm_lpmf(500, 1, x, alpha, beta),
-                std::domain_error);
+               std::domain_error);
   EXPECT_THROW(binomial_logit_glm_lpmf(-10, N, x, alpha, beta),
-                std::domain_error);
+               std::domain_error);
   EXPECT_THROW(binomial_logit_glm_lpmf(n, -10, x, alpha, beta),
-                std::domain_error);
+               std::domain_error);
 
   Eigen::VectorXd alpha_inf = alpha;
   alpha[0] = INFTY;
@@ -74,9 +74,9 @@ TEST(ProbBinomialLogitGLM, throwsCorrectly) {
   x(0, 0) = INFTY;
 
   EXPECT_THROW(binomial_logit_glm_lpmf(n, N, x_inf, alpha, beta),
-                std::domain_error);
+               std::domain_error);
   EXPECT_THROW(binomial_logit_glm_lpmf(n, N, x, alpha_inf, beta),
-                std::domain_error);
+               std::domain_error);
   EXPECT_THROW(binomial_logit_glm_lpmf(n, N, x, alpha, beta_inf),
-                std::domain_error);
+               std::domain_error);
 }

--- a/test/unit/math/prim/prob/binomial_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/prim/prob/binomial_logit_glm_lpmf_test.cpp
@@ -1,0 +1,82 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbBinomialLogitGLM, matchesNonGLM) {
+  using stan::math::binomial_logit_lpmf;
+  using stan::math::binomial_logit_glm_lpmf;
+
+  std::vector<int> n{1, 2};
+  std::vector<int> N{5, 4};
+  Eigen::MatrixXd x = Eigen::MatrixXd::Random(2, 2);
+  Eigen::RowVectorXd x_row = x.row(0);
+  Eigen::VectorXd alpha = Eigen::VectorXd::Random(2);
+  Eigen::VectorXd beta = Eigen::VectorXd::Random(2);
+
+  Eigen::VectorXd theta = alpha + x * beta;
+
+  EXPECT_FLOAT_EQ(binomial_logit_lpmf(n, N, theta),
+                  binomial_logit_glm_lpmf(n, N, x, alpha, beta));
+  EXPECT_FLOAT_EQ(binomial_logit_lpmf(n[0], N, theta),
+                  binomial_logit_glm_lpmf(n[0], N, x, alpha, beta));
+  EXPECT_FLOAT_EQ(binomial_logit_lpmf(n, N[0], theta),
+                  binomial_logit_glm_lpmf(n, N[0], x, alpha, beta));
+  EXPECT_FLOAT_EQ(binomial_logit_lpmf(n[0], N[0], theta),
+                  binomial_logit_glm_lpmf(n[0], N[0], x, alpha, beta));
+
+  theta = (alpha[0] + (x * beta).array()).matrix();
+
+  EXPECT_FLOAT_EQ(binomial_logit_lpmf(n, N, theta),
+                  binomial_logit_glm_lpmf(n, N, x, alpha[0], beta));
+  EXPECT_FLOAT_EQ(binomial_logit_lpmf(n[0], N, theta),
+                  binomial_logit_glm_lpmf(n[0], N, x, alpha[0], beta));
+  EXPECT_FLOAT_EQ(binomial_logit_lpmf(n, N[0], theta),
+                  binomial_logit_glm_lpmf(n, N[0], x, alpha[0], beta));
+  EXPECT_FLOAT_EQ(binomial_logit_lpmf(n[0], N[0], theta),
+                  binomial_logit_glm_lpmf(n[0], N[0], x, alpha[0], beta));
+
+  theta = (alpha.array() + (x_row * beta)(0, 0)).matrix();
+
+  EXPECT_FLOAT_EQ(binomial_logit_lpmf(n, N, theta),
+                  binomial_logit_glm_lpmf(n, N, x_row, alpha, beta));
+  EXPECT_FLOAT_EQ(binomial_logit_lpmf(n[0], N, theta),
+                  binomial_logit_glm_lpmf(n[0], N, x_row, alpha, beta));
+  EXPECT_FLOAT_EQ(binomial_logit_lpmf(n, N[0], theta),
+                  binomial_logit_glm_lpmf(n, N[0], x_row, alpha, beta));
+  EXPECT_FLOAT_EQ(binomial_logit_lpmf(n[0], N[0], theta),
+                  binomial_logit_glm_lpmf(n[0], N[0], x_row, alpha, beta));
+}
+
+TEST(ProbBinomialLogitGLM, throwsCorrectly) {
+  using stan::math::binomial_logit_glm_lpmf;
+  using stan::math::INFTY;
+
+  std::vector<int> n{1, 2};
+  std::vector<int> N{5, 4};
+  Eigen::MatrixXd x = Eigen::MatrixXd::Random(2, 2);
+  Eigen::VectorXd alpha = Eigen::VectorXd::Random(2);
+  Eigen::VectorXd beta = Eigen::VectorXd::Random(2);
+
+  std::vector<int> N_mismatch_size{5, 4, 10};
+  EXPECT_THROW(binomial_logit_glm_lpmf(n, N_mismatch_size, x, alpha, beta),
+                std::invalid_argument);
+  EXPECT_THROW(binomial_logit_glm_lpmf(500, 1, x, alpha, beta),
+                std::domain_error);
+  EXPECT_THROW(binomial_logit_glm_lpmf(-10, N, x, alpha, beta),
+                std::domain_error);
+  EXPECT_THROW(binomial_logit_glm_lpmf(n, -10, x, alpha, beta),
+                std::domain_error);
+
+  Eigen::VectorXd alpha_inf = alpha;
+  alpha[0] = INFTY;
+  Eigen::VectorXd beta_inf = beta;
+  beta[0] = INFTY;
+  Eigen::MatrixXd x_inf = x;
+  x(0, 0) = INFTY;
+
+  EXPECT_THROW(binomial_logit_glm_lpmf(n, N, x_inf, alpha, beta),
+                std::domain_error);
+  EXPECT_THROW(binomial_logit_glm_lpmf(n, N, x, alpha_inf, beta),
+                std::domain_error);
+  EXPECT_THROW(binomial_logit_glm_lpmf(n, N, x, alpha, beta_inf),
+                std::domain_error);
+}


### PR DESCRIPTION
## Summary

This PR adds the `binomial_logit_glm_lpmf` distribution, the binomial equivalent of the `bernoulli_logit_glm_lpmf`. Much of the log-probability and derivative construction is the same between the two, so this implementation closely follows the existing `bernoulli_logit_glm_lpmf` implementation.

## Tests

All valid scalar/container combinations tested via:

- `prim` tests for equality with `binomial_logit(alpha + x*beta)` and throwing behaviour
- `mix` tests 

## Side Effects

N/A

## Release notes

`binomial_logit_glm_lpmf` distribution added

## Checklist

- [x] Math issue #1964 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
