### PR TITLE
Update to rtools43 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Windows Rtools40
+name: Windows Rtools43
 
 on:
   pull_request:
@@ -30,15 +30,15 @@ jobs:
         python-version: '3.x'
     - uses: r-lib/actions/setup-r@v2
       with:
-        r-version: 4.1.3
+        r-version: 4.3.1
 
-    - name: Set path for Rtools40
+    - name: Set path for Rtools43
       if: runner.os == 'Windows'
-      run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: echo "C:/rtools43/usr/bin;C:/rtools43/ucrt64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Install mingw32-make and check toolchain path
       if: runner.os == 'Windows'
       run: |
-        pacman -Syu mingw-w64-x86_64-make --noconfirm
+        pacman -Syu mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-gcc --noconfirm
         g++ --version
         Get-Command g++ | Select-Object -ExpandProperty Definition
         mingw32-make --version
@@ -49,6 +49,8 @@ jobs:
       shell: powershell
       run: |
         Add-Content make\local "O=1`n"
+        Add-Content make\local "CXXFLAGS += -Wno-nonnull -D_UCRT`n"
+        Add-Content make\local "TBB_CXXFLAGS= -D_UCRT`n"
         mingw32-make -f make/standalone math-libs -j2
     - name: Add TBB to PATH
       shell: powershell
@@ -80,15 +82,15 @@ jobs:
         python-version: '3.x'
     - uses: r-lib/actions/setup-r@v2
       with:
-        r-version: 4.1.3
+        r-version: 4.3.1
 
-    - name: Set path for Rtools40
+    - name: Set path for Rtools43
       if: runner.os == 'Windows'
-      run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: echo "C:/rtools43/usr/bin;C:/rtools43/ucrt64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Install mingw32-make and check toolchain path
       if: runner.os == 'Windows'
       run: |
-        pacman -Syu mingw-w64-x86_64-make --noconfirm
+        pacman -Syu mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-gcc --noconfirm
         g++ --version
         Get-Command g++ | Select-Object -ExpandProperty Definition
         mingw32-make --version
@@ -99,6 +101,8 @@ jobs:
       shell: powershell
       run: |
         Add-Content make\local "O=1`n"
+        Add-Content make\local "CXXFLAGS += -Wno-nonnull -D_UCRT`n"
+        Add-Content make\local "TBB_CXXFLAGS= -D_UCRT`n"
         mingw32-make -f make/standalone math-libs -j2
     - name: Add TBB to PATH
       shell: powershell
@@ -134,15 +138,15 @@ jobs:
         python-version: '3.x'
     - uses: r-lib/actions/setup-r@v2
       with:
-        r-version: 4.1.3
+        r-version: 4.3.1
 
-    - name: Set path for Rtools40
+    - name: Set path for Rtools43
       if: runner.os == 'Windows'
-      run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: echo "C:/rtools43/usr/bin;C:/rtools43/ucrt64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Install mingw32-make and check toolchain path
       if: runner.os == 'Windows'
       run: |
-        pacman -Syu mingw-w64-x86_64-make --noconfirm
+        pacman -Syu mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-gcc --noconfirm
         g++ --version
         Get-Command g++ | Select-Object -ExpandProperty Definition
         mingw32-make --version
@@ -153,6 +157,8 @@ jobs:
       shell: powershell
       run: |
         Add-Content make\local "O=1`n"
+        Add-Content make\local "CXXFLAGS += -Wno-nonnull -D_UCRT`n"
+        Add-Content make\local "TBB_CXXFLAGS= -D_UCRT`n"
         mingw32-make -f make/standalone math-libs -j2
     - name: Add TBB to PATH
       shell: powershell
@@ -171,7 +177,7 @@ jobs:
       with:
         name: gtest_outputs_xml
         path: '**/*_test.xml'
-        
+
   mix-fun-2:
     name: mix/fun tests 2
     runs-on: windows-latest
@@ -183,15 +189,15 @@ jobs:
         python-version: '3.x'
     - uses: r-lib/actions/setup-r@v2
       with:
-        r-version: 4.1.3
+        r-version: 4.3.1
 
-    - name: Set path for Rtools40
+    - name: Set path for Rtools43
       if: runner.os == 'Windows'
-      run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: echo "C:/rtools43/usr/bin;C:/rtools43/ucrt64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Install mingw32-make and check toolchain path
       if: runner.os == 'Windows'
       run: |
-        pacman -Syu mingw-w64-x86_64-make --noconfirm
+        pacman -Syu mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-gcc --noconfirm
         g++ --version
         Get-Command g++ | Select-Object -ExpandProperty Definition
         mingw32-make --version
@@ -202,6 +208,8 @@ jobs:
       shell: powershell
       run: |
         Add-Content make\local "O=1`n"
+        Add-Content make\local "CXXFLAGS += -Wno-nonnull -D_UCRT`n"
+        Add-Content make\local "TBB_CXXFLAGS= -D_UCRT`n"
         mingw32-make -f make/standalone math-libs -j2
     - name: Add TBB to PATH
       shell: powershell


### PR DESCRIPTION
## Summary

Our GHA CI for running Windows headers/tests is using RTools40. Given that the current R version is 4.3, we should be testing using RTools43.

This PR updates our CI to use RTools43, following the installation instructions in the manual: https://mc-stan.org/docs/cmdstan-guide/cmdstan-installation.html#rtools42-rtools43

## Tests

N/A - current tests should still pass

## Side Effects

N/A

## Release notes

Update CI to use RTools43

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
