### PR TITLE
Add makeflag for building TBB under UCRT automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ lib/tbb
 
 # local make include
 /make/local
+/make/ucrt
 
 # python byte code
 *.pyc

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -121,6 +121,15 @@ CXXFLAGS_LANG ?= -std=c++1y
 CXXFLAGS_SUNDIALS ?= -pipe $(CXXFLAGS_OPTIM_SUNDIALS) $(CPPFLAGS_FLTO_SUNDIALS)
 #CXXFLAGS_GTEST
 
+make/ucrt:
+  pound := \#
+  UCRT_STRING := $(shell echo '$(pound)include <windows.h>' | $(CXX) -E -dM -  | findstr _UCRT)
+  ifneq (,$(UCRT_STRING))
+    IS_UCRT ?= true
+  else
+    IS_UCRT ?= false
+  endif
+  $(shell echo "IS_UCRT ?= $(IS_UCRT)" > $(MATH)make/ucrt)
 
 ## These are the other compiler flags that can be set.
 ##
@@ -161,18 +170,7 @@ ifeq ($(OS),Windows_NT)
     CXXFLAGS_OS ?= -m64
   endif
 
-  ifeq (,$(wildcard $(MATH)make/ucrt))
-    UCRT_STRING := $(shell echo "#include <windows.h>" | $(CXX) -E -dM -  | findstr _UCRT)
-    ifneq (,$(UCRT_STRING))
-      IS_UCRT ?= true
-    else
-      IS_UCRT ?= false
-    endif
-    $(shell echo "IS_UCRT ?= $(IS_UCRT)" > $(MATH)make/ucrt)
-  else
-    -include $(MATH)make/ucrt
-  endif
-
+  include make/ucrt
   ifeq ($(IS_UCRT),true)
     CXXFLAGS_OS += -D_UCRT
   endif

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -121,15 +121,6 @@ CXXFLAGS_LANG ?= -std=c++1y
 CXXFLAGS_SUNDIALS ?= -pipe $(CXXFLAGS_OPTIM_SUNDIALS) $(CPPFLAGS_FLTO_SUNDIALS)
 #CXXFLAGS_GTEST
 
-make/ucrt:
-  pound := \#
-  UCRT_STRING := $(shell echo '$(pound)include <windows.h>' | $(CXX) -E -dM -  | findstr _UCRT)
-  ifneq (,$(UCRT_STRING))
-    IS_UCRT ?= true
-  else
-    IS_UCRT ?= false
-  endif
-  $(shell echo "IS_UCRT ?= $(IS_UCRT)" > $(MATH)make/ucrt)
 
 ## These are the other compiler flags that can be set.
 ##
@@ -169,6 +160,16 @@ ifeq ($(OS),Windows_NT)
   else
     CXXFLAGS_OS ?= -m64
   endif
+
+  make/ucrt:
+    pound := \#
+    UCRT_STRING := $(shell echo '$(pound)include <windows.h>' | $(CXX) -E -dM -  | findstr _UCRT)
+    ifneq (,$(UCRT_STRING))
+      IS_UCRT ?= true
+    else
+      IS_UCRT ?= false
+    endif
+    $(shell echo "IS_UCRT ?= $(IS_UCRT)" > $(MATH)make/ucrt)
 
   include make/ucrt
   ifeq ($(IS_UCRT),true)

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -161,8 +161,19 @@ ifeq ($(OS),Windows_NT)
     CXXFLAGS_OS ?= -m64
   endif
 
-  UCRT_STRING := $(shell echo "\#include <windows.h>" | $(CXX) -E -dM -  | grep -i _UCRT)
-  ifneq (,$(UCRT_STRING))
+  ifeq (,$(wildcard $(MATH)make/ucrt))
+    UCRT_STRING := $(shell echo "#include <windows.h>" | $(CXX) -E -dM -  | findstr _UCRT)
+    ifneq (,$(UCRT_STRING))
+      IS_UCRT ?= true
+    else
+      IS_UCRT ?= false
+    endif
+    $(shell echo "IS_UCRT ?= $(IS_UCRT)" > $(MATH)make/ucrt)
+  else
+    -include $(MATH)make/ucrt
+  endif
+
+  ifeq ($(IS_UCRT),true)
     CXXFLAGS_OS += -D_UCRT
   endif
 

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -167,11 +167,6 @@ ifeq ($(OS),Windows_NT)
     LDLIBS_OS ?= -static-libgcc -static-libstdc++
   endif
 
-  UCRT_STRING := $(shell echo "\#include <windows.h>" | $(CXX) -E -dM -  | grep -i _UCRT)
-  ifneq (,$(UCRT_STRING))
-    CXXFLAGS_OS += -D_UCRT
-  endif
-
   EXE := .exe
 endif
 

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -161,6 +161,11 @@ ifeq ($(OS),Windows_NT)
     CXXFLAGS_OS ?= -m64
   endif
 
+  UCRT_STRING := $(shell echo "\#include <windows.h>" | $(CXX) -E -dM -  | grep -i _UCRT)
+  ifneq (,$(UCRT_STRING))
+    CXXFLAGS_OS += -D_UCRT
+  endif
+
   ifneq (gcc,$(CXX_TYPE))
     LDLIBS_OS ?= -static-libgcc
   else

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -167,6 +167,11 @@ ifeq ($(OS),Windows_NT)
     LDLIBS_OS ?= -static-libgcc -static-libstdc++
   endif
 
+  UCRT_STRING := $(shell echo "#include <windows.h>"| $(CXX) -E -dM -  | grep -i _UCRT)
+  ifneq (,$(UCRT_STRING))
+    CXXFLAGS_OS += -D_UCRT
+  endif
+
   EXE := .exe
 endif
 

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -167,7 +167,7 @@ ifeq ($(OS),Windows_NT)
     LDLIBS_OS ?= -static-libgcc -static-libstdc++
   endif
 
-  UCRT_STRING := $(shell echo "#include <windows.h>"| $(CXX) -E -dM -  | grep -i _UCRT)
+  UCRT_STRING := $(shell echo "\#include <windows.h>" | $(CXX) -E -dM -  | grep -i _UCRT)
   ifneq (,$(UCRT_STRING))
     CXXFLAGS_OS += -D_UCRT
   endif

--- a/make/libraries
+++ b/make/libraries
@@ -139,6 +139,10 @@ ifeq (Linux, $(OS))
   SHELL = /usr/bin/env bash
 endif
 
+ifneq (,$(UCRT_STRING))
+	TBB_CXXFLAGS += -D_UCRT
+endif
+
 # If brackets or spaces are found in MAKE on Windows
 # we error, as those characters cause issues when building.
 ifeq (Windows_NT, $(OS))

--- a/make/libraries
+++ b/make/libraries
@@ -139,8 +139,11 @@ ifeq (Linux, $(OS))
   SHELL = /usr/bin/env bash
 endif
 
-ifneq (,$(UCRT_STRING))
-	TBB_CXXFLAGS += -D_UCRT
+ifeq (Windows_NT, $(OS))
+  UCRT_STRING := $(shell echo "\#include <windows.h>" | $(CXX) -E -dM -  | grep -i _UCRT)
+  ifneq (,$(UCRT_STRING))
+	  TBB_CXXFLAGS += -D_UCRT
+  endif
 endif
 
 # If brackets or spaces are found in MAKE on Windows

--- a/make/libraries
+++ b/make/libraries
@@ -140,7 +140,7 @@ ifeq (Linux, $(OS))
 endif
 
 ifeq (Windows_NT, $(OS))
-  ifneq (,$(UCRT_STRING))
+  ifeq ($(IS_UCRT),true)
     TBB_CXXFLAGS += -D_UCRT
   endif
 endif

--- a/make/libraries
+++ b/make/libraries
@@ -140,9 +140,8 @@ ifeq (Linux, $(OS))
 endif
 
 ifeq (Windows_NT, $(OS))
-  UCRT_STRING := $(shell echo "\#include <windows.h>" | $(CXX) -E -dM -  | grep -i _UCRT)
   ifneq (,$(UCRT_STRING))
-	  TBB_CXXFLAGS += -D_UCRT
+    TBB_CXXFLAGS += -D_UCRT
   endif
 endif
 

--- a/make/tests
+++ b/make/tests
@@ -106,7 +106,7 @@ else
 endif
 
 %.hpp-test : %.hpp test/dummy.cpp
-	$(COMPILE.cpp) $(CXXFLAGS) -O0 -include $^ -S -o $(DEV_NULL) -Wunused-local-typedefs
+	$(COMPILE.cpp) $(CXXFLAGS) -O0 -include $^ -o $(DEV_NULL) -Wunused-local-typedefs
 
 test/dummy.cpp:
 	@mkdir -p test

--- a/make/tests
+++ b/make/tests
@@ -101,12 +101,15 @@ HEADER_TESTS := $(addsuffix -test,$(call findfiles,stan,*.hpp))
 
 ifeq ($(OS),Windows_NT)
   DEV_NULL = nul
+  ifeq ($(IS_UCRT),true)
+    UCRT_NULL_FLAG = -S
+  endif
 else
   DEV_NULL = /dev/null
 endif
 
 %.hpp-test : %.hpp test/dummy.cpp
-	$(COMPILE.cpp) $(CXXFLAGS) -O0 -include $^ -S -o $(DEV_NULL) -Wunused-local-typedefs
+	$(COMPILE.cpp) $(CXXFLAGS) -O0 -include $^ $(UCRT_NULL_FLAG) -o $(DEV_NULL) -Wunused-local-typedefs
 
 test/dummy.cpp:
 	@mkdir -p test

--- a/make/tests
+++ b/make/tests
@@ -106,7 +106,7 @@ else
 endif
 
 %.hpp-test : %.hpp test/dummy.cpp
-	$(COMPILE.cpp) $(CXXFLAGS) -O0 -include $^ -o $(DEV_NULL) -Wunused-local-typedefs
+	$(COMPILE.cpp) $(CXXFLAGS) -O0 -include $^ -S -o $(DEV_NULL) -Wunused-local-typedefs
 
 test/dummy.cpp:
 	@mkdir -p test

--- a/makefile
+++ b/makefile
@@ -125,6 +125,7 @@ clean-deps:
 	@$(RM) $(call findfiles,test,*.d.*)
 	@$(RM) $(call findfiles,lib,*.d.*)
 	@$(RM) $(call findfiles,stan,*.dSYM)
+	@$(RM) $(call findfiles,make,ucrt)
 
 clean-all: clean clean-doxygen clean-deps clean-libraries
 


### PR DESCRIPTION
# Summary

Windows users (and cmdstan interfaces) currently need to add `-D_UCRT` to `make/local` when building on windows with a UCRT toolchain. This PR updates the makefiles to detect whether a UCRT toolchain is being used on Windows, and to add the flag automatically if needed.

We can detect UCRT-ness by checking whether the `UCRT` macro is defined after pre-processing the `windows.h` header

UCRT Toolchain:
```
PS C:\> echo "#include <windows.h>"| C:/rtools43/ucrt64/bin/g++ -E -dM -  | grep -i _UCRT
#define _UCRT
```

Non-UCRT Toolchain:
```
PS C:\> echo "#include <windows.h>"| C:/rtools43/mingw64/bin/g++ -E -dM -  | grep -i _UCRT
PS C:\>
```

I've tested that the TBB (and Stan) successfully build under both the UCRT `mingw-w64-ucrt-x86_64-gcc` and the non-UCRT `mingw-w64-x86_64-gcc` toolchains

## Tests

N/A

## Side Effects

N/A

## Release notes

Automatically detect UCRT toolchain use on Windows

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
