### PR TITLE
Don't duplicate -rpath for TBB

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -257,8 +257,8 @@ else
 CXXFLAGS_TBB ?= -I $(TBB)/include
 endif
 
-LDFLAGS_TBB ?= -Wl,-L,"$(TBB_LIB)" -Wl,-rpath,"$(TBB_LIB)" -Wl,--disable-new-dtags -ltbb
-LDLIBS_TBB ?= $(LDFLAGS_TBB)
+LDFLAGS_TBB ?= -Wl,-L,"$(TBB_LIB)" -Wl,-rpath,"$(TBB_LIB)" -Wl,--disable-new-dtags
+LDLIBS_TBB ?= -ltbb
 
 else
 
@@ -276,7 +276,7 @@ endif
 
 CXXFLAGS_TBB ?= -I $(TBB)/include
 LDFLAGS_TBB ?= -Wl,-L,"$(TBB_BIN_ABSOLUTE_PATH)" -Wl,-rpath,"$(TBB_BIN_ABSOLUTE_PATH)" $(LDFLAGS_FLTO_FLTO) $(LDFLAGS_OPTIM_TBB)
-LDLIBS_TBB ?= $(LDFLAGS_TBB)
+LDLIBS_TBB ?= -ltbb
 
 endif
 


### PR DESCRIPTION


## Summary

Reported on the [forums,](https://discourse.mc-stan.org/t/warning-of-duplicate-rpath-when-compiling-and-installing-cmdstan/32921) some versions of ld are now issuing warnings for repeated copies of `-rpath`.
I think the fact that we were passing it twice already was an error/misinterpretation of LDFLAGS and LDLIBS.

## Tests

## Side Effects



## Release notes

Fixed the RPATH to the TBB library being passed twice on the command line

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
