### PR TITLE
Split eigendecompose test for CI mem issues

### DIFF
--- a/test/unit/math/mix/fun/eigendecompose_part1_test.cpp
+++ b/test/unit/math/mix/fun/eigendecompose_part1_test.cpp
@@ -1,0 +1,22 @@
+#include <test/unit/math/test_ad.hpp>
+#include <stdexcept>
+
+TEST(mathMixFun, eigendecompose) {
+  auto f = [](const auto& x) {
+    using stan::math::eigendecompose;
+    return std::get<0>(eigendecompose(x));
+  };
+  auto g = [](const auto& x) {
+    using stan::math::eigendecompose;
+    return std::get<1>(eigendecompose(x));
+  };
+  for (const auto& x : stan::test::square_test_matrices(0, 2)) {
+    stan::test::expect_ad(f, x);
+    stan::test::expect_ad(g, x);
+  }
+
+  Eigen::MatrixXd a32(3, 2);
+  a32 << 3, -5, 7, -7.2, 9.1, -6.3;
+  EXPECT_THROW(f(a32), std::invalid_argument);
+  EXPECT_THROW(g(a32), std::invalid_argument);
+}

--- a/test/unit/math/mix/fun/eigendecompose_part2_test.cpp
+++ b/test/unit/math/mix/fun/eigendecompose_part2_test.cpp
@@ -1,26 +1,6 @@
 #include <test/unit/math/test_ad.hpp>
 #include <stdexcept>
 
-TEST(mathMixFun, eigendecompose) {
-  auto f = [](const auto& x) {
-    using stan::math::eigendecompose;
-    return std::get<0>(eigendecompose(x));
-  };
-  auto g = [](const auto& x) {
-    using stan::math::eigendecompose;
-    return std::get<1>(eigendecompose(x));
-  };
-  for (const auto& x : stan::test::square_test_matrices(0, 2)) {
-    stan::test::expect_ad(f, x);
-    stan::test::expect_ad(g, x);
-  }
-
-  Eigen::MatrixXd a32(3, 2);
-  a32 << 3, -5, 7, -7.2, 9.1, -6.3;
-  EXPECT_THROW(f(a32), std::invalid_argument);
-  EXPECT_THROW(g(a32), std::invalid_argument);
-}
-
 TEST(mathMixFun, eigendecomposeComplex) {
   auto f = [](const auto& x) {
     using stan::math::eigendecompose;


### PR DESCRIPTION
## Summary

The windows CI checks are sporadically failing due to memory issues when compiling the `eigendecompose` mix test ([see this run](https://github.com/stan-dev/math/actions/runs/6353960117/job/17259580928)).

This PR just splits the test into two files to avoid this

## Tests

N/A 

## Side Effects

N/A

## Release notes

Split `eigendecompose` mix tests to fix CI memory issues

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
