### PR TITLE
Fix Row-Vector Distribution test failures

### DIFF
--- a/stan/math/prim/prob/bernoulli_cdf.hpp
+++ b/stan/math/prim/prob/bernoulli_cdf.hpp
@@ -34,7 +34,7 @@ return_type_t<T_prob> bernoulli_cdf(const T_n& n, const T_prob& theta) {
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
   T_theta_ref theta_ref = theta;
-  const auto& n_arr = as_array_or_scalar(n);
+  const auto& n_arr = as_value_column_array_or_scalar(n);
   const auto& theta_arr = as_value_column_array_or_scalar(theta_ref);
   check_bounded(function, "Probability parameter", theta_arr, 0.0, 1.0);
 

--- a/stan/math/prim/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lccdf.hpp
@@ -35,7 +35,7 @@ return_type_t<T_prob> bernoulli_lccdf(const T_n& n, const T_prob& theta) {
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
   T_theta_ref theta_ref = theta;
-  const auto& n_arr = as_array_or_scalar(n);
+  const auto& n_arr = as_value_column_array_or_scalar(n);
   const auto& theta_arr = as_value_column_array_or_scalar(theta_ref);
   check_bounded(function, "Probability parameter", theta_arr, 0.0, 1.0);
 

--- a/stan/math/prim/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lcdf.hpp
@@ -33,7 +33,7 @@ return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
   T_theta_ref theta_ref = theta;
-  const auto& n_arr = as_array_or_scalar(n);
+  const auto& n_arr = as_value_column_array_or_scalar(n);
   const auto& theta_arr = as_value_column_array_or_scalar(theta_ref);
   check_bounded(function, "Probability parameter", theta_arr, 0.0, 1.0);
 


### PR DESCRIPTION
## Summary

@WardBrian pointed out that the distribution tests have been failing since #2784 was merged. This was because I'd assumed that only `std::vector<int>` types would be passed as the vectorised form for `int`, but the distribution tests also pass `Eigen::RowVector` `int` types.

This PR updates the handling of the `bernoulli` CDF functions to make sure that dimensionality is not assumed.

## Tests

N/A

## Side Effects
N/A

## Release notes

Fix distribution test failures with row-vector integer inputs to bernoulli CDF functions

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
