### PR TITLE
updating PR template: removing Math issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,8 +26,6 @@ Replace this text with a short note on what will change if this pull request is 
 
 ## Checklist
 
-- [ ] Math issue #(issue number)
-
 - [ ] Copyright holder: (fill in copyright holder information)
 
     The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:


### PR DESCRIPTION
## Summary

The existing PR template asks about a Math issue number. Over the years GitHub has gotten better with linking issues and PRs which has lead to us not using the issue by default. I think it's a good time to change our template to match current practices. 


## Checklist

- [x] Copyright holder: Daniel Lee

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

