### PR TITLE
Fix: generate_tests does not need to link tbb

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -124,6 +124,7 @@ ifdef GENERATE_DISTRIBUTION_TESTS
 ##
 # Test generator for distribution tests
 ##
+test/prob/generate_tests$(EXE) : LDLIBS_TBB =
 test/prob/generate_tests$(EXE) : test/prob/generate_tests.cpp
 	@mkdir -p $(dir $@)
 	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)


### PR DESCRIPTION
## Summary

Follow on to #2952, we don't need to link TBB into the `generate_tests` utility program. 

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
