### PR TITLE
Add `ref_type_if_not_constant_t<>` type trait

### DIFF
--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_META_REF_TYPE_HPP
 
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/meta/is_constant.hpp>
 #include <stan/math/prim/meta/is_eigen.hpp>
 #include <stan/math/prim/meta/is_arena_matrix.hpp>
 #include <stan/math/prim/meta/is_vector.hpp>

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -56,6 +56,10 @@ using ref_type_t = typename ref_type_if<true, T>::type;
 template <bool Condition, typename T>
 using ref_type_if_t = typename ref_type_if<Condition, T>::type;
 
+template <typename T>
+using ref_type_if_not_const_t
+  = typename ref_type_if<!is_constant<T>::value, T>::type;
+
 }  // namespace stan
 
 #endif

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -58,7 +58,7 @@ template <bool Condition, typename T>
 using ref_type_if_t = typename ref_type_if<Condition, T>::type;
 
 template <typename T>
-using ref_type_if_not_const_t =
+using ref_type_if_not_constant_t =
     typename ref_type_if<!is_constant<T>::value, T>::type;
 
 }  // namespace stan

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -57,8 +57,8 @@ template <bool Condition, typename T>
 using ref_type_if_t = typename ref_type_if<Condition, T>::type;
 
 template <typename T>
-using ref_type_if_not_const_t
-  = typename ref_type_if<!is_constant<T>::value, T>::type;
+using ref_type_if_not_const_t =
+    typename ref_type_if<!is_constant<T>::value, T>::type;
 
 }  // namespace stan
 

--- a/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
@@ -65,9 +65,9 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   using T_xbeta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_xbeta_partials,
                                   Array<T_xbeta_partials, Dynamic, 1>>;
-  using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
+  using T_x_ref = ref_type_if_not_const_t<T_x>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_alpha>;
+  using T_beta_ref = ref_type_if_not_const_t<T_beta>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
@@ -65,9 +65,9 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   using T_xbeta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_xbeta_partials,
                                   Array<T_xbeta_partials, Dynamic, 1>>;
-  using T_x_ref = ref_type_if_not_const_t<T_x>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_alpha>;
-  using T_beta_ref = ref_type_if_not_const_t<T_beta>;
+  using T_x_ref = ref_type_if_not_constant_t<T_x>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_alpha>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_beta>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
@@ -37,8 +37,8 @@ return_type_t<T_prob> bernoulli_logit_lpmf(const T_n& n, const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_prob>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using std::exp;
-  using T_n_ref = ref_type_if_not_const_t<T_n>;
-  using T_theta_ref = ref_type_if_not_const_t<T_prob>;
+  using T_n_ref = ref_type_if_not_constant_t<T_n>;
+  using T_theta_ref = ref_type_if_not_constant_t<T_prob>;
   static const char* function = "bernoulli_logit_lpmf";
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);

--- a/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
@@ -37,8 +37,8 @@ return_type_t<T_prob> bernoulli_logit_lpmf(const T_n& n, const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_prob>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using std::exp;
-  using T_n_ref = ref_type_if_t<!is_constant<T_n>::value, T_n>;
-  using T_theta_ref = ref_type_if_t<!is_constant<T_prob>::value, T_prob>;
+  using T_n_ref = ref_type_if_not_const_t<T_n>;
+  using T_theta_ref = ref_type_if_not_const_t<T_prob>;
   static const char* function = "bernoulli_logit_lpmf";
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);

--- a/stan/math/prim/prob/beta_lpdf.hpp
+++ b/stan/math/prim/prob/beta_lpdf.hpp
@@ -48,10 +48,8 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
     const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
   using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_alpha_ref
-      = ref_type_if_not_const_t<T_scale_succ>;
-  using T_beta_ref
-      = ref_type_if_not_const_t<T_scale_fail>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_scale_succ>;
+  using T_beta_ref = ref_type_if_not_const_t<T_scale_fail>;
   static const char* function = "beta_lpdf";
   check_consistent_sizes(function, "Random variable", y,
                          "First shape parameter", alpha,

--- a/stan/math/prim/prob/beta_lpdf.hpp
+++ b/stan/math/prim/prob/beta_lpdf.hpp
@@ -47,11 +47,11 @@ template <bool propto, typename T_y, typename T_scale_succ,
 return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
     const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
   using T_alpha_ref
-      = ref_type_if_t<!is_constant<T_scale_succ>::value, T_scale_succ>;
+      = ref_type_if_not_const_t<T_scale_succ>;
   using T_beta_ref
-      = ref_type_if_t<!is_constant<T_scale_fail>::value, T_scale_fail>;
+      = ref_type_if_not_const_t<T_scale_fail>;
   static const char* function = "beta_lpdf";
   check_consistent_sizes(function, "Random variable", y,
                          "First shape parameter", alpha,

--- a/stan/math/prim/prob/beta_lpdf.hpp
+++ b/stan/math/prim/prob/beta_lpdf.hpp
@@ -47,9 +47,9 @@ template <bool propto, typename T_y, typename T_scale_succ,
 return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
     const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_scale_succ>;
-  using T_beta_ref = ref_type_if_not_const_t<T_scale_fail>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_scale_succ>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_scale_fail>;
   static const char* function = "beta_lpdf";
   check_consistent_sizes(function, "Random variable", y,
                          "First shape parameter", alpha,

--- a/stan/math/prim/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lpdf.hpp
@@ -53,9 +53,9 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
                                                        const T_prec& kappa) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_prec>;
   using std::log;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_kappa_ref = ref_type_if_t<!is_constant<T_prec>::value, T_prec>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_kappa_ref = ref_type_if_not_const_t<T_prec>;
   static const char* function = "beta_proportion_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Precision parameter", kappa);

--- a/stan/math/prim/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lpdf.hpp
@@ -53,9 +53,9 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
                                                        const T_prec& kappa) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_prec>;
   using std::log;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_kappa_ref = ref_type_if_not_const_t<T_prec>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_kappa_ref = ref_type_if_not_constant_t<T_prec>;
   static const char* function = "beta_proportion_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Precision parameter", kappa);

--- a/stan/math/prim/prob/binomial_logit_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_lpmf.hpp
@@ -37,9 +37,9 @@ template <bool propto, typename T_n, typename T_N, typename T_prob,
 return_type_t<T_prob> binomial_logit_lpmf(const T_n& n, const T_N& N,
                                           const T_prob& alpha) {
   using T_partials_return = partials_return_t<T_n, T_N, T_prob>;
-  using T_n_ref = ref_type_if_t<!is_constant<T_n>::value, T_n>;
-  using T_N_ref = ref_type_if_t<!is_constant<T_N>::value, T_N>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_prob>::value, T_prob>;
+  using T_n_ref = ref_type_if_not_const_t<T_n>;
+  using T_N_ref = ref_type_if_not_const_t<T_N>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_prob>;
   static const char* function = "binomial_logit_lpmf";
   check_consistent_sizes(function, "Successes variable", n,
                          "Population size parameter", N,

--- a/stan/math/prim/prob/binomial_logit_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_lpmf.hpp
@@ -37,9 +37,9 @@ template <bool propto, typename T_n, typename T_N, typename T_prob,
 return_type_t<T_prob> binomial_logit_lpmf(const T_n& n, const T_N& N,
                                           const T_prob& alpha) {
   using T_partials_return = partials_return_t<T_n, T_N, T_prob>;
-  using T_n_ref = ref_type_if_not_const_t<T_n>;
-  using T_N_ref = ref_type_if_not_const_t<T_N>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_prob>;
+  using T_n_ref = ref_type_if_not_constant_t<T_n>;
+  using T_N_ref = ref_type_if_not_constant_t<T_N>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_prob>;
   static const char* function = "binomial_logit_lpmf";
   check_consistent_sizes(function, "Successes variable", n,
                          "Population size parameter", N,

--- a/stan/math/prim/prob/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_logit_glm_lpmf.hpp
@@ -54,9 +54,9 @@ return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_lpmf(
   using std::isfinite;
   using std::log;
   using T_y_ref = ref_type_t<T_y>;
-  using T_x_ref = ref_type_if_not_const_t<T_x>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_alpha>;
-  using T_beta_ref = ref_type_if_not_const_t<T_beta>;
+  using T_x_ref = ref_type_if_not_constant_t<T_x>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_alpha>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_beta>;
   using T_beta_partials = partials_type_t<scalar_type_t<T_beta>>;
   constexpr int T_x_rows = T_x::RowsAtCompileTime;
 

--- a/stan/math/prim/prob/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_logit_glm_lpmf.hpp
@@ -54,9 +54,9 @@ return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_lpmf(
   using std::isfinite;
   using std::log;
   using T_y_ref = ref_type_t<T_y>;
-  using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
+  using T_x_ref = ref_type_if_not_const_t<T_x>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_alpha>;
+  using T_beta_ref = ref_type_if_not_const_t<T_beta>;
   using T_beta_partials = partials_type_t<scalar_type_t<T_beta>>;
   constexpr int T_x_rows = T_x::RowsAtCompileTime;
 

--- a/stan/math/prim/prob/cauchy_lpdf.hpp
+++ b/stan/math/prim/prob/cauchy_lpdf.hpp
@@ -44,9 +44,9 @@ return_type_t<T_y, T_loc, T_scale> cauchy_lpdf(const T_y& y, const T_loc& mu,
                                                const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
   using std::log;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "cauchy_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);

--- a/stan/math/prim/prob/cauchy_lpdf.hpp
+++ b/stan/math/prim/prob/cauchy_lpdf.hpp
@@ -44,9 +44,9 @@ return_type_t<T_y, T_loc, T_scale> cauchy_lpdf(const T_y& y, const T_loc& mu,
                                                const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
   using std::log;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "cauchy_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);

--- a/stan/math/prim/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/prob/double_exponential_cdf.hpp
@@ -45,9 +45,9 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_cdf(
                                || is_vector<T_scale>::value,
                            T_partials_array, T_partials_return>;
   using std::exp;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "double_exponential_cdf";
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;

--- a/stan/math/prim/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/prob/double_exponential_cdf.hpp
@@ -45,9 +45,9 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_cdf(
                                || is_vector<T_scale>::value,
                            T_partials_array, T_partials_return>;
   using std::exp;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "double_exponential_cdf";
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;

--- a/stan/math/prim/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lpdf.hpp
@@ -42,9 +42,9 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "double_exponential_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Shape parameter", sigma);

--- a/stan/math/prim/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lpdf.hpp
@@ -42,9 +42,9 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "double_exponential_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Shape parameter", sigma);

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -31,11 +31,11 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   using T_lambda_ref
-      = ref_type_if_t<!is_constant<T_inv_scale>::value, T_inv_scale>;
+      = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exp_mod_normal_cdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Inv_scale paramter",

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -34,8 +34,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
   using T_y_ref = ref_type_if_not_const_t<T_y>;
   using T_mu_ref = ref_type_if_not_const_t<T_loc>;
   using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_lambda_ref
-      = ref_type_if_not_const_t<T_inv_scale>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exp_mod_normal_cdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Inv_scale paramter",

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -31,10 +31,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_inv_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static const char* function = "exp_mod_normal_cdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Inv_scale paramter",

--- a/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
@@ -32,10 +32,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_inv_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static const char* function = "exp_mod_normal_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Inv_scale paramter",

--- a/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
@@ -35,8 +35,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
   using T_y_ref = ref_type_if_not_const_t<T_y>;
   using T_mu_ref = ref_type_if_not_const_t<T_loc>;
   using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_lambda_ref
-      = ref_type_if_not_const_t<T_inv_scale>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exp_mod_normal_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Inv_scale paramter",

--- a/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
@@ -32,11 +32,11 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   using T_lambda_ref
-      = ref_type_if_t<!is_constant<T_inv_scale>::value, T_inv_scale>;
+      = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exp_mod_normal_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Inv_scale paramter",

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -32,11 +32,11 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   using T_lambda_ref
-      = ref_type_if_t<!is_constant<T_inv_scale>::value, T_inv_scale>;
+      = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exp_mod_normal_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Inv_scale paramter",

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -32,10 +32,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_inv_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static const char* function = "exp_mod_normal_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Inv_scale paramter",

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -35,8 +35,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
   using T_y_ref = ref_type_if_not_const_t<T_y>;
   using T_mu_ref = ref_type_if_not_const_t<T_loc>;
   using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_lambda_ref
-      = ref_type_if_not_const_t<T_inv_scale>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exp_mod_normal_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Inv_scale paramter",

--- a/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
@@ -30,11 +30,11 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   using T_lambda_ref
-      = ref_type_if_t<!is_constant<T_inv_scale>::value, T_inv_scale>;
+      = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exp_mod_normal_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Inv_scale paramter",

--- a/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
@@ -33,8 +33,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
   using T_y_ref = ref_type_if_not_const_t<T_y>;
   using T_mu_ref = ref_type_if_not_const_t<T_loc>;
   using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_lambda_ref
-      = ref_type_if_not_const_t<T_inv_scale>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exp_mod_normal_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Inv_scale paramter",

--- a/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
@@ -30,10 +30,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_inv_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static const char* function = "exp_mod_normal_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Inv_scale paramter",

--- a/stan/math/prim/prob/exponential_cdf.hpp
+++ b/stan/math/prim/prob/exponential_cdf.hpp
@@ -36,9 +36,9 @@ return_type_t<T_y, T_inv_scale> exponential_cdf(const T_y& y,
                                                 const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
   using T_beta_ref
-      = ref_type_if_t<!is_constant<T_inv_scale>::value, T_inv_scale>;
+      = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exponential_cdf";
   T_y_ref y_ref = y;
   T_beta_ref beta_ref = beta;

--- a/stan/math/prim/prob/exponential_cdf.hpp
+++ b/stan/math/prim/prob/exponential_cdf.hpp
@@ -36,8 +36,8 @@ return_type_t<T_y, T_inv_scale> exponential_cdf(const T_y& y,
                                                 const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_beta_ref = ref_type_if_not_const_t<T_inv_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static const char* function = "exponential_cdf";
   T_y_ref y_ref = y;
   T_beta_ref beta_ref = beta;

--- a/stan/math/prim/prob/exponential_cdf.hpp
+++ b/stan/math/prim/prob/exponential_cdf.hpp
@@ -37,8 +37,7 @@ return_type_t<T_y, T_inv_scale> exponential_cdf(const T_y& y,
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_beta_ref
-      = ref_type_if_not_const_t<T_inv_scale>;
+  using T_beta_ref = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exponential_cdf";
   T_y_ref y_ref = y;
   T_beta_ref beta_ref = beta;

--- a/stan/math/prim/prob/exponential_lccdf.hpp
+++ b/stan/math/prim/prob/exponential_lccdf.hpp
@@ -21,8 +21,8 @@ return_type_t<T_y, T_inv_scale> exponential_lccdf(const T_y& y,
                                                   const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_beta_ref = ref_type_if_not_const_t<T_inv_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static const char* function = "exponential_lccdf";
   T_y_ref y_ref = y;
   T_beta_ref beta_ref = beta;

--- a/stan/math/prim/prob/exponential_lccdf.hpp
+++ b/stan/math/prim/prob/exponential_lccdf.hpp
@@ -21,9 +21,9 @@ return_type_t<T_y, T_inv_scale> exponential_lccdf(const T_y& y,
                                                   const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
   using T_beta_ref
-      = ref_type_if_t<!is_constant<T_inv_scale>::value, T_inv_scale>;
+      = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exponential_lccdf";
   T_y_ref y_ref = y;
   T_beta_ref beta_ref = beta;

--- a/stan/math/prim/prob/exponential_lccdf.hpp
+++ b/stan/math/prim/prob/exponential_lccdf.hpp
@@ -22,8 +22,7 @@ return_type_t<T_y, T_inv_scale> exponential_lccdf(const T_y& y,
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_beta_ref
-      = ref_type_if_not_const_t<T_inv_scale>;
+  using T_beta_ref = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exponential_lccdf";
   T_y_ref y_ref = y;
   T_beta_ref beta_ref = beta;

--- a/stan/math/prim/prob/exponential_lcdf.hpp
+++ b/stan/math/prim/prob/exponential_lcdf.hpp
@@ -24,8 +24,8 @@ template <typename T_y, typename T_inv_scale,
 return_type_t<T_y, T_inv_scale> exponential_lcdf(const T_y& y,
                                                  const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_beta_ref = ref_type_if_not_const_t<T_inv_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static const char* function = "exponential_lcdf";
   T_y_ref y_ref = y;
   T_beta_ref beta_ref = beta;

--- a/stan/math/prim/prob/exponential_lcdf.hpp
+++ b/stan/math/prim/prob/exponential_lcdf.hpp
@@ -24,9 +24,9 @@ template <typename T_y, typename T_inv_scale,
 return_type_t<T_y, T_inv_scale> exponential_lcdf(const T_y& y,
                                                  const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
   using T_beta_ref
-      = ref_type_if_t<!is_constant<T_inv_scale>::value, T_inv_scale>;
+      = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exponential_lcdf";
   T_y_ref y_ref = y;
   T_beta_ref beta_ref = beta;

--- a/stan/math/prim/prob/exponential_lcdf.hpp
+++ b/stan/math/prim/prob/exponential_lcdf.hpp
@@ -25,8 +25,7 @@ return_type_t<T_y, T_inv_scale> exponential_lcdf(const T_y& y,
                                                  const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
   using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_beta_ref
-      = ref_type_if_not_const_t<T_inv_scale>;
+  using T_beta_ref = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exponential_lcdf";
   T_y_ref y_ref = y;
   T_beta_ref beta_ref = beta;

--- a/stan/math/prim/prob/exponential_lpdf.hpp
+++ b/stan/math/prim/prob/exponential_lpdf.hpp
@@ -53,8 +53,8 @@ return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
                                                  const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_beta_ref = ref_type_if_not_const_t<T_inv_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static const char* function = "exponential_lpdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Inverse scale parameter", beta);

--- a/stan/math/prim/prob/exponential_lpdf.hpp
+++ b/stan/math/prim/prob/exponential_lpdf.hpp
@@ -53,9 +53,9 @@ return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
                                                  const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
   using T_beta_ref
-      = ref_type_if_t<!is_constant<T_inv_scale>::value, T_inv_scale>;
+      = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exponential_lpdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Inverse scale parameter", beta);

--- a/stan/math/prim/prob/exponential_lpdf.hpp
+++ b/stan/math/prim/prob/exponential_lpdf.hpp
@@ -54,8 +54,7 @@ return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_beta_ref
-      = ref_type_if_not_const_t<T_inv_scale>;
+  using T_beta_ref = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "exponential_lpdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Inverse scale parameter", beta);

--- a/stan/math/prim/prob/gamma_lpdf.hpp
+++ b/stan/math/prim/prob/gamma_lpdf.hpp
@@ -55,8 +55,7 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
   using T_partials_return = partials_return_t<T_y, T_shape, T_inv_scale>;
   using T_y_ref = ref_type_if_not_const_t<T_y>;
   using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
-  using T_beta_ref
-      = ref_type_if_not_const_t<T_inv_scale>;
+  using T_beta_ref = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "gamma_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Inverse scale parameter", beta);

--- a/stan/math/prim/prob/gamma_lpdf.hpp
+++ b/stan/math/prim/prob/gamma_lpdf.hpp
@@ -53,10 +53,10 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
                                                     const T_shape& alpha,
                                                     const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_inv_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
   using T_beta_ref
-      = ref_type_if_t<!is_constant<T_inv_scale>::value, T_inv_scale>;
+      = ref_type_if_not_const_t<T_inv_scale>;
   static const char* function = "gamma_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Inverse scale parameter", beta);

--- a/stan/math/prim/prob/gamma_lpdf.hpp
+++ b/stan/math/prim/prob/gamma_lpdf.hpp
@@ -53,9 +53,9 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
                                                     const T_shape& alpha,
                                                     const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_inv_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
-  using T_beta_ref = ref_type_if_not_const_t<T_inv_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static const char* function = "gamma_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Inverse scale parameter", beta);

--- a/stan/math/prim/prob/gumbel_cdf.hpp
+++ b/stan/math/prim/prob/gumbel_cdf.hpp
@@ -40,9 +40,9 @@ return_type_t<T_y, T_loc, T_scale> gumbel_cdf(const T_y& y, const T_loc& mu,
                                               const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_beta_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "gumbel_cdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", beta);

--- a/stan/math/prim/prob/gumbel_cdf.hpp
+++ b/stan/math/prim/prob/gumbel_cdf.hpp
@@ -40,9 +40,9 @@ return_type_t<T_y, T_loc, T_scale> gumbel_cdf(const T_y& y, const T_loc& mu,
                                               const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
   using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_beta_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "gumbel_cdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", beta);

--- a/stan/math/prim/prob/gumbel_lccdf.hpp
+++ b/stan/math/prim/prob/gumbel_lccdf.hpp
@@ -39,9 +39,9 @@ template <typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> gumbel_lccdf(const T_y& y, const T_loc& mu,
                                                 const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_beta_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "gumbel_lccdf";
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;

--- a/stan/math/prim/prob/gumbel_lccdf.hpp
+++ b/stan/math/prim/prob/gumbel_lccdf.hpp
@@ -39,9 +39,9 @@ template <typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> gumbel_lccdf(const T_y& y, const T_loc& mu,
                                                 const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_beta_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "gumbel_lccdf";
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;

--- a/stan/math/prim/prob/gumbel_lcdf.hpp
+++ b/stan/math/prim/prob/gumbel_lcdf.hpp
@@ -38,9 +38,9 @@ template <typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> gumbel_lcdf(const T_y& y, const T_loc& mu,
                                                const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_beta_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "gumbel_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", beta);

--- a/stan/math/prim/prob/gumbel_lcdf.hpp
+++ b/stan/math/prim/prob/gumbel_lcdf.hpp
@@ -38,9 +38,9 @@ template <typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> gumbel_lcdf(const T_y& y, const T_loc& mu,
                                                const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_beta_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "gumbel_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", beta);

--- a/stan/math/prim/prob/gumbel_lpdf.hpp
+++ b/stan/math/prim/prob/gumbel_lpdf.hpp
@@ -40,9 +40,9 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> gumbel_lpdf(const T_y& y, const T_loc& mu,
                                                const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_beta_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "gumbel_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", beta);

--- a/stan/math/prim/prob/gumbel_lpdf.hpp
+++ b/stan/math/prim/prob/gumbel_lpdf.hpp
@@ -40,9 +40,9 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> gumbel_lpdf(const T_y& y, const T_loc& mu,
                                                const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_beta_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "gumbel_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", beta);

--- a/stan/math/prim/prob/hmm_marginal.hpp
+++ b/stan/math/prim/prob/hmm_marginal.hpp
@@ -79,9 +79,9 @@ inline auto hmm_marginal(const T_omega& log_omegas, const T_Gamma& Gamma,
   using eig_matrix_partial
       = Eigen::Matrix<T_partial_type, Eigen::Dynamic, Eigen::Dynamic>;
   using eig_vector_partial = Eigen::Matrix<T_partial_type, Eigen::Dynamic, 1>;
-  using T_omega_ref = ref_type_if_t<!is_constant<T_omega>::value, T_omega>;
-  using T_Gamma_ref = ref_type_if_t<!is_constant<T_Gamma>::value, T_Gamma>;
-  using T_rho_ref = ref_type_if_t<!is_constant<T_rho>::value, T_rho>;
+  using T_omega_ref = ref_type_if_not_const_t<T_omega>;
+  using T_Gamma_ref = ref_type_if_not_const_t<T_Gamma>;
+  using T_rho_ref = ref_type_if_not_const_t<T_rho>;
   int n_states = log_omegas.rows();
   int n_transitions = log_omegas.cols() - 1;
 

--- a/stan/math/prim/prob/hmm_marginal.hpp
+++ b/stan/math/prim/prob/hmm_marginal.hpp
@@ -79,9 +79,9 @@ inline auto hmm_marginal(const T_omega& log_omegas, const T_Gamma& Gamma,
   using eig_matrix_partial
       = Eigen::Matrix<T_partial_type, Eigen::Dynamic, Eigen::Dynamic>;
   using eig_vector_partial = Eigen::Matrix<T_partial_type, Eigen::Dynamic, 1>;
-  using T_omega_ref = ref_type_if_not_const_t<T_omega>;
-  using T_Gamma_ref = ref_type_if_not_const_t<T_Gamma>;
-  using T_rho_ref = ref_type_if_not_const_t<T_rho>;
+  using T_omega_ref = ref_type_if_not_constant_t<T_omega>;
+  using T_Gamma_ref = ref_type_if_not_constant_t<T_Gamma>;
+  using T_rho_ref = ref_type_if_not_constant_t<T_rho>;
   int n_states = log_omegas.rows();
   int n_transitions = log_omegas.cols() - 1;
 

--- a/stan/math/prim/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/inv_chi_square_lpdf.hpp
@@ -48,8 +48,8 @@ template <bool propto, typename T_y, typename T_dof,
               T_y, T_dof>* = nullptr>
 return_type_t<T_y, T_dof> inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_nu_ref = ref_type_if_not_const_t<T_dof>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_nu_ref = ref_type_if_not_constant_t<T_dof>;
   static const char* function = "inv_chi_square_lpdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);

--- a/stan/math/prim/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/inv_chi_square_lpdf.hpp
@@ -48,8 +48,8 @@ template <bool propto, typename T_y, typename T_dof,
               T_y, T_dof>* = nullptr>
 return_type_t<T_y, T_dof> inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_nu_ref = ref_type_if_t<!is_constant<T_dof>::value, T_dof>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_nu_ref = ref_type_if_not_const_t<T_dof>;
   static const char* function = "inv_chi_square_lpdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);

--- a/stan/math/prim/prob/inv_gamma_lpdf.hpp
+++ b/stan/math/prim/prob/inv_gamma_lpdf.hpp
@@ -45,9 +45,9 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lpdf(const T_y& y,
                                                     const T_shape& alpha,
                                                     const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_beta_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "inv_gamma_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Scale parameter", beta);

--- a/stan/math/prim/prob/inv_gamma_lpdf.hpp
+++ b/stan/math/prim/prob/inv_gamma_lpdf.hpp
@@ -45,9 +45,9 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lpdf(const T_y& y,
                                                     const T_shape& alpha,
                                                     const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
-  using T_beta_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "inv_gamma_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Scale parameter", beta);

--- a/stan/math/prim/prob/logistic_lpdf.hpp
+++ b/stan/math/prim/prob/logistic_lpdf.hpp
@@ -28,9 +28,9 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> logistic_lpdf(const T_y& y, const T_loc& mu,
                                                  const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "logistic_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);

--- a/stan/math/prim/prob/logistic_lpdf.hpp
+++ b/stan/math/prim/prob/logistic_lpdf.hpp
@@ -28,9 +28,9 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> logistic_lpdf(const T_y& y, const T_loc& mu,
                                                  const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "logistic_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);

--- a/stan/math/prim/prob/loglogistic_lpdf.hpp
+++ b/stan/math/prim/prob/loglogistic_lpdf.hpp
@@ -46,9 +46,9 @@ return_type_t<T_y, T_scale, T_shape> loglogistic_lpdf(const T_y& y,
                                                       const T_scale& alpha,
                                                       const T_shape& beta) {
   using T_partials_return = partials_return_t<T_y, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_scale_ref = ref_type_if_not_const_t<T_scale>;
-  using T_shape_ref = ref_type_if_not_const_t<T_shape>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_scale_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_shape_ref = ref_type_if_not_constant_t<T_shape>;
   using std::pow;
   static const char* function = "loglogistic_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",

--- a/stan/math/prim/prob/loglogistic_lpdf.hpp
+++ b/stan/math/prim/prob/loglogistic_lpdf.hpp
@@ -46,9 +46,9 @@ return_type_t<T_y, T_scale, T_shape> loglogistic_lpdf(const T_y& y,
                                                       const T_scale& alpha,
                                                       const T_shape& beta) {
   using T_partials_return = partials_return_t<T_y, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_scale_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_shape_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_scale_ref = ref_type_if_not_const_t<T_scale>;
+  using T_shape_ref = ref_type_if_not_const_t<T_shape>;
   using std::pow;
   static const char* function = "loglogistic_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",

--- a/stan/math/prim/prob/lognormal_cdf.hpp
+++ b/stan/math/prim/prob/lognormal_cdf.hpp
@@ -28,9 +28,9 @@ template <typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> lognormal_cdf(const T_y& y, const T_loc& mu,
                                                  const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "lognormal_cdf";
 
   T_y_ref y_ref = y;

--- a/stan/math/prim/prob/lognormal_cdf.hpp
+++ b/stan/math/prim/prob/lognormal_cdf.hpp
@@ -28,9 +28,9 @@ template <typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> lognormal_cdf(const T_y& y, const T_loc& mu,
                                                  const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "lognormal_cdf";
 
   T_y_ref y_ref = y;

--- a/stan/math/prim/prob/lognormal_lccdf.hpp
+++ b/stan/math/prim/prob/lognormal_lccdf.hpp
@@ -29,9 +29,9 @@ return_type_t<T_y, T_loc, T_scale> lognormal_lccdf(const T_y& y,
                                                    const T_loc& mu,
                                                    const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "lognormal_lccdf";
 
   T_y_ref y_ref = y;

--- a/stan/math/prim/prob/lognormal_lccdf.hpp
+++ b/stan/math/prim/prob/lognormal_lccdf.hpp
@@ -29,9 +29,9 @@ return_type_t<T_y, T_loc, T_scale> lognormal_lccdf(const T_y& y,
                                                    const T_loc& mu,
                                                    const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "lognormal_lccdf";
 
   T_y_ref y_ref = y;

--- a/stan/math/prim/prob/lognormal_lcdf.hpp
+++ b/stan/math/prim/prob/lognormal_lcdf.hpp
@@ -28,9 +28,9 @@ template <typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> lognormal_lcdf(const T_y& y, const T_loc& mu,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "lognormal_lcdf";
 
   T_y_ref y_ref = y;

--- a/stan/math/prim/prob/lognormal_lcdf.hpp
+++ b/stan/math/prim/prob/lognormal_lcdf.hpp
@@ -28,9 +28,9 @@ template <typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> lognormal_lcdf(const T_y& y, const T_loc& mu,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "lognormal_lcdf";
 
   T_y_ref y_ref = y;

--- a/stan/math/prim/prob/lognormal_lpdf.hpp
+++ b/stan/math/prim/prob/lognormal_lpdf.hpp
@@ -28,9 +28,9 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> lognormal_lpdf(const T_y& y, const T_loc& mu,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "lognormal_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);

--- a/stan/math/prim/prob/lognormal_lpdf.hpp
+++ b/stan/math/prim/prob/lognormal_lpdf.hpp
@@ -28,9 +28,9 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> lognormal_lpdf(const T_y& y, const T_loc& mu,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "lognormal_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);

--- a/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -90,11 +90,11 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   using T_xbeta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_xbeta_partials,
                                   Array<T_xbeta_partials, Dynamic, 1>>;
-  using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
+  using T_x_ref = ref_type_if_not_const_t<T_x>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_alpha>;
+  using T_beta_ref = ref_type_if_not_const_t<T_beta>;
   using T_phi_ref
-      = ref_type_if_t<!is_constant<T_precision>::value, T_precision>;
+      = ref_type_if_not_const_t<T_precision>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -93,8 +93,7 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   using T_x_ref = ref_type_if_not_const_t<T_x>;
   using T_alpha_ref = ref_type_if_not_const_t<T_alpha>;
   using T_beta_ref = ref_type_if_not_const_t<T_beta>;
-  using T_phi_ref
-      = ref_type_if_not_const_t<T_precision>;
+  using T_phi_ref = ref_type_if_not_const_t<T_precision>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -90,10 +90,10 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   using T_xbeta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_xbeta_partials,
                                   Array<T_xbeta_partials, Dynamic, 1>>;
-  using T_x_ref = ref_type_if_not_const_t<T_x>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_alpha>;
-  using T_beta_ref = ref_type_if_not_const_t<T_beta>;
-  using T_phi_ref = ref_type_if_not_const_t<T_precision>;
+  using T_x_ref = ref_type_if_not_constant_t<T_x>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_alpha>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_beta>;
+  using T_phi_ref = ref_type_if_not_constant_t<T_precision>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/prob/normal_id_glm_lpdf.hpp
@@ -71,11 +71,11 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   using T_y_scaled_tmp =
       typename std::conditional_t<T_x_rows == 1, T_partials_return,
                                   Array<T_partials_return, Dynamic, 1>>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_x_ref = ref_type_if_not_const_t<T_x>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_alpha>;
+  using T_beta_ref = ref_type_if_not_const_t<T_beta>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/prob/normal_id_glm_lpdf.hpp
@@ -71,11 +71,11 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   using T_y_scaled_tmp =
       typename std::conditional_t<T_x_rows == 1, T_partials_return,
                                   Array<T_partials_return, Dynamic, 1>>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_x_ref = ref_type_if_not_const_t<T_x>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_alpha>;
-  using T_beta_ref = ref_type_if_not_const_t<T_beta>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_x_ref = ref_type_if_not_constant_t<T_x>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_alpha>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_beta>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/normal_lpdf.hpp
+++ b/stan/math/prim/prob/normal_lpdf.hpp
@@ -45,9 +45,9 @@ inline return_type_t<T_y, T_loc, T_scale> normal_lpdf(const T_y& y,
                                                       const T_loc& mu,
                                                       const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "normal_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);

--- a/stan/math/prim/prob/normal_lpdf.hpp
+++ b/stan/math/prim/prob/normal_lpdf.hpp
@@ -45,9 +45,9 @@ inline return_type_t<T_y, T_loc, T_scale> normal_lpdf(const T_y& y,
                                                       const T_loc& mu,
                                                       const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "normal_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);

--- a/stan/math/prim/prob/normal_sufficient_lpdf.hpp
+++ b/stan/math/prim/prob/normal_sufficient_lpdf.hpp
@@ -55,11 +55,11 @@ return_type_t<T_y, T_s, T_loc, T_scale> normal_sufficient_lpdf(
     const T_y& y_bar, const T_s& s_squared, const T_n& n_obs, const T_loc& mu,
     const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_s, T_n, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_s_ref = ref_type_if_t<!is_constant<T_s>::value, T_s>;
-  using T_n_ref = ref_type_if_t<!is_constant<T_n>::value, T_n>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_s_ref = ref_type_if_not_const_t<T_s>;
+  using T_n_ref = ref_type_if_not_const_t<T_n>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "normal_sufficient_lpdf";
   check_consistent_sizes(function, "Location parameter sufficient statistic",
                          y_bar, "Scale parameter sufficient statistic",

--- a/stan/math/prim/prob/normal_sufficient_lpdf.hpp
+++ b/stan/math/prim/prob/normal_sufficient_lpdf.hpp
@@ -55,11 +55,11 @@ return_type_t<T_y, T_s, T_loc, T_scale> normal_sufficient_lpdf(
     const T_y& y_bar, const T_s& s_squared, const T_n& n_obs, const T_loc& mu,
     const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_s, T_n, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_s_ref = ref_type_if_not_const_t<T_s>;
-  using T_n_ref = ref_type_if_not_const_t<T_n>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_s_ref = ref_type_if_not_constant_t<T_s>;
+  using T_n_ref = ref_type_if_not_constant_t<T_n>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "normal_sufficient_lpdf";
   check_consistent_sizes(function, "Location parameter sufficient statistic",
                          y_bar, "Scale parameter sufficient statistic",

--- a/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
@@ -63,9 +63,9 @@ return_type_t<T_x, T_beta, T_cuts> ordered_logistic_glm_lpmf(
       Eigen::Matrix<T_xbeta_partials, Eigen::Dynamic, 1>>
       T_location;
   using T_y_ref = ref_type_t<T_y>;
-  using T_x_ref = ref_type_if_not_const_t<T_x>;
-  using T_beta_ref = ref_type_if_not_const_t<T_beta>;
-  using T_cuts_ref = ref_type_if_not_const_t<T_cuts>;
+  using T_x_ref = ref_type_if_not_constant_t<T_x>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_beta>;
+  using T_cuts_ref = ref_type_if_not_constant_t<T_cuts>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
@@ -63,9 +63,9 @@ return_type_t<T_x, T_beta, T_cuts> ordered_logistic_glm_lpmf(
       Eigen::Matrix<T_xbeta_partials, Eigen::Dynamic, 1>>
       T_location;
   using T_y_ref = ref_type_t<T_y>;
-  using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
-  using T_cuts_ref = ref_type_if_t<!is_constant<T_cuts>::value, T_cuts>;
+  using T_x_ref = ref_type_if_not_const_t<T_x>;
+  using T_beta_ref = ref_type_if_not_const_t<T_beta>;
+  using T_cuts_ref = ref_type_if_not_const_t<T_cuts>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/ordered_logistic_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_lpmf.hpp
@@ -78,8 +78,8 @@ return_type_t<T_loc, T_cut> ordered_logistic_lpmf(const T_y& y,
   using T_partials_return = partials_return_t<T_loc, T_cut>;
   using T_cuts_val = partials_return_t<T_cut>;
   using T_y_ref = ref_type_t<T_y>;
-  using T_lambda_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_cut_ref = ref_type_if_t<!is_constant<T_cut>::value, T_cut>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_loc>;
+  using T_cut_ref = ref_type_if_not_const_t<T_cut>;
   using Eigen::Array;
   using Eigen::Dynamic;
   static const char* function = "ordered_logistic";

--- a/stan/math/prim/prob/ordered_logistic_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_lpmf.hpp
@@ -78,8 +78,8 @@ return_type_t<T_loc, T_cut> ordered_logistic_lpmf(const T_y& y,
   using T_partials_return = partials_return_t<T_loc, T_cut>;
   using T_cuts_val = partials_return_t<T_cut>;
   using T_y_ref = ref_type_t<T_y>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_loc>;
-  using T_cut_ref = ref_type_if_not_const_t<T_cut>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_cut_ref = ref_type_if_not_constant_t<T_cut>;
   using Eigen::Array;
   using Eigen::Dynamic;
   static const char* function = "ordered_logistic";

--- a/stan/math/prim/prob/pareto_lccdf.hpp
+++ b/stan/math/prim/prob/pareto_lccdf.hpp
@@ -28,9 +28,9 @@ return_type_t<T_y, T_scale, T_shape> pareto_lccdf(const T_y& y,
                                                   const T_scale& y_min,
                                                   const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_y_min_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_y_min_ref = ref_type_if_not_const_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
   using std::isinf;
   static const char* function = "pareto_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",

--- a/stan/math/prim/prob/pareto_lccdf.hpp
+++ b/stan/math/prim/prob/pareto_lccdf.hpp
@@ -28,9 +28,9 @@ return_type_t<T_y, T_scale, T_shape> pareto_lccdf(const T_y& y,
                                                   const T_scale& y_min,
                                                   const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_y_min_ref = ref_type_if_not_const_t<T_scale>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_y_min_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   using std::isinf;
   static const char* function = "pareto_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",

--- a/stan/math/prim/prob/pareto_lcdf.hpp
+++ b/stan/math/prim/prob/pareto_lcdf.hpp
@@ -28,9 +28,9 @@ return_type_t<T_y, T_scale, T_shape> pareto_lcdf(const T_y& y,
                                                  const T_scale& y_min,
                                                  const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_y_min_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_y_min_ref = ref_type_if_not_const_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
   using std::isinf;
   static const char* function = "pareto_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",

--- a/stan/math/prim/prob/pareto_lcdf.hpp
+++ b/stan/math/prim/prob/pareto_lcdf.hpp
@@ -28,9 +28,9 @@ return_type_t<T_y, T_scale, T_shape> pareto_lcdf(const T_y& y,
                                                  const T_scale& y_min,
                                                  const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_y_min_ref = ref_type_if_not_const_t<T_scale>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_y_min_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   using std::isinf;
   static const char* function = "pareto_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",

--- a/stan/math/prim/prob/pareto_lpdf.hpp
+++ b/stan/math/prim/prob/pareto_lpdf.hpp
@@ -28,9 +28,9 @@ return_type_t<T_y, T_scale, T_shape> pareto_lpdf(const T_y& y,
                                                  const T_scale& y_min,
                                                  const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_y_min_ref = ref_type_if_not_const_t<T_scale>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_y_min_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static const char* function = "pareto_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          y_min, "Shape parameter", alpha);

--- a/stan/math/prim/prob/pareto_lpdf.hpp
+++ b/stan/math/prim/prob/pareto_lpdf.hpp
@@ -28,9 +28,9 @@ return_type_t<T_y, T_scale, T_shape> pareto_lpdf(const T_y& y,
                                                  const T_scale& y_min,
                                                  const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_y_min_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_y_min_ref = ref_type_if_not_const_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
   static const char* function = "pareto_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          y_min, "Shape parameter", alpha);

--- a/stan/math/prim/prob/pareto_type_2_cdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_cdf.hpp
@@ -25,10 +25,10 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_cdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_scale>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   using std::pow;
   static const char* function = "pareto_type_2_cdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",

--- a/stan/math/prim/prob/pareto_type_2_cdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_cdf.hpp
@@ -25,10 +25,10 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_cdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_lambda_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
   using std::pow;
   static const char* function = "pareto_type_2_cdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",

--- a/stan/math/prim/prob/pareto_type_2_lccdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lccdf.hpp
@@ -25,10 +25,10 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_lambda_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
   static const char* function = "pareto_type_2_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", lambda, "Shape parameter",

--- a/stan/math/prim/prob/pareto_type_2_lccdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lccdf.hpp
@@ -25,10 +25,10 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_scale>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static const char* function = "pareto_type_2_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", lambda, "Shape parameter",

--- a/stan/math/prim/prob/pareto_type_2_lcdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lcdf.hpp
@@ -25,10 +25,10 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_lambda_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
   using std::pow;
   static const char* function = "pareto_type_2_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",

--- a/stan/math/prim/prob/pareto_type_2_lcdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lcdf.hpp
@@ -25,10 +25,10 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_scale>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   using std::pow;
   static const char* function = "pareto_type_2_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",

--- a/stan/math/prim/prob/pareto_type_2_lpdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lpdf.hpp
@@ -28,10 +28,10 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_lambda_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
   static const char* function = "pareto_type_2_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", lambda, "Shape parameter",

--- a/stan/math/prim/prob/pareto_type_2_lpdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lpdf.hpp
@@ -28,10 +28,10 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_scale>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static const char* function = "pareto_type_2_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", lambda, "Shape parameter",

--- a/stan/math/prim/prob/poisson_cdf.hpp
+++ b/stan/math/prim/prob/poisson_cdf.hpp
@@ -26,8 +26,8 @@ namespace math {
 template <typename T_n, typename T_rate>
 return_type_t<T_rate> poisson_cdf(const T_n& n, const T_rate& lambda) {
   using T_partials_return = partials_return_t<T_n, T_rate>;
-  using T_n_ref = ref_type_if_t<!is_constant<T_n>::value, T_n>;
-  using T_lambda_ref = ref_type_if_t<!is_constant<T_rate>::value, T_rate>;
+  using T_n_ref = ref_type_if_not_const_t<T_n>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_rate>;
   using std::pow;
   static const char* function = "poisson_cdf";
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",

--- a/stan/math/prim/prob/poisson_cdf.hpp
+++ b/stan/math/prim/prob/poisson_cdf.hpp
@@ -26,8 +26,8 @@ namespace math {
 template <typename T_n, typename T_rate>
 return_type_t<T_rate> poisson_cdf(const T_n& n, const T_rate& lambda) {
   using T_partials_return = partials_return_t<T_n, T_rate>;
-  using T_n_ref = ref_type_if_not_const_t<T_n>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_rate>;
+  using T_n_ref = ref_type_if_not_constant_t<T_n>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_rate>;
   using std::pow;
   static const char* function = "poisson_cdf";
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",

--- a/stan/math/prim/prob/poisson_lccdf.hpp
+++ b/stan/math/prim/prob/poisson_lccdf.hpp
@@ -27,8 +27,8 @@ namespace math {
 template <typename T_n, typename T_rate>
 return_type_t<T_rate> poisson_lccdf(const T_n& n, const T_rate& lambda) {
   using T_partials_return = partials_return_t<T_n, T_rate>;
-  using T_n_ref = ref_type_if_t<!is_constant<T_n>::value, T_n>;
-  using T_lambda_ref = ref_type_if_t<!is_constant<T_rate>::value, T_rate>;
+  using T_n_ref = ref_type_if_not_const_t<T_n>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_rate>;
   static const char* function = "poisson_lccdf";
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",
                          lambda);

--- a/stan/math/prim/prob/poisson_lccdf.hpp
+++ b/stan/math/prim/prob/poisson_lccdf.hpp
@@ -27,8 +27,8 @@ namespace math {
 template <typename T_n, typename T_rate>
 return_type_t<T_rate> poisson_lccdf(const T_n& n, const T_rate& lambda) {
   using T_partials_return = partials_return_t<T_n, T_rate>;
-  using T_n_ref = ref_type_if_not_const_t<T_n>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_rate>;
+  using T_n_ref = ref_type_if_not_constant_t<T_n>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_rate>;
   static const char* function = "poisson_lccdf";
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",
                          lambda);

--- a/stan/math/prim/prob/poisson_lcdf.hpp
+++ b/stan/math/prim/prob/poisson_lcdf.hpp
@@ -27,8 +27,8 @@ namespace math {
 template <typename T_n, typename T_rate>
 return_type_t<T_rate> poisson_lcdf(const T_n& n, const T_rate& lambda) {
   using T_partials_return = partials_return_t<T_n, T_rate>;
-  using T_n_ref = ref_type_if_not_const_t<T_n>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_rate>;
+  using T_n_ref = ref_type_if_not_constant_t<T_n>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_rate>;
   static const char* function = "poisson_lcdf";
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",
                          lambda);

--- a/stan/math/prim/prob/poisson_lcdf.hpp
+++ b/stan/math/prim/prob/poisson_lcdf.hpp
@@ -27,8 +27,8 @@ namespace math {
 template <typename T_n, typename T_rate>
 return_type_t<T_rate> poisson_lcdf(const T_n& n, const T_rate& lambda) {
   using T_partials_return = partials_return_t<T_n, T_rate>;
-  using T_n_ref = ref_type_if_t<!is_constant<T_n>::value, T_n>;
-  using T_lambda_ref = ref_type_if_t<!is_constant<T_rate>::value, T_rate>;
+  using T_n_ref = ref_type_if_not_const_t<T_n>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_rate>;
   static const char* function = "poisson_lcdf";
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",
                          lambda);

--- a/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
@@ -68,9 +68,9 @@ return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(const T_y& y,
   using T_xbeta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_xbeta_partials,
                                   Array<T_xbeta_partials, Dynamic, 1>>;
-  using T_x_ref = ref_type_if_not_const_t<T_x>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_alpha>;
-  using T_beta_ref = ref_type_if_not_const_t<T_beta>;
+  using T_x_ref = ref_type_if_not_constant_t<T_x>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_alpha>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_beta>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
@@ -68,9 +68,9 @@ return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(const T_y& y,
   using T_xbeta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_xbeta_partials,
                                   Array<T_xbeta_partials, Dynamic, 1>>;
-  using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
+  using T_x_ref = ref_type_if_not_const_t<T_x>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_alpha>;
+  using T_beta_ref = ref_type_if_not_const_t<T_beta>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/poisson_log_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_lpmf.hpp
@@ -29,9 +29,9 @@ template <bool propto, typename T_n, typename T_log_rate,
 return_type_t<T_log_rate> poisson_log_lpmf(const T_n& n,
                                            const T_log_rate& alpha) {
   using T_partials_return = partials_return_t<T_n, T_log_rate>;
-  using T_n_ref = ref_type_if_t<!is_constant<T_n>::value, T_n>;
+  using T_n_ref = ref_type_if_not_const_t<T_n>;
   using T_alpha_ref
-      = ref_type_if_t<!is_constant<T_log_rate>::value, T_log_rate>;
+      = ref_type_if_not_const_t<T_log_rate>;
   using std::isinf;
   static const char* function = "poisson_log_lpmf";
   check_consistent_sizes(function, "Random variable", n, "Log rate parameter",

--- a/stan/math/prim/prob/poisson_log_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_lpmf.hpp
@@ -30,8 +30,7 @@ return_type_t<T_log_rate> poisson_log_lpmf(const T_n& n,
                                            const T_log_rate& alpha) {
   using T_partials_return = partials_return_t<T_n, T_log_rate>;
   using T_n_ref = ref_type_if_not_const_t<T_n>;
-  using T_alpha_ref
-      = ref_type_if_not_const_t<T_log_rate>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_log_rate>;
   using std::isinf;
   static const char* function = "poisson_log_lpmf";
   check_consistent_sizes(function, "Random variable", n, "Log rate parameter",

--- a/stan/math/prim/prob/poisson_log_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_lpmf.hpp
@@ -29,8 +29,8 @@ template <bool propto, typename T_n, typename T_log_rate,
 return_type_t<T_log_rate> poisson_log_lpmf(const T_n& n,
                                            const T_log_rate& alpha) {
   using T_partials_return = partials_return_t<T_n, T_log_rate>;
-  using T_n_ref = ref_type_if_not_const_t<T_n>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_log_rate>;
+  using T_n_ref = ref_type_if_not_constant_t<T_n>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_log_rate>;
   using std::isinf;
   static const char* function = "poisson_log_lpmf";
   check_consistent_sizes(function, "Random variable", n, "Log rate parameter",

--- a/stan/math/prim/prob/poisson_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_lpmf.hpp
@@ -28,8 +28,8 @@ template <bool propto, typename T_n, typename T_rate,
               T_n, T_rate>* = nullptr>
 return_type_t<T_rate> poisson_lpmf(const T_n& n, const T_rate& lambda) {
   using T_partials_return = partials_return_t<T_n, T_rate>;
-  using T_n_ref = ref_type_if_t<!is_constant<T_n>::value, T_n>;
-  using T_lambda_ref = ref_type_if_t<!is_constant<T_rate>::value, T_rate>;
+  using T_n_ref = ref_type_if_not_const_t<T_n>;
+  using T_lambda_ref = ref_type_if_not_const_t<T_rate>;
   using std::isinf;
   static const char* function = "poisson_lpmf";
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",

--- a/stan/math/prim/prob/poisson_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_lpmf.hpp
@@ -28,8 +28,8 @@ template <bool propto, typename T_n, typename T_rate,
               T_n, T_rate>* = nullptr>
 return_type_t<T_rate> poisson_lpmf(const T_n& n, const T_rate& lambda) {
   using T_partials_return = partials_return_t<T_n, T_rate>;
-  using T_n_ref = ref_type_if_not_const_t<T_n>;
-  using T_lambda_ref = ref_type_if_not_const_t<T_rate>;
+  using T_n_ref = ref_type_if_not_constant_t<T_n>;
+  using T_lambda_ref = ref_type_if_not_constant_t<T_rate>;
   using std::isinf;
   static const char* function = "poisson_lpmf";
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",

--- a/stan/math/prim/prob/rayleigh_cdf.hpp
+++ b/stan/math/prim/prob/rayleigh_cdf.hpp
@@ -24,8 +24,8 @@ template <typename T_y, typename T_scale,
               T_y, T_scale>* = nullptr>
 return_type_t<T_y, T_scale> rayleigh_cdf(const T_y& y, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "rayleigh_cdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);

--- a/stan/math/prim/prob/rayleigh_cdf.hpp
+++ b/stan/math/prim/prob/rayleigh_cdf.hpp
@@ -24,8 +24,8 @@ template <typename T_y, typename T_scale,
               T_y, T_scale>* = nullptr>
 return_type_t<T_y, T_scale> rayleigh_cdf(const T_y& y, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "rayleigh_cdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);

--- a/stan/math/prim/prob/rayleigh_lccdf.hpp
+++ b/stan/math/prim/prob/rayleigh_lccdf.hpp
@@ -22,8 +22,8 @@ template <typename T_y, typename T_scale,
               T_y, T_scale>* = nullptr>
 return_type_t<T_y, T_scale> rayleigh_lccdf(const T_y& y, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "rayleigh_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);

--- a/stan/math/prim/prob/rayleigh_lccdf.hpp
+++ b/stan/math/prim/prob/rayleigh_lccdf.hpp
@@ -22,8 +22,8 @@ template <typename T_y, typename T_scale,
               T_y, T_scale>* = nullptr>
 return_type_t<T_y, T_scale> rayleigh_lccdf(const T_y& y, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "rayleigh_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);

--- a/stan/math/prim/prob/rayleigh_lcdf.hpp
+++ b/stan/math/prim/prob/rayleigh_lcdf.hpp
@@ -24,8 +24,8 @@ template <typename T_y, typename T_scale,
               T_y, T_scale>* = nullptr>
 return_type_t<T_y, T_scale> rayleigh_lcdf(const T_y& y, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "rayleigh_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);

--- a/stan/math/prim/prob/rayleigh_lcdf.hpp
+++ b/stan/math/prim/prob/rayleigh_lcdf.hpp
@@ -24,8 +24,8 @@ template <typename T_y, typename T_scale,
               T_y, T_scale>* = nullptr>
 return_type_t<T_y, T_scale> rayleigh_lcdf(const T_y& y, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "rayleigh_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);

--- a/stan/math/prim/prob/rayleigh_lpdf.hpp
+++ b/stan/math/prim/prob/rayleigh_lpdf.hpp
@@ -24,8 +24,8 @@ template <bool propto, typename T_y, typename T_scale,
               T_y, T_scale>* = nullptr>
 return_type_t<T_y, T_scale> rayleigh_lpdf(const T_y& y, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "rayleigh_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);

--- a/stan/math/prim/prob/rayleigh_lpdf.hpp
+++ b/stan/math/prim/prob/rayleigh_lpdf.hpp
@@ -24,8 +24,8 @@ template <bool propto, typename T_y, typename T_scale,
               T_y, T_scale>* = nullptr>
 return_type_t<T_y, T_scale> rayleigh_lpdf(const T_y& y, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "rayleigh_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);

--- a/stan/math/prim/prob/skew_double_exponential_lpdf.hpp
+++ b/stan/math/prim/prob/skew_double_exponential_lpdf.hpp
@@ -44,10 +44,10 @@ return_type_t<T_y, T_loc, T_scale, T_skewness> skew_double_exponential_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_skewness& tau) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_skewness>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_tau_ref = ref_type_if_t<!is_constant<T_skewness>::value, T_skewness>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_tau_ref = ref_type_if_not_const_t<T_skewness>;
   static const char* function = "skew_double_exponential_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Shape parameter", sigma, "Skewness parameter",

--- a/stan/math/prim/prob/skew_double_exponential_lpdf.hpp
+++ b/stan/math/prim/prob/skew_double_exponential_lpdf.hpp
@@ -44,10 +44,10 @@ return_type_t<T_y, T_loc, T_scale, T_skewness> skew_double_exponential_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_skewness& tau) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_skewness>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_tau_ref = ref_type_if_not_const_t<T_skewness>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_tau_ref = ref_type_if_not_constant_t<T_skewness>;
   static const char* function = "skew_double_exponential_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Shape parameter", sigma, "Skewness parameter",

--- a/stan/math/prim/prob/skew_normal_cdf.hpp
+++ b/stan/math/prim/prob/skew_normal_cdf.hpp
@@ -28,10 +28,10 @@ template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_cdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
   static const char* function = "skew_normal_cdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape paramter", alpha);

--- a/stan/math/prim/prob/skew_normal_cdf.hpp
+++ b/stan/math/prim/prob/skew_normal_cdf.hpp
@@ -28,10 +28,10 @@ template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_cdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static const char* function = "skew_normal_cdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape paramter", alpha);

--- a/stan/math/prim/prob/skew_normal_lccdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lccdf.hpp
@@ -26,10 +26,10 @@ template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static const char* function = "skew_normal_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape paramter", alpha);

--- a/stan/math/prim/prob/skew_normal_lccdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lccdf.hpp
@@ -26,10 +26,10 @@ template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
   static const char* function = "skew_normal_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape paramter", alpha);

--- a/stan/math/prim/prob/skew_normal_lcdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lcdf.hpp
@@ -28,10 +28,10 @@ template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
   static const char* function = "skew_normal_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape parameter",

--- a/stan/math/prim/prob/skew_normal_lcdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lcdf.hpp
@@ -28,10 +28,10 @@ template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static const char* function = "skew_normal_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape parameter",

--- a/stan/math/prim/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lpdf.hpp
@@ -29,10 +29,10 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static const char* function = "skew_normal_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape paramter", alpha);

--- a/stan/math/prim/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lpdf.hpp
@@ -29,10 +29,10 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
   static const char* function = "skew_normal_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape paramter", alpha);

--- a/stan/math/prim/prob/student_t_lpdf.hpp
+++ b/stan/math/prim/prob/student_t_lpdf.hpp
@@ -61,10 +61,10 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lpdf(const T_y& y,
                                                          const T_loc& mu,
                                                          const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_dof, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_nu_ref = ref_type_if_not_const_t<T_dof>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_nu_ref = ref_type_if_not_constant_t<T_dof>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   static const char* function = "student_t_lpdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu,

--- a/stan/math/prim/prob/student_t_lpdf.hpp
+++ b/stan/math/prim/prob/student_t_lpdf.hpp
@@ -61,10 +61,10 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lpdf(const T_y& y,
                                                          const T_loc& mu,
                                                          const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_dof, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_nu_ref = ref_type_if_t<!is_constant<T_dof>::value, T_dof>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_nu_ref = ref_type_if_not_const_t<T_dof>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   static const char* function = "student_t_lpdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu,

--- a/stan/math/prim/prob/uniform_cdf.hpp
+++ b/stan/math/prim/prob/uniform_cdf.hpp
@@ -23,9 +23,9 @@ template <typename T_y, typename T_low, typename T_high,
 return_type_t<T_y, T_low, T_high> uniform_cdf(const T_y& y, const T_low& alpha,
                                               const T_high& beta) {
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_low>;
-  using T_beta_ref = ref_type_if_not_const_t<T_high>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_low>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_high>;
   static const char* function = "uniform_cdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Lower bound parameter", alpha,

--- a/stan/math/prim/prob/uniform_cdf.hpp
+++ b/stan/math/prim/prob/uniform_cdf.hpp
@@ -23,9 +23,9 @@ template <typename T_y, typename T_low, typename T_high,
 return_type_t<T_y, T_low, T_high> uniform_cdf(const T_y& y, const T_low& alpha,
                                               const T_high& beta) {
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_low>::value, T_low>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_high>::value, T_high>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_low>;
+  using T_beta_ref = ref_type_if_not_const_t<T_high>;
   static const char* function = "uniform_cdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Lower bound parameter", alpha,

--- a/stan/math/prim/prob/uniform_lccdf.hpp
+++ b/stan/math/prim/prob/uniform_lccdf.hpp
@@ -26,9 +26,9 @@ return_type_t<T_y, T_low, T_high> uniform_lccdf(const T_y& y,
                                                 const T_low& alpha,
                                                 const T_high& beta) {
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_low>::value, T_low>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_high>::value, T_high>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_low>;
+  using T_beta_ref = ref_type_if_not_const_t<T_high>;
   static const char* function = "uniform_lccdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Lower bound parameter", alpha,

--- a/stan/math/prim/prob/uniform_lccdf.hpp
+++ b/stan/math/prim/prob/uniform_lccdf.hpp
@@ -26,9 +26,9 @@ return_type_t<T_y, T_low, T_high> uniform_lccdf(const T_y& y,
                                                 const T_low& alpha,
                                                 const T_high& beta) {
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_low>;
-  using T_beta_ref = ref_type_if_not_const_t<T_high>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_low>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_high>;
   static const char* function = "uniform_lccdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Lower bound parameter", alpha,

--- a/stan/math/prim/prob/uniform_lcdf.hpp
+++ b/stan/math/prim/prob/uniform_lcdf.hpp
@@ -25,9 +25,9 @@ template <typename T_y, typename T_low, typename T_high,
 return_type_t<T_y, T_low, T_high> uniform_lcdf(const T_y& y, const T_low& alpha,
                                                const T_high& beta) {
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_low>::value, T_low>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_high>::value, T_high>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_low>;
+  using T_beta_ref = ref_type_if_not_const_t<T_high>;
   static const char* function = "uniform_lcdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Lower bound parameter", alpha,

--- a/stan/math/prim/prob/uniform_lcdf.hpp
+++ b/stan/math/prim/prob/uniform_lcdf.hpp
@@ -25,9 +25,9 @@ template <typename T_y, typename T_low, typename T_high,
 return_type_t<T_y, T_low, T_high> uniform_lcdf(const T_y& y, const T_low& alpha,
                                                const T_high& beta) {
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_low>;
-  using T_beta_ref = ref_type_if_not_const_t<T_high>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_low>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_high>;
   static const char* function = "uniform_lcdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Lower bound parameter", alpha,

--- a/stan/math/prim/prob/uniform_lpdf.hpp
+++ b/stan/math/prim/prob/uniform_lpdf.hpp
@@ -47,9 +47,9 @@ template <bool propto, typename T_y, typename T_low, typename T_high,
 return_type_t<T_y, T_low, T_high> uniform_lpdf(const T_y& y, const T_low& alpha,
                                                const T_high& beta) {
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_low>;
-  using T_beta_ref = ref_type_if_not_const_t<T_high>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_low>;
+  using T_beta_ref = ref_type_if_not_constant_t<T_high>;
   static const char* function = "uniform_lpdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Lower bound parameter", alpha,

--- a/stan/math/prim/prob/uniform_lpdf.hpp
+++ b/stan/math/prim/prob/uniform_lpdf.hpp
@@ -47,9 +47,9 @@ template <bool propto, typename T_y, typename T_low, typename T_high,
 return_type_t<T_y, T_low, T_high> uniform_lpdf(const T_y& y, const T_low& alpha,
                                                const T_high& beta) {
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_low>::value, T_low>;
-  using T_beta_ref = ref_type_if_t<!is_constant<T_high>::value, T_high>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_low>;
+  using T_beta_ref = ref_type_if_not_const_t<T_high>;
   static const char* function = "uniform_lpdf";
   check_consistent_sizes(function, "Random variable", y,
                          "Lower bound parameter", alpha,

--- a/stan/math/prim/prob/von_mises_lpdf.hpp
+++ b/stan/math/prim/prob/von_mises_lpdf.hpp
@@ -26,9 +26,9 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
                                                   T_scale const& kappa) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_mu_ref = ref_type_if_t<!is_constant<T_loc>::value, T_loc>;
-  using T_kappa_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
+  using T_kappa_ref = ref_type_if_not_const_t<T_scale>;
   static char const* const function = "von_mises_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", kappa);

--- a/stan/math/prim/prob/von_mises_lpdf.hpp
+++ b/stan/math/prim/prob/von_mises_lpdf.hpp
@@ -26,9 +26,9 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
                                                   T_scale const& kappa) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_mu_ref = ref_type_if_not_const_t<T_loc>;
-  using T_kappa_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
+  using T_kappa_ref = ref_type_if_not_constant_t<T_scale>;
   static char const* const function = "von_mises_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", kappa);

--- a/stan/math/prim/prob/weibull_cdf.hpp
+++ b/stan/math/prim/prob/weibull_cdf.hpp
@@ -40,9 +40,9 @@ return_type_t<T_y, T_shape, T_scale> weibull_cdf(const T_y& y,
                                                  const T_shape& alpha,
                                                  const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   using std::pow;
   static const char* function = "weibull_cdf";
 

--- a/stan/math/prim/prob/weibull_cdf.hpp
+++ b/stan/math/prim/prob/weibull_cdf.hpp
@@ -40,9 +40,9 @@ return_type_t<T_y, T_shape, T_scale> weibull_cdf(const T_y& y,
                                                  const T_shape& alpha,
                                                  const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   using std::pow;
   static const char* function = "weibull_cdf";
 

--- a/stan/math/prim/prob/weibull_lccdf.hpp
+++ b/stan/math/prim/prob/weibull_lccdf.hpp
@@ -38,9 +38,9 @@ return_type_t<T_y, T_shape, T_scale> weibull_lccdf(const T_y& y,
                                                    const T_shape& alpha,
                                                    const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   using std::pow;
   static const char* function = "weibull_lccdf";
 

--- a/stan/math/prim/prob/weibull_lccdf.hpp
+++ b/stan/math/prim/prob/weibull_lccdf.hpp
@@ -38,9 +38,9 @@ return_type_t<T_y, T_shape, T_scale> weibull_lccdf(const T_y& y,
                                                    const T_shape& alpha,
                                                    const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   using std::pow;
   static const char* function = "weibull_lccdf";
 

--- a/stan/math/prim/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/prob/weibull_lcdf.hpp
@@ -40,9 +40,9 @@ return_type_t<T_y, T_shape, T_scale> weibull_lcdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   using std::pow;
   static const char* function = "weibull_lcdf";
 

--- a/stan/math/prim/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/prob/weibull_lcdf.hpp
@@ -40,9 +40,9 @@ return_type_t<T_y, T_shape, T_scale> weibull_lcdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   using std::pow;
   static const char* function = "weibull_lcdf";
 

--- a/stan/math/prim/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/prob/weibull_lpdf.hpp
@@ -41,9 +41,9 @@ return_type_t<T_y, T_shape, T_scale> weibull_lpdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-  using T_y_ref = ref_type_if_not_const_t<T_y>;
-  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
-  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
+  using T_y_ref = ref_type_if_not_constant_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
+  using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
   using std::pow;
   static const char* function = "weibull_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",

--- a/stan/math/prim/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/prob/weibull_lpdf.hpp
@@ -41,9 +41,9 @@ return_type_t<T_y, T_shape, T_scale> weibull_lpdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_alpha_ref = ref_type_if_t<!is_constant<T_shape>::value, T_shape>;
-  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
+  using T_y_ref = ref_type_if_not_const_t<T_y>;
+  using T_alpha_ref = ref_type_if_not_const_t<T_shape>;
+  using T_sigma_ref = ref_type_if_not_const_t<T_scale>;
   using std::pow;
   static const char* function = "weibull_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",


### PR DESCRIPTION
## Summary

When deducing whether to use a Ref type for inputs based on whether the input is constant or not, we frequently use the following pattern:

```cpp
using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
```

This PR just introduces some syntactic sugar to make this a bit more explicit and simpler:
```cpp
using T_x_ref = ref_type_if_not_constant_t<T_x>;
```

## Tests

N/A existing tests should still pass

## Side Effects
N/A

## Release notes

Simplified usage of ref-type deduction

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
