### PR TITLE
Add OpenCL implementation for `binomial_logit_glm`

### DIFF
--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -112,6 +112,7 @@
 #include <stan/math/opencl/prim/beta_proportion_lpdf.hpp>
 #include <stan/math/opencl/prim/binomial_logit_lpmf.hpp>
 #include <stan/math/opencl/prim/binomial_lpmf.hpp>
+#include <stan/math/opencl/prim/binomial_logit_glm_lpmf.hpp>
 #include <stan/math/opencl/prim/block.hpp>
 #include <stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp>
 #include <stan/math/opencl/prim/cauchy_cdf.hpp>

--- a/stan/math/opencl/prim/binomial_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/binomial_logit_glm_lpmf.hpp
@@ -1,0 +1,141 @@
+#ifndef STAN_MATH_OPENCL_PRIM_BINOMIAL_LOGIT_GLM_LPMF_HPP
+#define STAN_MATH_OPENCL_PRIM_BINOMIAL_LOGIT_GLM_LPMF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/prim/size.hpp>
+#include <stan/math/opencl/rev/operands_and_partials.hpp>
+#include <stan/math/opencl/copy.hpp>
+#include <stan/math/opencl/prim/multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/max.hpp>
+#include <stan/math/prim/fun/size.hpp>
+#include <stan/math/prim/fun/size_zero.hpp>
+#include <stan/math/prim/fun/sum.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/fun/value_of_rec.hpp>
+
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+template <bool propto, typename T_n_cl, typename T_N_cl,
+          typename T_x_cl, typename T_alpha_cl,
+          typename T_beta_cl,
+          require_all_prim_or_rev_kernel_expression_t<
+              T_n_cl, T_N_cl, T_x_cl, T_alpha_cl, T_beta_cl>* = nullptr>
+return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> binomial_logit_glm_lpmf(
+    const T_n_cl& n, const T_N_cl& N, const T_x_cl& x, const T_alpha_cl& alpha,
+    const T_beta_cl& beta) {
+  static const char* function = "binomial_logit_glm_lpmf(OpenCL)";
+  using T_partials_return = partials_return_t<T_x_cl, T_alpha_cl, T_beta_cl>;
+  constexpr bool is_y_vector = !is_stan_scalar<T_n_cl>::value;
+  constexpr bool is_alpha_vector = !is_stan_scalar<T_alpha_cl>::value;
+
+  const size_t N_instances = max(max_size(n, N, alpha),
+                                  static_cast<size_t>(x.rows()));
+  const size_t N_attributes = x.cols();
+
+  check_consistent_sizes(function, "Successes variable", n,
+                         "Population size parameter", N);
+  check_consistent_size(function, "Successes variable", n, N_instances);
+  check_consistent_size(function, "Population size parameter", N, N_instances);
+  check_consistent_size(function, "Weight vector", beta, N_attributes);
+  check_consistent_size(function, "Vector of intercepts", alpha, N_instances);
+
+  if (N_instances == 0 || N_attributes == 0) {
+    return 0;
+  }
+  if (!include_summand<propto, T_x_cl, T_alpha_cl, T_beta_cl>::value) {
+    return 0;
+  }
+
+  auto&& x_val = value_of(x);
+  auto&& alpha_val = value_of(alpha);
+  auto&& beta_val = value_of(beta);
+
+  auto check_n_bounded
+      = check_cl(function, "Successes variable", n, "in the interval [0, N]");
+  auto n_bounded = 0 <= n && n <= N;
+  auto check_N_nonnegative
+      = check_cl(function, "Population size variable", n, "nonnegative");
+  auto N_nonnegative = N >= 0;
+
+  auto theta_expr = matrix_vector_multiply(x_val, beta_val) + alpha_val;
+  auto log_inv_logit_theta = log_inv_logit(theta_expr);
+  auto log1m_inv_logit_theta = log1m_inv_logit(theta_expr);
+  auto n_diff = N - n;
+  auto logp_expr1 = elt_multiply(n, log_inv_logit_theta)
+                    + elt_multiply(n_diff, log1m_inv_logit_theta);
+  auto logp_expr
+      = static_select<include_summand<propto, T_n_cl, T_N_cl>::value>(
+          logp_expr1 + binomial_coefficient_log(N, n), logp_expr1);
+
+  constexpr bool need_theta_deriv =
+    !is_constant_all<T_beta_cl, T_x_cl, T_alpha_cl>::value;
+  auto theta_deriv_expr = n - elt_multiply(N, exp(log_inv_logit_theta));
+
+  constexpr bool need_theta_deriv_sum = need_theta_deriv && !is_alpha_vector;
+  matrix_cl<double> logp_cl;
+  matrix_cl<double> theta_deriv_cl;
+  matrix_cl<double> theta_deriv_sum_cl;
+
+  results(check_n_bounded, check_N_nonnegative, logp_cl,
+          theta_deriv_cl, theta_deriv_sum_cl) = expressions(
+      n_bounded, N_nonnegative, logp_expr,
+      calc_if<need_theta_deriv>(theta_deriv_expr),
+      calc_if<need_theta_deriv_sum>(colwise_sum(theta_deriv_expr)));
+
+  T_partials_return logp = sum(from_matrix_cl(logp_cl));
+  using std::isfinite;
+  if (!isfinite(logp)) {
+    check_cl(function, "Intercept", alpha_val, "finite")
+        = isfinite(alpha_val);
+    check_cl(function, "Weight vector", beta_val, "finite")
+        = isfinite(beta_val);
+    check_cl(function, "Matrix of independent variables", x_val, "finite")
+        = isfinite(x_val);
+  }
+
+  auto ops_partials = make_partials_propagator(x, alpha, beta);
+  if (!is_constant_all<T_x_cl>::value) {
+    partials<0>(ops_partials)
+        = transpose(beta_val * transpose(theta_deriv_cl));
+  }
+  if (!is_constant_all<T_alpha_cl>::value) {
+    if (is_alpha_vector) {
+      partials<1>(ops_partials) = theta_deriv_cl;
+    } else {
+      forward_as<internal::broadcast_array<double>>(
+          partials<1>(ops_partials))[0]
+          = sum(from_matrix_cl(theta_deriv_sum_cl));
+    }
+  }
+  if (!is_constant_all<T_beta_cl>::value) {
+    // transposition of a vector can be done without copying
+    const matrix_cl<double> theta_derivative_transpose_cl(
+        theta_deriv_cl.buffer(), 1, theta_deriv_cl.rows());
+    matrix_cl<double> edge3_partials_transpose_cl
+        = theta_derivative_transpose_cl * x_val;
+    partials<2>(ops_partials)
+        = matrix_cl<double>(edge3_partials_transpose_cl.buffer(),
+                            edge3_partials_transpose_cl.cols(), 1);
+    if (beta_val.rows() != 0) {
+      edge<2>(ops_partials)
+          .partials_.add_write_event(
+              edge3_partials_transpose_cl.write_events().back());
+    }
+  }
+  return ops_partials.build(logp);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/stan/math/opencl/prim/binomial_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/binomial_logit_glm_lpmf.hpp
@@ -24,9 +24,8 @@
 namespace stan {
 namespace math {
 
-template <bool propto, typename T_n_cl, typename T_N_cl,
-          typename T_x_cl, typename T_alpha_cl,
-          typename T_beta_cl,
+template <bool propto, typename T_n_cl, typename T_N_cl, typename T_x_cl,
+          typename T_alpha_cl, typename T_beta_cl,
           require_all_prim_or_rev_kernel_expression_t<
               T_n_cl, T_N_cl, T_x_cl, T_alpha_cl, T_beta_cl>* = nullptr>
 return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> binomial_logit_glm_lpmf(
@@ -37,8 +36,8 @@ return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> binomial_logit_glm_lpmf(
   constexpr bool is_y_vector = !is_stan_scalar<T_n_cl>::value;
   constexpr bool is_alpha_vector = !is_stan_scalar<T_alpha_cl>::value;
 
-  const size_t N_instances = max(max_size(n, N, alpha),
-                                  static_cast<size_t>(x.rows()));
+  const size_t N_instances
+      = max(max_size(n, N, alpha), static_cast<size_t>(x.rows()));
   const size_t N_attributes = x.cols();
 
   check_consistent_sizes(function, "Successes variable", n,
@@ -76,8 +75,8 @@ return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> binomial_logit_glm_lpmf(
       = static_select<include_summand<propto, T_n_cl, T_N_cl>::value>(
           logp_expr1 + binomial_coefficient_log(N, n), logp_expr1);
 
-  constexpr bool need_theta_deriv =
-    !is_constant_all<T_beta_cl, T_x_cl, T_alpha_cl>::value;
+  constexpr bool need_theta_deriv
+      = !is_constant_all<T_beta_cl, T_x_cl, T_alpha_cl>::value;
   auto theta_deriv_expr = n - elt_multiply(N, exp(log_inv_logit_theta));
 
   constexpr bool need_theta_deriv_sum = need_theta_deriv && !is_alpha_vector;
@@ -85,17 +84,17 @@ return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> binomial_logit_glm_lpmf(
   matrix_cl<double> theta_deriv_cl;
   matrix_cl<double> theta_deriv_sum_cl;
 
-  results(check_n_bounded, check_N_nonnegative, logp_cl,
-          theta_deriv_cl, theta_deriv_sum_cl) = expressions(
-      n_bounded, N_nonnegative, logp_expr,
-      calc_if<need_theta_deriv>(theta_deriv_expr),
-      calc_if<need_theta_deriv_sum>(colwise_sum(theta_deriv_expr)));
+  results(check_n_bounded, check_N_nonnegative, logp_cl, theta_deriv_cl,
+          theta_deriv_sum_cl)
+      = expressions(
+          n_bounded, N_nonnegative, logp_expr,
+          calc_if<need_theta_deriv>(theta_deriv_expr),
+          calc_if<need_theta_deriv_sum>(colwise_sum(theta_deriv_expr)));
 
   T_partials_return logp = sum(from_matrix_cl(logp_cl));
   using std::isfinite;
   if (!isfinite(logp)) {
-    check_cl(function, "Intercept", alpha_val, "finite")
-        = isfinite(alpha_val);
+    check_cl(function, "Intercept", alpha_val, "finite") = isfinite(alpha_val);
     check_cl(function, "Weight vector", beta_val, "finite")
         = isfinite(beta_val);
     check_cl(function, "Matrix of independent variables", x_val, "finite")
@@ -104,8 +103,7 @@ return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> binomial_logit_glm_lpmf(
 
   auto ops_partials = make_partials_propagator(x, alpha, beta);
   if (!is_constant_all<T_x_cl>::value) {
-    partials<0>(ops_partials)
-        = transpose(beta_val * transpose(theta_deriv_cl));
+    partials<0>(ops_partials) = transpose(beta_val * transpose(theta_deriv_cl));
   }
   if (!is_constant_all<T_alpha_cl>::value) {
     if (is_alpha_vector) {

--- a/test/unit/math/opencl/rev/binomial_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/binomial_logit_glm_lpmf_test.cpp
@@ -6,8 +6,8 @@
 #include <vector>
 
 TEST(ProbDistributionsBinomialLogitGLM, error_checking) {
-  using stan::math::matrix_cl;
   using stan::math::binomial_logit_glm_lpmf;
+  using stan::math::matrix_cl;
 
   int N = 3;
   int M = 2;
@@ -80,10 +80,10 @@ TEST(ProbDistributionsBinomialLogitGLM, error_checking) {
       binomial_logit_glm_lpmf(n_cl, trials_cl, x_cl, alpha_cl, beta_size_cl),
       std::invalid_argument);
 
-   EXPECT_THROW(
+  EXPECT_THROW(
       binomial_logit_glm_lpmf(n_value_cl, trials_cl, x_cl, alpha_cl, beta_cl),
       std::domain_error);
-   EXPECT_THROW(
+  EXPECT_THROW(
       binomial_logit_glm_lpmf(n_cl, trials_value_cl, x_cl, alpha_cl, beta_cl),
       std::domain_error);
   EXPECT_THROW(
@@ -98,15 +98,15 @@ TEST(ProbDistributionsBinomialLogitGLM, error_checking) {
 }
 
 auto binomial_logit_glm_lpmf_functor
-    = [](const auto& n, const auto& trials, const auto& x,
-          const auto& alpha, const auto& beta) {
+    = [](const auto& n, const auto& trials, const auto& x, const auto& alpha,
+         const auto& beta) {
         return stan::math::binomial_logit_glm_lpmf(n, trials, x, alpha, beta);
       };
 auto binomial_logit_glm_lpmf_functor_propto
-    = [](const auto& n, const auto& trials, const auto& x,
-          const auto& alpha, const auto& beta) {
-        return stan::math::binomial_logit_glm_lpmf<true>(n, trials, x,
-                                                          alpha, beta);
+    = [](const auto& n, const auto& trials, const auto& x, const auto& alpha,
+         const auto& beta) {
+        return stan::math::binomial_logit_glm_lpmf<true>(n, trials, x, alpha,
+                                                         beta);
       };
 
 TEST(ProbDistributionsBinomialLogitGLM, opencl_matches_cpu_small_simple) {
@@ -121,8 +121,8 @@ TEST(ProbDistributionsBinomialLogitGLM, opencl_matches_cpu_small_simple) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(
-      binomial_logit_glm_lpmf_functor, n, trials, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(binomial_logit_glm_lpmf_functor,
+                                                n, trials, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       binomial_logit_glm_lpmf_functor_propto, n, trials, x, alpha, beta);
 }
@@ -156,8 +156,8 @@ TEST(ProbDistributionsBinomialLogitGLM, opencl_matches_cpu_zero_instances) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(
-      binomial_logit_glm_lpmf_functor, n, trials, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(binomial_logit_glm_lpmf_functor,
+                                                n, trials, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       binomial_logit_glm_lpmf_functor_propto, n, trials, x, alpha, beta);
 }
@@ -172,15 +172,13 @@ TEST(ProbDistributionsBinomialLogitGLM, opencl_matches_cpu_zero_attributes) {
   Eigen::VectorXd beta(M);
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(
-      binomial_logit_glm_lpmf_functor, n, trials, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(binomial_logit_glm_lpmf_functor,
+                                                n, trials, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       binomial_logit_glm_lpmf_functor_propto, n, trials, x, alpha, beta);
 }
 
-
-TEST(ProbDistributionsBinomialLogitGLM,
-     opencl_matches_cpu_small_vector_alpha) {
+TEST(ProbDistributionsBinomialLogitGLM, opencl_matches_cpu_small_vector_alpha) {
   int N = 3;
   int M = 2;
 
@@ -193,8 +191,8 @@ TEST(ProbDistributionsBinomialLogitGLM,
   Eigen::VectorXd alpha(N);
   alpha << 0.3, -0.8, 1.8;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(
-      binomial_logit_glm_lpmf_functor, n, trials, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(binomial_logit_glm_lpmf_functor,
+                                                n, trials, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       binomial_logit_glm_lpmf_functor_propto, n, trials, x, alpha, beta);
 }
@@ -213,8 +211,8 @@ TEST(ProbDistributionsBinomialLogitGLM, opencl_matches_cpu_big) {
   Eigen::VectorXd beta = Eigen::VectorXd::Random(M);
   Eigen::VectorXd alpha = Eigen::VectorXd::Random(N);
 
-  stan::math::test::compare_cpu_opencl_prim_rev(
-      binomial_logit_glm_lpmf_functor, n, trials, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(binomial_logit_glm_lpmf_functor,
+                                                n, trials, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       binomial_logit_glm_lpmf_functor_propto, n, trials, x, alpha, beta);
 }

--- a/test/unit/math/opencl/rev/binomial_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/binomial_logit_glm_lpmf_test.cpp
@@ -1,0 +1,222 @@
+#ifdef STAN_OPENCL
+#include <stan/math.hpp>
+#include <stan/math/opencl/rev.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsBinomialLogitGLM, error_checking) {
+  using stan::math::matrix_cl;
+  using stan::math::binomial_logit_glm_lpmf;
+
+  int N = 3;
+  int M = 2;
+
+  std::vector<int> n{1, 0, 1};
+  std::vector<int> n_size{1, 0, 1, 0};
+  std::vector<int> n_value{0, 1, -23};
+
+  std::vector<int> trials{10, 5, 2};
+  std::vector<int> trials_size{1, 0, 1, 0};
+  std::vector<int> trials_value{5, 1, -1};
+
+  Eigen::MatrixXd x(N, M);
+  x << -12, 46, -42, 24, 25, 27;
+  Eigen::MatrixXd x_size1(N - 1, M);
+  x_size1 << -12, 46, -42, 24;
+  Eigen::MatrixXd x_size2(N, M - 1);
+  x_size2 << -12, 46, -42;
+  Eigen::MatrixXd x_value(N, M);
+  x_value << -12, 46, -42, 24, 25, -INFINITY;
+  Eigen::VectorXd beta(M);
+  beta << 0.3, 2;
+  Eigen::VectorXd beta_size(M + 1);
+  beta_size << 0.3, 2, 0.4;
+  Eigen::VectorXd beta_value(M);
+  beta_value << 0.3, INFINITY;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, -0.8, 1.8;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, -0.8;
+  Eigen::VectorXd alpha_value(N);
+  alpha_value << 0.3, -0.8, NAN;
+
+  matrix_cl<double> x_cl(x);
+  matrix_cl<double> x_size1_cl(x_size1);
+  matrix_cl<double> x_size2_cl(x_size2);
+  matrix_cl<double> x_value_cl(x_value);
+  matrix_cl<int> n_cl(n);
+  matrix_cl<int> n_size_cl(n_size);
+  matrix_cl<int> n_value_cl(n_value);
+  matrix_cl<int> trials_cl(trials);
+  matrix_cl<int> trials_size_cl(trials_size);
+  matrix_cl<int> trials_value_cl(trials_value);
+  matrix_cl<double> beta_cl(beta);
+  matrix_cl<double> beta_size_cl(beta_size);
+  matrix_cl<double> beta_value_cl(beta_value);
+  matrix_cl<double> alpha_cl(alpha);
+  matrix_cl<double> alpha_size_cl(alpha_size);
+  matrix_cl<double> alpha_value_cl(alpha_value);
+
+  EXPECT_NO_THROW(
+      binomial_logit_glm_lpmf(n_cl, trials_cl, x_cl, alpha_cl, beta_cl));
+
+  EXPECT_THROW(
+      binomial_logit_glm_lpmf(n_size_cl, trials_cl, x_cl, alpha_cl, beta_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      binomial_logit_glm_lpmf(n_cl, trials_size_cl, x_cl, alpha_cl, beta_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      binomial_logit_glm_lpmf(n_cl, trials_cl, x_size1_cl, alpha_cl, beta_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      binomial_logit_glm_lpmf(n_cl, trials_cl, x_size2_cl, alpha_cl, beta_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      binomial_logit_glm_lpmf(n_cl, trials_cl, x_cl, alpha_size_cl, beta_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      binomial_logit_glm_lpmf(n_cl, trials_cl, x_cl, alpha_cl, beta_size_cl),
+      std::invalid_argument);
+
+   EXPECT_THROW(
+      binomial_logit_glm_lpmf(n_value_cl, trials_cl, x_cl, alpha_cl, beta_cl),
+      std::domain_error);
+   EXPECT_THROW(
+      binomial_logit_glm_lpmf(n_cl, trials_value_cl, x_cl, alpha_cl, beta_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      binomial_logit_glm_lpmf(n_cl, trials_cl, x_value_cl, alpha_cl, beta_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      binomial_logit_glm_lpmf(n_cl, trials_cl, x_cl, alpha_value_cl, beta_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      binomial_logit_glm_lpmf(n_cl, trials_cl, x_cl, alpha_cl, beta_value_cl),
+      std::domain_error);
+}
+
+auto binomial_logit_glm_lpmf_functor
+    = [](const auto& n, const auto& trials, const auto& x,
+          const auto& alpha, const auto& beta) {
+        return stan::math::binomial_logit_glm_lpmf(n, trials, x, alpha, beta);
+      };
+auto binomial_logit_glm_lpmf_functor_propto
+    = [](const auto& n, const auto& trials, const auto& x,
+          const auto& alpha, const auto& beta) {
+        return stan::math::binomial_logit_glm_lpmf<true>(n, trials, x,
+                                                          alpha, beta);
+      };
+
+TEST(ProbDistributionsBinomialLogitGLM, opencl_matches_cpu_small_simple) {
+  int N = 3;
+  int M = 2;
+
+  std::vector<int> n{0, 1, 0};
+  std::vector<int> trials{10, 4, 15};
+  Eigen::MatrixXd x(N, M);
+  x << -12, 46, -42, 24, 25, 27;
+  Eigen::VectorXd beta(M);
+  beta << 0.3, 2;
+  double alpha = 0.3;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      binomial_logit_glm_lpmf_functor, n, trials, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      binomial_logit_glm_lpmf_functor_propto, n, trials, x, alpha, beta);
+}
+
+TEST(ProbDistributionsBinomialLogitGLM, opencl_broadcast_n) {
+  int N = 3;
+  int M = 2;
+
+  int n_scal = 1;
+  std::vector<int> trials{10, 4, 15};
+  Eigen::MatrixXd x(N, M);
+  x << -12, 46, -42, 24, 25, 27;
+  Eigen::VectorXd beta(M);
+  beta << 0.3, 2;
+  double alpha = 0.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      binomial_logit_glm_lpmf_functor, n_scal, trials, x, alpha, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      binomial_logit_glm_lpmf_functor_propto, n_scal, trials, x, alpha, beta);
+}
+
+TEST(ProbDistributionsBinomialLogitGLM, opencl_matches_cpu_zero_instances) {
+  int N = 0;
+  int M = 2;
+
+  std::vector<int> n{};
+  std::vector<int> trials{};
+  Eigen::MatrixXd x(N, M);
+  Eigen::VectorXd beta(M);
+  beta << 0.3, 2;
+  double alpha = 0.3;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      binomial_logit_glm_lpmf_functor, n, trials, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      binomial_logit_glm_lpmf_functor_propto, n, trials, x, alpha, beta);
+}
+
+TEST(ProbDistributionsBinomialLogitGLM, opencl_matches_cpu_zero_attributes) {
+  int N = 3;
+  int M = 0;
+
+  std::vector<int> n{0, 1, 0};
+  std::vector<int> trials{10, 5, 4};
+  Eigen::MatrixXd x(N, M);
+  Eigen::VectorXd beta(M);
+  double alpha = 0.3;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      binomial_logit_glm_lpmf_functor, n, trials, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      binomial_logit_glm_lpmf_functor_propto, n, trials, x, alpha, beta);
+}
+
+
+TEST(ProbDistributionsBinomialLogitGLM,
+     opencl_matches_cpu_small_vector_alpha) {
+  int N = 3;
+  int M = 2;
+
+  std::vector<int> n{0, 1, 0};
+  std::vector<int> trials{0, 1, 0};
+  Eigen::MatrixXd x(N, M);
+  x << -12, 46, -42, 24, 25, 27;
+  Eigen::VectorXd beta(M);
+  beta << 0.3, 2;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, -0.8, 1.8;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      binomial_logit_glm_lpmf_functor, n, trials, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      binomial_logit_glm_lpmf_functor_propto, n, trials, x, alpha, beta);
+}
+
+TEST(ProbDistributionsBinomialLogitGLM, opencl_matches_cpu_big) {
+  int N = 153;
+  int M = 71;
+
+  std::vector<int> n(N);
+  std::vector<int> trials(N);
+  for (int i = 0; i < N; i++) {
+    n[i] = Eigen::ArrayXi::Random(1, 1).abs()(0);
+    trials[i] = n[i] + Eigen::ArrayXi::Random(1, 1).abs()(0);
+  }
+  Eigen::MatrixXd x = Eigen::MatrixXd::Random(N, M);
+  Eigen::VectorXd beta = Eigen::VectorXd::Random(M);
+  Eigen::VectorXd alpha = Eigen::VectorXd::Random(N);
+
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      binomial_logit_glm_lpmf_functor, n, trials, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      binomial_logit_glm_lpmf_functor_propto, n, trials, x, alpha, beta);
+}
+
+#endif


### PR DESCRIPTION
## Summary

This PR is the follow-up to #2946, adding OpenCL support for the new `binomial_logit_glm` distribution. As with the CPU implementation, this is heavily derived from the current `bernoulli_logit_glm` and `binomial_logit` OpenCL implementations

## Tests

OpenCL tests for throwing and consistency with CPU implementation added.

## Side Effects

N/A

## Release notes

Added OpenCL support for the `binomial_logit_glm` distribution

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
