### PR TITLE
jenkins: use builtin disableConcurrentBuilds abortPrevious

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,7 @@ pipeline {
         preserveStashes(buildCount: 7)
         parallelsAlwaysFailFast()
         buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '30'))
+        disableConcurrentBuilds(abortPrevious: true)
     }
     environment {
         STAN_NUM_THREADS = 4
@@ -65,18 +66,6 @@ pipeline {
         GIT_COMMITTER_EMAIL = 'mc.stanislaw@gmail.com'
     }
     stages {
-
-        stage('Kill previous builds') {
-            when {
-                not { branch 'develop' }
-                not { branch 'master' }
-            }
-            steps {
-                script {
-                    utils.killOldBuilds()
-                }
-            }
-        }
 
         stage("Clang-format") {
             agent {


### PR DESCRIPTION
Currently it's using a custom `killOldBuilds` script which relies on insecure access to the whole project tree.  This functionality is now built-in so there should no need to use this function anymore.  (This does affect all branches now, which seems better anyway, but could be made conditional if necessary.)