### PR TITLE
Optimization for chol2inv

### DIFF
--- a/stan/math/prim/fun/chol2inv.hpp
+++ b/stan/math/prim/fun/chol2inv.hpp
@@ -5,7 +5,7 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/dot_self.hpp>
 #include <stan/math/prim/fun/dot_product.hpp>
-#include <stan/math/prim/fun/mdivide_left_tri_low.hpp>
+#include <stan/math/prim/fun/mdivide_left_tri.hpp>
 #include <stan/math/prim/fun/inv_square.hpp>
 
 namespace stan {
@@ -35,7 +35,7 @@ plain_type_t<T> chol2inv(const T& L) {
     X.coeffRef(0) = inv_square(L_ref.coeff(0, 0));
     return X;
   }
-  T_result L_inv = mdivide_left_tri_low(L_ref, T_result::Identity(K, K));
+  T_result L_inv = mdivide_left_tri<Eigen::Lower>(L_ref);
   T_result X(K, K);
   for (int k = 0; k < K; ++k) {
     X.coeffRef(k, k) = dot_self(L_inv.col(k).tail(K - k).eval());


### PR DESCRIPTION
## Summary

The code in `chol2inv` uses `mdivide_left_tri_low` and creates an identity matrix to perform the matrix inversion. Instead we can do an in-place solve using `mdivide_left_tri` which avoids creating an extra matrix.

## Tests

None needed. 

## Side Effects

No.

## Release notes

Invert the input matrix in-place which reduces the memory requirement for this function.

## Checklist

- [x] Copyright holder: Sean Pinkney

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
