### PR TITLE
Fix usages of fabs in check_symmetric with llvm17

### DIFF
--- a/stan/math/prim/err/check_symmetric.hpp
+++ b/stan/math/prim/err/check_symmetric.hpp
@@ -33,6 +33,7 @@ inline void check_symmetric(const char* function, const char* name,
                             const EigMat& y) {
   check_square(function, name, y);
   using std::fabs;
+  using stan::math::fabs;
 
   Eigen::Index k = y.rows();
   if (k <= 1) {

--- a/stan/math/prim/err/check_symmetric.hpp
+++ b/stan/math/prim/err/check_symmetric.hpp
@@ -32,8 +32,8 @@ template <typename EigMat, require_matrix_t<EigMat>* = nullptr>
 inline void check_symmetric(const char* function, const char* name,
                             const EigMat& y) {
   check_square(function, name, y);
-  using std::fabs;
   using stan::math::fabs;
+  using std::fabs;
 
   Eigen::Index k = y.rows();
   if (k <= 1) {

--- a/test/unit/math/prim/err/check_symmetric_test.cpp
+++ b/test/unit/math/prim/err/check_symmetric_test.cpp
@@ -64,3 +64,15 @@ TEST(ErrorHandlingMatrix, checkSymmetric_non_square) {
   EXPECT_THROW(stan::math::check_symmetric("checkSymmetric", "y", y),
                std::invalid_argument);
 }
+
+
+TEST(ErrorHandlingMatrix, checkSymmetric_complex) {
+  Eigen::MatrixXcd y(2,2);
+  y << std::complex<double>(1,1), std::complex<double>(2,2),
+       std::complex<double>(2,2), std::complex<double>(1,1);
+
+  EXPECT_NO_THROW(stan::math::check_symmetric("checkSymmetric", "y", y));
+  y(0,1) = std::complex<double>(2,3);
+  EXPECT_THROW(stan::math::check_symmetric("checkSymmetric", "y", y),
+               std::domain_error);
+}

--- a/test/unit/math/prim/err/check_symmetric_test.cpp
+++ b/test/unit/math/prim/err/check_symmetric_test.cpp
@@ -65,14 +65,13 @@ TEST(ErrorHandlingMatrix, checkSymmetric_non_square) {
                std::invalid_argument);
 }
 
-
 TEST(ErrorHandlingMatrix, checkSymmetric_complex) {
-  Eigen::MatrixXcd y(2,2);
-  y << std::complex<double>(1,1), std::complex<double>(2,2),
-       std::complex<double>(2,2), std::complex<double>(1,1);
+  Eigen::MatrixXcd y(2, 2);
+  y << std::complex<double>(1, 1), std::complex<double>(2, 2),
+      std::complex<double>(2, 2), std::complex<double>(1, 1);
 
   EXPECT_NO_THROW(stan::math::check_symmetric("checkSymmetric", "y", y));
-  y(0,1) = std::complex<double>(2,3);
+  y(0, 1) = std::complex<double>(2, 3);
   EXPECT_THROW(stan::math::check_symmetric("checkSymmetric", "y", y),
                std::domain_error);
 }

--- a/test/unit/math/prim/fun/fabs_test.cpp
+++ b/test/unit/math/prim/fun/fabs_test.cpp
@@ -5,3 +5,9 @@ TEST(primScalFun, fabs) {
   stan::test::expect_common_prim([](auto x) { return std::fabs(x); },
                                  [](auto x) { return stan::math::fabs(x); });
 }
+
+TEST(primScalFun, fabs_complex) {
+  using stan::math::fabs;
+  std::complex<double> z(1.0, 2.0);
+  EXPECT_FLOAT_EQ(fabs(z), 2.236068);
+}


### PR DESCRIPTION
## Summary

This fixes an issue found in llvm17 (really libc++ 17, clang version seems to not be the important factor) which broke argument-dependent-lookup of the `fabs` function. 
So far as I can tell, the only place we were depending on this that could actually get `std::complex` inputs is in `check_symmetric`. 

To be completely honest, I'm not sure why this specific change fixes the issue, or if there is something better. 

Reminder: [we probably should not be using `std::complex` in Stan Math!](https://github.com/stan-dev/cmdstan/issues/1158#issuecomment-1518093146)

## Tests

I added some tests, but because this is in a bleeding edge compiler they won't make much of a difference immediately. They will be run in the next [bleeding edge pipeline run](https://jenkins.flatironinstitute.org/blue/organizations/jenkins/Stan%2FBleedingEdgeCompilersMonthly/activity).

## Side Effects

I don't believe so

## Release notes

Fixed a compilation issue with the `check_symmetric` function on complex-valued inputs under LLVM 17

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
