### PR TITLE
Missing include guard for OpenCL rev headers

### DIFF
--- a/stan/math/rev.hpp
+++ b/stan/math/rev.hpp
@@ -3,7 +3,9 @@
 
 #include <stan/math/prim/fun/Eigen.hpp>
 
+#ifdef STAN_OPENCL
 #include <stan/math/opencl/rev.hpp>
+#endif
 
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/meta.hpp>


### PR DESCRIPTION
## Summary

The `stan/math/rev.hpp` meta-header is missing the `#ifdef STAN_OPENCL` conditional includes for the OpenCL headers, which are present in the [prim](https://github.com/stan-dev/math/blob/ae90c3edca5d3b5e5234fdd6cbd1146f1666761d/stan/math/prim.hpp#L6) and [fwd](https://github.com/stan-dev/math/blob/ae90c3edca5d3b5e5234fdd6cbd1146f1666761d/stan/math/fwd.hpp#L6) equivalents.

## Tests

N/A

## Side Effects

N/A

## Release notes

Fixed missing include guard for OpenCL rev headers

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
