### PR TITLE
adding input checks for cholesky factors 

### DIFF
--- a/stan/math/prim/prob/inv_wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/inv_wishart_cholesky_lpdf.hpp
@@ -49,15 +49,16 @@ return_type_t<T_y, T_dof, T_scale> inv_wishart_cholesky_lpdf(
   using T_return = return_type_t<T_y, T_dof, T_scale>;
   static const char* function = "inv_wishart_cholesky_lpdf";
   Eigen::Index k = L_Y.rows();
-  check_cholesky_factor(function, "Cholesky random variable", L_Y);
   check_greater(function, "Degrees of freedom parameter", nu, k - 1);
-  check_cholesky_factor(function, "Cholesky Scale matrix", L_S);
   check_size_match(function, "Rows of random variable", L_Y.rows(),
                    "columns of scale parameter", L_S.rows());
 
   T_L_Y_ref L_Y_ref = L_Y;
+  check_cholesky_factor(function, "Cholesky random variable", L_Y_ref);
+
   T_nu_ref nu_ref = nu;
   T_L_S_ref L_S_ref = L_S;
+  check_cholesky_factor(function, "Cholesky Scale matrix", L_S_ref);
 
   T_return lp(0.0);
 

--- a/stan/math/prim/prob/inv_wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/inv_wishart_cholesky_lpdf.hpp
@@ -49,23 +49,15 @@ return_type_t<T_y, T_dof, T_scale> inv_wishart_cholesky_lpdf(
   using T_return = return_type_t<T_y, T_dof, T_scale>;
   static const char* function = "inv_wishart_cholesky_lpdf";
   Eigen::Index k = L_Y.rows();
-  check_size_match(function, "Rows of Random variable", L_Y.rows(),
-                   "columns of scale parameter", L_S.rows());
+  check_cholesky_factor(function, "Cholesky random variable", L_Y);
+  check_greater(function, "Degrees of freedom parameter", nu, k - 1);
+  check_cholesky_factor(function, "Cholesky Scale matrix", L_S);
   check_size_match(function, "Rows of random variable", L_Y.rows(),
-                   "columns of Random variable", L_Y.cols());
-  check_size_match(function, "Rows of scale parameter", L_S.rows(),
-                   "columns of scale parameter", L_S.cols());
+                   "columns of scale parameter", L_S.rows());
 
   T_L_Y_ref L_Y_ref = L_Y;
   T_nu_ref nu_ref = nu;
   T_L_S_ref L_S_ref = L_S;
-
-  check_greater(function, "Degrees of freedom parameter", nu_ref, k - 1);
-  check_positive(function, "Cholesky Random variable", L_Y_ref.diagonal());
-  check_positive(function, "columns of Cholesky Random variable",
-                 L_Y_ref.cols());
-  check_positive(function, "Cholesky Scale matrix", L_S_ref.diagonal());
-  check_positive(function, "columns of Cholesky Scale matrix", L_S_ref.cols());
 
   T_return lp(0.0);
 

--- a/stan/math/prim/prob/inv_wishart_cholesky_rng.hpp
+++ b/stan/math/prim/prob/inv_wishart_cholesky_rng.hpp
@@ -44,7 +44,7 @@ inline Eigen::MatrixXd inv_wishart_cholesky_rng(double nu,
     }
     B(j, j) = std::sqrt(chi_square_rng(nu - k + j + 1, rng));
   }
-  
+
   return mdivide_right_tri_low(L_S, B);
 }
 

--- a/stan/math/prim/prob/inv_wishart_cholesky_rng.hpp
+++ b/stan/math/prim/prob/inv_wishart_cholesky_rng.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
-#include <stan/math/prim/fun/mdivide_left_tri_low.hpp>
+#include <stan/math/prim/fun/mdivide_right_tri_low.hpp>
 
 namespace stan {
 namespace math {
@@ -34,10 +34,8 @@ inline Eigen::MatrixXd inv_wishart_cholesky_rng(double nu,
   using Eigen::MatrixXd;
   static const char* function = "inv_wishart_cholesky_rng";
   index_type_t<MatrixXd> k = L_S.rows();
-  check_square(function, "Cholesky Scale matrix", L_S);
   check_greater(function, "degrees of freedom > dims - 1", nu, k - 1);
-  check_positive(function, "Cholesky Scale matrix", L_S.diagonal());
-  check_positive(function, "columns of Cholesky Scale matrix", L_S.cols());
+  check_cholesky_factor(function, "Cholesky Scale matrix", L_S);
 
   MatrixXd B = MatrixXd::Zero(k, k);
   for (int j = 0; j < k; ++j) {
@@ -46,8 +44,8 @@ inline Eigen::MatrixXd inv_wishart_cholesky_rng(double nu,
     }
     B(j, j) = std::sqrt(chi_square_rng(nu - k + j + 1, rng));
   }
-
-  return mdivide_left_tri_low(B, L_S);
+  
+  return mdivide_right_tri_low(L_S, B);
 }
 
 }  // namespace math

--- a/stan/math/prim/prob/lkj_corr_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/lkj_corr_cholesky_lpdf.hpp
@@ -19,10 +19,10 @@ return_type_t<T_covar, T_shape> lkj_corr_cholesky_lpdf(const T_covar& L,
                                                        const T_shape& eta) {
   using lp_ret = return_type_t<T_covar, T_shape>;
   static const char* function = "lkj_corr_cholesky_lpdf";
-  const auto& L_ref = to_ref(L);
   check_positive(function, "Shape parameter", eta);
-  check_lower_triangular(function, "Random variable", L_ref);
+  check_cholesky_factor(function, "Random variable", L);
 
+  const auto& L_ref = to_ref(L);
   const unsigned int K = L.rows();
   if (K == 0) {
     return 0.0;

--- a/stan/math/prim/prob/lkj_corr_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/lkj_corr_cholesky_lpdf.hpp
@@ -20,9 +20,10 @@ return_type_t<T_covar, T_shape> lkj_corr_cholesky_lpdf(const T_covar& L,
   using lp_ret = return_type_t<T_covar, T_shape>;
   static const char* function = "lkj_corr_cholesky_lpdf";
   check_positive(function, "Shape parameter", eta);
-  check_cholesky_factor(function, "Random variable", L);
 
   const auto& L_ref = to_ref(L);
+  check_cholesky_factor(function, "Random variable", L_ref);
+
   const unsigned int K = L.rows();
   if (K == 0) {
     return 0.0;

--- a/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
@@ -49,10 +49,11 @@ return_type_t<T_y, T_covar, T_w> multi_gp_cholesky_lpdf(const T_y& y,
                    "rows of covariance parameter", L.rows());
   check_positive_finite(function, "Kernel scales", w);
   check_finite(function, "Random variable", y);
-  check_cholesky_factor(function, "Cholesky decomposition of kernel matrix", L);
 
   const auto& y_ref = to_ref(y);
   const auto& L_ref = to_ref(L);
+  check_cholesky_factor(function, "Cholesky decomposition of kernel matrix",
+                        L_ref);
   const auto& w_ref = to_ref(w);
 
   if (y.rows() == 0) {

--- a/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
@@ -55,7 +55,7 @@ return_type_t<T_y, T_covar, T_w> multi_gp_cholesky_lpdf(const T_y& y,
                         L_ref);
   const auto& w_ref = to_ref(w);
   check_positive_finite(function, "Kernel scales", w_ref);
-  
+
   if (y.rows() == 0) {
     return 0;
   }

--- a/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
@@ -47,15 +47,15 @@ return_type_t<T_y, T_covar, T_w> multi_gp_cholesky_lpdf(const T_y& y,
                    "Size of kernel scales (w)", w.size());
   check_size_match(function, "Size of random variable", y.cols(),
                    "rows of covariance parameter", L.rows());
-  check_positive_finite(function, "Kernel scales", w);
-  check_finite(function, "Random variable", y);
 
   const auto& y_ref = to_ref(y);
+  check_finite(function, "Random variable", y_ref);
   const auto& L_ref = to_ref(L);
   check_cholesky_factor(function, "Cholesky decomposition of kernel matrix",
                         L_ref);
   const auto& w_ref = to_ref(w);
-
+  check_positive_finite(function, "Kernel scales", w_ref);
+  
   if (y.rows() == 0) {
     return 0;
   }

--- a/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
@@ -47,11 +47,13 @@ return_type_t<T_y, T_covar, T_w> multi_gp_cholesky_lpdf(const T_y& y,
                    "Size of kernel scales (w)", w.size());
   check_size_match(function, "Size of random variable", y.cols(),
                    "rows of covariance parameter", L.rows());
+  check_positive_finite(function, "Kernel scales", w);
+  check_finite(function, "Random variable", y);
+  check_cholesky_factor(function, "Cholesky decomposition of kernel matrix", L);
+
   const auto& y_ref = to_ref(y);
   const auto& L_ref = to_ref(L);
   const auto& w_ref = to_ref(w);
-  check_positive_finite(function, "Kernel scales", w_ref);
-  check_finite(function, "Random variable", y_ref);
 
   if (y.rows() == 0) {
     return 0;

--- a/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
@@ -99,13 +99,13 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
                    "size of location parameter", size_mu);
   check_size_match(function, "Size of random variable", size_y,
                    "rows of covariance parameter", L.rows());
-  check_size_match(function, "Size of random variable", size_y,
-                   "columns of covariance parameter", L.cols());
 
   for (size_t i = 0; i < size_vec; i++) {
     check_finite(function, "Location parameter", mu_vec[i]);
     check_not_nan(function, "Random variable", y_vec[i]);
   }
+  check_cholesky_factor(function, "Cholesky decomposition of a variance matrix",
+                        L);
 
   if (unlikely(size_y == 0)) {
     return T_return(0);

--- a/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
@@ -105,7 +105,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
     check_not_nan(function, "Random variable", y_vec[i]);
   }
   check_cholesky_factor(function, "Cholesky decomposition of a variance matrix",
-                        L);
+                        L_ref);
 
   if (unlikely(size_y == 0)) {
     return T_return(0);

--- a/stan/math/prim/prob/multi_normal_cholesky_rng.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_rng.hpp
@@ -55,6 +55,7 @@ multi_normal_cholesky_rng(
   for (size_t i = 0; i < N; i++) {
     check_finite(function, "Location parameter", mu_vec[i]);
   }
+  check_cholesky_factor(function, "Cholesky factor of covariance matrix", L);
 
   const auto& L_ref = to_ref(L);
 

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -50,16 +50,17 @@ return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& L_Y,
   static const char* function = "wishart_cholesky_lpdf";
   Eigen::Index k = L_Y.rows();
 
-  check_cholesky_factor(function, "Cholesky random variable", L_Y);
   check_greater(function, "Degrees of freedom parameter", nu, k - 1);
-  check_cholesky_factor(function, "Cholesky scale matrix", L_S);
   check_size_match(function, "Rows of random variable", L_Y.rows(),
                    "columns of scale parameter", L_S.rows());
 
   T_L_Y_ref L_Y_ref = L_Y;
-  T_nu_ref nu_ref = nu;
-  T_L_S_ref L_S_ref = L_S;
+  check_cholesky_factor(function, "Cholesky random variable", L_Y_ref);
 
+  T_L_S_ref L_S_ref = L_S;
+  check_cholesky_factor(function, "Cholesky scale matrix", L_S_ref);
+
+  T_nu_ref nu_ref = nu;
   T_return lp(0.0);
 
   if (include_summand<propto, T_dof>::value) {

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -49,22 +49,16 @@ return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& L_Y,
   using T_return = return_type_t<T_y, T_dof, T_scale>;
   static const char* function = "wishart_cholesky_lpdf";
   Eigen::Index k = L_Y.rows();
-  check_size_match(function, "Rows of RSandom variable", L_Y.rows(),
-                   "columns of scale parameter", L_S.rows());
+
+  check_cholesky_factor(function, "Cholesky random variable", L_Y);
+  check_greater(function, "Degrees of freedom parameter", nu, k - 1);
+  check_cholesky_factor(function, "Cholesky scale matrix", L_S);
   check_size_match(function, "Rows of random variable", L_Y.rows(),
-                   "columns of random variable", L_Y.cols());
-  check_size_match(function, "Rows of scale parameter", L_S.rows(),
-                   "columns of scale parameter", L_S.cols());
+                   "columns of scale parameter", L_S.rows());
+
   T_L_Y_ref L_Y_ref = L_Y;
   T_nu_ref nu_ref = nu;
   T_L_S_ref L_S_ref = L_S;
-
-  check_greater(function, "Degrees of freedom parameter", nu_ref, k - 1);
-  check_positive(function, "Cholesky Random variable", L_Y_ref.diagonal());
-  check_positive(function, "columns of Cholesky Random variable",
-                 L_Y_ref.cols());
-  check_positive(function, "Cholesky scale matrix", L_S_ref.diagonal());
-  check_positive(function, "columns of Cholesky scale matrix", L_S_ref.cols());
 
   T_return lp(0.0);
 

--- a/stan/math/prim/prob/wishart_cholesky_rng.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_rng.hpp
@@ -34,10 +34,8 @@ inline Eigen::MatrixXd wishart_cholesky_rng(double nu,
   using Eigen::MatrixXd;
   static const char* function = "wishart_cholesky_rng";
   index_type_t<MatrixXd> k = L_S.rows();
-  check_square(function, "Cholesky Scale matrix", L_S);
   check_greater(function, "degrees of freedom > dims - 1", nu, k - 1);
-  check_positive(function, "Cholesky Scale matrix", L_S.diagonal());
-  check_positive(function, "columns of Cholesky Scale matrix", L_S.cols());
+  check_cholesky_factor(function, "Cholesky Scale matrix", L_S);
 
   MatrixXd B = MatrixXd::Zero(k, k);
   for (int j = 0; j < k; ++j) {

--- a/test/unit/math/mix/prob/inv_wishart_cholesky_test.cpp
+++ b/test/unit/math/mix/prob/inv_wishart_cholesky_test.cpp
@@ -6,12 +6,9 @@ TEST(ProbDistributionsInvWishartCholesky, matvar) {
     auto symmetric_Sigma = ((Sigma + Sigma.transpose()) * 0.5).eval();
 
     auto L_Y = stan::math::cholesky_decompose(symmetric_Y);
-    stan::plain_type_t<decltype(L_Y)> L_Y_plain = L_Y;
-
     auto L_S = stan::math::cholesky_decompose(symmetric_Sigma);
-    stan::plain_type_t<decltype(L_S)> L_S_plain = L_S;
 
-    return stan::math::inv_wishart_cholesky_lpdf(L_Y, dof, L_S_plain);
+    return stan::math::inv_wishart_cholesky_lpdf(L_Y, dof, L_S);
   };
 
   double dof = 3.4;

--- a/test/unit/math/mix/prob/inv_wishart_cholesky_test.cpp
+++ b/test/unit/math/mix/prob/inv_wishart_cholesky_test.cpp
@@ -1,37 +1,44 @@
 #include <test/unit/math/test_ad.hpp>
 
 TEST(ProbDistributionsInvWishartCholesky, matvar) {
-  auto f = [](const auto& L_Y, const auto& dof, const auto& L_S) {
-    return stan::math::inv_wishart_cholesky_lpdf(L_Y, dof, L_S);
+  auto f = [](const auto& Y, const auto& dof, const auto& Sigma) {
+    auto symmetric_Y = ((Y + Y.transpose()) * 0.5).eval();
+    auto symmetric_Sigma = ((Sigma + Sigma.transpose()) * 0.5).eval();
+
+    auto L_Y = stan::math::cholesky_decompose(symmetric_Y);
+    stan::plain_type_t<decltype(L_Y)> L_Y_plain = L_Y;
+
+    auto L_S = stan::math::cholesky_decompose(symmetric_Sigma);
+    stan::plain_type_t<decltype(L_S)> L_S_plain = L_S;
+
+    return stan::math::inv_wishart_cholesky_lpdf(L_Y, dof, L_S_plain);
   };
 
   double dof = 3.4;
-  Eigen::MatrixXd L_Y11(1, 1);
-  L_Y11 << 1;
-  Eigen::MatrixXd L_S11(1, 1);
-  L_S11 << 1;
-  stan::test::expect_ad(f, L_Y11, dof, L_S11);
-  stan::test::expect_ad_matvar(f, L_Y11, dof, L_S11);
+  Eigen::MatrixXd Y11(1, 1);
+  Y11 << 1;
+  Eigen::MatrixXd Sigma11(1, 1);
+  Sigma11 << 1;
+  stan::test::expect_ad(f, Y11, dof, Sigma11);
+  stan::test::expect_ad_matvar(f, Y11, dof, Sigma11);
 
-  Eigen::MatrixXd L_Y00(0, 0);
-  Eigen::MatrixXd L_S00(0, 0);
-  stan::test::expect_ad(f, L_Y00, dof, L_S00);
-  stan::test::expect_ad_matvar(f, L_Y00, dof, L_S00);
+  Eigen::MatrixXd Y00(0, 0);
+  Eigen::MatrixXd Sigma00(0, 0);
+  stan::test::expect_ad(f, Y00, dof, Sigma00);
+  stan::test::expect_ad_matvar(f, Y00, dof, Sigma00);
 
-  Eigen::MatrixXd y22(2, 2);
-  y22 << 1.0, 0.1, 0.1, 1.5;
-  Eigen::MatrixXd L_Y22 = y22.llt().matrixL();
+  Eigen::MatrixXd Y22(2, 2);
+  Y22 << 1.0, 0.1, 0.1, 1.5;
   Eigen::MatrixXd Sigma22(2, 2);
   Sigma22 << 1.5, 0.5, 0.5, 1.1;
-  Eigen::MatrixXd L_S22 = Sigma22.llt().matrixL();
-  stan::test::expect_ad(f, L_Y22, dof, L_S22);
-  stan::test::expect_ad_matvar(f, L_Y22, dof, L_S22);
+  stan::test::expect_ad(f, Y22, dof, Sigma22);
+  stan::test::expect_ad_matvar(f, Y22, dof, Sigma22);
 
   // Error sizes
-  stan::test::expect_ad(f, L_Y00, dof, L_S11);
-  stan::test::expect_ad(f, L_Y11, dof, L_S00);
-  stan::test::expect_ad_matvar(f, L_Y00, dof, L_S11);
-  stan::test::expect_ad_matvar(f, L_Y11, dof, L_S00);
+  stan::test::expect_ad(f, Y00, dof, Sigma11);
+  stan::test::expect_ad(f, Y11, dof, Sigma00);
+  stan::test::expect_ad_matvar(f, Y00, dof, Sigma11);
+  stan::test::expect_ad_matvar(f, Y11, dof, Sigma00);
 }
 
 TEST(ProbDistributionsInvWishartCholesky, fvar_var) {

--- a/test/unit/math/mix/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/mix/prob/wishart_cholesky_test.cpp
@@ -1,37 +1,44 @@
 #include <test/unit/math/test_ad.hpp>
 
 TEST(ProbDistributionsWishartCholesky, matvar) {
-  auto f = [](const auto& L_Y, const auto& dof, const auto& L_S) {
-    return stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S);
+  auto f = [](const auto& Y, const auto& dof, const auto& Sigma) {
+    auto symmetric_Y = ((Y + Y.transpose()) * 0.5).eval();
+    auto symmetric_Sigma = ((Sigma + Sigma.transpose()) * 0.5).eval();
+
+    auto L_Y = stan::math::cholesky_decompose(symmetric_Y);
+    stan::plain_type_t<decltype(L_Y)> L_Y_plain = L_Y;
+
+    auto L_S = stan::math::cholesky_decompose(symmetric_Sigma);
+    stan::plain_type_t<decltype(L_S)> L_S_plain = L_S;
+
+    return stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S_plain);
   };
 
   double dof = 3.4;
-  Eigen::MatrixXd L_Y11(1, 1);
-  L_Y11 << 1;
-  Eigen::MatrixXd L_S11(1, 1);
-  L_S11 << 1;
-  stan::test::expect_ad(f, L_Y11, dof, L_S11);
-  stan::test::expect_ad_matvar(f, L_Y11, dof, L_S11);
+  Eigen::MatrixXd Y11(1, 1);
+  Y11 << 1;
+  Eigen::MatrixXd Sigma11(1, 1);
+  Sigma11 << 1;
+  stan::test::expect_ad(f, Y11, dof, Sigma11);
+  stan::test::expect_ad_matvar(f, Y11, dof, Sigma11);
 
-  Eigen::MatrixXd L_Y00(0, 0);
-  Eigen::MatrixXd L_S00(0, 0);
-  stan::test::expect_ad(f, L_Y00, dof, L_S00);
-  stan::test::expect_ad_matvar(f, L_Y00, dof, L_S00);
+  Eigen::MatrixXd Y00(0, 0);
+  Eigen::MatrixXd Sigma00(0, 0);
+  stan::test::expect_ad(f, Y00, dof, Sigma00);
+  stan::test::expect_ad_matvar(f, Y00, dof, Sigma00);
 
-  Eigen::MatrixXd y22(2, 2);
-  y22 << 1.0, 0.1, 0.1, 1.5;
-  Eigen::MatrixXd L_Y22 = y22.llt().matrixL();
+  Eigen::MatrixXd Y22(2, 2);
+  Y22 << 1.0, 0.1, 0.1, 1.5;
   Eigen::MatrixXd Sigma22(2, 2);
   Sigma22 << 1.5, 0.5, 0.5, 1.1;
-  Eigen::MatrixXd L_S22 = Sigma22.llt().matrixL();
-  stan::test::expect_ad(f, L_Y22, dof, L_S22);
-  stan::test::expect_ad_matvar(f, L_Y22, dof, L_S22);
+  stan::test::expect_ad(f, Y22, dof, Sigma22);
+  stan::test::expect_ad_matvar(f, Y22, dof, Sigma22);
 
   // Error sizes
-  stan::test::expect_ad(f, L_Y00, dof, L_S11);
-  stan::test::expect_ad(f, L_Y11, dof, L_S00);
-  stan::test::expect_ad_matvar(f, L_Y00, dof, L_S11);
-  stan::test::expect_ad_matvar(f, L_Y11, dof, L_S00);
+  stan::test::expect_ad(f, Y00, dof, Sigma11);
+  stan::test::expect_ad(f, Y11, dof, Sigma00);
+  stan::test::expect_ad_matvar(f, Y00, dof, Sigma11);
+  stan::test::expect_ad_matvar(f, Y11, dof, Sigma00);
 }
 
 TEST(ProbDistributionsWishartCholesky, fvar_var) {

--- a/test/unit/math/mix/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/mix/prob/wishart_cholesky_test.cpp
@@ -6,12 +6,9 @@ TEST(ProbDistributionsWishartCholesky, matvar) {
     auto symmetric_Sigma = ((Sigma + Sigma.transpose()) * 0.5).eval();
 
     auto L_Y = stan::math::cholesky_decompose(symmetric_Y);
-    stan::plain_type_t<decltype(L_Y)> L_Y_plain = L_Y;
-
     auto L_S = stan::math::cholesky_decompose(symmetric_Sigma);
-    stan::plain_type_t<decltype(L_S)> L_S_plain = L_S;
 
-    return stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S_plain);
+    return stan::math::wishart_cholesky_lpdf(L_Y, dof, L_S);
   };
 
   double dof = 3.4;

--- a/test/unit/math/opencl/rev/multi_normal_cholesky_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/multi_normal_cholesky_lpdf_test.cpp
@@ -105,7 +105,7 @@ TEST(ProbDistributionsMultiNormalCholesky, opencl_matches_cpu_small) {
   std::vector<Eigen::VectorXd> mu3{mu1, mu2};
   std::vector<Eigen::RowVectorXd> mu4{mu2, mu1};
   Eigen::MatrixXd L(N, N);
-  L << 1, 0, 0, 2, 3, 0, -4, 5, -6;
+  L << 4, 0, 0, -1, 1, 0, -4, -2, 3;
 
   stan::math::test::compare_cpu_opencl_prim_rev(
       multi_normal_cholesky_lpdf_functor, y1, mu1, L);

--- a/test/unit/math/prim/prob/inv_wishart_cholesky_rng_test.cpp
+++ b/test/unit/math/prim/prob/inv_wishart_cholesky_rng_test.cpp
@@ -17,7 +17,7 @@ TEST(ProbDistributionsInvWishartCholesky, rng) {
 
   MatrixXd omega(3, 4);
   EXPECT_THROW(inv_wishart_cholesky_rng(3.0, omega, rng),
-               std::invalid_argument);
+               std::domain_error);
 
   MatrixXd sigma(3, 3);
   sigma << 9.0, -3.0, 0.0, -3.0, 4.0, 1.0, 0.0, 1.0, 3.0;
@@ -124,19 +124,22 @@ TEST(ProbDistributionsInvWishartCholesky, compareToInvWishart) {
   using stan::math::qr_thin_Q;
 
   boost::random::mt19937 rng(92343U);
-  int N = 1e5;
+  int N = 1e4;
   double tol = 0.05;
-  for (int k = 1; k < 5; k++) {
+  for (int k = 1; k < 4; k++) {
     MatrixXd L = qr_thin_Q(MatrixXd::Random(k, k)).transpose();
     L.diagonal() = stan::math::abs(L.diagonal());
     MatrixXd sigma = multiply_lower_tri_self_transpose(L);
-    MatrixXd Z_mean = sigma / (k + 3);
+    MatrixXd L_S = stan::math::cholesky_decompose(sigma);
+    MatrixXd Z_mean = MatrixXd::Zero(k, k);
     MatrixXd Z_est = MatrixXd::Zero(k, k);
     for (int i = 0; i < N; i++) {
       Z_est += multiply_lower_tri_self_transpose(
-          inv_wishart_cholesky_rng(k + 4, L, rng));
+          inv_wishart_cholesky_rng(k + 4, L_S, rng));
+      Z_mean += inv_wishart_rng(k + 4, sigma, rng);
     }
     Z_est /= N;
+    Z_mean /= N;
     for (int j = 0; j < k; j++) {
       for (int i = 0; i < j; i++) {
         EXPECT_NEAR(Z_est(i, j), Z_mean(i, j), tol);

--- a/test/unit/math/prim/prob/inv_wishart_cholesky_rng_test.cpp
+++ b/test/unit/math/prim/prob/inv_wishart_cholesky_rng_test.cpp
@@ -16,8 +16,7 @@ TEST(ProbDistributionsInvWishartCholesky, rng) {
   boost::random::mt19937 rng;
 
   MatrixXd omega(3, 4);
-  EXPECT_THROW(inv_wishart_cholesky_rng(3.0, omega, rng),
-               std::domain_error);
+  EXPECT_THROW(inv_wishart_cholesky_rng(3.0, omega, rng), std::domain_error);
 
   MatrixXd sigma(3, 3);
   sigma << 9.0, -3.0, 0.0, -3.0, 4.0, 1.0, 0.0, 1.0, 3.0;

--- a/test/unit/math/prim/prob/inv_wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/inv_wishart_cholesky_test.cpp
@@ -163,7 +163,7 @@ TEST(ProbDistributionsInvWishartCholesky, Error) {
   nu = 5;
   MatrixXd Sigma(2, 1);
   EXPECT_THROW(inv_wishart_cholesky_lpdf(MatrixXd::Identity(1, 1), nu, Sigma),
-               std::domain_error);
+               std::invalid_argument);
 
   nu = 5;
   MatrixXd Y(2, 1);

--- a/test/unit/math/prim/prob/inv_wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/inv_wishart_cholesky_test.cpp
@@ -163,12 +163,12 @@ TEST(ProbDistributionsInvWishartCholesky, Error) {
   nu = 5;
   MatrixXd Sigma(2, 1);
   EXPECT_THROW(inv_wishart_cholesky_lpdf(MatrixXd::Identity(1, 1), nu, Sigma),
-               std::invalid_argument);
+               std::domain_error);
 
   nu = 5;
   MatrixXd Y(2, 1);
   EXPECT_THROW(inv_wishart_cholesky_lpdf(Y, nu, MatrixXd::Identity(2, 2)),
-               std::invalid_argument);
+               std::domain_error);
 
   nu = 5;
   EXPECT_THROW(inv_wishart_cholesky_lpdf(MatrixXd::Identity(3, 3), nu,

--- a/test/unit/math/prim/prob/wishart_cholesky_rng_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_rng_test.cpp
@@ -16,7 +16,7 @@ TEST(ProbDistributionsWishartCholesky, rng) {
   boost::random::mt19937 rng;
 
   MatrixXd omega(3, 4);
-  EXPECT_THROW(wishart_cholesky_rng(3.0, omega, rng), std::invalid_argument);
+  EXPECT_THROW(wishart_cholesky_rng(3.0, omega, rng), std::domain_error);
 
   MatrixXd sigma(3, 3);
   sigma << 9.0, -3.0, 0.0, -3.0, 4.0, 1.0, 0.0, 1.0, 3.0;

--- a/test/unit/math/prim/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_test.cpp
@@ -211,12 +211,12 @@ TEST(ProbDistributionsWishartCholesky, error) {
   nu = 5;
   MatrixXd Sigma(2, 1);
   EXPECT_THROW(wishart_cholesky_lpdf(MatrixXd::Identity(1, 1), nu, Sigma),
-               std::invalid_argument);
+               std::domain_error);
 
   nu = 5;
   MatrixXd Y(2, 1);
   EXPECT_THROW(wishart_cholesky_lpdf(Y, nu, MatrixXd::Identity(2, 2)),
-               std::invalid_argument);
+               std::domain_error);
 
   nu = 5;
   EXPECT_THROW(wishart_cholesky_lpdf(MatrixXd::Identity(3, 3), nu,

--- a/test/unit/math/prim/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_test.cpp
@@ -211,7 +211,7 @@ TEST(ProbDistributionsWishartCholesky, error) {
   nu = 5;
   MatrixXd Sigma(2, 1);
   EXPECT_THROW(wishart_cholesky_lpdf(MatrixXd::Identity(1, 1), nu, Sigma),
-               std::domain_error);
+               std::invalid_argument);
 
   nu = 5;
   MatrixXd Y(2, 1);


### PR DESCRIPTION
## Summary

We weren't checking cholesky factors in the code in multivariate distributions. This appeared in a user-facing RNG generating NaN for all quantities.

The fix here is to validate input arguments.

## Tests

No new tests.

For anyone reviewing, if it makes sense, please let me know what should be tested.

## Side Effects

Some existing models may no longer work if they accept matrixes and compute something (even if it's non-sensical) based on the inputs.

## Release notes

Bug fix. Added checks for Cholesky factors in multivariate distributions. This fixes issues in `inv_wishart_cholesky_lpdf`, `lkj_corr_cholesky_lpdf`, `multi_gp_cholesky_lpdf`, `multi_normal_cholesky_lpdf`, and `wishart_cholesky_lpdf`. This also affects the random number generators for `inv_wishart_cholesky_rng`, `multi_normal_cholesky_rng`, and `wishart_cholesky_rng`. 

## Checklist

- [x] Copyright holder: Daniel Lee

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
