### PR TITLE
Optimise `von_mises_lpdf` gradient calc

### DIFF
--- a/stan/math/prim/prob/von_mises_lpdf.hpp
+++ b/stan/math/prim/prob/von_mises_lpdf.hpp
@@ -81,7 +81,7 @@ return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
   if (!is_constant_all<T_scale>::value) {
     edge<2>(ops_partials).partials_
         = cos_mu_minus_y
-          - modified_bessel_first_kind(-1, kappa_val)
+          - modified_bessel_first_kind(1, kappa_val)
                 / modified_bessel_first_kind(0, kappa_val);
   }
 

--- a/test/unit/math/mix/prob/von_mises_test.cpp
+++ b/test/unit/math/mix/prob/von_mises_test.cpp
@@ -1,103 +1,23 @@
 #include <stan/math/mix.hpp>
-#include <test/unit/math/rev/fun/util.hpp>
-#include <gtest/gtest.h>
-#include <vector>
+#include <test/unit/math/test_ad.hpp>
 
-std::vector<double> test_von_mises_lpdf(double y, double mu, double kappa) {
-  using stan::math::var;
-  using stan::math::von_mises_lpdf;
+TEST(mathMixScalFun, von_mises_lpdf) {
+  auto f = [](const auto& y, const auto& mu, const auto& kappa) {
+    return stan::math::von_mises_lpdf(y, mu, kappa);
+  };
 
-  var y_var = y;
-  var mu_var = mu;
-  var kappa_var = kappa;
+  Eigen::VectorXd y(2);
+  y << 1.0, 2.0;
+  Eigen::VectorXd mu(2);
+  mu << 1.0, 0.5;
+  Eigen::VectorXd kappa(2);
+  kappa << 1.0, 0.5;
 
-  std::vector<var> x;
-  x.push_back(y_var);
-  x.push_back(mu_var);
-  x.push_back(kappa_var);
-
-  var logp = von_mises_lpdf<false>(y_var, mu_var, kappa_var);
-  std::vector<double> grad;
-  logp.grad(x, grad);
-  return grad;
-}
-
-TEST(ProbAgradDistributionsVonMises, derivatives) {
-  using stan::math::fvar;
-  using stan::math::von_mises_lpdf;
-
-  std::vector<double> grad = test_von_mises_lpdf(0, 1, 0);
-
-  fvar<double> lp = von_mises_lpdf<false>(0, 1, fvar<double>(0, 1));
-  EXPECT_FLOAT_EQ(grad[2], lp.d());
-
-  fvar<double> kappa1(0, 1);
-  EXPECT_FLOAT_EQ(von_mises_lpdf(0, 1, kappa1).val_, -1.8378770664093453390819);
-  EXPECT_FLOAT_EQ(von_mises_lpdf(0, 1, kappa1).d_, 0.54030230586813976501);
-
-  fvar<fvar<double>> kappa2(0);
-  EXPECT_NO_THROW(von_mises_lpdf(0, 1, kappa2));
-}
-
-TEST(ProbAgradDistributionsVonMises, FvarVar_1stDeriv) {
-  using stan::math::fvar;
-  using stan::math::var;
-  using stan::math::von_mises_lpdf;
-
-  fvar<var> y_(0, 1);
-  double mu(1);
-  double kappa(0);
-
-  fvar<var> logp = von_mises_lpdf(y_, mu, kappa);
-
-  std::vector<stan::math::var> y{y_.val_};
-  std::vector<double> g;
-  logp.val_.grad(y, g);
-  EXPECT_FLOAT_EQ(0, g[0]);
-}
-
-TEST(ProbAgradDistributionsVonMises, FvarVar_2ndDeriv1) {
-  using stan::math::fvar;
-  using stan::math::var;
-  using stan::math::von_mises_lpdf;
-
-  double y_(0);
-  fvar<var> mu(1, 1);
-  double kappa(0);
-  fvar<var> logp = von_mises_lpdf(y_, mu, kappa);
-
-  std::vector<stan::math::var> y{mu.val_};
-  std::vector<double> g;
-  logp.d_.grad(y, g);
-  EXPECT_FLOAT_EQ(0, g[0]);
-}
-
-TEST(ProbAgradDistributionsVonMises, FvarVar_2ndDeriv2) {
-  using stan::math::fvar;
-  using stan::math::var;
-  using stan::math::von_mises_lpdf;
-
-  double y_(0);
-  double mu(1);
-  fvar<var> kappa(0, 1);
-  fvar<var> logp = von_mises_lpdf(y_, mu, kappa);
-
-  std::vector<stan::math::var> y{kappa.val_};
-  std::vector<double> g;
-  logp.d_.grad(y, g);
-  // Fails: g[0] is -nan
-  // EXPECT_FLOAT_EQ(0, g[0]);
-}
-
-// This test once failed sanitizer checks -- nothing explicitly tested in the
-// code itself
-TEST(ProbAgradDistributionsVonMises, sanitizer_error_fixed) {
-  using stan::math::var;
-  double y = boost::math::constants::third_pi<double>();
-  double mu = boost::math::constants::sixth_pi<double>();
-  std::vector<var> kappa = {0.5};
-
-  auto lp = stan::math::von_mises_lpdf(y, mu, kappa);
-
-  lp.grad();
+  stan::test::expect_ad(f, y[0], mu[0], kappa[0]);
+  stan::test::expect_ad(f, y[0], mu, kappa);
+  stan::test::expect_ad(f, y, mu[0], kappa);
+  stan::test::expect_ad(f, y, mu, kappa[0]);
+  stan::test::expect_ad(f, y[0], mu[0], kappa);
+  stan::test::expect_ad(f, y, mu[0], kappa[0]);
+  stan::test::expect_ad(f, y[0], mu, kappa[0]);
 }


### PR DESCRIPTION
## Summary

Closes #3008 by using the reflection identity of the `modified_bessel_first_kind` to use order 1 instead of -1, as Boost's implementation is more optimised with order 1

## Tests

Replaced the `von_mises_lpdf` `mix` tests with the AD testing framework, expanded to test vectorised signatures as well

## Side Effects

N/A

## Release notes

Improved efficiency of `von_mises_lpdf` gradient calculation, credit to @venpopov

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
