### PR TITLE
Fix missing squareness check in cholesky functions

### DIFF
--- a/stan/math/prim/prob/inv_wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/inv_wishart_cholesky_lpdf.hpp
@@ -50,8 +50,11 @@ return_type_t<T_y, T_dof, T_scale> inv_wishart_cholesky_lpdf(
   static const char* function = "inv_wishart_cholesky_lpdf";
   Eigen::Index k = L_Y.rows();
   check_greater(function, "Degrees of freedom parameter", nu, k - 1);
-  check_size_match(function, "Rows of random variable", L_Y.rows(),
-                   "columns of scale parameter", L_S.rows());
+
+  check_square(function, "Cholesky random variable", L_Y);
+  check_square(function, "Cholesky Scale parameter", L_S);
+  check_size_match(function, "side length of random variable", L_Y.rows(),
+                   "side length of scale parameter", L_S.rows());
 
   T_L_Y_ref L_Y_ref = L_Y;
   check_cholesky_factor(function, "Cholesky random variable", L_Y_ref);

--- a/stan/math/prim/prob/inv_wishart_cholesky_rng.hpp
+++ b/stan/math/prim/prob/inv_wishart_cholesky_rng.hpp
@@ -34,6 +34,7 @@ inline Eigen::MatrixXd inv_wishart_cholesky_rng(double nu,
   using Eigen::MatrixXd;
   static const char* function = "inv_wishart_cholesky_rng";
   index_type_t<MatrixXd> k = L_S.rows();
+  check_square(function, "Cholesky Scale matrix", L_S);
   check_greater(function, "degrees of freedom > dims - 1", nu, k - 1);
   check_cholesky_factor(function, "Cholesky Scale matrix", L_S);
 

--- a/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
@@ -101,7 +101,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
                    "rows of covariance parameter", L.rows());
   check_size_match(function, "Size of random variable", size_y,
                    "columns of covariance parameter", L.cols());
-                   
+
   for (size_t i = 0; i < size_vec; i++) {
     check_finite(function, "Location parameter", mu_vec[i]);
     check_not_nan(function, "Random variable", y_vec[i]);

--- a/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
@@ -99,7 +99,9 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
                    "size of location parameter", size_mu);
   check_size_match(function, "Size of random variable", size_y,
                    "rows of covariance parameter", L.rows());
-
+  check_size_match(function, "Size of random variable", size_y,
+                   "columns of covariance parameter", L.cols());
+                   
   for (size_t i = 0; i < size_vec; i++) {
     check_finite(function, "Location parameter", mu_vec[i]);
     check_not_nan(function, "Random variable", y_vec[i]);

--- a/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_lpdf.hpp
@@ -51,8 +51,11 @@ return_type_t<T_y, T_dof, T_scale> wishart_cholesky_lpdf(const T_y& L_Y,
   Eigen::Index k = L_Y.rows();
 
   check_greater(function, "Degrees of freedom parameter", nu, k - 1);
-  check_size_match(function, "Rows of random variable", L_Y.rows(),
-                   "columns of scale parameter", L_S.rows());
+
+  check_square(function, "Cholesky random variable", L_Y);
+  check_square(function, "Cholesky scale parameter", L_S);
+  check_size_match(function, "side length of random variable", L_Y.rows(),
+                   "side length of scale parameter", L_S.rows());
 
   T_L_Y_ref L_Y_ref = L_Y;
   check_cholesky_factor(function, "Cholesky random variable", L_Y_ref);

--- a/stan/math/prim/prob/wishart_cholesky_rng.hpp
+++ b/stan/math/prim/prob/wishart_cholesky_rng.hpp
@@ -35,6 +35,7 @@ inline Eigen::MatrixXd wishart_cholesky_rng(double nu,
   static const char* function = "wishart_cholesky_rng";
   index_type_t<MatrixXd> k = L_S.rows();
   check_greater(function, "degrees of freedom > dims - 1", nu, k - 1);
+  check_square(function, "Cholesky Scale matrix", L_S);
   check_cholesky_factor(function, "Cholesky Scale matrix", L_S);
 
   MatrixXd B = MatrixXd::Zero(k, k);

--- a/test/unit/math/prim/prob/inv_wishart_cholesky_rng_test.cpp
+++ b/test/unit/math/prim/prob/inv_wishart_cholesky_rng_test.cpp
@@ -16,7 +16,8 @@ TEST(ProbDistributionsInvWishartCholesky, rng) {
   boost::random::mt19937 rng;
 
   MatrixXd omega(3, 4);
-  EXPECT_THROW(inv_wishart_cholesky_rng(3.0, omega, rng), std::domain_error);
+  EXPECT_THROW(inv_wishart_cholesky_rng(3.0, omega, rng),
+               std::invalid_argument);
 
   MatrixXd sigma(3, 3);
   sigma << 9.0, -3.0, 0.0, -3.0, 4.0, 1.0, 0.0, 1.0, 3.0;

--- a/test/unit/math/prim/prob/inv_wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/inv_wishart_cholesky_test.cpp
@@ -168,7 +168,7 @@ TEST(ProbDistributionsInvWishartCholesky, Error) {
   nu = 5;
   MatrixXd Y(2, 1);
   EXPECT_THROW(inv_wishart_cholesky_lpdf(Y, nu, MatrixXd::Identity(2, 2)),
-               std::domain_error);
+               std::invalid_argument);
 
   nu = 5;
   EXPECT_THROW(inv_wishart_cholesky_lpdf(MatrixXd::Identity(3, 3), nu,

--- a/test/unit/math/prim/prob/wishart_cholesky_rng_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_rng_test.cpp
@@ -16,7 +16,7 @@ TEST(ProbDistributionsWishartCholesky, rng) {
   boost::random::mt19937 rng;
 
   MatrixXd omega(3, 4);
-  EXPECT_THROW(wishart_cholesky_rng(3.0, omega, rng), std::domain_error);
+  EXPECT_THROW(wishart_cholesky_rng(3.0, omega, rng), std::invalid_argument);
 
   MatrixXd sigma(3, 3);
   sigma << 9.0, -3.0, 0.0, -3.0, 4.0, 1.0, 0.0, 1.0, 3.0;

--- a/test/unit/math/prim/prob/wishart_cholesky_test.cpp
+++ b/test/unit/math/prim/prob/wishart_cholesky_test.cpp
@@ -216,7 +216,7 @@ TEST(ProbDistributionsWishartCholesky, error) {
   nu = 5;
   MatrixXd Y(2, 1);
   EXPECT_THROW(wishart_cholesky_lpdf(Y, nu, MatrixXd::Identity(2, 2)),
-               std::domain_error);
+               std::invalid_argument);
 
   nu = 5;
   EXPECT_THROW(wishart_cholesky_lpdf(MatrixXd::Identity(3, 3), nu,


### PR DESCRIPTION
## Summary

#3007 introduced a few bugs by assuming `check_cholesky_factor` internally called `check_square`. This re-adds the missing checks.

## Tests

## Side Effects


## Release notes

Fixed a few additional issues in checking the inputs to distributions defined over cholesky matrices. 


## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
