### PR TITLE
CVODES exceptions converted to domain_error

### DIFF
--- a/stan/math/prim/err/check_flag_sundials.hpp
+++ b/stan/math/prim/err/check_flag_sundials.hpp
@@ -176,23 +176,19 @@ inline std::array<std::string, 2> cvodes_flag_msg(int flag) {
 }
 
 /**
- * Throws a std::runtime_error exception when a Sundial function fails
+ * Throws a std::domain_error exception when a Sundial function fails
  * (i.e. returns a negative flag)
  *
  * @param flag Error flag
  * @param func_name Name of the function that returned the flag
- * @throw <code>std::runtime_error</code> if the flag is negative
+ * @throw <code>std::domain_error</code> if the flag is negative
  */
 inline void cvodes_check(int flag, const char* func_name) {
   if (flag < 0) {
     std::ostringstream ss;
     ss << func_name << " failed with error flag " << flag << ": \n"
        << cvodes_flag_msg(flag).at(1) << ".";
-    if (flag == -1 || flag == -4) {
-      throw std::domain_error(ss.str());
-    } else {
-      throw std::runtime_error(ss.str());
-    }
+    throw std::domain_error(ss.str());
   }
 }
 
@@ -368,11 +364,7 @@ inline void idas_check(int flag, const char* func_name) {
     std::ostringstream ss;
     ss << func_name << " failed with error flag " << flag << ": \n"
        << idas_flag_msg(flag).at(1);
-    if (flag == -1 || flag == -4) {
-      throw std::domain_error(ss.str());
-    } else {
-      throw std::runtime_error(ss.str());
-    }
+    throw std::domain_error(ss.str());
   }
 }
 

--- a/test/unit/math/rev/functor/index_3_dae_typed_test.cpp
+++ b/test/unit/math/rev/functor/index_3_dae_typed_test.cpp
@@ -25,10 +25,10 @@ using dae_test_types = boost::mp11::mp_product<
 
 TYPED_TEST_SUITE_P(index_3_dae_test);
 TYPED_TEST_P(index_3_dae_test, solver_failure) {
-  EXPECT_THROW_MSG(this->apply_solver(), std::runtime_error,
+  EXPECT_THROW_MSG(this->apply_solver(), std::domain_error,
                    "Error test failures occurred too many times");
   this->ts = {0.0001};
-  EXPECT_THROW_MSG(this->apply_solver_tol(), std::runtime_error,
+  EXPECT_THROW_MSG(this->apply_solver_tol(), std::domain_error,
                    "Error test failures occurred too many times");
 }
 


### PR DESCRIPTION
## Summary

The errors we throw based on CVODES flags were sometimes `std::runtime_error`s, which we'd like to be able to use for other things (e.g. `exit()` in the language and other things which aren't recoverable).

This changes all of them to domain_error, which is what we use for other issues that could be resolved by changing the parameters and trying again.

I believe this should close #1039, which was already partially addressed by #2620

## Tests


## Side Effects

## Release notes

Functions which are wrappers around CVODES and IDAS routines from Sundials now throw `domain_error`, rather than a mix of `domain_error` and `runtime_error`

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
