### PR TITLE
Ensure pointer is 8-byte aligned in stack_alloc::alloc

### DIFF
--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -167,9 +167,11 @@ class stack_alloc {
    * @return A pointer to the allocated memory.
    */
   inline void* alloc(size_t len) {
+    size_t pad = len % 8 == 0 ? 0 : 8 - len % 8;
+
     // Typically, just return and increment the next location.
     char* result = next_loc_;
-    next_loc_ += len;
+    next_loc_ += len + pad;
     // Occasionally, we have to switch blocks.
     if (unlikely(next_loc_ >= cur_block_end_)) {
       result = move_to_next_block(len);

--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -158,7 +158,9 @@ class stack_alloc {
    * Return a newly allocated block of memory of the appropriate
    * size managed by the stack allocator.
    *
-   * The allocated pointer will be 8-byte aligned.
+   * The allocated pointer will be 8-byte aligned. If the number
+   * of bytes requested is not a multiple of 8, the reserved space
+   * will be padded up to the next multiple of 8.
    *
    * This function may call C++'s <code>malloc()</code> function,
    * with any exceptions percolated through this function.

--- a/test/unit/math/memory/stack_alloc_test.cpp
+++ b/test/unit/math/memory/stack_alloc_test.cpp
@@ -91,7 +91,7 @@ TEST(stack_alloc, alloc) {
   allocator.recover_all();
 }
 
-TEST(stack_alloc, alloc_aligned){
+TEST(stack_alloc, alloc_aligned) {
   stan::math::stack_alloc allocator;
   int* x = allocator.alloc_array<int>(3);
 

--- a/test/unit/math/memory/stack_alloc_test.cpp
+++ b/test/unit/math/memory/stack_alloc_test.cpp
@@ -91,6 +91,15 @@ TEST(stack_alloc, alloc) {
   allocator.recover_all();
 }
 
+TEST(stack_alloc, alloc_aligned){
+  stan::math::stack_alloc allocator;
+  int* x = allocator.alloc_array<int>(3);
+
+  double* y = allocator.alloc_array<double>(4);
+  EXPECT_TRUE(stan::math::is_aligned(y, 8));
+  allocator.recover_all();
+}
+
 TEST(stack_alloc, in_stack) {
   stan::math::stack_alloc allocator;
 
@@ -113,7 +122,11 @@ TEST(stack_alloc, in_stack_second_block) {
   char* y = allocator.alloc_array<char>(1);
   EXPECT_TRUE(allocator.in_stack(x));
   EXPECT_TRUE(allocator.in_stack(y));
-  EXPECT_FALSE(allocator.in_stack(y + 1));
+  // effect of padding
+  EXPECT_TRUE(allocator.in_stack(y + 1));
+  EXPECT_TRUE(allocator.in_stack(y + 7));
+
+  EXPECT_FALSE(allocator.in_stack(y + 8));
 
   allocator.recover_all();
   EXPECT_FALSE(allocator.in_stack(x));


### PR DESCRIPTION
## Summary

This was originally found using UBSAN on the `csr_matrix_times_vector` function: https://github.com/stan-dev/rstan/issues/1111

The issue there was that that function places `u`, which is ` std::vector<int>`, in our memory arena. If `u` contained an odd number of elements (e.g., 3 in the above issue), this resulted in a call to `alloc` with a `len` of `12`. 

The _next_ call to `alloc` would then return a pointer which was not 8-byte aligned, which is undefined behavior. On x86 this is relatively benign, but on other platforms this could be either very slow or cause processor exceptions.

## Tests

I have updated `stack_alloc_test`

## Side Effects

This will add a few unused bytes (always less than 8) to allocations of types that `sizeof(T) % 8 !=0`. Additionally, a bit of extra math is needed in the `alloc` function, but @SteveBronder and I checked that this gets compiled down to just a `and`, `sub`, and `cmov`

## Release notes
Fixed the stack_allocator being able to return non-8-byte aligned pointers

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
