### PR TITLE
Silence unused variable warning in Boost

### DIFF
--- a/lib/boost_1.84.0/STAN_CHANGES
+++ b/lib/boost_1.84.0/STAN_CHANGES
@@ -1,0 +1,4 @@
+This file documents changes done for the stan-math project
+
+- Added a `#ifndef BOOST_DISABLE_ASSERTS` to boost/math/special_functions/detail/ibeta_inverse.hpp
+  to silence a warning about an unused variable.

--- a/lib/boost_1.84.0/boost/math/special_functions/detail/ibeta_inverse.hpp
+++ b/lib/boost_1.84.0/boost/math/special_functions/detail/ibeta_inverse.hpp
@@ -26,8 +26,10 @@ template <class T>
 struct temme_root_finder
 {
    temme_root_finder(const T t_, const T a_) : t(t_), a(a_) {
+      #ifndef BOOST_DISABLE_ASSERTS
       const T x_extrema = 1 / (1 + a);
       BOOST_MATH_ASSERT(0 < x_extrema && x_extrema < 1);
+      #endif
    }
 
    boost::math::tuple<T, T> operator()(T x)
@@ -121,7 +123,7 @@ T temme_method_1_ibeta_inverse(T a, T b, T z, const Policy& pol)
       x = 0;
    else if (x > 1)
       x = 1;
-   
+
    BOOST_MATH_ASSERT(eta * (x - 0.5) >= 0);
 #ifdef BOOST_INSTRUMENT
    std::cout << "Estimating x with Temme method 1: " << x << std::endl;
@@ -406,7 +408,7 @@ T temme_method_3_ibeta_inverse(T a, T b, T p, T q, const Policy& pol)
 
    // Early exit for cases with numerical precision issues.
    if (cross == 0 || cross == 1) { return cross; }
-   
+
    x = tools::newton_raphson_iterate(
       temme_root_finder<T>(u, mu), x, lower, upper, policies::digits<T, Policy>() / 2);
 #ifdef BOOST_INSTRUMENT
@@ -842,7 +844,7 @@ T ibeta_inv_imp(T a, T b, T p, T q, const Policy& pol, T* py)
       else if(pow(p, 1/a) < 0.5)
       {
 #ifndef BOOST_NO_EXCEPTIONS
-         try 
+         try
          {
 #endif
             x = pow(p * a * boost::math::beta(a, b, pol), 1 / a);
@@ -863,7 +865,7 @@ T ibeta_inv_imp(T a, T b, T p, T q, const Policy& pol, T* py)
       {
          // model a distorted quarter circle:
 #ifndef BOOST_NO_EXCEPTIONS
-         try 
+         try
          {
 #endif
             y = pow(1 - pow(p, b * boost::math::beta(a, b, pol)), 1/b);


### PR DESCRIPTION
## Summary

Closes #3017

## Tests
None
## Side Effects
None
## Release notes
Silenced an unused variable warning in Boost.
## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
