### PR TITLE
[CI] ensure clean working directory for OpenCL GPU tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ import org.stan.Utils
 
 def runTests(String testPath, boolean jumbo = false) {
     try {
+        sh "cat make/local"
         if (jumbo && !params.disableJumbo) {
             sh "python3 runTests.py -j${env.PARALLEL} ${testPath} --jumbo --debug"
         } else {
@@ -344,6 +345,7 @@ pipeline {
                             runTests("test/unit/multiple_translation_units_test.cpp")
                         }
                     }
+                    post { always { retry(3) { deleteDir() } } }
                 }
             }
         }
@@ -393,6 +395,7 @@ pipeline {
                             sh "python ./test/varmat_compatibility_test.py"
                             withEnv(['PATH+TBB=./lib/tbb']) {
                                 sh "python ./test/expressions/test_expression_testing_framework.py"
+                                sh "cat make/local"
                                 try { sh "./runTests.py -j${PARALLEL} test/expressions" }
                                 finally { junit 'test/**/*.xml' }
                             }
@@ -400,6 +403,7 @@ pipeline {
                             sh "echo STAN_THREADS=true >> make/local"
                             withEnv(['PATH+TBB=./lib/tbb']) {
                                 try {
+                                    sh "cat make/local"
                                     sh "./runTests.py -j${PARALLEL} test/expressions --only-functions reduce_sum map_rect"
 				                }
                                 finally { junit 'test/**/*.xml' }
@@ -498,6 +502,7 @@ pipeline {
                                             sh "echo CXXFLAGS+=-DSTAN_PROB_TEST_ALL >> make/local"
                                         }
                                     }
+                                    sh "cat make/local"
                                     sh "./runTests.py -j${PARALLEL} ${names}"
                                 }
                                 deleteDir()


### PR DESCRIPTION

## Summary

Ensure workdir is clean after step, cat make/local before running runTests.py

## Tests

## Side Effects

## Release notes

## Checklist

- [ ] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
