### PR TITLE
updating opencl multi_normal_cholesky_lpdf to match the other implementation

### DIFF
--- a/stan/math/opencl/prim/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/opencl/prim/multi_normal_cholesky_lpdf.hpp
@@ -44,9 +44,11 @@ inline return_type_t<T_y_cl, T_loc_cl, T_covar_cl> multi_normal_cholesky_lpdf(
   static const char* function = "multi_normal_cholesky_lpdf(OpenCL)";
 
   check_consistent_sizes(function, "y", y, "mu", mu);
-  check_square(function, "covariance parameter", L);
   check_size_match(function, "Size of random variable", y.rows(),
                    "rows of covariance parameter", L.rows());
+  check_square(function, "Cholesky decomposition of a variance matrix", L);
+  check_cholesky_factor(function, "Cholesky decomposition of a variance matrix",
+                        L);
 
   if (max_size(y, mu, L) == 0) {
     return 0.0;


### PR DESCRIPTION
## Summary

#3002 missed checking cholesky factor for the opencl version of multi_normal_cholesky_lpdf.

This PR adds in the `check_cholesky_factor`. This should now pass the CI tests.

## Tests

No new tests. There is a current test in `develop` that fails when running with opencl.


## Side Effects

None.

## Release notes

Updating opencl multi_cholesky_normal_lpdf implementation to check that the input is a valid cholesky factor.

## Checklist

- [x] Copyright holder: Daniel Lee

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
