### PR TITLE
Fix the return type of linspaced_array

### DIFF
--- a/stan/math/prim/fun/linspaced_array.hpp
+++ b/stan/math/prim/fun/linspaced_array.hpp
@@ -23,7 +23,7 @@ namespace math {
  * @throw std::domain_error if K is negative, if low is nan or infinite,
  * if high is nan or infinite, or if high is less than low.
  */
-inline std::vector<int> linspaced_array(int K, double low, double high) {
+inline std::vector<double> linspaced_array(int K, double low, double high) {
   static const char* function = "linspaced_array";
   check_nonnegative(function, "size", K);
   check_finite(function, "low", low);

--- a/test/unit/math/prim/fun/linspaced_array_test.cpp
+++ b/test/unit/math/prim/fun/linspaced_array_test.cpp
@@ -12,6 +12,11 @@ TEST(MathFunctions, linspaced_array) {
                              std::vector<int>({1, 2, 3, 4, 5}));
   EXPECT_STD_VECTOR_FLOAT_EQ(linspaced_array(5, -2, 2),
                              std::vector<int>({-2, -1, 0, 1, 2}));
+
+  std::vector<double> x = linspaced_array(5, 1.1, 5.5);
+  EXPECT_STD_VECTOR_FLOAT_EQ(x,
+                             std::vector<int>({1.1,2.2,3.3,4.4,5.5}));
+                             
 }
 
 TEST(MathFunctions, linspaced_array_throw) {


### PR DESCRIPTION
## Summary

Closes #3022 

## Tests

Added the example in #3022, and tried to set up the test such that compilation would fail if the same mistake is made again.

## Side Effects

None

## Release notes

Fixed a bug where `linspaced_array` was returning its results truncated to integers. 

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
