### PR TITLE
Fix: max(int,int) returning double

### DIFF
--- a/stan/math/prim/fun/max.hpp
+++ b/stan/math/prim/fun/max.hpp
@@ -22,7 +22,7 @@ namespace math {
  * @return maximum value of the two arguments
  */
 template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
-return_type_t<T1, T2> max(T1 x, T2 y) {
+auto max(T1 x, T2 y) {
   return std::max(x, y);
 }
 

--- a/stan/math/prim/fun/min.hpp
+++ b/stan/math/prim/fun/min.hpp
@@ -21,7 +21,7 @@ namespace math {
  * @return minimum value of the two arguments
  */
 template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
-return_type_t<T1, T2> min(T1 x, T2 y) {
+auto min(T1 x, T2 y) {
   return std::min(x, y);
 }
 

--- a/test/unit/math/prim/fun/max_test.cpp
+++ b/test/unit/math/prim/fun/max_test.cpp
@@ -66,6 +66,14 @@ TEST(MathMatrixPrimMat, max) {
   EXPECT_FLOAT_EQ(2.0, max(m));
 }
 
+TEST(MathMatrixPrimMat, max_scalars) {
+  int a = 1, b = 2, c = 3;
+  int max_ab = stan::math::max(a, b);
+  EXPECT_EQ(2, max_ab);
+  int max_abc = stan::math::max(stan::math::max(a,b), c);
+  EXPECT_EQ(3, max_abc);
+}
+
 TEST(MathMatrixPrimMat, max_exception) {
   using Eigen::Dynamic;
   using Eigen::Matrix;

--- a/test/unit/math/prim/fun/max_test.cpp
+++ b/test/unit/math/prim/fun/max_test.cpp
@@ -70,7 +70,7 @@ TEST(MathMatrixPrimMat, max_scalars) {
   int a = 1, b = 2, c = 3;
   int max_ab = stan::math::max(a, b);
   EXPECT_EQ(2, max_ab);
-  int max_abc = stan::math::max(stan::math::max(a,b), c);
+  int max_abc = stan::math::max(stan::math::max(a, b), c);
   EXPECT_EQ(3, max_abc);
 }
 

--- a/test/unit/math/prim/fun/min_test.cpp
+++ b/test/unit/math/prim/fun/min_test.cpp
@@ -66,6 +66,15 @@ TEST(MathMatrixPrimMat, min) {
   EXPECT_FLOAT_EQ(-10.0, min(m));
 }
 
+
+TEST(MathMatrixPrimMat, min_scalars) {
+  int a = 3, b = 2, c = 1;
+  int max_ab = stan::math::min(a, b);
+  EXPECT_EQ(2, max_ab);
+  int max_abc = stan::math::min(stan::math::min(a, b), c);
+  EXPECT_EQ(1, max_abc);
+}
+
 TEST(MathMatrixPrimMat, min_exception) {
   using Eigen::Dynamic;
   using Eigen::Matrix;

--- a/test/unit/math/prim/fun/min_test.cpp
+++ b/test/unit/math/prim/fun/min_test.cpp
@@ -66,7 +66,6 @@ TEST(MathMatrixPrimMat, min) {
   EXPECT_FLOAT_EQ(-10.0, min(m));
 }
 
-
 TEST(MathMatrixPrimMat, min_scalars) {
   int a = 3, b = 2, c = 1;
   int max_ab = stan::math::min(a, b);


### PR DESCRIPTION
## Summary
Initially reported downstream: https://github.com/stan-dev/rstan/issues/1116

I believe this may signal a larger issue with return_type_t usage, because the minimum type considered there is `double`, so we should probably avoid using it on functions which accept and want to return all ints.

## Tests

There were no existing tests for the `max(scalar, scalar)` case, so I added a few, including ones testing that int is returned. 

## Side Effects

None

## Release notes

Fixed the return type of `max(int, int)` being a double.

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
