### PR TITLE
Fix some unused variable warnings

### DIFF
--- a/stan/math/prim/functor/hcubature.hpp
+++ b/stan/math/prim/functor/hcubature.hpp
@@ -421,14 +421,6 @@ inline auto hcubature(const F& integrand, const ParsTuple& pars, const int dim,
       Eigen::Matrix<double, 5, 1>, Eigen::Matrix<double, 4, 1>>
       genz_malik;
 
-  auto gk_lambda = [&integrand, &pars](auto&& c) {
-    return stan::math::apply(
-        [](auto&& integrand, auto&& c, auto&&... args) {
-          return integrand(c, args...);
-        },
-        pars, integrand, c);
-  };
-
   if (dim == 1) {
     std::tie(result, err)
         = internal::gauss_kronrod(integrand, a[0], b[0], pars);

--- a/stan/math/prim/prob/wiener5_lpdf.hpp
+++ b/stan/math/prim/prob/wiener5_lpdf.hpp
@@ -405,7 +405,6 @@ inline auto wiener5_grad_a(const T_y& y, const T_a& a, const T_v& v_value,
                            const T_w& w_value, const T_sv& sv,
                            T_err&& err = log(1e-12)) noexcept {
   const auto two_log_a = 2 * log(a);
-  const auto log_y_asq = log(y) - two_log_a;
   const auto error_term
       = wiener5_compute_error_term(y, a, v_value, w_value, sv);
   const auto w = 1.0 - w_value;


### PR DESCRIPTION
## Summary

While working on https://github.com/stan-dev/stanc3/pull/1411 I noticed these were leading to a ton of compiler warnings when a model used the new lpdfs. 

## Tests

None

## Side Effects


## Release notes


## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
