### PR TITLE
Remove extra token in von_mises_text.hpp

### DIFF
--- a/test/prob/von_mises/von_mises_test.hpp
+++ b/test/prob/von_mises/von_mises_test.hpp
@@ -2,7 +2,7 @@
 #include <stan/math/prim/prob/von_mises_log.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/log.hpp>
-#include <stan/math/prim/fun/modified_bessel_first_kind.hpp>>
+#include <stan/math/prim/fun/modified_bessel_first_kind.hpp>
 
 using stan::math::var;
 using std::numeric_limits;


### PR DESCRIPTION
## Summary

Was generating `./test/prob/von_mises/von_mises_test.hpp:5:61: warning: extra tokens at end of #include directive [-Wextra-tokens]`

## Tests
None

## Side Effects

None

## Release notes

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
