### PR TITLE
Improve numerical stability of von_mises_lpdf

### DIFF
--- a/stan/math/prim/prob/von_mises_lpdf.hpp
+++ b/stan/math/prim/prob/von_mises_lpdf.hpp
@@ -81,8 +81,8 @@ return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
   if (!is_constant_all<T_scale>::value) {
     edge<2>(ops_partials).partials_
         = cos_mu_minus_y
-          - modified_bessel_first_kind(1, kappa_val)
-                / modified_bessel_first_kind(0, kappa_val);
+          - exp(log_modified_bessel_first_kind(1, kappa_val)
+                - log_modified_bessel_first_kind(0, kappa_val));   
   }
 
   return ops_partials.build(logp);

--- a/stan/math/prim/prob/von_mises_lpdf.hpp
+++ b/stan/math/prim/prob/von_mises_lpdf.hpp
@@ -82,7 +82,7 @@ return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
     edge<2>(ops_partials).partials_
         = cos_mu_minus_y
           - exp(log_modified_bessel_first_kind(1, kappa_val)
-                - log_modified_bessel_first_kind(0, kappa_val));   
+                - log_modified_bessel_first_kind(0, kappa_val));
   }
 
   return ops_partials.build(logp);


### PR DESCRIPTION
## Summary

This PR implements the proposal in #3035. The motivation, approach and consequences are described there.

## Tests

The existing tests for the von_mises distribution run. No new tests since its a small change to an existing distribution.

## Side Effects

As described in #3035, this makes von_mises_lpdf run slightly slower. However, the end result is faster because now the likelihood can be vectorized.

## Release notes

Improved stability of the von_mises_lpdf function to avoid numeric overflow. Now it's no longer necessary to use the normal_lpdf for kappa>100, allowing vectorizing the likelihood.

## Checklist

- [ X] Copyright holder: Vencislav Popov

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [ X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ X] the new changes are tested
