### PR TITLE
Make Weibull cdf & lcdf more robust, handle y = 0 inputs

### DIFF
--- a/stan/math/prim/prob/weibull_cdf.hpp
+++ b/stan/math/prim/prob/weibull_cdf.hpp
@@ -69,8 +69,8 @@ return_type_t<T_y, T_shape, T_scale> weibull_cdf(const T_y& y,
   constexpr bool any_derivs = !is_constant_all<T_y, T_shape, T_scale>::value;
   const auto& log_y = to_ref_if<any_derivs>(log(y_val));
   const auto& log_sigma = to_ref_if<any_derivs>(log(sigma_val));
-  const auto& log_pow_n
-      = to_ref_if<any_derivs>(alpha_val * log_y - alpha_val * log_sigma);
+  const auto& log_y_div_sigma = to_ref_if<any_derivs>(log_y - log_sigma);
+  const auto& log_pow_n = to_ref_if<any_derivs>(alpha_val * log_y_div_sigma);
   const auto& pow_n = to_ref_if<any_derivs>(exp(log_pow_n));
   const auto& log_cdf_n = to_ref_if<any_derivs>(log1m_exp(-pow_n));
 
@@ -88,7 +88,7 @@ return_type_t<T_y, T_shape, T_scale> weibull_cdf(const T_y& y,
       }
     }
     if (!is_constant_all<T_shape>::value) {
-      partials<1>(ops_partials) = exp(log_rep_deriv) * (log_y - log_sigma);
+      partials<1>(ops_partials) = exp(log_rep_deriv) * log_y_div_sigma;
     }
   }
   return ops_partials.build(exp(log_cdf));

--- a/stan/math/prim/prob/weibull_cdf.hpp
+++ b/stan/math/prim/prob/weibull_cdf.hpp
@@ -69,8 +69,8 @@ return_type_t<T_y, T_shape, T_scale> weibull_cdf(const T_y& y,
   constexpr bool any_derivs = !is_constant_all<T_y, T_shape, T_scale>::value;
   const auto& log_y = to_ref_if<any_derivs>(log(y_val));
   const auto& log_sigma = to_ref_if<any_derivs>(log(sigma_val));
-  const auto& log_pow_n = to_ref_if<any_derivs>(
-    alpha_val * log_y - alpha_val * log_sigma);
+  const auto& log_pow_n
+      = to_ref_if<any_derivs>(alpha_val * log_y - alpha_val * log_sigma);
   const auto& pow_n = to_ref_if<any_derivs>(exp(log_pow_n));
   const auto& log_cdf_n = to_ref_if<any_derivs>(log1m_exp(-pow_n));
 

--- a/stan/math/prim/prob/weibull_cdf.hpp
+++ b/stan/math/prim/prob/weibull_cdf.hpp
@@ -62,35 +62,33 @@ return_type_t<T_y, T_shape, T_scale> weibull_cdf(const T_y& y,
     return 1.0;
   }
 
-  auto ops_partials = make_partials_propagator(y_ref, alpha_ref, sigma_ref);
-
   constexpr bool any_derivs = !is_constant_all<T_y, T_shape, T_scale>::value;
-  const auto& pow_n = to_ref_if<any_derivs>(pow(y_val / sigma_val, alpha_val));
-  const auto& exp_n = to_ref_if<any_derivs>(exp(-pow_n));
-  const auto& cdf_n = to_ref_if<any_derivs>(1 - exp_n);
+  const auto& log_y = to_ref_if<any_derivs>(log(y_val));
+  const auto& log_sigma = to_ref_if<any_derivs>(log(sigma_val));
+  const auto& log_pow_n = to_ref_if<any_derivs>(
+    alpha_val * log_y - alpha_val * log_sigma);
+  const auto& pow_n = to_ref_if<any_derivs>(exp(log_pow_n));
+  const auto& log_cdf_n = to_ref_if<any_derivs>(log1m_exp(-pow_n));
 
-  T_partials_return cdf = prod(cdf_n);
+  T_partials_return log_cdf = sum(log_cdf_n);
 
+  auto ops_partials = make_partials_propagator(y_ref, alpha_ref, sigma_ref);
   if (any_derivs) {
-    const auto& rep_deriv = to_ref_if<(!is_constant_all<T_y, T_scale>::value
-                                       && !is_constant_all<T_shape>::value)>(
-        exp_n * pow_n * cdf / cdf_n);
+    const auto& log_rep_deriv = to_ref(log_pow_n + log_cdf - log_cdf_n - pow_n);
     if (!is_constant_all<T_y, T_scale>::value) {
-      const auto& deriv_y_sigma = to_ref_if<(
-          !is_constant_all<T_y>::value && !is_constant_all<T_scale>::value)>(
-          rep_deriv * alpha_val);
+      const auto& log_deriv_y_sigma = to_ref(log_rep_deriv + log(alpha_val));
       if (!is_constant_all<T_y>::value) {
-        partials<0>(ops_partials) = deriv_y_sigma / y_val;
+        partials<0>(ops_partials) = exp(log_deriv_y_sigma - log_y);
       }
       if (!is_constant_all<T_scale>::value) {
-        partials<2>(ops_partials) = -deriv_y_sigma / sigma_val;
+        partials<2>(ops_partials) = -exp(log_deriv_y_sigma - log_sigma);
       }
     }
     if (!is_constant_all<T_shape>::value) {
-      partials<1>(ops_partials) = rep_deriv * log(y_val / sigma_val);
+      partials<1>(ops_partials) = exp(log_rep_deriv) * (log_y - log_sigma);
     }
   }
-  return ops_partials.build(cdf);
+  return ops_partials.build(exp(log_cdf));
 }
 
 }  // namespace math

--- a/stan/math/prim/prob/weibull_cdf.hpp
+++ b/stan/math/prim/prob/weibull_cdf.hpp
@@ -43,7 +43,6 @@ return_type_t<T_y, T_shape, T_scale> weibull_cdf(const T_y& y,
   using T_y_ref = ref_type_if_not_constant_t<T_y>;
   using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
-  using std::pow;
   static constexpr const char* function = "weibull_cdf";
 
   T_y_ref y_ref = y;

--- a/stan/math/prim/prob/weibull_cdf.hpp
+++ b/stan/math/prim/prob/weibull_cdf.hpp
@@ -62,6 +62,11 @@ return_type_t<T_y, T_shape, T_scale> weibull_cdf(const T_y& y,
     return 1.0;
   }
 
+  auto ops_partials = make_partials_propagator(y_ref, alpha_ref, sigma_ref);
+  if (any(value_of_rec(y_val) == 0)) {
+    return ops_partials.build(0.0);
+  }
+
   constexpr bool any_derivs = !is_constant_all<T_y, T_shape, T_scale>::value;
   const auto& log_y = to_ref_if<any_derivs>(log(y_val));
   const auto& log_sigma = to_ref_if<any_derivs>(log(sigma_val));
@@ -72,7 +77,6 @@ return_type_t<T_y, T_shape, T_scale> weibull_cdf(const T_y& y,
 
   T_partials_return log_cdf = sum(log_cdf_n);
 
-  auto ops_partials = make_partials_propagator(y_ref, alpha_ref, sigma_ref);
   if (any_derivs) {
     const auto& log_rep_deriv = to_ref(log_pow_n + log_cdf - log_cdf_n - pow_n);
     if (!is_constant_all<T_y, T_scale>::value) {

--- a/stan/math/prim/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/prob/weibull_lcdf.hpp
@@ -39,7 +39,6 @@ template <typename T_y, typename T_shape, typename T_scale,
 return_type_t<T_y, T_shape, T_scale> weibull_lcdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {
-  using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
   using T_y_ref = ref_type_if_not_constant_t<T_y>;
   using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;

--- a/stan/math/prim/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/prob/weibull_lcdf.hpp
@@ -68,8 +68,8 @@ return_type_t<T_y, T_shape, T_scale> weibull_lcdf(const T_y& y,
   constexpr bool any_derivs = !is_constant_all<T_y, T_shape, T_scale>::value;
   const auto& log_y = to_ref_if<any_derivs>(log(y_val));
   const auto& log_sigma = to_ref_if<any_derivs>(log(sigma_val));
-  const auto& log_pow_n = to_ref_if<any_derivs>(
-    alpha_val * log_y - alpha_val * log_sigma);
+  const auto& log_pow_n
+      = to_ref_if<any_derivs>(alpha_val * log_y - alpha_val * log_sigma);
   const auto& pow_n = to_ref_if<any_derivs>(exp(log_pow_n));
 
   if (any_derivs) {

--- a/stan/math/prim/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/prob/weibull_lcdf.hpp
@@ -68,8 +68,8 @@ return_type_t<T_y, T_shape, T_scale> weibull_lcdf(const T_y& y,
   constexpr bool any_derivs = !is_constant_all<T_y, T_shape, T_scale>::value;
   const auto& log_y = to_ref_if<any_derivs>(log(y_val));
   const auto& log_sigma = to_ref_if<any_derivs>(log(sigma_val));
-  const auto& log_pow_n
-      = to_ref_if<any_derivs>(alpha_val * log_y - alpha_val * log_sigma);
+  const auto& log_y_div_sigma = to_ref_if<any_derivs>(log_y - log_sigma);
+  const auto& log_pow_n = to_ref_if<any_derivs>(alpha_val * log_y_div_sigma);
   const auto& pow_n = to_ref_if<any_derivs>(exp(log_pow_n));
 
   if (any_derivs) {
@@ -85,7 +85,7 @@ return_type_t<T_y, T_shape, T_scale> weibull_lcdf(const T_y& y,
       }
     }
     if (!is_constant_all<T_shape>::value) {
-      partials<1>(ops_partials) = exp(log_rep_deriv) * (log_y - log_sigma);
+      partials<1>(ops_partials) = exp(log_rep_deriv) * log_y_div_sigma;
     }
   }
   return ops_partials.build(sum(log1m_exp(-pow_n)));

--- a/stan/math/prim/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/prob/weibull_lcdf.hpp
@@ -43,7 +43,6 @@ return_type_t<T_y, T_shape, T_scale> weibull_lcdf(const T_y& y,
   using T_y_ref = ref_type_if_not_constant_t<T_y>;
   using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
-  using std::pow;
   static constexpr const char* function = "weibull_lcdf";
 
   T_y_ref y_ref = y;
@@ -63,34 +62,34 @@ return_type_t<T_y, T_shape, T_scale> weibull_lcdf(const T_y& y,
   }
 
   auto ops_partials = make_partials_propagator(y_ref, alpha_ref, sigma_ref);
+  if (any(value_of_rec(y_val) == 0)) {
+    return ops_partials.build(stan::math::NEGATIVE_INFTY);
+  }
 
   constexpr bool any_derivs = !is_constant_all<T_y, T_shape, T_scale>::value;
-  const auto& pow_n = to_ref_if<any_derivs>(pow(y_val / sigma_val, alpha_val));
-  const auto& exp_n = to_ref_if<any_derivs>(exp(-pow_n));
+  const auto& log_y = to_ref_if<any_derivs>(log(y_val));
+  const auto& log_sigma = to_ref_if<any_derivs>(log(sigma_val));
+  const auto& log_pow_n = to_ref_if<any_derivs>(
+    alpha_val * log_y - alpha_val * log_sigma);
+  const auto& pow_n = to_ref_if<any_derivs>(exp(log_pow_n));
 
-  // TODO(Andrew) Further simplify derivatives and log1m_exp below
-  T_partials_return cdf_log = sum(log1m(exp_n));
+  if (any_derivs) {
+    const auto& log_rep_deriv = to_ref(log_pow_n - log_diff_exp(pow_n, 0.0));
 
-  if (!is_constant_all<T_y, T_scale, T_shape>::value) {
-    const auto& rep_deriv = to_ref_if<(!is_constant_all<T_y, T_scale>::value
-                                       && !is_constant_all<T_shape>::value)>(
-        pow_n / (1.0 / exp_n - 1.0));
     if (!is_constant_all<T_y, T_scale>::value) {
-      const auto& deriv_y_sigma = to_ref_if<(
-          !is_constant_all<T_y>::value && !is_constant_all<T_scale>::value)>(
-          rep_deriv * alpha_val);
+      const auto& log_deriv_y_sigma = to_ref(log_rep_deriv + log(alpha_val));
       if (!is_constant_all<T_y>::value) {
-        partials<0>(ops_partials) = deriv_y_sigma / y_val;
+        partials<0>(ops_partials) = exp(log_deriv_y_sigma - log_y);
       }
       if (!is_constant_all<T_scale>::value) {
-        partials<2>(ops_partials) = -deriv_y_sigma / sigma_val;
+        partials<2>(ops_partials) = -exp(log_deriv_y_sigma - log_sigma);
       }
     }
     if (!is_constant_all<T_shape>::value) {
-      partials<1>(ops_partials) = rep_deriv * log(y_val / sigma_val);
+      partials<1>(ops_partials) = exp(log_rep_deriv) * (log_y - log_sigma);
     }
   }
-  return ops_partials.build(cdf_log);
+  return ops_partials.build(sum(log1m_exp(-pow_n)));
 }
 
 }  // namespace math

--- a/test/unit/math/mix/prob/weibull_cdf_test.cpp
+++ b/test/unit/math/mix/prob/weibull_cdf_test.cpp
@@ -9,14 +9,14 @@ TEST(mathMixScalFun, weibull_cdf) {
     using stan::math::positive_constrain;
 
     return stan::math::weibull_cdf(lb_constrain(y, 0.0),
-                                    positive_constrain(alpha),
-                                    positive_constrain(sigma));
+                                   positive_constrain(alpha),
+                                   positive_constrain(sigma));
   };
 
   using stan::math::log;
 
   Eigen::VectorXd y(3);
-  y << stan::math::NEGATIVE_INFTY, 1.2, 0.0; // lb_constrain(y[0], 0.0) = 0.0
+  y << stan::math::NEGATIVE_INFTY, 1.2, 0.0;  // lb_constrain(y[0], 0.0) = 0.0
 
   Eigen::VectorXd alpha(3);
   alpha << 2.0, 3.0, 4.0;

--- a/test/unit/math/mix/prob/weibull_cdf_test.cpp
+++ b/test/unit/math/mix/prob/weibull_cdf_test.cpp
@@ -2,9 +2,20 @@
 #include <test/unit/math/test_ad.hpp>
 
 TEST(mathMixScalFun, weibull_cdf) {
+  // Inputs are tested on the log (i.e., unconstrained) scale so that the
+  // finite-diffs don't result in invalid inputs.
   auto f = [](const auto& y, const auto& alpha, const auto& sigma) {
-    return stan::math::weibull_cdf(y, alpha, sigma);
+    using stan::math::lb_constrain;
+    using stan::math::positive_constrain;
+
+    return stan::math::weibull_cdf(lb_constrain(y, 0.0),
+                                    positive_constrain(alpha),
+                                    positive_constrain(sigma));
   };
 
-  stan::test::expect_ad(f, 10, 10, 10);
+  using stan::math::log;
+
+  stan::test::expect_ad(f, log(1.2), log(4), log(20));
+  stan::test::expect_ad(f, 0.0, 0.0, 0.0);
+  stan::test::expect_ad(f, stan::math::NEGATIVE_INFTY, 0.0, 0.0); // y = 0.0
 }

--- a/test/unit/math/mix/prob/weibull_cdf_test.cpp
+++ b/test/unit/math/mix/prob/weibull_cdf_test.cpp
@@ -1,0 +1,10 @@
+#include <stan/math/mix.hpp>
+#include <test/unit/math/test_ad.hpp>
+
+TEST(mathMixScalFun, weibull_cdf) {
+  auto f = [](const auto& y, const auto& alpha, const auto& sigma) {
+    return stan::math::weibull_cdf(y, alpha, sigma);
+  };
+
+  stan::test::expect_ad(f, 10, 10, 10);
+}

--- a/test/unit/math/mix/prob/weibull_cdf_test.cpp
+++ b/test/unit/math/mix/prob/weibull_cdf_test.cpp
@@ -16,7 +16,7 @@ TEST(mathMixScalFun, weibull_cdf) {
   using stan::math::log;
 
   Eigen::VectorXd y(3);
-  y << stan::math::NEGATIVE_INFTY, 1.2, 0.0;
+  y << stan::math::NEGATIVE_INFTY, 1.2, 0.0; // lb_constrain(y[0], 0.0) = 0.0
 
   Eigen::VectorXd alpha(3);
   alpha << 2.0, 3.0, 4.0;

--- a/test/unit/math/mix/prob/weibull_lcdf_test.cpp
+++ b/test/unit/math/mix/prob/weibull_lcdf_test.cpp
@@ -16,7 +16,7 @@ TEST(mathMixScalFun, weibull_lcdf) {
   using stan::math::log;
 
   Eigen::VectorXd y(3);
-  y << stan::math::NEGATIVE_INFTY, 1.2, 0.0; // lb_constrain(y[0], 0.0) = 0.0
+  y << stan::math::NEGATIVE_INFTY, 1.2, 0.0;  // lb_constrain(y[0], 0.0) = 0.0
 
   Eigen::VectorXd alpha(3);
   alpha << 2.0, 3.0, 4.0;

--- a/test/unit/math/mix/prob/weibull_lcdf_test.cpp
+++ b/test/unit/math/mix/prob/weibull_lcdf_test.cpp
@@ -16,7 +16,7 @@ TEST(mathMixScalFun, weibull_lcdf) {
   using stan::math::log;
 
   Eigen::VectorXd y(3);
-  y << stan::math::NEGATIVE_INFTY, 1.2, 0.0;
+  y << stan::math::NEGATIVE_INFTY, 1.2, 0.0; // lb_constrain(y[0], 0.0) = 0.0
 
   Eigen::VectorXd alpha(3);
   alpha << 2.0, 3.0, 4.0;

--- a/test/unit/math/mix/prob/weibull_lcdf_test.cpp
+++ b/test/unit/math/mix/prob/weibull_lcdf_test.cpp
@@ -1,14 +1,14 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
 
-TEST(mathMixScalFun, weibull_cdf) {
+TEST(mathMixScalFun, weibull_lcdf) {
   // Inputs are tested on the log (i.e., unconstrained) scale so that the
   // finite-diffs don't result in invalid inputs.
   auto f = [](const auto& y, const auto& alpha, const auto& sigma) {
     using stan::math::lb_constrain;
     using stan::math::positive_constrain;
 
-    return stan::math::weibull_cdf(lb_constrain(y, 0.0),
+    return stan::math::weibull_lcdf(lb_constrain(y, 0.0),
                                     positive_constrain(alpha),
                                     positive_constrain(sigma));
   };


### PR DESCRIPTION
## Summary

Reworks #2811 so that more of the (L)CDF & gradient calculations are on the log scale for stability

## Tests

Mix tests added using the AD framework for all combinations or scalar and vector inputs, including `y == 0.0`

## Side Effects

N/A

## Release notes

Updated the `weibull_cdf` and `weibull_lcdf` functions for numerical stability as well as correct handling of `y == 0.0`

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
