### PR TITLE
Fix wording of error on dimension mismatch

### DIFF
--- a/stan/math/prim/err/check_matching_dims.hpp
+++ b/stan/math/prim/err/check_matching_dims.hpp
@@ -85,9 +85,9 @@ inline void check_matching_dims(const char* function, const char* name1,
     [&]() STAN_COLD_PATH {
       std::ostringstream y1_err;
       std::ostringstream msg_str;
-      y1_err << "(" << y1.rows() << ", " << y1.cols() << ")";
-      msg_str << y2.rows() << ", " << y2.cols() << ") must match in size";
-      invalid_argument(function, name1, y1_err.str(), "(",
+      y1_err << "(" << y1.rows() << ", " << y1.cols() << ") and ";
+      msg_str << " (" << y2.rows() << ", " << y2.cols() << ") must match in size";
+      invalid_argument(function, name1, name2, std::string(y1_err.str()).c_str(),
                        std::string(msg_str.str()).c_str());
     }();
   }

--- a/stan/math/prim/err/check_matching_dims.hpp
+++ b/stan/math/prim/err/check_matching_dims.hpp
@@ -86,8 +86,10 @@ inline void check_matching_dims(const char* function, const char* name1,
       std::ostringstream y1_err;
       std::ostringstream msg_str;
       y1_err << "(" << y1.rows() << ", " << y1.cols() << ") and ";
-      msg_str << " (" << y2.rows() << ", " << y2.cols() << ") must match in size";
-      invalid_argument(function, name1, name2, std::string(y1_err.str()).c_str(),
+      msg_str << " (" << y2.rows() << ", " << y2.cols()
+              << ") must match in size";
+      invalid_argument(function, name1, name2,
+                       std::string(y1_err.str()).c_str(),
                        std::string(msg_str.str()).c_str());
     }();
   }


### PR DESCRIPTION
## Summary

Originally reported [on the forums](https://discourse.mc-stan.org/t/stan-error-messages/34820)

The error message for mismatching dimensions was pretty mangled. Previously, it could generate an error like:

```
 Exception: subtract: a ((5, 1)2, 1) must match in size
```

After this change, it would instead be

```
Exception: subtract: a (5, 1) and b (2, 1) must match in size
```

## Tests



## Side Effects


## Release notes

Improved error messages when variables dimensions do not match in operations that require it.

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [] the new changes are tested
