### PR TITLE
use a seperate class for csr_matrix adjoint

### DIFF
--- a/stan/math/rev/fun/csr_matrix_times_vector.hpp
+++ b/stan/math/rev/fun/csr_matrix_times_vector.hpp
@@ -14,14 +14,18 @@ namespace math {
 namespace internal {
 /**
  * `vari` for csr_matrix_times_vector
- * @note `csr_matrix_times_vector` uses the old inheritance 
- *  style to set up the reverse pass because of a linking 
+ * @note `csr_matrix_times_vector` uses the old inheritance
+ *  style to set up the reverse pass because of a linking
  *  issue on windows when using flto.
- * 
- * @tparam Result_ Either a type inheriting from `Eigen::DenseBase` with scalar type `var` or a `var<T>` where `T` inherits from `Eigen::DenseBase`
- * @tparam WMat_ Either a type inheriting from `Eigen::DenseBase` with scalar type `var` or `double`. Or a `var<T>` where `T` inherits from `Eigen::SparseBase`
- * @tparam B_ Either a type inheriting from `Eigen::DenseBase` with scalar type `var` or `double`. Or a `var<T>` where `T` inherits from `Eigen::DenseBase`
- *   
+ *
+ * @tparam Result_ Either a type inheriting from `Eigen::DenseBase` with scalar
+ * type `var` or a `var<T>` where `T` inherits from `Eigen::DenseBase`
+ * @tparam WMat_ Either a type inheriting from `Eigen::DenseBase` with scalar
+ * type `var` or `double`. Or a `var<T>` where `T` inherits from
+ * `Eigen::SparseBase`
+ * @tparam B_ Either a type inheriting from `Eigen::DenseBase` with scalar type
+ * `var` or `double`. Or a `var<T>` where `T` inherits from `Eigen::DenseBase`
+ *
  */
 template <typename Result_, typename WMat_, typename B_>
 struct csr_adjoint : public vari {
@@ -40,9 +44,12 @@ struct csr_adjoint : public vari {
 
   /**
    * Overload for calculating adjoints of `w_mat` and `b`
-   * @tparam Result Either a type inheriting from `Eigen::DenseBase` with scalar type `var` or a `var<T>` where `T` inherits from `Eigen::DenseBase`
-   * @tparam WMat Either a type inheriting from `Eigen::DenseBase` with scalar type `var`. Or a `var<T>` where `T` inherits from `Eigen::SparseBase`
-   * @tparam B Either a type inheriting from `Eigen::DenseBase` with scalar type `var`. Or a `var<T>` where `T` inherits from `Eigen::DenseBase`
+   * @tparam Result Either a type inheriting from `Eigen::DenseBase` with scalar
+   * type `var` or a `var<T>` where `T` inherits from `Eigen::DenseBase`
+   * @tparam WMat Either a type inheriting from `Eigen::DenseBase` with scalar
+   * type `var`. Or a `var<T>` where `T` inherits from `Eigen::SparseBase`
+   * @tparam B Either a type inheriting from `Eigen::DenseBase` with scalar type
+   * `var`. Or a `var<T>` where `T` inherits from `Eigen::DenseBase`
    * @param res The vector result of the forward pass calculation
    * @param w_mat A sparse matrix
    * @param b A vector
@@ -57,9 +64,12 @@ struct csr_adjoint : public vari {
 
   /**
    * Overload for calculating adjoints of `w_mat`
-   * @tparam Result Either a type inheriting from `Eigen::DenseBase` with scalar type `var` or a `var<T>` where `T` inherits from `Eigen::DenseBase`
-   * @tparam WMat Either a type inheriting from `Eigen::DenseBase` with scalar type `var`. Or a `var<T>` where `T` inherits from `Eigen::SparseBase`
-   * @tparam B Either a type inheriting from `Eigen::DenseBase` with scalar type `double`
+   * @tparam Result Either a type inheriting from `Eigen::DenseBase` with scalar
+   * type `var` or a `var<T>` where `T` inherits from `Eigen::DenseBase`
+   * @tparam WMat Either a type inheriting from `Eigen::DenseBase` with scalar
+   * type `var`. Or a `var<T>` where `T` inherits from `Eigen::SparseBase`
+   * @tparam B Either a type inheriting from `Eigen::DenseBase` with scalar type
+   * `double`
    * @param res The vector result of the forward pass calculation
    * @param w_mat A sparse matrix
    * @param b A vector
@@ -73,9 +83,12 @@ struct csr_adjoint : public vari {
 
   /**
    * Overload for calculating adjoints of `b`
-   * @tparam Result Either a type inheriting from `Eigen::DenseBase` with scalar type `var` or a `var<T>` where `T` inherits from `Eigen::DenseBase`
-   * @tparam WMat Either a type inheriting from `Eigen::DenseBase` with scalar type `double`
-   * @tparam B Either a type inheriting from `Eigen::DenseBase` with scalar type `var` or a `var<T>` where `T` inherits from `Eigen::DenseBase`
+   * @tparam Result Either a type inheriting from `Eigen::DenseBase` with scalar
+   * type `var` or a `var<T>` where `T` inherits from `Eigen::DenseBase`
+   * @tparam WMat Either a type inheriting from `Eigen::DenseBase` with scalar
+   * type `double`
+   * @tparam B Either a type inheriting from `Eigen::DenseBase` with scalar type
+   * `var` or a `var<T>` where `T` inherits from `Eigen::DenseBase`
    * @param res The vector result of the forward pass calculation
    * @param w_mat A sparse matrix
    * @param b A vector
@@ -90,19 +103,23 @@ struct csr_adjoint : public vari {
 
 /**
  * Helper function to construct the csr_adjoint struct.
- * @tparam Result_ Either a type inheriting from `Eigen::DenseBase` with scalar type `var` or a `var<T>` where `T` inherits from `Eigen::DenseBase`
- * @tparam WMat_ Either a type inheriting from `Eigen::DenseBase` with scalar type `var` or `double`. Or a `var<T>` where `T` inherits from `Eigen::SparseBase`
- * @tparam B_ Either a type inheriting from `Eigen::DenseBase` with scalar type `var` or `double`. Or a `var<T>` where `T` inherits from `Eigen::DenseBase`
- * 
+ * @tparam Result_ Either a type inheriting from `Eigen::DenseBase` with scalar
+ * type `var` or a `var<T>` where `T` inherits from `Eigen::DenseBase`
+ * @tparam WMat_ Either a type inheriting from `Eigen::DenseBase` with scalar
+ * type `var` or `double`. Or a `var<T>` where `T` inherits from
+ * `Eigen::SparseBase`
+ * @tparam B_ Either a type inheriting from `Eigen::DenseBase` with scalar type
+ * `var` or `double`. Or a `var<T>` where `T` inherits from `Eigen::DenseBase`
+ *
  * @param res The vector result of the forward pass calculation
  * @param w_mat A sparse matrix
- * @param b A vector 
+ * @param b A vector
  */
 template <typename Result_, typename WMat_, typename B_>
 inline void make_csr_adjoint(Result_&& res, WMat_&& w_mat, B_&& b) {
-  new csr_adjoint<std::decay_t<Result_>, std::decay_t<WMat_>, std::decay_t<B_>>(std::forward<Result_>(res),
-                                             std::forward<WMat_>(w_mat),
-                                             std::forward<B_>(b));
+  new csr_adjoint<std::decay_t<Result_>, std::decay_t<WMat_>, std::decay_t<B_>>(
+      std::forward<Result_>(res), std::forward<WMat_>(w_mat),
+      std::forward<B_>(b));
   return;
 }
 }  // namespace internal

--- a/stan/math/rev/fun/csr_matrix_times_vector.hpp
+++ b/stan/math/rev/fun/csr_matrix_times_vector.hpp
@@ -11,6 +11,50 @@
 namespace stan {
 namespace math {
 
+namespace internal {
+  template <typename Result_, typename WMat_, typename B_>
+  struct csr_adjoint : public vari {
+    std::decay_t<Result_> res_;
+    std::decay_t<WMat_> w_mat_;
+    std::decay_t<B_> b_;
+    template <typename T1, typename T2, typename T3>
+    csr_adjoint(T1&& res, T2&& w_mat, T3&& b)
+        : vari(0.0), res_(std::forward<T1>(res)),
+          w_mat_(std::forward<T2>(w_mat)), b_(std::forward<T3>(b)) {}
+
+    void chain() {
+      chain_internal(res_, w_mat_, b_);
+    }
+    template <typename Result, typename WMat, typename B,
+      require_rev_matrix_t<WMat>* = nullptr,
+      require_rev_matrix_t<B>* = nullptr>
+    void chain_internal(Result&& res, WMat&& w_mat, B&& b) {
+      w_mat.adj() += res.adj() * b.val().transpose();
+      b.adj() += w_mat.val().transpose() * res.adj();
+    }
+
+    template <typename Result, typename WMat, typename B,
+      require_rev_matrix_t<WMat>* = nullptr,
+      require_not_rev_matrix_t<B>* = nullptr>
+    void chain_internal(Result&& res, WMat&& w_mat, B&& b) {
+      w_mat.adj() += res.adj() * b.transpose();
+    }
+
+    template <typename Result, typename WMat, typename B,
+      require_not_rev_matrix_t<WMat>* = nullptr,
+      require_rev_matrix_t<B>* = nullptr>
+    void chain_internal(Result&& res, WMat&& w_mat, B&& b) {
+      b.adj() += w_mat.transpose() * res.adj();
+    }
+  };
+  template <typename Result_, typename WMat_, typename B_>
+  inline vari* make_csr_adjoint(Result_&& res, WMat_&& w_mat, B_&& b) {
+    return new csr_adjoint<Result_, WMat_, B_>(
+        std::forward<Result_>(res), std::forward<WMat_>(w_mat),
+        std::forward<B_>(b));
+  }
+}
+
 /**
  * \addtogroup csr_format
  * Return the multiplication of the sparse matrix (specified by
@@ -74,10 +118,7 @@ inline auto csr_matrix_times_vector(int m, int n, const T1& w,
     sparse_var_value_t w_mat_arena
         = to_soa_sparse_matrix<Eigen::RowMajor>(m, n, w, u_arena, v_arena);
     arena_t<return_t> res = w_mat_arena.val() * value_of(b_arena);
-    reverse_pass_callback([res, w_mat_arena, b_arena]() mutable {
-      w_mat_arena.adj() += res.adj() * b_arena.val().transpose();
-      b_arena.adj() += w_mat_arena.val().transpose() * res.adj();
-    });
+    stan::math::internal::make_csr_adjoint(res, w_mat_arena, b_arena);
     return return_t(res);
   } else if (!is_constant<T2>::value) {
     arena_t<promote_scalar_t<var, T2>> b_arena = b;
@@ -85,18 +126,14 @@ inline auto csr_matrix_times_vector(int m, int n, const T1& w,
     sparse_val_mat w_val_mat(m, n, w_val_arena.size(), u_arena.data(),
                              v_arena.data(), w_val_arena.data());
     arena_t<return_t> res = w_val_mat * value_of(b_arena);
-    reverse_pass_callback([w_val_mat, res, b_arena]() mutable {
-      b_arena.adj() += w_val_mat.transpose() * res.adj();
-    });
+    stan::math::internal::make_csr_adjoint(res, w_val_mat, b_arena);
     return return_t(res);
   } else {
     sparse_var_value_t w_mat_arena
         = to_soa_sparse_matrix<Eigen::RowMajor>(m, n, w, u_arena, v_arena);
     auto b_arena = to_arena(value_of(b));
     arena_t<return_t> res = w_mat_arena.val() * b_arena;
-    reverse_pass_callback([res, w_mat_arena, b_arena]() mutable {
-      w_mat_arena.adj() += res.adj() * b_arena.transpose();
-    });
+    stan::math::internal::make_csr_adjoint(res, w_mat_arena, b_arena);
     return return_t(res);
   }
 }

--- a/stan/math/rev/fun/csr_matrix_times_vector.hpp
+++ b/stan/math/rev/fun/csr_matrix_times_vector.hpp
@@ -12,48 +12,48 @@ namespace stan {
 namespace math {
 
 namespace internal {
-  template <typename Result_, typename WMat_, typename B_>
-  struct csr_adjoint : public vari {
-    std::decay_t<Result_> res_;
-    std::decay_t<WMat_> w_mat_;
-    std::decay_t<B_> b_;
-    template <typename T1, typename T2, typename T3>
-    csr_adjoint(T1&& res, T2&& w_mat, T3&& b)
-        : vari(0.0), res_(std::forward<T1>(res)),
-          w_mat_(std::forward<T2>(w_mat)), b_(std::forward<T3>(b)) {}
+template <typename Result_, typename WMat_, typename B_>
+struct csr_adjoint : public vari {
+  std::decay_t<Result_> res_;
+  std::decay_t<WMat_> w_mat_;
+  std::decay_t<B_> b_;
+  template <typename T1, typename T2, typename T3>
+  csr_adjoint(T1&& res, T2&& w_mat, T3&& b)
+      : vari(0.0),
+        res_(std::forward<T1>(res)),
+        w_mat_(std::forward<T2>(w_mat)),
+        b_(std::forward<T3>(b)) {}
 
-    void chain() {
-      chain_internal(res_, w_mat_, b_);
-    }
-    template <typename Result, typename WMat, typename B,
-      require_rev_matrix_t<WMat>* = nullptr,
-      require_rev_matrix_t<B>* = nullptr>
-    void chain_internal(Result&& res, WMat&& w_mat, B&& b) {
-      w_mat.adj() += res.adj() * b.val().transpose();
-      b.adj() += w_mat.val().transpose() * res.adj();
-    }
-
-    template <typename Result, typename WMat, typename B,
-      require_rev_matrix_t<WMat>* = nullptr,
-      require_not_rev_matrix_t<B>* = nullptr>
-    void chain_internal(Result&& res, WMat&& w_mat, B&& b) {
-      w_mat.adj() += res.adj() * b.transpose();
-    }
-
-    template <typename Result, typename WMat, typename B,
-      require_not_rev_matrix_t<WMat>* = nullptr,
-      require_rev_matrix_t<B>* = nullptr>
-    void chain_internal(Result&& res, WMat&& w_mat, B&& b) {
-      b.adj() += w_mat.transpose() * res.adj();
-    }
-  };
-  template <typename Result_, typename WMat_, typename B_>
-  inline vari* make_csr_adjoint(Result_&& res, WMat_&& w_mat, B_&& b) {
-    return new csr_adjoint<Result_, WMat_, B_>(
-        std::forward<Result_>(res), std::forward<WMat_>(w_mat),
-        std::forward<B_>(b));
+  void chain() { chain_internal(res_, w_mat_, b_); }
+  template <typename Result, typename WMat, typename B,
+            require_rev_matrix_t<WMat>* = nullptr,
+            require_rev_matrix_t<B>* = nullptr>
+  void chain_internal(Result&& res, WMat&& w_mat, B&& b) {
+    w_mat.adj() += res.adj() * b.val().transpose();
+    b.adj() += w_mat.val().transpose() * res.adj();
   }
+
+  template <typename Result, typename WMat, typename B,
+            require_rev_matrix_t<WMat>* = nullptr,
+            require_not_rev_matrix_t<B>* = nullptr>
+  void chain_internal(Result&& res, WMat&& w_mat, B&& b) {
+    w_mat.adj() += res.adj() * b.transpose();
+  }
+
+  template <typename Result, typename WMat, typename B,
+            require_not_rev_matrix_t<WMat>* = nullptr,
+            require_rev_matrix_t<B>* = nullptr>
+  void chain_internal(Result&& res, WMat&& w_mat, B&& b) {
+    b.adj() += w_mat.transpose() * res.adj();
+  }
+};
+template <typename Result_, typename WMat_, typename B_>
+inline vari* make_csr_adjoint(Result_&& res, WMat_&& w_mat, B_&& b) {
+  return new csr_adjoint<Result_, WMat_, B_>(std::forward<Result_>(res),
+                                             std::forward<WMat_>(w_mat),
+                                             std::forward<B_>(b));
 }
+}  // namespace internal
 
 /**
  * \addtogroup csr_format


### PR DESCRIPTION
## Summary

Tries to fix the linking issue again in https://github.com/stan-dev/rstanarm/issues/620

## Tests

Same tests as before

@WardBrian or @bgoodri can you try using this version in stanheaders to see what happens?

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
