### PR TITLE
Don't set build and clean rules for SUNDIALS if external libs are used

### DIFF
--- a/make/libraries
+++ b/make/libraries
@@ -23,6 +23,7 @@ CPPLINT ?= $(MATH)lib/cpplint_1.4.5
 #       Fortran bindings which we do not need for stan-math. Thus these targets
 #       are ignored here. This convention was introduced with 4.0.
 ##
+ifndef SUNDIALS_TARGETS
 
 SUNDIALS_CVODES := $(patsubst %.c,%.o,\
   $(wildcard $(SUNDIALS)/src/cvodes/*.c) \
@@ -87,7 +88,7 @@ $(STAN_SUNDIALS_HEADERS) : $(SUNDIALS_TARGETS)
 clean-sundials:
 	@echo '  cleaning sundials targets'
 	$(RM) $(wildcard $(sort $(SUNDIALS_CVODES) $(SUNDIALS_IDAS) $(SUNDIALS_KINSOL) $(SUNDIALS_NVECSERIAL) $(SUNDIALS_TARGETS)))
-
+endif
 
 ############################################################
 # TBB build rules


### PR DESCRIPTION
## Summary

When using an external SUNDIALS library via the `SUNDIALS_TARGETS` variable added in #2861, Stan will still try to delete the library files when calling `make clean-all`.

With `make/local`:
```
SUNDIALS = $(SUNDIALS_ROOT)
SUNDIALS_TARGETS = $(SUNDIALS_ROOT)/lib64/libsundials_nvecserial.a \
                    $(SUNDIALS_ROOT)/lib64/libsundials_cvodes.a \
                    $(SUNDIALS_ROOT)/lib64/libsundials_idas.a \
                    $(SUNDIALS_ROOT)/lib64/libsundials_kinsol.a
```

Gives `clean-all` behaviour:

```
[johnsoa2@login3 cmdstan-2.34.1]$ make clean-all
rm -f -r test
rm -f 
rm -f 
rm -f 
rm -f 
  removing dependency files
rm -f    
rm -f   
rm -f   
  cleaning sundials targets
rm -f /share/apps/scibuilder-spack/aalto-centos7/2023-01/software/linux-centos7-haswell/gcc-11.3.0/sundials-6.1.1-z5ytfe2/lib64/libsundials_cvodes.a /share/apps/scibuilder-spack/aalto-centos7/2023-01/software/linux-centos7-haswell/gcc-11.3.0/sundials-6.1.1-z5ytfe2/lib64/libsundials_idas.a /share/apps/scibuilder-spack/aalto-centos7/2023-01/software/linux-centos7-haswell/gcc-11.3.0/sundials-6.1.1-z5ytfe2/lib64/libsundials_kinsol.a /share/apps/scibuilder-spack/aalto-centos7/2023-01/software/linux-centos7-haswell/gcc-11.3.0/sundials-6.1.1-z5ytfe2/lib64/libsundials_nvecserial.a
rm: cannot remove ‘/share/apps/scibuilder-spack/aalto-centos7/2023-01/software/linux-centos7-haswell/gcc-11.3.0/sundials-6.1.1-z5ytfe2/lib64/libsundials_cvodes.a’: Permission denied
rm: cannot remove ‘/share/apps/scibuilder-spack/aalto-centos7/2023-01/software/linux-centos7-haswell/gcc-11.3.0/sundials-6.1.1-z5ytfe2/lib64/libsundials_idas.a’: Permission denied
rm: cannot remove ‘/share/apps/scibuilder-spack/aalto-centos7/2023-01/software/linux-centos7-haswell/gcc-11.3.0/sundials-6.1.1-z5ytfe2/lib64/libsundials_kinsol.a’: Permission denied
rm: cannot remove ‘/share/apps/scibuilder-spack/aalto-centos7/2023-01/software/linux-centos7-haswell/gcc-11.3.0/sundials-6.1.1-z5ytfe2/lib64/libsundials_nvecserial.a’: Permission denied
make: *** [clean-sundials] Error 1
```

This PR simply wraps the SUNDIALS build and clean rules in an `ifndef`, so that they are ignored when `SUNDIALS_TARGETS` is specified


## Tests

N/A

## Side Effects

N/A

## Release notes

Fixed `clean-all` error when using external SUNDIALS libraries

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
