### PR TITLE
Allow Hessian functors to return Hessian as compressed sparse matrix

### DIFF
--- a/stan/math/fwd/functor/hessian.hpp
+++ b/stan/math/fwd/functor/hessian.hpp
@@ -99,7 +99,7 @@ void hessian(const F& f, const Eigen::Matrix<T, Eigen::Dynamic, 1>& x, T& fx,
   hessian(f, x, fx, grad, hess_sparse);
 
   H = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>(hess_sparse)
-        .template selfadjointView<Eigen::Lower>();
+          .template selfadjointView<Eigen::Lower>();
 }
 
 }  // namespace math

--- a/stan/math/fwd/functor/hessian.hpp
+++ b/stan/math/fwd/functor/hessian.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_FWD_FUNCTOR_HESSIAN_HPP
 
 #include <stan/math/fwd/core.hpp>
+#include <stan/math/fwd/fun/value_of.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 
 namespace stan {
@@ -47,7 +48,7 @@ void hessian(const F& f, const Eigen::Matrix<T, Eigen::Dynamic, 1>& x, T& fx,
              Eigen::SparseMatrix<T>& H) {
   int d = x.size();
   if (d == 0) {
-    fx = f(x);
+    fx = value_of(f(x));
     return;
   }
 

--- a/stan/math/fwd/functor/hessian.hpp
+++ b/stan/math/fwd/functor/hessian.hpp
@@ -68,7 +68,7 @@ void hessian(const F& f, const Eigen::Matrix<T, Eigen::Dynamic, 1>& x, T& fx,
       if (i == j) {
         grad(i) = fx_fvar.d_.val_;
       }
-      H(j, i) = fx_fvar.d_.d_;
+      H.insert(j, i) = fx_fvar.d_.d_;
     }
   }
   H.makeCompressed();

--- a/stan/math/mix/functor/hessian.hpp
+++ b/stan/math/mix/functor/hessian.hpp
@@ -14,6 +14,9 @@ namespace math {
  * of the specified function at the specified argument in
  * O(N^2) time and O(N^2) space.
  *
+ * Instead of returning the full symmetric Hessian, we return the
+ * lower-triangular only as a column-major compressed sparse matrix.
+ *
  * <p>The functor must implement
  *
  * <code>
@@ -36,20 +39,23 @@ namespace math {
  * @param[in] x Argument to function
  * @param[out] fx Function applied to argument
  * @param[out] grad gradient of function at argument
- * @param[out] H Hessian of function at argument
+ * @param[out] H Hessian of function at argument, as a lower-triangular
+ *                      compressed sparse matrix
  */
 template <typename F>
-void hessian(const F& f, const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
-             double& fx, Eigen::Matrix<double, Eigen::Dynamic, 1>& grad,
-             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& H) {
-  H.resize(x.size(), x.size());
-  grad.resize(x.size());
-
-  // need to compute fx even with size = 0
-  if (x.size() == 0) {
+void hessian(const F& f, const Eigen::VectorXd& x,
+             double& fx, Eigen::VectorXd& grad,
+             Eigen::SparseMatrix<double>& H) {
+  int d = x.size();
+  if (d == 0) {
     fx = f(x);
     return;
   }
+
+  grad.resize(d);
+  H.resize(d, d);
+  H.reserve(Eigen::VectorXi::LinSpaced(d, 1, d).reverse());
+
   for (int i = 0; i < x.size(); ++i) {
     // Run nested autodiff in this scope
     nested_rev_autodiff nested;
@@ -64,10 +70,35 @@ void hessian(const F& f, const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
       fx = fx_fvar.val_.val();
     }
     stan::math::grad(fx_fvar.d_.vi_);
-    for (int j = 0; j < x.size(); ++j) {
-      H(i, j) = x_fvar(j).val_.adj();
+    for (int j = i; j < x.size(); ++j) {
+      H.insert(j, i) = x_fvar(j).val_.adj();
     }
   }
+  H.makeCompressed();
+}
+
+/**
+ * Calculate the value, the gradient, and the Hessian,
+ * of the specified function at the specified argument in
+ * O(N^2) time and O(N^2) space.
+ *
+ * Overload for returning the Hessian as a symmetric dense matrix.
+ *
+ * @tparam F Type of function
+ * @param[in] f Function
+ * @param[in] x Argument to function
+ * @param[out] fx Function applied to argument
+ * @param[out] grad gradient of function at argument
+ * @param[out] H Hessian of function at argument, as a symmetric matrix
+ */
+template <typename F>
+void hessian(const F& f, const Eigen::VectorXd& x,
+             double& fx, Eigen::VectorXd& grad,
+             Eigen::MatrixXd& H) {
+  Eigen::SparseMatrix<double> hess_sparse;
+  hessian(f, x, fx, grad, hess_sparse);
+
+  H = Eigen::MatrixXd(hess_sparse).selfadjointView<Eigen::Lower>();
 }
 
 }  // namespace math

--- a/stan/math/mix/functor/hessian.hpp
+++ b/stan/math/mix/functor/hessian.hpp
@@ -43,9 +43,8 @@ namespace math {
  *                      compressed sparse matrix
  */
 template <typename F>
-void hessian(const F& f, const Eigen::VectorXd& x,
-             double& fx, Eigen::VectorXd& grad,
-             Eigen::SparseMatrix<double>& H) {
+void hessian(const F& f, const Eigen::VectorXd& x, double& fx,
+             Eigen::VectorXd& grad, Eigen::SparseMatrix<double>& H) {
   int d = x.size();
   if (d == 0) {
     fx = f(x);
@@ -92,9 +91,8 @@ void hessian(const F& f, const Eigen::VectorXd& x,
  * @param[out] H Hessian of function at argument, as a symmetric matrix
  */
 template <typename F>
-void hessian(const F& f, const Eigen::VectorXd& x,
-             double& fx, Eigen::VectorXd& grad,
-             Eigen::MatrixXd& H) {
+void hessian(const F& f, const Eigen::VectorXd& x, double& fx,
+             Eigen::VectorXd& grad, Eigen::MatrixXd& H) {
   Eigen::SparseMatrix<double> hess_sparse;
   hessian(f, x, fx, grad, hess_sparse);
 

--- a/stan/math/mix/functor/hessian.hpp
+++ b/stan/math/mix/functor/hessian.hpp
@@ -1,9 +1,11 @@
 #ifndef STAN_MATH_MIX_FUNCTOR_HESSIAN_HPP
 #define STAN_MATH_MIX_FUNCTOR_HESSIAN_HPP
 
-#include <stan/math/fwd/core.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/fwd/core.hpp>
+#include <stan/math/fwd/fun/value_of_rec.hpp>
 #include <stan/math/rev/core.hpp>
+#include <stan/math/rev/fun/value_of_rec.hpp>
 #include <stdexcept>
 
 namespace stan {
@@ -47,7 +49,7 @@ void hessian(const F& f, const Eigen::VectorXd& x, double& fx,
              Eigen::VectorXd& grad, Eigen::SparseMatrix<double>& H) {
   int d = x.size();
   if (d == 0) {
-    fx = f(x);
+    fx = value_of_rec(f(x));
     return;
   }
 

--- a/stan/math/mix/functor/hessian_times_vector.hpp
+++ b/stan/math/mix/functor/hessian_times_vector.hpp
@@ -42,9 +42,9 @@ void hessian_times_vector(const F& f,
                           Eigen::Matrix<T, Eigen::Dynamic, 1>& Hv) {
   using Eigen::Matrix;
   Matrix<T, Eigen::Dynamic, 1> grad;
-  Matrix<T, Eigen::Dynamic, Eigen::Dynamic> H;
+  Eigen::SparseMatrix<T> H;
   hessian(f, x, fx, grad, H);
-  Hv = H * v;
+  Hv = H.template triangularview<Eigen::Lower>() * v;
 }
 
 }  // namespace math

--- a/stan/math/mix/functor/hessian_times_vector.hpp
+++ b/stan/math/mix/functor/hessian_times_vector.hpp
@@ -44,7 +44,7 @@ void hessian_times_vector(const F& f,
   Matrix<T, Eigen::Dynamic, 1> grad;
   Eigen::SparseMatrix<T> H;
   hessian(f, x, fx, grad, H);
-  Hv = H.template triangularview<Eigen::Lower>() * v;
+  Hv = H.template selfadjointView<Eigen::Lower>() * v;
 }
 
 }  // namespace math

--- a/stan/math/rev/functor/finite_diff_hessian_auto.hpp
+++ b/stan/math/rev/functor/finite_diff_hessian_auto.hpp
@@ -84,8 +84,9 @@ void finite_diff_hessian_auto(const F& f, const Eigen::VectorXd& x, double& fx,
   // approximate the hessian as a finite difference of gradients
   for (int i = 0; i < d; ++i) {
     for (int j = i; j < d; ++j) {
-      hess_fx.insert(j, i) = (g_plus[j](i) - g_minus[j](i)) / (4 * epsilons[j])
-                      + (g_plus[i](j) - g_minus[i](j)) / (4 * epsilons[i]);
+      hess_fx.insert(j, i)
+          = (g_plus[j](i) - g_minus[j](i)) / (4 * epsilons[j])
+            + (g_plus[i](j) - g_minus[i](j)) / (4 * epsilons[i]);
     }
   }
   hess_fx.makeCompressed();

--- a/stan/math/rev/functor/finite_diff_hessian_auto.hpp
+++ b/stan/math/rev/functor/finite_diff_hessian_auto.hpp
@@ -86,8 +86,9 @@ void finite_diff_hessian_auto(const F& f, const Eigen::VectorXd& x, double& fx,
   // approximate the hessian as a finite difference of gradients
   for (int i = 0; i < d; ++i) {
     for (int j = i; j < d; ++j) {
-      hess_fx.insert(j, i) = (g_plus[j](i) - g_minus[j](i)) / (4 * epsilons[j])
-                      + (g_plus[i](j) - g_minus[i](j)) / (4 * epsilons[i]);
+      hess_fx.insert(j, i)
+          = (g_plus[j](i) - g_minus[j](i)) / (4 * epsilons[j])
+            + (g_plus[i](j) - g_minus[i](j)) / (4 * epsilons[i]);
     }
   }
   hess_fx.makeCompressed();

--- a/test/unit/math/rev/functor/finite_diff_hessian_auto_test.cpp
+++ b/test/unit/math/rev/functor/finite_diff_hessian_auto_test.cpp
@@ -56,6 +56,7 @@ struct exp_full {
 struct one_arg {
   template <typename T>
   inline T operator()(const Matrix<T, Dynamic, 1>& x) const {
+    using stan::math::pow;
     return pow(x(0), 3);
   }
 };

--- a/test/unit/math/rev/functor/finite_diff_hessian_auto_test.cpp
+++ b/test/unit/math/rev/functor/finite_diff_hessian_auto_test.cpp
@@ -56,7 +56,6 @@ struct exp_full {
 struct one_arg {
   template <typename T>
   inline T operator()(const Matrix<T, Dynamic, 1>& x) const {
-    using stan::math::pow;
     return pow(x(0), 3);
   }
 };


### PR DESCRIPTION
## Summary

The Hessian functors currently return a full symmetric matrix for the Hessian, using double the memory needed. This PR updates the Hessian functors to return only the lower-triangular of the Hessian as a compressed sparse matrix by default, with overloads for returning the full symmetric matrix.

## Tests

N/A - Current signatures now delegate to the sparse implementation, so current tests should continue to pass

## Side Effects

Possibility of reduced memory usage and more efficient Eigen expressions for functions which need to manipulate the Hessian.

## Release notes

Added compressed sparse matrix return for Hessian functors

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
