### PR TITLE
Request C++17 by default, add fallback flag for now

### DIFF
--- a/doxygen/contributor_help_pages/developer_doc.md
+++ b/doxygen/contributor_help_pages/developer_doc.md
@@ -184,7 +184,7 @@ These are the more common make flags that could be set:
 These are the rest of the variables that can be set:
 
 - C++ compiler flags
-    - `CXXFLAGS_LANG`: sets the language. Currently defaults to `-std=c++1y`
+    - `CXXFLAGS_LANG`: sets the language. Currently defaults to `-std=c++17`
     - `CXXFLAGS_WARNINGS`: compiler options to squash compiler warnings
     - `CXXFLAGS_BOOST`: Boost-specific compiler flags
     - `CXXFLAGS_EIGEN`: Eigen-specific compiler flags

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -123,8 +123,12 @@ CPPFLAGS_SUNDIALS ?= -DNO_FPRINTF_OUTPUT $(CPPFLAGS_OPTIM_SUNDIALS) $(CXXFLAGS_F
 #CPPFLAGS_GTEST ?=
 
 
-## setup compiler flags
-CXXFLAGS_LANG ?= -std=c++1y
+ifeq ($(STAN_USE_CPP14),)
+  CXXFLAGS_LANG ?= -std=c++17
+else
+  $(warning "Because STAN_USE_CPP14 is set C++14 standard is requested. This will not be possible in the next release!")
+  CXXFLAGS_LANG ?= -std=c++1y
+endif
 #CXXFLAGS_BOOST ?=
 CXXFLAGS_SUNDIALS ?= -pipe $(CXXFLAGS_OPTIM_SUNDIALS) $(CPPFLAGS_FLTO_SUNDIALS)
 #CXXFLAGS_GTEST

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -120,44 +120,31 @@ INC_GTEST ?= -I $(GTEST)/include -I $(GTEST)
 CPPFLAGS_BOOST ?= -DBOOST_DISABLE_ASSERTS
 CPPFLAGS_SUNDIALS ?= -DNO_FPRINTF_OUTPUT $(CPPFLAGS_OPTIM_SUNDIALS) $(CXXFLAGS_FLTO_SUNDIALS)
 #CPPFLAGS_GTEST ?=
-HAS_CXX17 := false
+STAN_HAS_CXX17 ?= false
 ifeq ($(CXX_TYPE), gcc)
   GCC_GE_73 := $(shell [ $(CXX_MAJOR) -gt 7 -o \( $(CXX_MAJOR) -eq 7 -a $(CXX_MINOR) -ge 1 \) ] && echo true)
   ifeq ($(GCC_GE_73),true)
-    CXXFLAGS_LANG ?= -std=c++17
-    CXXFLAGS_STANDARD ?= c++17
-    HAS_CXX17 := true
+    STAN_HAS_CXX17 := true
   endif
 else ifeq ($(CXX_TYPE), clang)
   CLANG_GE_5 := $(shell [ $(CXX_MAJOR) -gt 5 -o \( $(CXX_MAJOR) -eq 5 -a $(CXX_MINOR) -ge 0 \) ] && echo true)
   ifeq ($(CLANG_GE_5),true)
-    CXXFLAGS_LANG ?= -std=c++17
-    CXXFLAGS_STANDARD ?= c++17
-    HAS_CXX17 := true
+    STAN_HAS_CXX17 := true
   endif
 else ifeq ($(CXX_TYPE), mingw32-gcc)
   MINGW_GE_50 := $(shell [ $(CXX_MAJOR) -gt 5 -o \( $(CXX_MAJOR) -eq 5 -a $(CXX_MINOR) -ge 0 \) ] && echo true)
   ifeq ($(MINGW_GE_50),true)
-    CXXFLAGS_LANG ?= -std=c++17
-    CXXFLAGS_STANDARD ?= c++17
-    HAS_CXX17 := true
+    STAN_HAS_CXX17 := true
   endif
-else ifeq ($(STAN_USE_CPP14),)
-  CXXFLAGS_LANG ?= -std=c++17
-  CXXFLAGS_STANDARD ?= c++17
-  HAS_CXX17 := true
-else
-  $(warning "Because STAN_USE_CPP14 is set C++14 standard is requested. This will not be possible in the next release!")
-  CXXFLAGS_LANG ?= -std=c++1y
-  CXXFLAGS_STANDARD ?= c++1y
-  HAS_CXX17 := false
 endif
 
-ifeq ($(HAS_CXX17), false)
-  $(warning "Because STAN_USE_CPP14 is set C++14 standard is requested. This will not be possible in the next release!")
+ifeq ($(STAN_HAS_CXX17), true)
+  CXXFLAGS_LANG ?= -std=c++17
+  CXXFLAGS_STANDARD ?= c++17
+else
+  $(warning "Stan cannot detect if your compiler has the C++17 standard. If it does, please set STAN_HAS_CXX17=true in your make/local file. C++17 support is mandatory in the next release of Stan. Defaulting to C++14")
   CXXFLAGS_LANG ?= -std=c++1y
   CXXFLAGS_STANDARD ?= c++1y
-  HAS_CXX17 := true
 endif
 #CXXFLAGS_BOOST ?=
 CXXFLAGS_SUNDIALS ?= -pipe $(CXXFLAGS_OPTIM_SUNDIALS) $(CPPFLAGS_FLTO_SUNDIALS)

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -150,7 +150,7 @@ else
   $(warning "Because STAN_USE_CPP14 is set C++14 standard is requested. This will not be possible in the next release!")
   CXXFLAGS_LANG ?= -std=c++1y
   CXXFLAGS_STANDARD ?= c++1y
-  HAS_CXX17 := true
+  HAS_CXX17 := false
 endif
 
 ifeq ($(HAS_CXX17), false)

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -120,35 +120,45 @@ INC_GTEST ?= -I $(GTEST)/include -I $(GTEST)
 CPPFLAGS_BOOST ?= -DBOOST_DISABLE_ASSERTS
 CPPFLAGS_SUNDIALS ?= -DNO_FPRINTF_OUTPUT $(CPPFLAGS_OPTIM_SUNDIALS) $(CXXFLAGS_FLTO_SUNDIALS)
 #CPPFLAGS_GTEST ?=
-
+HAS_CXX17 := false
 ifeq ($(CXX_TYPE), gcc)
   GCC_GE_73 := $(shell [ $(CXX_MAJOR) -gt 7 -o \( $(CXX_MAJOR) -eq 7 -a $(CXX_MINOR) -ge 1 \) ] && echo true)
   ifeq ($(GCC_GE_73),true)
     CXXFLAGS_LANG ?= -std=c++17
     CXXFLAGS_STANDARD ?= c++17
+    HAS_CXX17 := true
   endif
 else ifeq ($(CXX_TYPE), clang)
   CLANG_GE_5 := $(shell [ $(CXX_MAJOR) -gt 5 -o \( $(CXX_MAJOR) -eq 5 -a $(CXX_MINOR) -ge 0 \) ] && echo true)
   ifeq ($(CLANG_GE_5),true)
     CXXFLAGS_LANG ?= -std=c++17
     CXXFLAGS_STANDARD ?= c++17
+    HAS_CXX17 := true
   endif
 else ifeq ($(CXX_TYPE), mingw32-gcc)
   MINGW_GE_50 := $(shell [ $(CXX_MAJOR) -gt 5 -o \( $(CXX_MAJOR) -eq 5 -a $(CXX_MINOR) -ge 0 \) ] && echo true)
   ifeq ($(MINGW_GE_50),true)
     CXXFLAGS_LANG ?= -std=c++17
     CXXFLAGS_STANDARD ?= c++17
+    HAS_CXX17 := true
   endif
 else ifeq ($(STAN_USE_CPP14),)
   CXXFLAGS_LANG ?= -std=c++17
   CXXFLAGS_STANDARD ?= c++17
+  HAS_CXX17 := true
 else
   $(warning "Because STAN_USE_CPP14 is set C++14 standard is requested. This will not be possible in the next release!")
   CXXFLAGS_LANG ?= -std=c++1y
   CXXFLAGS_STANDARD ?= c++1y
+  HAS_CXX17 := true
 endif
 
-
+ifeq ($(HAS_CXX17), false)
+  $(warning "Because STAN_USE_CPP14 is set C++14 standard is requested. This will not be possible in the next release!")
+  CXXFLAGS_LANG ?= -std=c++1y
+  CXXFLAGS_STANDARD ?= c++1y
+  HAS_CXX17 := true
+endif
 #CXXFLAGS_BOOST ?=
 CXXFLAGS_SUNDIALS ?= -pipe $(CXXFLAGS_OPTIM_SUNDIALS) $(CPPFLAGS_FLTO_SUNDIALS)
 #CXXFLAGS_GTEST

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -70,7 +70,6 @@ CXX_VERSION :=  $(shell $(CXX) -dumpfullversion -dumpversion 2>&1)
 CXX_MAJOR := $(word 1,$(subst ., ,$(CXX_VERSION)))
 CXX_MINOR := $(word 2,$(subst ., ,$(CXX_VERSION)))
 
-
 ################################################################################
 # Set optional compiler flags for performance
 #
@@ -122,13 +121,34 @@ CPPFLAGS_BOOST ?= -DBOOST_DISABLE_ASSERTS
 CPPFLAGS_SUNDIALS ?= -DNO_FPRINTF_OUTPUT $(CPPFLAGS_OPTIM_SUNDIALS) $(CXXFLAGS_FLTO_SUNDIALS)
 #CPPFLAGS_GTEST ?=
 
-
-ifeq ($(STAN_USE_CPP14),)
+ifeq ($(CXX_TYPE), gcc)
+  GCC_GE_73 := $(shell [ $(CXX_MAJOR) -gt 7 -o \( $(CXX_MAJOR) -eq 7 -a $(CXX_MINOR) -ge 1 \) ] && echo true)
+  ifeq ($(GCC_GE_73),true)
+    CXXFLAGS_LANG ?= -std=c++17
+    CXXFLAGS_STANDARD ?= c++17
+  endif
+else ifeq ($(CXX_TYPE), clang)
+  CLANG_GE_5 := $(shell [ $(CXX_MAJOR) -gt 5 -o \( $(CXX_MAJOR) -eq 5 -a $(CXX_MINOR) -ge 0 \) ] && echo true)
+  ifeq ($(CLANG_GE_5),true)
+    CXXFLAGS_LANG ?= -std=c++17
+    CXXFLAGS_STANDARD ?= c++17
+  endif
+else ifeq ($(CXX_TYPE), mingw32-gcc)
+  MINGW_GE_50 := $(shell [ $(CXX_MAJOR) -gt 5 -o \( $(CXX_MAJOR) -eq 5 -a $(CXX_MINOR) -ge 0 \) ] && echo true)
+  ifeq ($(MINGW_GE_50),true)
+    CXXFLAGS_LANG ?= -std=c++17
+    CXXFLAGS_STANDARD ?= c++17
+  endif
+else ifeq ($(STAN_USE_CPP14),)
   CXXFLAGS_LANG ?= -std=c++17
+  CXXFLAGS_STANDARD ?= c++17
 else
   $(warning "Because STAN_USE_CPP14 is set C++14 standard is requested. This will not be possible in the next release!")
   CXXFLAGS_LANG ?= -std=c++1y
+  CXXFLAGS_STANDARD ?= c++1y
 endif
+
+
 #CXXFLAGS_BOOST ?=
 CXXFLAGS_SUNDIALS ?= -pipe $(CXXFLAGS_OPTIM_SUNDIALS) $(CPPFLAGS_FLTO_SUNDIALS)
 #CXXFLAGS_GTEST

--- a/make/libraries
+++ b/make/libraries
@@ -176,11 +176,11 @@ endif
 $(TBB_BIN)/tbb.def: $(TBB_BIN)/tbb-make-check
 	@mkdir -p $(TBB_BIN)
 	touch $(TBB_BIN)/version_$(notdir $(TBB))
-	tbb_root="$(TBB_RELATIVE_PATH)" WINARM64="$(WINARM64)" CXX="$(CXX)" CC="$(TBB_CC)" LDFLAGS='$(LDFLAGS_TBB)' '$(MAKE)' -C "$(TBB_BIN)" -r -f "$(TBB_ABSOLUTE_PATH)/build/Makefile.tbb" compiler=$(TBB_CXX_TYPE) cfg=release stdver=c++1y  CXXFLAGS="$(TBB_CXXFLAGS)"
+	tbb_root="$(TBB_RELATIVE_PATH)" WINARM64="$(WINARM64)" CXX="$(CXX)" CC="$(TBB_CC)" LDFLAGS='$(LDFLAGS_TBB)' '$(MAKE)' -C "$(TBB_BIN)" -r -f "$(TBB_ABSOLUTE_PATH)/build/Makefile.tbb" compiler=$(TBB_CXX_TYPE) cfg=release stdver=$(CXXFLAGS_STANDARD)  CXXFLAGS="$(TBB_CXXFLAGS)"
 
 $(TBB_BIN)/tbbmalloc.def: $(TBB_BIN)/tbb-make-check
 	@mkdir -p $(TBB_BIN)
-	tbb_root="$(TBB_RELATIVE_PATH)" WINARM64="$(WINARM64)" CXX="$(CXX)" CC="$(TBB_CC)" LDFLAGS='$(LDFLAGS_TBB)' '$(MAKE)' -C "$(TBB_BIN)" -r -f "$(TBB_ABSOLUTE_PATH)/build/Makefile.tbbmalloc" compiler=$(TBB_CXX_TYPE) cfg=release stdver=c++1y malloc CXXFLAGS="$(TBB_CXXFLAGS)"
+	tbb_root="$(TBB_RELATIVE_PATH)" WINARM64="$(WINARM64)" CXX="$(CXX)" CC="$(TBB_CC)" LDFLAGS='$(LDFLAGS_TBB)' '$(MAKE)' -C "$(TBB_BIN)" -r -f "$(TBB_ABSOLUTE_PATH)/build/Makefile.tbbmalloc" compiler=$(TBB_CXX_TYPE) cfg=release stdver=$(CXXFLAGS_STANDARD) malloc CXXFLAGS="$(TBB_CXXFLAGS)"
 
 $(TBB_BIN)/libtbb.dylib: $(TBB_BIN)/tbb.def
 $(TBB_BIN)/libtbbmalloc.dylib: $(TBB_BIN)/tbbmalloc.def


### PR DESCRIPTION
## Summary

There have been discussions about moving to C++17 for [a while](https://github.com/stan-dev/math/issues/1300). Stan compiles fine under `-std=c++17` since https://github.com/stan-dev/math/pull/2693, and C++17 is already used by RStan. 

There so far hasn't been a push to actually use C++17 in our code base, and this is a proposal for the first step to do this:

1. We start requesting `-std=c++17` in our Makefiles.
2. We provide a flag called `STAN_USE_CPP14` to switch back to `-std=c++1y`.

That's it. 
This is essentially designed to smoke out users who can't support C++17 while providing them with something they can put in `make/local` to continue compiling for a version or two, **until** we actually add some C++17-requiring source code, at which point we delete the opt-out.

I tried to find a more clever way to do this, but automatically detecting which standards a compiler supports seems to be a difficult/brittle thing to do. 

## Tests

None

## Side Effects

## Release notes

Stan now requests `-std=c++17`. C++14 can still be used by defining the make variable `STAN_USE_CPP14`. This variable will go away and C++17 will become a requirement in a future version.

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
