### PR TITLE
use tbb::concurrent_unordered_map instead of std::map

### DIFF
--- a/stan/math/rev/core/profiling.hpp
+++ b/stan/math/rev/core/profiling.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/prim/err.hpp>
+#include <tbb/concurrent_unordered_map.h>
 #include <iostream>
 #include <sstream>
 #include <thread>
@@ -115,7 +116,24 @@ class profile_info {
 
 using profile_key = std::pair<std::string, std::thread::id>;
 
-using profile_map = std::map<profile_key, profile_info>;
+
+namespace internal {
+  struct hash_profile_key {
+    std::size_t operator()(const profile_key& key) const {
+      return std::hash<std::string>()(key.first)
+             ^ std::hash<std::thread::id>()(key.second);
+    }
+  };
+  struct equal_profile_key {
+    bool operator()(const profile_key& lhs, const profile_key& rhs) const {
+      return lhs.first == rhs.first && lhs.second == rhs.second;
+    }
+  };
+
+}
+
+using profile_map = tbb::concurrent_unordered_map<profile_key,
+  profile_info, internal::hash_profile_key, internal::equal_profile_key>;
 
 /**
  * Profiles C++ lines where the object is in scope.

--- a/stan/math/rev/core/profiling.hpp
+++ b/stan/math/rev/core/profiling.hpp
@@ -116,24 +116,24 @@ class profile_info {
 
 using profile_key = std::pair<std::string, std::thread::id>;
 
-
 namespace internal {
-  struct hash_profile_key {
-    std::size_t operator()(const profile_key& key) const {
-      return std::hash<std::string>()(key.first)
-             ^ std::hash<std::thread::id>()(key.second);
-    }
-  };
-  struct equal_profile_key {
-    bool operator()(const profile_key& lhs, const profile_key& rhs) const {
-      return lhs.first == rhs.first && lhs.second == rhs.second;
-    }
-  };
+struct hash_profile_key {
+  std::size_t operator()(const profile_key& key) const {
+    return std::hash<std::string>()(key.first)
+           ^ std::hash<std::thread::id>()(key.second);
+  }
+};
+struct equal_profile_key {
+  bool operator()(const profile_key& lhs, const profile_key& rhs) const {
+    return lhs.first == rhs.first && lhs.second == rhs.second;
+  }
+};
 
-}
+}  // namespace internal
 
-using profile_map = tbb::concurrent_unordered_map<profile_key,
-  profile_info, internal::hash_profile_key, internal::equal_profile_key>;
+using profile_map = tbb::concurrent_unordered_map<profile_key, profile_info,
+                                                  internal::hash_profile_key,
+                                                  internal::equal_profile_key>;
 
 /**
  * Profiles C++ lines where the object is in scope.

--- a/test/unit/math/rev/core/profiling_test.cpp
+++ b/test/unit/math/rev/core/profiling_test.cpp
@@ -6,16 +6,16 @@
 TEST(Profiling, double_basic) {
   using stan::math::profile;
   using stan::math::var;
-  stan::math::profile_map profiles;
+  stan::math::profile_map prof_map;
   double a = 3.0, b = 2.0, c;
   {
-    profile<double> p1("p1", profiles);
+    profile<double> p1("p1", prof_map);
     c = log(exp(a)) * log(exp(b));
     std::chrono::milliseconds timespan(10);
     std::this_thread::sleep_for(timespan);
   }
   {
-    profile<int> p1("p1", profiles);
+    profile<int> p1("p1", prof_map);
     c = log(exp(a)) * log(exp(b));
     std::chrono::milliseconds timespan(10);
     std::this_thread::sleep_for(timespan);
@@ -23,14 +23,14 @@ TEST(Profiling, double_basic) {
 
   stan::math::profile_key key = {"p1", std::this_thread::get_id()};
   EXPECT_NEAR(c, 6.0, 1E-8);
-  EXPECT_EQ(profiles[key].get_chain_stack_used(), 0);
-  EXPECT_EQ(profiles[key].get_nochain_stack_used(), 0);
-  EXPECT_FLOAT_EQ(profiles[key].get_rev_time(), 0.0);
-  EXPECT_EQ(profiles[key].get_num_rev_passes(), 0);
-  EXPECT_EQ(profiles[key].get_num_fwd_passes(), 2);
-  EXPECT_EQ(profiles[key].get_num_no_AD_fwd_passes(), 2);
-  EXPECT_EQ(profiles[key].get_num_AD_fwd_passes(), 0);
-  EXPECT_TRUE(profiles[key].get_fwd_time() > 0.0);
+  EXPECT_EQ(prof_map[key].get_chain_stack_used(), 0);
+  EXPECT_EQ(prof_map[key].get_nochain_stack_used(), 0);
+  EXPECT_FLOAT_EQ(prof_map[key].get_rev_time(), 0.0);
+  EXPECT_EQ(prof_map[key].get_num_rev_passes(), 0);
+  EXPECT_EQ(prof_map[key].get_num_fwd_passes(), 2);
+  EXPECT_EQ(prof_map[key].get_num_no_AD_fwd_passes(), 2);
+  EXPECT_EQ(prof_map[key].get_num_AD_fwd_passes(), 0);
+  EXPECT_TRUE(prof_map[key].get_fwd_time() > 0.0);
 }
 
 TEST(Profiling, var_basic) {


### PR DESCRIPTION
## Summary

use tbb::concurrent_unordered_map instead of std::map so data races do not happen when multiple threads attempt to write to the map

## Tests

No new tests added 


## Release notes

Use `tbb::concurrent_unordered_map` for profiling

## Checklist

- [x] Copyright holder: Simon's Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
