### PR TITLE
[WIP] Sparse cholesky

### DIFF
--- a/stan/math/prim/err/check_pos_definite.hpp
+++ b/stan/math/prim/err/check_pos_definite.hpp
@@ -68,7 +68,6 @@ inline void check_pos_definite(const char* function, const char* name,
   }
 }
 
-
 /**
  * Check if the specified LDLT decomposition of a matrix is positive definite.
  *

--- a/stan/math/prim/err/check_pos_definite.hpp
+++ b/stan/math/prim/err/check_pos_definite.hpp
@@ -68,6 +68,44 @@ inline void check_pos_definite(const char* function, const char* name,
   }
 }
 
+
+/**
+ * Check if the specified LDLT decomposition of a matrix is positive definite.
+ *
+ * @tparam Derived type of the Eigen::LDLT decomposition
+ * @param function function name (for error messages)
+ * @param name variable name (for error messages)
+ * @param cholesky Eigen::LDLT to test, whose progenitor
+ * must not have any NaN elements
+ * @throw std::domain_error if the matrix is not positive definite
+ */
+template <typename Derived>
+inline void check_pos_definite(const char* function, const char* name,
+                               const Eigen::LDLT<Derived>& cholesky) {
+  if (cholesky.info() != Eigen::Success || !cholesky.isPositive()
+      || !(cholesky.vectorD().array() > 0.0).all()) {
+    throw_domain_error(function, "LDLT decomposition of", " failed", name);
+  }
+}
+
+/**
+ * Check if a sparse LLT decomposition of a matrix is positive definite.
+ *
+ * @tparam Derived type of the Eigen::SimplicalLLT decomposition
+ * @param function function name (for error messages)
+ * @param name variable name (for error messages)
+ * @param cholesky Eigen::SimplicalLLTT to test, whose progenitor
+ * must not have any NaN elements
+ * @throw std::domain_error if the matrix is not positive definite
+ */
+template <typename Derived>
+inline void check_pos_definite(const char* function, const char* name,
+                               const Eigen::SimplicialLLT<Derived>& cholesky) {
+  if (cholesky.info() != Eigen::Success) {
+    throw_domain_error(function, "LDLT decomposition of", " failed", name);
+  }
+}
+
 /**
  * Check if the specified LLT decomposition was successful.
  *

--- a/stan/math/prim/fun/cholesky_decompose.hpp
+++ b/stan/math/prim/fun/cholesky_decompose.hpp
@@ -41,41 +41,37 @@ cholesky_decompose(const EigMat& m) {
   return llt.matrixL();
 }
 
-
 /**
  * Return the sparse lower-triangular Cholesky factor (i.e., matrix
  * square root) of the specified sparse square, symmetric matrix.  The return
  * value \f$L\f$ will be a sparse lower-triangular matrix such that the
  * original matrix \f$A\f$ is given by
  * <p>\f$A = P^TL  L^TP\f$,
- * where \f$P\f$ is a permutation matrix that has been computed to minimize 
- * fill-in. 
+ * where \f$P\f$ is a permutation matrix that has been computed to minimize
+ * fill-in.
  *
- * @tparam SpEigMat type of the matrix (must be derived from \c Eigen::SparseMatrixBase)
+ * @tparam SpEigMat type of the matrix (must be derived from \c
+ * Eigen::SparseMatrixBase)
  * @param m Sparse symmetric matrix.
  * @return A Eigen::SimplicialLLT<SpEigMat> object containing
  * the sparse cholesky factor matrix and its associated metadata
  * (most importantly its permutation vector).
  * @note Unlike the dense matrix specialization, this version does
  * *not* return a matrix. The matrix can be accessed through the `matrixL()`
- * member function but remember this is the Cholesky factor of 
+ * member function but remember this is the Cholesky factor of
  * @throw std::domain_error if m is not a symmetric matrix or
  *   if m is not positive definite (if m has more than 0 elements)
  */
-template <typename SpEigMat, 
-  require_eigen_sparse_base_t<SpEigMat>* = nullptr,
-  require_not_eigen_vt<is_var, SpEigMat>* = nullptr>
-inline Eigen::SimplicialLLT<SpEigMat>
-cholesky_decompose(const EigMat& m) {
+template <typename SpEigMat, require_eigen_sparse_base_t<SpEigMat>* = nullptr,
+          require_not_eigen_vt<is_var, SpEigMat>* = nullptr>
+inline Eigen::SimplicialLLT<SpEigMat> cholesky_decompose(const EigMat& m) {
   const eval_return_type_t<SpEigMat>& m_eval = m.eval();
   check_symmetric("cholesky_decompose", "m", m_eval);
   check_not_nan("cholesky_decompose", "m", m_eval);
-  Eigen::SimplicialLLT<SpEigMat>
-      llt = m_eval.llt();
+  Eigen::SimplicialLLT<SpEigMat> llt = m_eval.llt();
   check_pos_definite("cholesky_decompose", "m", llt);
   return llt;
 }
-
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/cholesky_decompose.hpp
+++ b/stan/math/prim/fun/cholesky_decompose.hpp
@@ -41,6 +41,42 @@ cholesky_decompose(const EigMat& m) {
   return llt.matrixL();
 }
 
+
+/**
+ * Return the sparse lower-triangular Cholesky factor (i.e., matrix
+ * square root) of the specified sparse square, symmetric matrix.  The return
+ * value \f$L\f$ will be a sparse lower-triangular matrix such that the
+ * original matrix \f$A\f$ is given by
+ * <p>\f$A = P^TL  L^TP\f$,
+ * where \f$P\f$ is a permutation matrix that has been computed to minimize 
+ * fill-in. 
+ *
+ * @tparam SpEigMat type of the matrix (must be derived from \c Eigen::SparseMatrixBase)
+ * @param m Sparse symmetric matrix.
+ * @return A Eigen::SimplicialLLT<SpEigMat> object containing
+ * the sparse cholesky factor matrix and its associated metadata
+ * (most importantly its permutation vector).
+ * @note Unlike the dense matrix specialization, this version does
+ * *not* return a matrix. The matrix can be accessed through the `matrixL()`
+ * member function but remember this is the Cholesky factor of 
+ * @throw std::domain_error if m is not a symmetric matrix or
+ *   if m is not positive definite (if m has more than 0 elements)
+ */
+template <typename SpEigMat, 
+  require_eigen_sparse_base_t<SpEigMat>* = nullptr,
+  require_not_eigen_vt<is_var, SpEigMat>* = nullptr>
+inline Eigen::SimplicialLLT<SpEigMat>
+cholesky_decompose(const EigMat& m) {
+  const eval_return_type_t<SpEigMat>& m_eval = m.eval();
+  check_symmetric("cholesky_decompose", "m", m_eval);
+  check_not_nan("cholesky_decompose", "m", m_eval);
+  Eigen::SimplicialLLT<SpEigMat>
+      llt = m_eval.llt();
+  check_pos_definite("cholesky_decompose", "m", llt);
+  return llt;
+}
+
+
 }  // namespace math
 }  // namespace stan
 


### PR DESCRIPTION
## Summary

Decided to dive in on the sparse cholesky. This is a WIP.

- [ ] Implement prim sparse cholesky
- [ ] Implement prim sparse triangular solves
- [ ] Implement prim sparse triangular multiplies
- [ ] Other things that a sparse triangular matrix should be able to do?
- [ ] rev mode all things
- [ ] Tests
- [ ] Docs

The interesting wrinkle here is that 
```
Eigen::SimplicialLLT<SpMat>(A) llt =  m.llt()
```
 does not (without a lot of coercing) perform a Cholesky decomposition of `A`. It instead performs a Cholesky of `A.twistedBy(perm)`, where `perm` is stored in the `Eigen::SimplicialLLT<T>` class. This means that it is not enough for `cholesky_decompose` to return
```
llt.matrixL()
```
as this will not be the matrix we are looking for. This is the problem with @SteveBronder's old branch https://github.com/stan-dev/math/blob/a97bfa2f9a418bba192666133a28930651066fe7/stan/math/prim/mat/fun/cholesky_decompose.hpp#L114

The two options here are to compute perm explicitly somewhere else and carry it around (I do not like this option). The other option is to carry treat `Eigen::SimplicialLLT<T>` _as if it were the lower triangular matrix_ when performing triangular solves, multiplication, and anything else we might need. (those operations require knowledge of `perm`).

I'm not quite sure how my preferred option will work with autodiff - we might need a light specialization.


## Tests

Coming

## Side Effects

By adding a new, non-matrix Eigen type, we need to be very careful that none of the other template patterns match it. It should be fine, but care is needed.

## Release notes

Replace this text with a short note on what will change if this pull request is merged in which case this will be included in the release notes.

## Checklist

- [x] Copyright holder: Daniel Simpson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
