### PR TITLE
Fix ld error with TBB_LIB on macos

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -284,7 +284,12 @@ CXXFLAGS_TBB ?= -I $(TBB_INC)
 else
 CXXFLAGS_TBB ?= -I $(TBB)/include
 endif
-LDFLAGS_TBB ?= -Wl,-L,"$(TBB_LIB)" -Wl,--disable-new-dtags
+LDFLAGS_TBB ?= -Wl,-L,"$(TBB_LIB)"
+
+# MacOS ld does not support --disable-new-dtags
+ifneq ($(OS),Darwin)
+  LDFLAGS_TBB += -Wl,--disable-new-dtags
+endif
 
 # Windows LLVM/Clang does not support -rpath, but is not needed on Windows anyway
 ifneq ($(OS), Windows_NT)


### PR DESCRIPTION
## Summary

While [helping a user](https://discourse.mc-stan.org/t/cannot-compile-in-cmdstanr-with-compile-model-methods-true/34464/4) specify the Homebrew TBB for use with CmdStan, I discovered that the linker on macos doesn't support the `-Wl,--disable-new-dtags` argument:

```
andrew@Andrews-MacBook-Air ~ % clang -v
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.5.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
andrew@Andrews-MacBook-Air ~ % touch foo.cpp
andrew@Andrews-MacBook-Air ~ % clang++ foo.cpp -Wl,--disable-new-dtags
ld: unknown options: --disable-new-dtags 
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

It's not an issue with the Linux clang though (checked in a Debian Sid docker image)

## Tests

N/A

## Side Effects

N/A

## Release notes

Fix linker error when using external TBB on MacOS

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
