### PR TITLE
Backport SUNDIALS bugfix for hashmap int overflow

### DIFF
--- a/lib/sundials_6.1.1/STAN_CHANGES
+++ b/lib/sundials_6.1.1/STAN_CHANGES
@@ -1,0 +1,3 @@
+This file documents changes done for the stan-math project
+
+  - Backported bugfix for hashmap int overflow on Windows (https://github.com/LLNL/sundials/pull/421)

--- a/lib/sundials_6.1.1/src/sundials/sundials_hashmap.h
+++ b/lib/sundials_6.1.1/src/sundials/sundials_hashmap.h
@@ -20,6 +20,7 @@
 #ifndef _SUNDIALS_HASHMAP_H
 #define _SUNDIALS_HASHMAP_H
 
+#include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -30,10 +31,10 @@
   This is a 64-bit implementation of the 'a' modification of the
   Fowler–Noll–Vo hash (i.e., FNV1-a).
  */
-static unsigned long fnv1a_hash(const char* str)
+static uint64_t fnv1a_hash(const char* str)
 {
-  const unsigned long prime = 14695981039346656037U;   /* prime */
-  unsigned long hash        = 1099511628211U;          /* offset basis */
+  const uint64_t prime = 14695981039346656037U;   /* prime */
+  uint64_t hash        = 1099511628211U;          /* offset basis */
   char c;
   while ((c = *str++))
     hash = (hash^c) * prime;


### PR DESCRIPTION
## Summary

Building SUNDIALS on Windows is giving a warning for integer overflow in the `sundials_hashmap.h` header (no idea why it hadn't triggered on CI before):

```
 * checking whether package 'StanHeaders' can be installed ... [39s] WARNING
Found the following significant warnings:
  sundials/sundials_hashmap.h:35:31: warning: conversion from 'long long unsigned int' to 'long unsigned int' changes value from '14695981039346656037' to '2216829733' [-Woverflow]
  sundials/sundials_hashmap.h:36:31: warning: conversion from 'long long unsigned int' to 'long unsigned int' changes value from '1099511628211' to '435' [-Woverflow]
See 'D:/a/rstan/rstan/StanHeaders/check/StanHeaders.Rcheck/00install.out' for details.
```

This has been patched [upstream for SUNDIALS 7.0.0](https://github.com/LLNL/sundials/pull/421), but it just requires using the `uint64_t` type so I've made the backport here

## Tests

N/A 

## Side Effects

N/A

## Release notes

Backported SUNDIALS bugfix for hashmap integer overflow

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
