### PR TITLE
Silence -Wclass-memaccess from TBB

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -246,6 +246,8 @@ endif
 
 ## silence warnings occuring due to the TBB and Eigen libraries
 CXXFLAGS_WARNINGS += -Wno-ignored-attributes
+## https://github.com/oneapi-src/oneTBB/issues/307
+CXXFLAGS_WARNINGS += -Wno-class-memaccess
 
 ################################################################################
 # Setup OpenCL

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -247,7 +247,9 @@ endif
 ## silence warnings occuring due to the TBB and Eigen libraries
 CXXFLAGS_WARNINGS += -Wno-ignored-attributes
 ## https://github.com/oneapi-src/oneTBB/issues/307
-CXXFLAGS_WARNINGS += -Wno-class-memaccess
+ifeq ($(CXX_TYPE), gcc)
+  CXXFLAGS_WARNINGS += -Wno-class-memaccess
+endif
 
 ################################################################################
 # Setup OpenCL


### PR DESCRIPTION
## Summary

The changes in #3066 lead to an extra warning when compiling models. This turns that off.

## Tests

## Side Effects


## Release notes


## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
