### PR TITLE
Remove problematic calls to std::move in hcubature

### DIFF
--- a/stan/math/prim/functor/hcubature.hpp
+++ b/stan/math/prim/functor/hcubature.hpp
@@ -479,8 +479,8 @@ inline auto hcubature(const F& integrand, const ParsTuple& pars, const int dim,
       std::tie(result_2, err_2, kdivide_2) = internal::integrate_GenzMalik(
           integrand, genz_malik, dim, box.a_, mb, pars);
     }
-    box_t box1(std::move(ma), std::move(box.b_), result_1, kdivide_1);
-    box_t box2(std::move(box.a_), std::move(mb), result_2, kdivide_2);
+    box_t box1(std::move(ma), box.b_, result_1, kdivide_1);
+    box_t box2(box.a_, std::move(mb), result_2, kdivide_2);
     result += result_1 + result_2 - box.I_;
     err += err_1 + err_2 - err_vec[err_idx];
     ms[err_idx].I_ = 0;

--- a/test/unit/math/prim/functor/hcubature_test.cpp
+++ b/test/unit/math/prim/functor/hcubature_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/prim/functor.hpp>
 #include <stan/math/prim/fun.hpp>
+#include <stan/math/prim/prob/wiener_full_lpdf.hpp>
 
 #include <gtest/gtest.h>
 #include <vector>
@@ -162,4 +163,23 @@ TEST(StanMath_hcubature_prim, test1) {
   test_integration([](auto&& x, auto&& a) { return hcubature_test::f7(x, a); },
                    std::make_tuple((1 + sqrt(10.0)) / 9.0), dim, a_4, b_4,
                    20000, 0.0, reqRelError_3, 0.999998);
+}
+
+
+TEST(StanMath_hcubature_prim, test_issue_3075) {
+  // test for regressions against issue https://github.com/stan-dev/math/issues/3075
+  using stan::math::internal::GradientCalc;
+  using stan::math::internal::wiener7_integrate;
+  using stan::math::internal::wiener5_density;
+
+  auto params_st = std::make_tuple(0.553273, 1, -3.5, 0.55, 0.553161,
+                                    1.06423, 0.0941929, 0.0, -28.3242);
+  Eigen::VectorXd xmin = Eigen::VectorXd::Zero(2);
+  Eigen::VectorXd xmax = Eigen::VectorXd::Ones(2);
+
+  auto f = wiener7_integrate<GradientCalc::OFF, GradientCalc::OFF>(
+              [](auto&&... args) { return wiener5_density<GradientCalc::ON>(args...); },
+              -18.3029, params_st, 1, xmin, xmax, 6000, 0, 4.5e-05);
+
+  ASSERT_FLOAT_EQ(f, 4.97571e-312);
 }


### PR DESCRIPTION
## Summary

This closes #3075. Commit a68fafb8c24a961123f4d55163f733a619268568 added calls to `std::move` to the internal loop of the hcubature integrator, which resulted in leaving null matrices in the `ms` vector. If these were revisited later, this lead to Eigen failures. 

## Tests

I've added @andrjohns's reproducible example as a test case. It's possible we could have a more direct one, but I don't understand enough about how the box selection works in the algorithm to craft it.

## Side Effects

## Release notes

Fixed a use-after-move bug in `hcubature`.

## Checklist

- [x] Copyright holder: Simons Foundation
    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
