### PR TITLE
CI Debug: print compiler flags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ import org.stan.Utils
 def runTests(String testPath, boolean jumbo = false) {
     try {
         sh "cat make/local"
+        sh "make print-compiler-flags"
         if (jumbo && !params.disableJumbo) {
             sh "python3 runTests.py -j${env.PARALLEL} ${testPath} --jumbo --debug"
         } else {
@@ -142,8 +143,8 @@ pipeline {
             }
             post {
                 always {
-                    recordIssues( 
-                        enabledForFailure: true, 
+                    recordIssues(
+                        enabledForFailure: true,
                         tools: [cppLint(),groovyScript(parserId: 'mathDependencies', pattern: '**/dependencies.log')]
                     )
                     deleteDir()
@@ -575,7 +576,7 @@ pipeline {
         always {
             node("linux") {
                 recordIssues(
-                    enabledForFailure: false, 
+                    enabledForFailure: false,
                     tool: clang()
                 )
             }


### PR DESCRIPTION
## Summary

This helps us spot if something in the makefile isn't being detected correctly. 


## Tests

## Side Effects

## Release notes

## Checklist

- [ ] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
