### PR TITLE
Fix index-out-of-bounds in gp_matern32_cov

### DIFF
--- a/stan/math/prim/fun/gp_matern32_cov.hpp
+++ b/stan/math/prim/fun/gp_matern32_cov.hpp
@@ -118,7 +118,6 @@ gp_matern32_cov(const std::vector<Eigen::Matrix<T_x, -1, 1>> &x,
     return cov;
   }
   const char *function = "gp_matern32_cov";
-  size_t l_size = length_scale.size();
   for (size_t n = 0; n < x_size; ++n) {
     check_not_nan(function, "x", x[n]);
   }
@@ -126,7 +125,8 @@ gp_matern32_cov(const std::vector<Eigen::Matrix<T_x, -1, 1>> &x,
   check_positive_finite(function, "magnitude", sigma);
   check_positive_finite(function, "length scale", length_scale);
 
-  for (size_t n = 0; n < x_size; ++n) {
+  size_t l_size = length_scale.size();
+  for (size_t n = 0; n < l_size; ++n) {
     check_not_nan(function, "length scale", length_scale[n]);
   }
 

--- a/test/unit/math/prim/fun/gp_matern32_cov_test.cpp
+++ b/test/unit/math/prim/fun/gp_matern32_cov_test.cpp
@@ -549,5 +549,6 @@ TEST(MathPrimMat, check_indexing_vector_vector_gp_matern32_cov) {
   int num_nodes = 10;
   std::vector<Eigen::Matrix<double, -1, 1>> x(num_nodes,
                                               stan::math::zeros_vector(p));
-  EXPECT_NO_THROW(stan::math::gp_matern32_cov(x, 1.3, std::vector<double>{0.7}));
+  EXPECT_NO_THROW(
+      stan::math::gp_matern32_cov(x, 1.3, std::vector<double>{0.7}));
 }

--- a/test/unit/math/prim/fun/gp_matern32_cov_test.cpp
+++ b/test/unit/math/prim/fun/gp_matern32_cov_test.cpp
@@ -543,3 +543,11 @@ TEST(MathPrimMat, check_dim_mismatch_gp_matern32_cov) {
   EXPECT_THROW(stan::math::gp_matern32_cov(x1, x2, sig, l),
                std::invalid_argument);
 }
+
+TEST(MathPrimMat, check_indexing_vector_vector_gp_matern32_cov) {
+  int p = 1;
+  int num_nodes = 10;
+  std::vector<Eigen::Matrix<double, -1, 1>> x(num_nodes,
+                                              stan::math::zeros_vector(p));
+  EXPECT_NO_THROW(stan::math::gp_matern32_cov(x, 1.3, std::vector<double>{0.7}));
+}


### PR DESCRIPTION

## Summary

Reported by @tillahoffmann on the forums: https://discourse.mc-stan.org/t/debugging-gp-matern32-cov/35502. 

One of the overloads of `gp_matern32_cov` was using `x_size` to index over a variable that actually had length `l_size`. Presumably a copy/paste error.

## Tests

I added a minified version of their reproducer. The behavior is undefined in the bug case, so unfortunately the test is not guaranteed to fail on all systems if the bug is re-introduced.

## Side Effects

None

## Release notes

Fixed an indexing bug inside gp_matern32_cov

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
