### PR TITLE
Consistently use 'long int' for return of size functions

### DIFF
--- a/stan/math/opencl/prim/binomial_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/binomial_logit_glm_lpmf.hpp
@@ -20,6 +20,7 @@
 #include <stan/math/prim/fun/value_of_rec.hpp>
 
 #include <cmath>
+#include <cstdint>
 
 namespace stan {
 namespace math {
@@ -37,7 +38,7 @@ return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> binomial_logit_glm_lpmf(
   constexpr bool is_alpha_vector = !is_stan_scalar<T_alpha_cl>::value;
 
   const size_t N_instances
-      = max(max_size(n, N, alpha), static_cast<size_t>(x.rows()));
+      = max(max_size(n, N, alpha), static_cast<int64_t>(x.rows()));
   const size_t N_attributes = x.cols();
 
   check_consistent_sizes(function, "Successes variable", n,

--- a/stan/math/opencl/prim/cols.hpp
+++ b/stan/math/opencl/prim/cols.hpp
@@ -3,6 +3,7 @@
 #ifdef STAN_OPENCL
 
 #include <stan/math/opencl/matrix_cl.hpp>
+#include <cstdint>
 
 namespace stan {
 namespace math {
@@ -17,7 +18,7 @@ namespace math {
  */
 template <typename T_x,
           require_nonscalar_prim_or_rev_kernel_expression_t<T_x>* = nullptr>
-inline int cols(const T_x& x) {
+inline int64_t cols(const T_x& x) {
   return x.cols();
 }
 }  // namespace math

--- a/stan/math/opencl/prim/num_elements.hpp
+++ b/stan/math/opencl/prim/num_elements.hpp
@@ -4,6 +4,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/opencl/prim/size.hpp>
+#include <cstdint>
 
 namespace stan {
 namespace math {
@@ -16,7 +17,7 @@ namespace math {
  */
 template <typename T,
           require_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr>
-size_t num_elements(const T& m) {
+int64_t num_elements(const T& m) {
   return math::size(m);
 }
 

--- a/stan/math/opencl/prim/rows.hpp
+++ b/stan/math/opencl/prim/rows.hpp
@@ -3,6 +3,7 @@
 #ifdef STAN_OPENCL
 
 #include <stan/math/opencl/matrix_cl.hpp>
+#include <cstdint>
 
 namespace stan {
 namespace math {
@@ -18,7 +19,7 @@ namespace math {
 
 template <typename T_x,
           require_nonscalar_prim_or_rev_kernel_expression_t<T_x>* = nullptr>
-inline int rows(const T_x& x) {
+inline int64_t rows(const T_x& x) {
   return x.rows();
 }
 

--- a/stan/math/opencl/prim/size.hpp
+++ b/stan/math/opencl/prim/size.hpp
@@ -3,6 +3,7 @@
 #ifdef STAN_OPENCL
 
 #include <stan/math/prim/meta.hpp>
+#include <cstdint>
 
 namespace stan {
 namespace math {
@@ -15,7 +16,7 @@ namespace math {
  */
 template <typename T,
           require_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr>
-size_t size(const T& m) {
+int64_t size(const T& m) {
   return m.rows() * m.cols();
 }
 

--- a/stan/math/prim/fun/cols.hpp
+++ b/stan/math/prim/fun/cols.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
+#include <cstdint>
 
 namespace stan {
 namespace math {
@@ -16,7 +17,7 @@ namespace math {
  * @return Number of columns.
  */
 template <typename T, require_matrix_t<T>* = nullptr>
-inline long int cols(const T& m) {
+inline int64_t cols(const T& m) {
   return m.cols();
 }
 

--- a/stan/math/prim/fun/cols.hpp
+++ b/stan/math/prim/fun/cols.hpp
@@ -16,7 +16,7 @@ namespace math {
  * @return Number of columns.
  */
 template <typename T, require_matrix_t<T>* = nullptr>
-inline Eigen::Index cols(const T& m) {
+inline long int cols(const T& m) {
   return m.cols();
 }
 

--- a/stan/math/prim/fun/max_size.hpp
+++ b/stan/math/prim/fun/max_size.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_FUN_MAX_SIZE_HPP
 
 #include <stan/math/prim/fun/size.hpp>
+#include <cstdint>
 #include <algorithm>
 
 namespace stan {
@@ -16,7 +17,7 @@ namespace math {
  * @return the size of the largest input
  */
 template <typename T1, typename... Ts>
-inline size_t max_size(const T1& x1, const Ts&... xs) {
+inline int64_t max_size(const T1& x1, const Ts&... xs) {
   return std::max({stan::math::size(x1), stan::math::size(xs)...});
 }
 

--- a/stan/math/prim/fun/max_size_mvt.hpp
+++ b/stan/math/prim/fun/max_size_mvt.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/fun/size_mvt.hpp>
 #include <algorithm>
+#include <cstdint>
 
 namespace stan {
 namespace math {
@@ -21,7 +22,7 @@ namespace math {
  * matrix or std::vector of Eigen matrices
  */
 template <typename T1, typename... Ts>
-inline size_t max_size_mvt(const T1& x1, const Ts&... xs) {
+inline int64_t max_size_mvt(const T1& x1, const Ts&... xs) {
   return std::max({stan::math::size_mvt(x1), stan::math::size_mvt(xs)...});
 }
 

--- a/stan/math/prim/fun/num_elements.hpp
+++ b/stan/math/prim/fun/num_elements.hpp
@@ -16,7 +16,7 @@ namespace math {
  * @return 1
  */
 template <typename T, require_stan_scalar_t<T>* = nullptr>
-inline int num_elements(const T& x) {
+inline long int num_elements(const T& x) {
   return 1;
 }
 
@@ -29,7 +29,7 @@ inline int num_elements(const T& x) {
  * @return size of matrix
  */
 template <typename T, require_matrix_t<T>* = nullptr>
-inline int num_elements(const T& m) {
+inline long int num_elements(const T& m) {
   return m.size();
 }
 
@@ -43,7 +43,7 @@ inline int num_elements(const T& m) {
  * @return number of contained arguments
  */
 template <typename T>
-inline int num_elements(const std::vector<T>& v) {
+inline long int num_elements(const std::vector<T>& v) {
   if (v.size() == 0) {
     return 0;
   }

--- a/stan/math/prim/fun/num_elements.hpp
+++ b/stan/math/prim/fun/num_elements.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
+#include <cstdint>
 #include <vector>
 
 namespace stan {
@@ -16,7 +17,7 @@ namespace math {
  * @return 1
  */
 template <typename T, require_stan_scalar_t<T>* = nullptr>
-inline long int num_elements(const T& x) {
+inline int64_t num_elements(const T& x) {
   return 1;
 }
 
@@ -29,7 +30,7 @@ inline long int num_elements(const T& x) {
  * @return size of matrix
  */
 template <typename T, require_matrix_t<T>* = nullptr>
-inline long int num_elements(const T& m) {
+inline int64_t num_elements(const T& m) {
   return m.size();
 }
 
@@ -43,7 +44,7 @@ inline long int num_elements(const T& m) {
  * @return number of contained arguments
  */
 template <typename T>
-inline long int num_elements(const std::vector<T>& v) {
+inline int64_t num_elements(const std::vector<T>& v) {
   if (v.size() == 0) {
     return 0;
   }

--- a/stan/math/prim/fun/rows.hpp
+++ b/stan/math/prim/fun/rows.hpp
@@ -16,7 +16,7 @@ namespace math {
  * @return Number of rows.
  */
 template <typename T, require_matrix_t<T>* = nullptr>
-inline int rows(const T& m) {
+inline long int rows(const T& m) {
   return m.rows();
 }
 

--- a/stan/math/prim/fun/rows.hpp
+++ b/stan/math/prim/fun/rows.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
+#include <cstdint>
 
 namespace stan {
 namespace math {
@@ -16,7 +17,7 @@ namespace math {
  * @return Number of rows.
  */
 template <typename T, require_matrix_t<T>* = nullptr>
-inline long int rows(const T& m) {
+inline int64_t rows(const T& m) {
   return m.rows();
 }
 

--- a/stan/math/prim/fun/size.hpp
+++ b/stan/math/prim/fun/size.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <cstdint>
 #include <vector>
 
 namespace stan {
@@ -13,7 +14,7 @@ namespace math {
  * that are always of length 1.
  */
 template <typename T, require_stan_scalar_t<T>* = nullptr>
-inline long int size(const T& /*x*/) {
+inline int64_t size(const T& /*x*/) {
   return 1;
 }
 
@@ -24,12 +25,12 @@ inline long int size(const T& /*x*/) {
  * @tparam T type of m
  */
 template <typename T, require_container_t<T>* = nullptr>
-inline long int size(const T& m) {
+inline int64_t size(const T& m) {
   return m.size();
 }
 
 template <typename T, require_var_matrix_t<T>* = nullptr>
-inline long int size(const T& m) {
+inline int64_t size(const T& m) {
   return m.size();
 }
 

--- a/stan/math/prim/fun/size.hpp
+++ b/stan/math/prim/fun/size.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <cstdlib>
 #include <vector>
 
 namespace stan {
@@ -14,8 +13,8 @@ namespace math {
  * that are always of length 1.
  */
 template <typename T, require_stan_scalar_t<T>* = nullptr>
-inline size_t size(const T& /*x*/) {
-  return 1U;
+inline long int size(const T& /*x*/) {
+  return 1;
 }
 
 /** \ingroup type_trait
@@ -25,12 +24,12 @@ inline size_t size(const T& /*x*/) {
  * @tparam T type of m
  */
 template <typename T, require_container_t<T>* = nullptr>
-inline size_t size(const T& m) {
+inline long int size(const T& m) {
   return m.size();
 }
 
 template <typename T, require_var_matrix_t<T>* = nullptr>
-inline size_t size(const T& m) {
+inline long int size(const T& m) {
   return m.size();
 }
 

--- a/stan/math/prim/fun/size_mvt.hpp
+++ b/stan/math/prim/fun/size_mvt.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <cstdint>
 #include <stdexcept>
 #include <vector>
 
@@ -21,17 +22,17 @@ namespace math {
  * @throw std::invalid_argument since the type is a scalar.
  */
 template <typename ScalarT, require_stan_scalar_t<ScalarT>* = nullptr>
-size_t size_mvt(const ScalarT& /* unused */) {
+int64_t size_mvt(const ScalarT& /* unused */) {
   throw std::invalid_argument("size_mvt passed to an unrecognized type.");
 }
 
 template <typename MatrixT, require_matrix_t<MatrixT>* = nullptr>
-size_t size_mvt(const MatrixT& /* unused */) {
-  return 1U;
+int64_t size_mvt(const MatrixT& /* unused */) {
+  return 1;
 }
 
 template <typename MatrixT, require_matrix_t<MatrixT>* = nullptr>
-size_t size_mvt(const std::vector<MatrixT>& x) {
+int64_t size_mvt(const std::vector<MatrixT>& x) {
   return x.size();
 }
 

--- a/stan/math/prim/prob/poisson_binomial_cdf.hpp
+++ b/stan/math/prim/prob/poisson_binomial_cdf.hpp
@@ -37,13 +37,13 @@ return_type_t<T_theta> poisson_binomial_cdf(const T_y& y,
                                             const T_theta& theta) {
   static constexpr const char* function = "poisson_binomial_cdf";
 
-  size_t size_theta = size_mvt(theta);
+  auto size_theta = size_mvt(theta);
   if (size_theta > 1) {
     check_consistent_sizes(function, "Successes variables", y,
                            "Probability parameters", theta);
   }
 
-  size_t max_sz = std::max(stan::math::size(y), size_theta);
+  auto max_sz = std::max(stan::math::size(y), size_theta);
   scalar_seq_view<T_y> y_vec(y);
   vector_seq_view<T_theta> theta_vec(theta);
 

--- a/stan/math/prim/prob/poisson_binomial_lccdf.hpp
+++ b/stan/math/prim/prob/poisson_binomial_lccdf.hpp
@@ -38,13 +38,13 @@ return_type_t<T_theta> poisson_binomial_lccdf(const T_y& y,
                                               const T_theta& theta) {
   static constexpr const char* function = "poisson_binomial_lccdf";
 
-  size_t size_theta = size_mvt(theta);
+  auto size_theta = size_mvt(theta);
   if (size_theta > 1) {
     check_consistent_sizes(function, "Successes variables", y,
                            "Probability parameters", theta);
   }
 
-  size_t max_sz = std::max(stan::math::size(y), size_mvt(theta));
+  auto max_sz = std::max(stan::math::size(y), size_mvt(theta));
   scalar_seq_view<T_y> y_vec(y);
   vector_seq_view<T_theta> theta_vec(theta);
 

--- a/stan/math/prim/prob/poisson_binomial_lcdf.hpp
+++ b/stan/math/prim/prob/poisson_binomial_lcdf.hpp
@@ -37,13 +37,13 @@ return_type_t<T_theta> poisson_binomial_lcdf(const T_y& y,
                                              const T_theta& theta) {
   static constexpr const char* function = "poisson_binomial_lcdf";
 
-  size_t size_theta = size_mvt(theta);
+  auto size_theta = size_mvt(theta);
   if (size_theta > 1) {
     check_consistent_sizes(function, "Successes variables", y,
                            "Probability parameters", theta);
   }
 
-  size_t max_sz = std::max(stan::math::size(y), size_theta);
+  auto max_sz = std::max(stan::math::size(y), size_theta);
   scalar_seq_view<T_y> y_vec(y);
   vector_seq_view<T_theta> theta_vec(theta);
 

--- a/stan/math/prim/prob/poisson_binomial_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_binomial_lpmf.hpp
@@ -29,13 +29,13 @@ return_type_t<T_theta> poisson_binomial_lpmf(const T_y& y,
                                              const T_theta& theta) {
   static constexpr const char* function = "poisson_binomial_lpmf";
 
-  size_t size_theta = size_mvt(theta);
+  auto size_theta = size_mvt(theta);
   if (size_theta > 1) {
     check_consistent_sizes(function, "Successes variables", y,
                            "Probability parameters", theta);
   }
 
-  size_t max_sz = std::max(stan::math::size(y), size_theta);
+  auto max_sz = std::max(stan::math::size(y), size_theta);
   scalar_seq_view<T_y> y_vec(y);
   vector_seq_view<T_theta> theta_vec(theta);
 

--- a/test/unit/math/opencl/util.hpp
+++ b/test/unit/math/opencl/util.hpp
@@ -233,11 +233,11 @@ T to_vector_if(const T& x, std::size_t N) {
 
 using stan::math::rows;
 template <typename T, require_not_container_t<T>* = nullptr>
-int rows(const T&) {
+int64_t rows(const T&) {
   return 1;
 }
 template <typename T, require_std_vector_t<T>* = nullptr>
-int rows(const T& x) {
+int64_t rows(const T& x) {
   return x.size();
 }
 


### PR DESCRIPTION

## Summary

Closes #3085 

## Tests

## Side Effects

I certainly hope we weren't relying on something like these having wrapping semantics.

## Release notes

Functions concerned with the number of entries in a container (`size`, `cols`, `rows`, ...) consistently use `long int` as their return type. 

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
