### PR TITLE
Add overloads for tuples of bounds to lub_free and lub_constrain

### DIFF
--- a/stan/math/prim/fun/lub_constrain.hpp
+++ b/stan/math/prim/fun/lub_constrain.hpp
@@ -400,6 +400,33 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
   }
 }
 
+/**
+ * Wrapper for tuple of bounds, simply delegates to the appropriate overload
+ */
+template <typename T, typename L, typename U>
+inline auto lub_constrain(const T& x, const std::tuple<L, U>& bounds) {
+  return lub_constrain(x, std::get<0>(bounds), std::get<1>(bounds));
+}
+
+/**
+ * Wrapper for tuple of bounds, simply delegates to the appropriate overload
+ */
+template <typename T, typename L, typename U>
+inline auto lub_constrain(const T& x, const std::tuple<L, U>& bounds,
+                          return_type_t<T, L, U>& lp) {
+  return lub_constrain(x, std::get<0>(bounds), std::get<1>(bounds), lp);
+}
+
+/**
+ * Wrapper for tuple of bounds, simply delegates to the appropriate overload
+ */
+template <bool Jacobian, typename T, typename L, typename U>
+inline auto lub_constrain(const T& x, const std::tuple<L, U>& bounds,
+                          return_type_t<T, L, U>& lp) {
+  return lub_constrain<Jacobian>(x, std::get<0>(bounds), std::get<1>(bounds),
+                                 lp);
+}
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/lub_free.hpp
+++ b/stan/math/prim/fun/lub_free.hpp
@@ -180,6 +180,14 @@ inline auto lub_free(const std::vector<T> y, const std::vector<L>& lb,
   }
   return ret;
 }
+
+/**
+ * Wrapper for tuple of bounds, simply delegates to the appropriate overload
+ */
+template <typename T, typename L, typename U>
+inline auto lub_free(T&& y, const std::tuple<L, U>& bounds) {
+  return lub_free(std::forward<T>(y), std::get<0>(bounds), std::get<1>(bounds));
+}
 ///@}
 
 }  // namespace math

--- a/test/unit/math/mix/fun/lub_constrain_helpers.hpp
+++ b/test/unit/math/mix/fun/lub_constrain_helpers.hpp
@@ -22,11 +22,21 @@ void expect(const T1& x, const T2& lb, const T3& ub) {
     auto xx = stan::math::lub_constrain<true>(x, lb, ub, lp);
     return stan::math::add(lp, stan::math::sum(xx));
   };
+  auto f5 = [](const auto& x, const auto& lb, const auto& ub) {
+    stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
+    return stan::math::lub_constrain<false>(x, std::make_tuple(lb, ub), lp);
+  };
+  auto f6 = [](const auto& x, const auto& lb, const auto& ub) {
+    stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
+    return stan::math::lub_constrain<true>(x, std::make_tuple(lb, ub), lp);
+  };
 
   stan::test::expect_ad(f1, x, lb, ub);
   stan::test::expect_ad(f2, x, lb, ub);
   stan::test::expect_ad(f3, x, lb, ub);
   stan::test::expect_ad(f4, x, lb, ub);
+  stan::test::expect_ad(f5, x, lb, ub);
+  stan::test::expect_ad(f6, x, lb, ub);
 }
 template <typename T1, typename T2, typename T3>
 void expect_vec(const T1& x, const T2& lb, const T3& ub) {
@@ -52,11 +62,21 @@ void expect_vec(const T1& x, const T2& lb, const T3& ub) {
     }
     return stan::math::add(lp, xx_acc);
   };
+  auto f5 = [](const auto& x, const auto& lb, const auto& ub) {
+    stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
+    return stan::math::lub_constrain<false>(x, std::make_tuple(lb, ub), lp);
+  };
+  auto f6 = [](const auto& x, const auto& lb, const auto& ub) {
+    stan::return_type_t<decltype(x), decltype(lb), decltype(ub)> lp = 0;
+    return stan::math::lub_constrain<true>(x, std::make_tuple(lb, ub), lp);
+  };
 
   stan::test::expect_ad(f1, x, lb, ub);
   stan::test::expect_ad(f2, x, lb, ub);
   stan::test::expect_ad(f3, x, lb, ub);
   stan::test::expect_ad(f4, x, lb, ub);
+  stan::test::expect_ad(f5, x, lb, ub);
+  stan::test::expect_ad(f6, x, lb, ub);
 }
 }  // namespace lub_constrain_tests
 


### PR DESCRIPTION
## Summary

Closes #3083 by allowing `lub_free` and `lub_constrain` to take a single tuple of bounds

## Tests

Current test framework for the `lub_transforms` updated with tuple arguments


## Side Effects

N/A

## Release notes

Add overloads for tuples of bounds to `lub_free` and `lub_constrain`

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
