### PR TITLE
adds constructor to vari for passing both initial values and adjoints

### DIFF
--- a/stan/math/opencl/rev/vari.hpp
+++ b/stan/math/opencl/rev/vari.hpp
@@ -227,7 +227,7 @@ class vari_value<T, require_matrix_cl_t<T>> : public chainable_alloc,
             require_vt_same<T, S>* = nullptr>
   explicit vari_value(const S& x)
       : chainable_alloc(), vari_cl_base<T>(x, constant(0, x.rows(), x.cols())) {
-    ChainableStack::instance_->var_stack_.push_back(this);
+    ChainableStack::instance_->var_nochain_stack_.push_back(this);
   }
 
   /**
@@ -257,6 +257,25 @@ class vari_value<T, require_matrix_cl_t<T>> : public chainable_alloc,
     } else {
       ChainableStack::instance_->var_nochain_stack_.push_back(this);
     }
+  }
+
+  /**
+   * Construct a dense Eigen variable implementation from a
+   *  preconstructed values and adjoints.
+   *
+   * All constructed variables are not added to the stack. Variables
+   * should be constructed before variables on which they depend
+   * to insure proper partial derivative propagation.
+   * @tparam S A dense Eigen type that is convertible to `value_type`
+   * @tparam K A dense Eigen type that is convertible to `value_type`
+   * @param val Matrix of values
+   * @param adj Matrix of adjoints
+   */
+  template <typename S, typename K, require_convertible_t<T, S>* = nullptr,
+            require_convertible_t<T, K>* = nullptr>
+  explicit vari_value(S&& val, K&& adj) : chainable_alloc(),
+    vari_cl_base<T>(std::forward<S>(val), std::forward<K>(adj)) {
+    ChainableStack::instance_->var_nochain_stack_.push_back(this);
   }
 
   /**

--- a/stan/math/opencl/rev/vari.hpp
+++ b/stan/math/opencl/rev/vari.hpp
@@ -273,8 +273,9 @@ class vari_value<T, require_matrix_cl_t<T>> : public chainable_alloc,
    */
   template <typename S, typename K, require_convertible_t<T, S>* = nullptr,
             require_convertible_t<T, K>* = nullptr>
-  explicit vari_value(S&& val, K&& adj) : chainable_alloc(),
-    vari_cl_base<T>(std::forward<S>(val), std::forward<K>(adj)) {
+  explicit vari_value(S&& val, K&& adj)
+      : chainable_alloc(),
+        vari_cl_base<T>(std::forward<S>(val), std::forward<K>(adj)) {
     ChainableStack::instance_->var_nochain_stack_.push_back(this);
   }
 

--- a/stan/math/rev/core/callback_vari.hpp
+++ b/stan/math/rev/core/callback_vari.hpp
@@ -15,7 +15,7 @@ struct callback_vari : public vari_value<T> {
   template <typename S,
             require_same_t<plain_type_t<T>, plain_type_t<S>>* = nullptr>
   explicit callback_vari(S&& value, F&& rev_functor)
-      : vari_value<T>(std::move(value)),
+      : vari_value<T>(std::move(value), true),
         rev_functor_(std::forward<F>(rev_functor)) {}
 
   inline void chain() final { rev_functor_(*this); }

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -746,9 +746,8 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
    * @param val Matrix of values
    * @param adj Matrix of adjoints
    */
-  template <typename S, typename K,
-    require_assignable_t<T, S>* = nullptr,
-    require_assignable_t<T, K>* = nullptr>
+  template <typename S, typename K, require_assignable_t<T, S>* = nullptr,
+            require_assignable_t<T, K>* = nullptr>
   explicit vari_value(const S& val, const K& adj) : val_(val), adj_(adj) {
     ChainableStack::instance_->var_nochain_stack_.push_back(this);
   }

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -678,11 +678,9 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
    * Construct a dense Eigen variable implementation from a value. The
    * adjoint is initialized to zero.
    *
-   * All constructed variables are added to the stack. Variables
+   * All constructed variables are added to the no chain stack. Variables
    * should be constructed before variables on which they depend
-   * to insure proper partial derivative propagation.  During
-   * derivative propagation, the chain() method of each variable
-   * will be called in the reverse order of construction.
+   * to insure proper partial derivative propagation.
    *
    * @tparam S A dense Eigen type that is convertible to `value_type`
    * @param x Value of the constructed variable.
@@ -699,7 +697,7 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
                  ? x.rows()
                  : x.cols()) {
     adj_.setZero();
-    ChainableStack::instance_->var_stack_.push_back(this);
+    ChainableStack::instance_->var_nochain_stack_.push_back(this);
   }
 
   /**
@@ -734,6 +732,25 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
     } else {
       ChainableStack::instance_->var_nochain_stack_.push_back(this);
     }
+  }
+
+  /**
+   * Construct a dense Eigen variable implementation from a
+   *  preconstructed values and adjoints.
+   *
+   * All constructed variables are not added to the stack. Variables
+   * should be constructed before variables on which they depend
+   * to insure proper partial derivative propagation.
+   * @tparam S A dense Eigen type that is convertible to `value_type`
+   * @tparam K A dense Eigen type that is convertible to `value_type`
+   * @param val Matrix of values
+   * @param adj Matrix of adjoints
+   */
+  template <typename S, typename K,
+    require_assignable_t<T, S>* = nullptr,
+    require_assignable_t<T, K>* = nullptr>
+  explicit vari_value(const S& val, const K& adj) : val_(val), adj_(adj) {
+    ChainableStack::instance_->var_nochain_stack_.push_back(this);
   }
 
  protected:

--- a/test/unit/math/opencl/rev/vari_test.cpp
+++ b/test/unit/math/opencl/rev/vari_test.cpp
@@ -20,6 +20,11 @@ TEST(AgradRev, matrix_cl_vari_block) {
                    stan::math::from_matrix_cl(B.block(0, 1, 2, 2).val_));
   EXPECT_MATRIX_EQ(b.block(0, 1, 2, 2),
                    stan::math::from_matrix_cl(B.block(0, 1, 2, 2).adj_));
+  vari_value<stan::math::matrix_cl<double>> C(a_cl, a_cl);
+  EXPECT_MATRIX_EQ(a.block(0, 1, 2, 2),
+                   stan::math::from_matrix_cl(C.block(0, 1, 2, 2).val_));
+  EXPECT_MATRIX_EQ(a.block(0, 1, 2, 2),
+                   stan::math::from_matrix_cl(C.block(0, 1, 2, 2).adj_));
 }
 
 #endif

--- a/test/unit/math/rev/core/vari_test.cpp
+++ b/test/unit/math/rev/core/vari_test.cpp
@@ -73,7 +73,15 @@ TEST(AgradRevVari, arena_matrix_matrix_vari) {
   EXPECT_MATRIX_FLOAT_EQ((*C).val(), x);
   auto* D = new vari_value<Eigen::MatrixXd>(x_ref, true);
   EXPECT_MATRIX_FLOAT_EQ((*D).val(), x);
+  auto* E = new vari_value<Eigen::MatrixXd>(x, (x.array() + 1.0).matrix());
+  EXPECT_MATRIX_FLOAT_EQ((*E).val(), x);
+  EXPECT_MATRIX_FLOAT_EQ((*E).adj(), (x.array() + 1.0).matrix());
+  auto* F = new vari_value<Eigen::MatrixXd>(x, x);
+  EXPECT_MATRIX_FLOAT_EQ((*F).val(), x);
+  EXPECT_MATRIX_FLOAT_EQ((*F).adj(), x);
+  EXPECT_EQ((*F).val().data(), (*F).adj().data());
 }
+
 
 TEST(AgradRevVari, dense_vari_matrix_views) {
   using stan::math::vari_value;

--- a/test/unit/math/rev/core/vari_test.cpp
+++ b/test/unit/math/rev/core/vari_test.cpp
@@ -82,7 +82,6 @@ TEST(AgradRevVari, arena_matrix_matrix_vari) {
   EXPECT_EQ((*F).val().data(), (*F).adj().data());
 }
 
-
 TEST(AgradRevVari, dense_vari_matrix_views) {
   using stan::math::vari_value;
   using eig_mat = Eigen::MatrixXd;


### PR DESCRIPTION
## Summary

For a PR I'm doing in the Stan repo I need a constructor for `vari_value<Matrix>` types that accepts both the initial value and adjoint.

This also changes the other constructors so that by default `vari_value<Matrix>` types are not put on the chainable stack. The var matrix type only needs it's chain called in the `callback_vari` type, but for all other purposes the matrix should actually not have it's chain method called. Instead it is normally called through a seperate empty `vari` made during `reverse_pass_callback()`
 
## Tests

Tests added that checks new constructor works and has the same pointer in the case the value and adjoint is the same matrix.

## Release notes

Adds constructor to vari for passing initial values and adjoints

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
