### PR TITLE
Remove support for ~/.config makefile inclusion

### DIFF
--- a/doxygen/README.md
+++ b/doxygen/README.md
@@ -125,8 +125,7 @@ export TBB_LIB="$TBB/lib/intel64/gcc4.8"
 
 - Set `Stan` local compiler flags to use the new TBB interface:
 ```bash
-mkdir -p ~/.config/stan
-echo TBB_INTERFACE_NEW=true>> ~/.config/stan/make.local
+echo TBB_INTERFACE_NEW=true>> ./make/local
 ```
 
 Compilers

--- a/doxygen/contributor_help_pages/developer_doc.md
+++ b/doxygen/contributor_help_pages/developer_doc.md
@@ -165,9 +165,7 @@ Within the Math library, the only build targets are the tests (there are no othe
 
 ## Makefile Variables
 
-To customize how the tests are built in C++, variables can be set in a file called `make/local`. This is the preferred way of customizing the build. You can also set it more permanently by setting variables in `~/.config/stan/make.local`.
-
-Note: variables in `make/local` override variables in `~/.config/stan/make/local`.
+To customize how the tests are built in C++, variables can be set in a file called `make/local`. This is the preferred way of customizing the build.
 
 There are a lot of make variables that can be set. In general, `CXXFLAGS_*` is for C++ compiler flags, `CPPFLAGS_*` is for C preprocessor flags, `LDFLAGS_*` is for linker flags, and `LDLBIS_*` is for libraries that need to be linked in.
 
@@ -310,7 +308,7 @@ If you want to use custom locations for the library locations, set these makefil
 - `GTEST`
 - `CPPLINT` (optional)
 
-Example `~/.config/stan/make.local` file:
+Example `make/local` file:
 ```
 BOOST = ~/boost
 ```

--- a/make/standalone
+++ b/make/standalone
@@ -14,7 +14,6 @@
 
 MATH_MAKE ?=$(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 MATH ?= $(realpath $(MATH_MAKE)..)/
--include $(HOME)/.config/stan/make.local
 -include $(MATH)make/local
 -include $(MATH)make/compiler_flags
 -include $(MATH)make/libraries

--- a/makefile
+++ b/makefile
@@ -2,16 +2,11 @@
 # Stan Math Library
 # -----------------
 #
-# To customize your build, set make variables in either:
-#    ~/.config/stan/make.local
-#    make/local
-# Variables in make/local is loaded after ~/.config/stan/make.local
-
+# To customize your build, set make variables in the file make/local.
 
 ## 'help' is the default make target.
 help:
 
--include $(HOME)/.config/stan/make.local  # user-defined variables
 -include make/local                       # user-defined variables
 
 include make/compiler_flags               # CXX, CXXFLAGS, LDFLAGS set by the end of this file


### PR DESCRIPTION


## Summary

Closes #3088 

## Tests

None 

## Side Effects


## Release notes

Removed support for adding makefile variables in `~/.config/stan/make.local`. Use the `make/local` file in the Math directory instead. 

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
