### PR TITLE
Resolve clang18 warning about ops_partials_edge

### DIFF
--- a/stan/math/prim/functor/operands_and_partials.hpp
+++ b/stan/math/prim/functor/operands_and_partials.hpp
@@ -55,7 +55,7 @@ class ops_partials_edge;
  */
 template <typename ViewElt, typename Op>
 class ops_partials_edge<ViewElt, Op, require_st_arithmetic<Op>> {
-  public:
+ public:
   using inner_op = std::conditional_t<is_eigen<value_type_t<Op>>::value,
                                       value_type_t<Op>, Op>;
   using partials_t = empty_broadcast_array<ViewElt, inner_op>;

--- a/stan/math/prim/functor/operands_and_partials.hpp
+++ b/stan/math/prim/functor/operands_and_partials.hpp
@@ -55,6 +55,7 @@ class ops_partials_edge;
  */
 template <typename ViewElt, typename Op>
 class ops_partials_edge<ViewElt, Op, require_st_arithmetic<Op>> {
+  public:
   using inner_op = std::conditional_t<is_eigen<value_type_t<Op>>::value,
                                       value_type_t<Op>, Op>;
   using partials_t = empty_broadcast_array<ViewElt, inner_op>;

--- a/stan/math/prim/functor/operands_and_partials.hpp
+++ b/stan/math/prim/functor/operands_and_partials.hpp
@@ -54,7 +54,7 @@ class ops_partials_edge;
  *  for this specialization must be a `Arithmetic`
  */
 template <typename ViewElt, typename Op>
-struct ops_partials_edge<ViewElt, Op, require_st_arithmetic<Op>> {
+class ops_partials_edge<ViewElt, Op, require_st_arithmetic<Op>> {
   using inner_op = std::conditional_t<is_eigen<value_type_t<Op>>::value,
                                       value_type_t<Op>, Op>;
   using partials_t = empty_broadcast_array<ViewElt, inner_op>;


### PR DESCRIPTION
## Summary

`ops_partials_edge` is forward declared as a class, but defined as a struct. This is leading to a warning in clang 18:

```
In file included from src/cmdstan/stansummary.cpp:2:
In file included from src\cmdstan/stansummary_helper.hpp:4:
In file included from stan/src\stan/mcmc/chains.hpp:4:
In file included from stan/src\stan/io/stan_csv_reader.hpp:5:
In file included from stan/lib/stan_math\stan/math/prim.hpp:14:
In file included from stan/lib/stan_math\stan/math/prim/fun.hpp:35:
In file included from stan/lib/stan_math\stan/math/prim/fun/binomial_coefficient_log.hpp:13:
In file included from stan/lib/stan_math\stan/math/prim/functor/partials_propagator.hpp:8:
stan/lib/stan_math\stan/math/prim/functor/operands_and_partials.hpp:57:1: warning: 'ops_partials_edge' defined as a struct template here but previously declared as a class template; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
   57 | struct ops_partials_edge<ViewElt, Op, require_st_arithmetic<Op>> {
      | ^
stan/lib/stan_math\stan/math/prim/functor/operands_and_partials.hpp:45:1: note: did you mean struct here?
   45 | class ops_partials_edge;
      | ^~~~~
      | struct
1 warning generated.

```

## Tests

None

## Side Effects
None
## Release notes

Fixed a warning about a mismatched struct/class declaration from clang 18

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
