### PR TITLE
Add perfect forwarding and constexpr to reverse mode functions

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -120,32 +120,8 @@ INC_GTEST ?= -I $(GTEST)/include -I $(GTEST)
 CPPFLAGS_BOOST ?= -DBOOST_DISABLE_ASSERTS
 CPPFLAGS_SUNDIALS ?= -DNO_FPRINTF_OUTPUT $(CPPFLAGS_OPTIM_SUNDIALS) $(CXXFLAGS_FLTO_SUNDIALS)
 #CPPFLAGS_GTEST ?=
-STAN_HAS_CXX17 ?= false
-ifeq ($(CXX_TYPE), gcc)
-  GCC_GE_73 := $(shell [ $(CXX_MAJOR) -gt 7 -o \( $(CXX_MAJOR) -eq 7 -a $(CXX_MINOR) -ge 1 \) ] && echo true)
-  ifeq ($(GCC_GE_73),true)
-    STAN_HAS_CXX17 := true
-  endif
-else ifeq ($(CXX_TYPE), clang)
-  CLANG_GE_5 := $(shell [ $(CXX_MAJOR) -gt 5 -o \( $(CXX_MAJOR) -eq 5 -a $(CXX_MINOR) -ge 0 \) ] && echo true)
-  ifeq ($(CLANG_GE_5),true)
-    STAN_HAS_CXX17 := true
-  endif
-else ifeq ($(CXX_TYPE), mingw32-gcc)
-  MINGW_GE_50 := $(shell [ $(CXX_MAJOR) -gt 5 -o \( $(CXX_MAJOR) -eq 5 -a $(CXX_MINOR) -ge 0 \) ] && echo true)
-  ifeq ($(MINGW_GE_50),true)
-    STAN_HAS_CXX17 := true
-  endif
-endif
-
-ifeq ($(STAN_HAS_CXX17), true)
-  CXXFLAGS_LANG ?= -std=c++17
-  CXXFLAGS_STANDARD ?= c++17
-else
-  $(warning "Stan cannot detect if your compiler has the C++17 standard. If it does, please set STAN_HAS_CXX17=true in your make/local file. C++17 support is mandatory in the next release of Stan. Defaulting to C++14")
-  CXXFLAGS_LANG ?= -std=c++1y
-  CXXFLAGS_STANDARD ?= c++1y
-endif
+CXXFLAGS_LANG ?= -std=c++17
+CXXFLAGS_STANDARD ?= c++17
 #CXXFLAGS_BOOST ?=
 CXXFLAGS_SUNDIALS ?= -pipe $(CXXFLAGS_OPTIM_SUNDIALS) $(CPPFLAGS_FLTO_SUNDIALS)
 #CXXFLAGS_GTEST

--- a/stan/math/prim/constraint/lb_constrain.hpp
+++ b/stan/math/prim/constraint/lb_constrain.hpp
@@ -149,7 +149,8 @@ inline auto lb_constrain(const T& x, const L& lb, return_type_t<T, L>& lp) {
  * @param[in] lb lower bound on output
  * @return lower-bound constrained value corresponding to inputs
  */
-template <typename T, typename L, require_std_vector_t<T>* = nullptr, require_not_std_vector_t<L>* = nullptr>
+template <typename T, typename L, require_std_vector_t<T>* = nullptr,
+          require_not_std_vector_t<L>* = nullptr>
 inline auto lb_constrain(T&& x, L&& lb) {
   std::vector<plain_type_t<decltype(lb_constrain(x[0], lb))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
@@ -173,7 +174,8 @@ inline auto lb_constrain(T&& x, L&& lb) {
  * @param[in,out] lp reference to log probability to increment
  * @return lower-bound constrained value corresponding to inputs
  */
-template <typename T, typename L, require_std_vector_t<T>* = nullptr, require_not_std_vector_t<L>* = nullptr>
+template <typename T, typename L, require_std_vector_t<T>* = nullptr,
+          require_not_std_vector_t<L>* = nullptr>
 inline auto lb_constrain(T&& x, L&& lb, return_type_t<T, L>& lp) {
   std::vector<plain_type_t<decltype(lb_constrain(x[0], lb))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
@@ -201,7 +203,8 @@ inline auto lb_constrain(T&& x, L&& lb) {
   check_matching_dims("lb_constrain", "x", x, "lb", lb);
   std::vector<plain_type_t<decltype(lb_constrain(x[0], lb[0]))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
-    if constexpr (std::is_rvalue_reference_v<T&&> && std::is_rvalue_reference_v<L&&>) {
+    if constexpr (std::is_rvalue_reference_v<
+                      T&&> && std::is_rvalue_reference_v<L&&>) {
       ret[i] = lb_constrain(std::move(x[i]), std::move(lb[i]));
     } else if constexpr (std::is_rvalue_reference_v<T&&>) {
       ret[i] = lb_constrain(std::move(x[i]), lb[i]);
@@ -209,7 +212,7 @@ inline auto lb_constrain(T&& x, L&& lb) {
       ret[i] = lb_constrain(x[i], std::move(lb[i]));
     } else {
       ret[i] = lb_constrain(x[i], lb[i]);
-    }  
+    }
   }
   return ret;
 }
@@ -230,7 +233,8 @@ inline auto lb_constrain(T&& x, L&& lb, return_type_t<T, L>& lp) {
   check_matching_dims("lb_constrain", "x", x, "lb", lb);
   std::vector<plain_type_t<decltype(lb_constrain(x[0], lb[0]))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
-    if constexpr (std::is_rvalue_reference_v<T&&> && std::is_rvalue_reference_v<L&&>) {
+    if constexpr (std::is_rvalue_reference_v<
+                      T&&> && std::is_rvalue_reference_v<L&&>) {
       ret[i] = lb_constrain(std::move(x[i]), std::move(lb[i]), lp);
     } else if constexpr (std::is_rvalue_reference_v<T&&>) {
       ret[i] = lb_constrain(std::move(x[i]), lb[i], lp);
@@ -238,7 +242,7 @@ inline auto lb_constrain(T&& x, L&& lb, return_type_t<T, L>& lp) {
       ret[i] = lb_constrain(x[i], std::move(lb[i]), lp);
     } else {
       ret[i] = lb_constrain(x[i], lb[i], lp);
-    }  
+    }
   }
   return ret;
 }

--- a/stan/math/prim/constraint/lb_constrain.hpp
+++ b/stan/math/prim/constraint/lb_constrain.hpp
@@ -149,11 +149,15 @@ inline auto lb_constrain(const T& x, const L& lb, return_type_t<T, L>& lp) {
  * @param[in] lb lower bound on output
  * @return lower-bound constrained value corresponding to inputs
  */
-template <typename T, typename L, require_not_std_vector_t<L>* = nullptr>
-inline auto lb_constrain(const std::vector<T>& x, const L& lb) {
+template <typename T, typename L, require_std_vector_t<T>* = nullptr, require_not_std_vector_t<L>* = nullptr>
+inline auto lb_constrain(T&& x, L&& lb) {
   std::vector<plain_type_t<decltype(lb_constrain(x[0], lb))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
-    ret[i] = lb_constrain(x[i], lb);
+    if constexpr (std::is_rvalue_reference_v<T&&>) {
+      ret[i] = lb_constrain(std::move(x[i]), lb);
+    } else {
+      ret[i] = lb_constrain(x[i], lb);
+    }
   }
   return ret;
 }
@@ -169,12 +173,15 @@ inline auto lb_constrain(const std::vector<T>& x, const L& lb) {
  * @param[in,out] lp reference to log probability to increment
  * @return lower-bound constrained value corresponding to inputs
  */
-template <typename T, typename L, require_not_std_vector_t<L>* = nullptr>
-inline auto lb_constrain(const std::vector<T>& x, const L& lb,
-                         return_type_t<T, L>& lp) {
+template <typename T, typename L, require_std_vector_t<T>* = nullptr, require_not_std_vector_t<L>* = nullptr>
+inline auto lb_constrain(T&& x, L&& lb, return_type_t<T, L>& lp) {
   std::vector<plain_type_t<decltype(lb_constrain(x[0], lb))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
-    ret[i] = lb_constrain(x[i], lb, lp);
+    if constexpr (std::is_rvalue_reference_v<T&&>) {
+      ret[i] = lb_constrain(std::move(x[i]), lb, lp);
+    } else {
+      ret[i] = lb_constrain(x[i], lb, lp);
+    }
   }
   return ret;
 }
@@ -189,12 +196,20 @@ inline auto lb_constrain(const std::vector<T>& x, const L& lb,
  * @param[in] lb lower bound on output
  * @return lower-bound constrained value corresponding to inputs
  */
-template <typename T, typename L>
-inline auto lb_constrain(const std::vector<T>& x, const std::vector<L>& lb) {
+template <typename T, typename L, require_all_std_vector_t<T, L>* = nullptr>
+inline auto lb_constrain(T&& x, L&& lb) {
   check_matching_dims("lb_constrain", "x", x, "lb", lb);
   std::vector<plain_type_t<decltype(lb_constrain(x[0], lb[0]))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
-    ret[i] = lb_constrain(x[i], lb[i]);
+    if constexpr (std::is_rvalue_reference_v<T&&> && std::is_rvalue_reference_v<L&&>) {
+      ret[i] = lb_constrain(std::move(x[i]), std::move(lb[i]));
+    } else if constexpr (std::is_rvalue_reference_v<T&&>) {
+      ret[i] = lb_constrain(std::move(x[i]), lb[i]);
+    } else if constexpr (std::is_rvalue_reference_v<L&&>) {
+      ret[i] = lb_constrain(x[i], std::move(lb[i]));
+    } else {
+      ret[i] = lb_constrain(x[i], lb[i]);
+    }  
   }
   return ret;
 }
@@ -210,13 +225,20 @@ inline auto lb_constrain(const std::vector<T>& x, const std::vector<L>& lb) {
  * @param[in,out] lp reference to log probability to increment
  * @return lower-bound constrained value corresponding to inputs
  */
-template <typename T, typename L>
-inline auto lb_constrain(const std::vector<T>& x, const std::vector<L>& lb,
-                         return_type_t<T, L>& lp) {
+template <typename T, typename L, require_all_std_vector_t<T, L>* = nullptr>
+inline auto lb_constrain(T&& x, L&& lb, return_type_t<T, L>& lp) {
   check_matching_dims("lb_constrain", "x", x, "lb", lb);
   std::vector<plain_type_t<decltype(lb_constrain(x[0], lb[0]))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
-    ret[i] = lb_constrain(x[i], lb[i], lp);
+    if constexpr (std::is_rvalue_reference_v<T&&> && std::is_rvalue_reference_v<L&&>) {
+      ret[i] = lb_constrain(std::move(x[i]), std::move(lb[i]), lp);
+    } else if constexpr (std::is_rvalue_reference_v<T&&>) {
+      ret[i] = lb_constrain(std::move(x[i]), lb[i], lp);
+    } else if constexpr (std::is_rvalue_reference_v<L&&>) {
+      ret[i] = lb_constrain(x[i], std::move(lb[i]), lp);
+    } else {
+      ret[i] = lb_constrain(x[i], lb[i], lp);
+    }  
   }
   return ret;
 }
@@ -240,11 +262,11 @@ inline auto lb_constrain(const std::vector<T>& x, const std::vector<L>& lb,
  * @return lower-bound constrained value corresponding to inputs
  */
 template <bool Jacobian, typename T, typename L>
-inline auto lb_constrain(const T& x, const L& lb, return_type_t<T, L>& lp) {
-  if (Jacobian) {
-    return lb_constrain(x, lb, lp);
+inline auto lb_constrain(T&& x, L&& lb, return_type_t<T, L>& lp) {
+  if constexpr (Jacobian) {
+    return lb_constrain(std::forward<T>(x), std::forward<L>(lb), lp);
   } else {
-    return lb_constrain(x, lb);
+    return lb_constrain(std::forward<T>(x), std::forward<L>(lb));
   }
 }
 

--- a/stan/math/prim/constraint/ordered_constrain.hpp
+++ b/stan/math/prim/constraint/ordered_constrain.hpp
@@ -54,7 +54,7 @@ template <typename EigVec, require_eigen_col_vector_t<EigVec>* = nullptr>
 inline auto ordered_constrain(EigVec&& x, value_type_t<EigVec>& lp) {
   auto&& x_ref = to_ref(std::forward<EigVec>(x));
   if (likely(x_ref.size() > 1)) {
-    lp += sum(x_ref.tail(x.size() - 1));
+    lp += sum(x_ref.tail(x_ref.size() - 1));
   }
   return ordered_constrain(std::forward<decltype(x_ref)>(x_ref));
 }

--- a/stan/math/prim/constraint/ordered_constrain.hpp
+++ b/stan/math/prim/constraint/ordered_constrain.hpp
@@ -53,7 +53,7 @@ inline plain_type_t<EigVec> ordered_constrain(const EigVec& x) {
 template <typename EigVec, require_eigen_col_vector_t<EigVec>* = nullptr>
 inline auto ordered_constrain(EigVec&& x, value_type_t<EigVec>& lp) {
   auto&& x_ref = to_ref(std::forward<EigVec>(x));
-  if (likely(x.size() > 1)) {
+  if (likely(x_ref.size() > 1)) {
     lp += sum(x_ref.tail(x.size() - 1));
   }
   return ordered_constrain(std::forward<decltype(x_ref)>(x_ref));

--- a/stan/math/prim/constraint/ordered_constrain.hpp
+++ b/stan/math/prim/constraint/ordered_constrain.hpp
@@ -51,12 +51,12 @@ inline plain_type_t<EigVec> ordered_constrain(const EigVec& x) {
  * @return Positive, increasing ordered vector.
  */
 template <typename EigVec, require_eigen_col_vector_t<EigVec>* = nullptr>
-inline auto ordered_constrain(const EigVec& x, value_type_t<EigVec>& lp) {
-  const auto& x_ref = to_ref(x);
+inline auto ordered_constrain(EigVec&& x, value_type_t<EigVec>& lp) {
+  auto&& x_ref = to_ref(std::forward<EigVec>(x));
   if (likely(x.size() > 1)) {
     lp += sum(x_ref.tail(x.size() - 1));
   }
-  return ordered_constrain(x_ref);
+  return ordered_constrain(std::forward<decltype(x_ref)>(x_ref));
 }
 
 /**
@@ -78,11 +78,11 @@ inline auto ordered_constrain(const EigVec& x, value_type_t<EigVec>& lp) {
  * @return Positive, increasing ordered vector.
  */
 template <bool Jacobian, typename T, require_not_std_vector_t<T>* = nullptr>
-inline auto ordered_constrain(const T& x, return_type_t<T>& lp) {
-  if (Jacobian) {
-    return ordered_constrain(x, lp);
+inline auto ordered_constrain(T&& x, return_type_t<T>& lp) {
+  if constexpr (Jacobian) {
+    return ordered_constrain(std::forward<T>(x), lp);
   } else {
-    return ordered_constrain(x);
+    return ordered_constrain(std::forward<T>(x));
   }
 }
 
@@ -105,9 +105,9 @@ inline auto ordered_constrain(const T& x, return_type_t<T>& lp) {
  * @return Positive, increasing ordered vector.
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
-inline auto ordered_constrain(const T& x, return_type_t<T>& lp) {
+inline auto ordered_constrain(T&& x, return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(
-      x, [&lp](auto&& v) { return ordered_constrain<Jacobian>(v, lp); });
+      std::forward<T>(x), [&lp](auto&& v) { return ordered_constrain<Jacobian>(std::forward<decltype(v)>(v), lp); });
 }
 
 }  // namespace math

--- a/stan/math/prim/constraint/ordered_constrain.hpp
+++ b/stan/math/prim/constraint/ordered_constrain.hpp
@@ -106,8 +106,9 @@ inline auto ordered_constrain(T&& x, return_type_t<T>& lp) {
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto ordered_constrain(T&& x, return_type_t<T>& lp) {
-  return apply_vector_unary<T>::apply(
-      std::forward<T>(x), [&lp](auto&& v) { return ordered_constrain<Jacobian>(std::forward<decltype(v)>(v), lp); });
+  return apply_vector_unary<T>::apply(std::forward<T>(x), [&lp](auto&& v) {
+    return ordered_constrain<Jacobian>(std::forward<decltype(v)>(v), lp);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/constraint/simplex_constrain.hpp
+++ b/stan/math/prim/constraint/simplex_constrain.hpp
@@ -99,8 +99,7 @@ inline plain_type_t<Vec> simplex_constrain(const Vec& y,
  * @return simplex of dimensionality one greater than `y`
  */
 template <bool Jacobian, typename Vec, require_not_std_vector_t<Vec>* = nullptr>
-inline auto simplex_constrain(Vec&& y,
-                                           return_type_t<Vec>& lp) {
+inline auto simplex_constrain(Vec&& y, return_type_t<Vec>& lp) {
   if constexpr (Jacobian) {
     return simplex_constrain(std::forward<Vec>(y), lp);
   } else {
@@ -126,8 +125,9 @@ inline auto simplex_constrain(Vec&& y,
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto simplex_constrain(T&& y, return_type_t<T>& lp) {
-  return apply_vector_unary<T>::apply(
-      std::forward<T>(y), [&lp](auto&& v) { return simplex_constrain<Jacobian>(std::forward<decltype(v)>(v), lp); });
+  return apply_vector_unary<T>::apply(std::forward<T>(y), [&lp](auto&& v) {
+    return simplex_constrain<Jacobian>(std::forward<decltype(v)>(v), lp);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/constraint/simplex_constrain.hpp
+++ b/stan/math/prim/constraint/simplex_constrain.hpp
@@ -99,12 +99,12 @@ inline plain_type_t<Vec> simplex_constrain(const Vec& y,
  * @return simplex of dimensionality one greater than `y`
  */
 template <bool Jacobian, typename Vec, require_not_std_vector_t<Vec>* = nullptr>
-inline plain_type_t<Vec> simplex_constrain(const Vec& y,
+inline auto simplex_constrain(Vec&& y,
                                            return_type_t<Vec>& lp) {
-  if (Jacobian) {
-    return simplex_constrain(y, lp);
+  if constexpr (Jacobian) {
+    return simplex_constrain(std::forward<Vec>(y), lp);
   } else {
-    return simplex_constrain(y);
+    return simplex_constrain(std::forward<Vec>(y));
   }
 }
 
@@ -125,9 +125,9 @@ inline plain_type_t<Vec> simplex_constrain(const Vec& y,
  * @return simplex of dimensionality one greater than `y`
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
-inline auto simplex_constrain(const T& y, return_type_t<T>& lp) {
+inline auto simplex_constrain(T&& y, return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(
-      y, [&lp](auto&& v) { return simplex_constrain<Jacobian>(v, lp); });
+      std::forward<T>(y), [&lp](auto&& v) { return simplex_constrain<Jacobian>(std::forward<decltype(v)>(v), lp); });
 }
 
 }  // namespace math

--- a/stan/math/prim/constraint/ub_constrain.hpp
+++ b/stan/math/prim/constraint/ub_constrain.hpp
@@ -159,7 +159,8 @@ inline auto ub_constrain(const T& x, const U& ub,
  * @param[in] ub upper bound on output
  * @return lower-bound constrained value corresponding to inputs
  */
-template <typename T, typename U, require_std_vector_t<T>* = nullptr, require_not_std_vector_t<U>* = nullptr>
+template <typename T, typename U, require_std_vector_t<T>* = nullptr,
+          require_not_std_vector_t<U>* = nullptr>
 inline auto ub_constrain(T&& x, const U& ub) {
   std::vector<plain_type_t<decltype(ub_constrain(x[0], ub))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
@@ -183,7 +184,8 @@ inline auto ub_constrain(T&& x, const U& ub) {
  * @param[in,out] lp reference to log probability to increment
  * @return lower-bound constrained value corresponding to inputs
  */
-template <typename T, typename U, require_std_vector_t<T>* = nullptr, require_not_std_vector_t<U>* = nullptr>
+template <typename T, typename U, require_std_vector_t<T>* = nullptr,
+          require_not_std_vector_t<U>* = nullptr>
 inline auto ub_constrain(T&& x, const U& ub, return_type_t<T, U>& lp) {
   std::vector<plain_type_t<decltype(ub_constrain(x[0], ub))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
@@ -207,11 +209,12 @@ inline auto ub_constrain(T&& x, const U& ub, return_type_t<T, U>& lp) {
  * @return lower-bound constrained value corresponding to inputs
  */
 template <typename T, typename U, require_all_std_vector_t<T, U>* = nullptr>
-inline auto ub_constrain(T&& x, U&& ub) { 
+inline auto ub_constrain(T&& x, U&& ub) {
   check_matching_dims("ub_constrain", "x", x, "ub", ub);
   std::vector<plain_type_t<decltype(ub_constrain(x[0], ub[0]))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
-    if constexpr (std::is_rvalue_reference_v<T&&> && std::is_rvalue_reference_v<U&&>) {
+    if constexpr (std::is_rvalue_reference_v<
+                      T&&> && std::is_rvalue_reference_v<U&&>) {
       ret[i] = ub_constrain(std::move(x[i]), std::move(ub[i]));
     } else if constexpr (std::is_rvalue_reference_v<T&&>) {
       ret[i] = ub_constrain(std::move(x[i]), ub[i]);
@@ -219,7 +222,7 @@ inline auto ub_constrain(T&& x, U&& ub) {
       ret[i] = ub_constrain(x[i], std::move(ub[i]));
     } else {
       ret[i] = ub_constrain(x[i], ub[i]);
-    }  
+    }
   }
   return ret;
 }
@@ -240,7 +243,8 @@ inline auto ub_constrain(T&& x, U&& ub, return_type_t<T, U>& lp) {
   check_matching_dims("ub_constrain", "x", x, "ub", ub);
   std::vector<plain_type_t<decltype(ub_constrain(x[0], ub[0]))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
-    if constexpr (std::is_rvalue_reference_v<T&&> && std::is_rvalue_reference_v<U&&>) {
+    if constexpr (std::is_rvalue_reference_v<
+                      T&&> && std::is_rvalue_reference_v<U&&>) {
       ret[i] = ub_constrain(std::move(x[i]), std::move(ub[i]), lp);
     } else if constexpr (std::is_rvalue_reference_v<T&&>) {
       ret[i] = ub_constrain(std::move(x[i]), ub[i], lp);
@@ -248,7 +252,7 @@ inline auto ub_constrain(T&& x, U&& ub, return_type_t<T, U>& lp) {
       ret[i] = ub_constrain(x[i], std::move(ub[i]), lp);
     } else {
       ret[i] = ub_constrain(x[i], ub[i], lp);
-    }  
+    }
   }
   return ret;
 }

--- a/stan/math/prim/constraint/unit_vector_constrain.hpp
+++ b/stan/math/prim/constraint/unit_vector_constrain.hpp
@@ -99,8 +99,9 @@ inline auto unit_vector_constrain(T&& y, return_type_t<T>& lp) {
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
 inline auto unit_vector_constrain(T&& y, return_type_t<T>& lp) {
-  return apply_vector_unary<T>::apply(
-      std::forward<T>(y), [&lp](auto&& v) { return unit_vector_constrain<Jacobian>(std::forward<decltype(v)>(v), lp); });
+  return apply_vector_unary<T>::apply(std::forward<T>(y), [&lp](auto&& v) {
+    return unit_vector_constrain<Jacobian>(std::forward<decltype(v)>(v), lp);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/constraint/unit_vector_constrain.hpp
+++ b/stan/math/prim/constraint/unit_vector_constrain.hpp
@@ -73,11 +73,11 @@ inline plain_type_t<T1> unit_vector_constrain(const T1& y, T2& lp) {
  * @return Unit length vector of dimension K
  */
 template <bool Jacobian, typename T, require_not_std_vector_t<T>* = nullptr>
-inline auto unit_vector_constrain(const T& y, return_type_t<T>& lp) {
-  if (Jacobian) {
-    return unit_vector_constrain(y, lp);
+inline auto unit_vector_constrain(T&& y, return_type_t<T>& lp) {
+  if constexpr (Jacobian) {
+    return unit_vector_constrain(std::forward<T>(y), lp);
   } else {
-    return unit_vector_constrain(y);
+    return unit_vector_constrain(std::forward<T>(y));
   }
 }
 
@@ -98,9 +98,9 @@ inline auto unit_vector_constrain(const T& y, return_type_t<T>& lp) {
  * @return Unit length vector of dimension K
  */
 template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
-inline auto unit_vector_constrain(const T& y, return_type_t<T>& lp) {
+inline auto unit_vector_constrain(T&& y, return_type_t<T>& lp) {
   return apply_vector_unary<T>::apply(
-      y, [&lp](auto&& v) { return unit_vector_constrain<Jacobian>(v, lp); });
+      std::forward<T>(y), [&lp](auto&& v) { return unit_vector_constrain<Jacobian>(std::forward<decltype(v)>(v), lp); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/grad_reg_inc_gamma.hpp
+++ b/stan/math/prim/fun/grad_reg_inc_gamma.hpp
@@ -49,7 +49,7 @@ namespace math {
  (a-1)_k\right) \frac{1}{z^k} \end{array} \f]
  */
 template <typename T1, typename T2>
-return_type_t<T1, T2> grad_reg_inc_gamma(T1 a, T2 z, T1 g, T1 dig,
+inline return_type_t<T1, T2> grad_reg_inc_gamma(T1 a, T2 z, T1 g, T1 dig,
                                          double precision = 1e-6,
                                          int max_steps = 1e5) {
   using std::exp;

--- a/stan/math/prim/fun/grad_reg_inc_gamma.hpp
+++ b/stan/math/prim/fun/grad_reg_inc_gamma.hpp
@@ -50,8 +50,8 @@ namespace math {
  */
 template <typename T1, typename T2>
 inline return_type_t<T1, T2> grad_reg_inc_gamma(T1 a, T2 z, T1 g, T1 dig,
-                                         double precision = 1e-6,
-                                         int max_steps = 1e5) {
+                                                double precision = 1e-6,
+                                                int max_steps = 1e5) {
   using std::exp;
   using std::fabs;
   using std::log;

--- a/stan/math/prim/meta/is_autodiff.hpp
+++ b/stan/math/prim/meta/is_autodiff.hpp
@@ -20,10 +20,12 @@ struct is_autodiff
                                       is_fvar<std::decay_t<T>>>::value> {};
 
 template <typename... Types>
-inline constexpr bool is_autodiff_v = math::conjunction<is_autodiff<Types>...>::value;
+inline constexpr bool is_autodiff_v
+    = math::conjunction<is_autodiff<Types>...>::value;
 
 template <typename... Types>
-inline constexpr bool is_autodiffable_v = math::conjunction<is_autodiff<scalar_type_t<Types>>...>::value;
+inline constexpr bool is_autodiffable_v
+    = math::conjunction<is_autodiff<scalar_type_t<Types>>...>::value;
 
 /*! \ingroup require_stan_scalar_real */
 /*! \defgroup autodiff_types autodiff  */

--- a/stan/math/prim/meta/is_autodiff.hpp
+++ b/stan/math/prim/meta/is_autodiff.hpp
@@ -19,6 +19,12 @@ struct is_autodiff
     : bool_constant<math::disjunction<is_var<std::decay_t<T>>,
                                       is_fvar<std::decay_t<T>>>::value> {};
 
+template <typename... Types>
+inline constexpr bool is_autodiff_v = math::conjunction<is_autodiff<Types>...>::value;
+
+template <typename... Types>
+inline constexpr bool is_autodiffable_v = math::conjunction<is_autodiff<scalar_type_t<Types>>...>::value;
+
 /*! \ingroup require_stan_scalar_real */
 /*! \defgroup autodiff_types autodiff  */
 /*! \addtogroup autodiff_types */

--- a/stan/math/prim/meta/is_complex.hpp
+++ b/stan/math/prim/meta/is_complex.hpp
@@ -107,6 +107,21 @@ using require_not_vt_complex
 template <typename T>
 using require_not_st_complex
     = require_not_t<is_complex<scalar_type_t<std::decay_t<T>>>>;
+
+/*! \brief Require any of the value types satisfy @ref is_complex */
+/*! @tparam Types The types with a valid overload of @ref value_type available
+ */
+template <typename... Types>
+using require_any_vt_complex
+    = require_any_t<is_complex<value_type_t<std::decay_t<Types>>>...>;
+
+/*! \brief Require none of the value types satisfy @ref is_complex */
+/*! @tparam Types The types with a valid overload of @ref value_type available
+ */
+template <typename... Types>
+using require_not_any_vt_complex
+    = require_any_t<bool_constant<!is_complex<value_type_t<std::decay_t<Types>>>::value>...>;
+
 /*! @} */
 
 /**

--- a/stan/math/prim/meta/is_complex.hpp
+++ b/stan/math/prim/meta/is_complex.hpp
@@ -119,8 +119,8 @@ using require_any_vt_complex
 /*! @tparam Types The types with a valid overload of @ref value_type available
  */
 template <typename... Types>
-using require_not_any_vt_complex
-    = require_any_t<bool_constant<!is_complex<value_type_t<std::decay_t<Types>>>::value>...>;
+using require_not_any_vt_complex = require_any_t<
+    bool_constant<!is_complex<value_type_t<std::decay_t<Types>>>::value>...>;
 
 /*! @} */
 

--- a/stan/math/prim/meta/is_constant.hpp
+++ b/stan/math/prim/meta/is_constant.hpp
@@ -65,6 +65,5 @@ struct is_constant<T, require_eigen_t<T>>
 template <typename T>
 inline constexpr bool is_constant_v = is_constant<T>::value;
 
-
 }  // namespace stan
 #endif

--- a/stan/math/prim/meta/is_constant.hpp
+++ b/stan/math/prim/meta/is_constant.hpp
@@ -62,8 +62,11 @@ template <typename T>
 struct is_constant<T, require_eigen_t<T>>
     : bool_constant<is_constant<typename std::decay_t<T>::Scalar>::value> {};
 
-template <typename T>
-inline constexpr bool is_constant_v = is_constant<T>::value;
+template <typename... Types>
+inline constexpr bool is_constant_all_v = is_constant_all<Types...>::value;
+
+template <typename... Types>
+inline constexpr bool is_constant_v = std::conjunction<is_constant<Types>...>::value;
 
 }  // namespace stan
 #endif

--- a/stan/math/prim/meta/is_constant.hpp
+++ b/stan/math/prim/meta/is_constant.hpp
@@ -66,7 +66,8 @@ template <typename... Types>
 inline constexpr bool is_constant_all_v = is_constant_all<Types...>::value;
 
 template <typename... Types>
-inline constexpr bool is_constant_v = std::conjunction<is_constant<Types>...>::value;
+inline constexpr bool is_constant_v
+    = std::conjunction<is_constant<Types>...>::value;
 
 }  // namespace stan
 #endif

--- a/stan/math/prim/meta/is_constant.hpp
+++ b/stan/math/prim/meta/is_constant.hpp
@@ -62,5 +62,9 @@ template <typename T>
 struct is_constant<T, require_eigen_t<T>>
     : bool_constant<is_constant<typename std::decay_t<T>::Scalar>::value> {};
 
+template <typename T>
+inline constexpr bool is_constant_v = is_constant<T>::value;
+
+
 }  // namespace stan
 #endif

--- a/stan/math/prim/meta/is_matrix.hpp
+++ b/stan/math/prim/meta/is_matrix.hpp
@@ -18,7 +18,8 @@ struct is_matrix
     : bool_constant<math::disjunction<is_rev_matrix<T>, is_eigen<T>>::value> {};
 
 template <typename... Types>
-inline constexpr bool is_matrix_v = stan::math::conjunction<is_matrix<Types>...>::value;
+inline constexpr bool is_matrix_v
+    = stan::math::conjunction<is_matrix<Types>...>::value;
 
 /*! \ingroup require_eigens_types */
 /*! \defgroup matrix_types matrix  */

--- a/stan/math/prim/meta/is_matrix.hpp
+++ b/stan/math/prim/meta/is_matrix.hpp
@@ -17,6 +17,9 @@ template <typename T>
 struct is_matrix
     : bool_constant<math::disjunction<is_rev_matrix<T>, is_eigen<T>>::value> {};
 
+template <typename T>
+inline constexpr bool is_matrix_v = is_matrix<T>::value;
+
 /*! \ingroup require_eigens_types */
 /*! \defgroup matrix_types matrix  */
 /*! \addtogroup matrix_types */

--- a/stan/math/prim/meta/is_matrix.hpp
+++ b/stan/math/prim/meta/is_matrix.hpp
@@ -17,8 +17,8 @@ template <typename T>
 struct is_matrix
     : bool_constant<math::disjunction<is_rev_matrix<T>, is_eigen<T>>::value> {};
 
-template <typename T>
-inline constexpr bool is_matrix_v = is_matrix<T>::value;
+template <typename... Types>
+inline constexpr bool is_matrix_v = stan::math::conjunction<is_matrix<Types>...>::value;
 
 /*! \ingroup require_eigens_types */
 /*! \defgroup matrix_types matrix  */

--- a/stan/math/prim/meta/is_stan_scalar.hpp
+++ b/stan/math/prim/meta/is_stan_scalar.hpp
@@ -28,6 +28,9 @@ struct is_stan_scalar
           is_fvar<std::decay_t<T>>, std::is_arithmetic<std::decay_t<T>>,
           is_complex<std::decay_t<T>>>::value> {};
 
+template <typename T>
+inline constexpr bool is_stan_scalar_v = is_stan_scalar<T>::value;
+
 /*! \ingroup require_stan_scalar_real */
 /*! \defgroup stan_scalar_types stan_scalar  */
 /*! \addtogroup stan_scalar_types */

--- a/stan/math/prim/meta/is_stan_scalar.hpp
+++ b/stan/math/prim/meta/is_stan_scalar.hpp
@@ -29,7 +29,8 @@ struct is_stan_scalar
           is_complex<std::decay_t<T>>>::value> {};
 
 template <typename... Types>
-inline constexpr bool is_stan_scalar_v = std::conjunction<is_stan_scalar<Types>...>::value;
+inline constexpr bool is_stan_scalar_v
+    = std::conjunction<is_stan_scalar<Types>...>::value;
 
 /*! \ingroup require_stan_scalar_real */
 /*! \defgroup stan_scalar_types stan_scalar  */

--- a/stan/math/prim/meta/is_stan_scalar.hpp
+++ b/stan/math/prim/meta/is_stan_scalar.hpp
@@ -28,8 +28,8 @@ struct is_stan_scalar
           is_fvar<std::decay_t<T>>, std::is_arithmetic<std::decay_t<T>>,
           is_complex<std::decay_t<T>>>::value> {};
 
-template <typename T>
-inline constexpr bool is_stan_scalar_v = is_stan_scalar<T>::value;
+template <typename... Types>
+inline constexpr bool is_stan_scalar_v = std::conjunction<is_stan_scalar<Types>...>::value;
 
 /*! \ingroup require_stan_scalar_real */
 /*! \defgroup stan_scalar_types stan_scalar  */

--- a/stan/math/prim/meta/is_vector.hpp
+++ b/stan/math/prim/meta/is_vector.hpp
@@ -597,6 +597,9 @@ struct is_std_vector<
     T, std::enable_if_t<internal::is_std_vector_impl<std::decay_t<T>>::value>>
     : std::true_type {};
 
+template <typename T>
+struct is_not_std_vector : bool_constant<!is_std_vector<std::decay_t<T>>::value> {};
+
 /** \ingroup type_trait
  * Specialization of scalar_type for vector to recursively return the inner
  * scalar type.

--- a/stan/math/prim/meta/is_vector.hpp
+++ b/stan/math/prim/meta/is_vector.hpp
@@ -598,7 +598,8 @@ struct is_std_vector<
     : std::true_type {};
 
 template <typename T>
-struct is_not_std_vector : bool_constant<!is_std_vector<std::decay_t<T>>::value> {};
+struct is_not_std_vector
+    : bool_constant<!is_std_vector<std::decay_t<T>>::value> {};
 
 /** \ingroup type_trait
  * Specialization of scalar_type for vector to recursively return the inner

--- a/stan/math/rev/constraint/ordered_constrain.hpp
+++ b/stan/math/rev/constraint/ordered_constrain.hpp
@@ -63,11 +63,11 @@ inline auto ordered_constrain(T&& x) {
  */
 template <typename VarVec, require_var_col_vector_t<VarVec>* = nullptr>
 auto ordered_constrain(VarVec&& x, scalar_type_t<VarVec>& lp) {
-  auto&& x_ref = to_ref(x);
+  auto&& x_ref = to_ref(std::forward<VarVec>(x));
   if (x_ref.size() > 1) {
     lp += sum(x_ref.tail(x_ref.size() - 1));
   }
-  return ordered_constrain(x_ref);
+  return ordered_constrain(std::forward<decltype(x_ref)>(x_ref));
 }
 
 }  // namespace math

--- a/stan/math/rev/constraint/ordered_constrain.hpp
+++ b/stan/math/rev/constraint/ordered_constrain.hpp
@@ -22,18 +22,18 @@ namespace math {
  * @return Increasing ordered vector
  */
 template <typename T, require_rev_col_vector_t<T>* = nullptr>
-inline auto ordered_constrain(const T& x) {
+inline auto ordered_constrain(T&& x) {
   using ret_type = plain_type_t<T>;
 
   using std::exp;
 
   size_t N = x.size();
   if (unlikely(N == 0)) {
-    return ret_type(x);
+    return arena_t<ret_type>(x);
   }
 
   Eigen::VectorXd y_val(N);
-  arena_t<T> arena_x = x;
+  arena_t<T> arena_x = std::forward<T>(x);
   arena_t<Eigen::VectorXd> exp_x(N - 1);
 
   y_val.coeffRef(0) = arena_x.val().coeff(0);
@@ -54,7 +54,7 @@ inline auto ordered_constrain(const T& x) {
     arena_x.adj().coeffRef(0) += rolling_adjoint_sum + y.adj().coeff(0);
   });
 
-  return ret_type(y);
+  return y;
 }
 
 /**
@@ -70,11 +70,11 @@ inline auto ordered_constrain(const T& x) {
  * @return Positive, increasing ordered vector.
  */
 template <typename VarVec, require_var_col_vector_t<VarVec>* = nullptr>
-auto ordered_constrain(const VarVec& x, scalar_type_t<VarVec>& lp) {
+auto ordered_constrain(VarVec&& x, scalar_type_t<VarVec>& lp) {
   if (x.size() > 1) {
     lp += sum(x.tail(x.size() - 1));
   }
-  return ordered_constrain(x);
+  return ordered_constrain(std::forward<VarVec>(x));
 }
 
 }  // namespace math

--- a/stan/math/rev/constraint/ordered_constrain.hpp
+++ b/stan/math/rev/constraint/ordered_constrain.hpp
@@ -24,36 +24,28 @@ namespace math {
 template <typename T, require_rev_col_vector_t<T>* = nullptr>
 inline auto ordered_constrain(T&& x) {
   using ret_type = plain_type_t<T>;
-
   using std::exp;
-
   size_t N = x.size();
   if (unlikely(N == 0)) {
     return arena_t<ret_type>(x);
   }
-
   Eigen::VectorXd y_val(N);
   arena_t<T> arena_x = std::forward<T>(x);
   arena_t<Eigen::VectorXd> exp_x(N - 1);
-
   y_val.coeffRef(0) = arena_x.val().coeff(0);
   for (Eigen::Index n = 1; n < N; ++n) {
     exp_x.coeffRef(n - 1) = exp(arena_x.val().coeff(n));
     y_val.coeffRef(n) = y_val.coeff(n - 1) + exp_x.coeff(n - 1);
   }
-
   arena_t<ret_type> y = y_val;
-
   reverse_pass_callback([arena_x, y, exp_x]() mutable {
     double rolling_adjoint_sum = 0.0;
-
     for (int n = arena_x.size() - 1; n > 0; --n) {
       rolling_adjoint_sum += y.adj().coeff(n);
       arena_x.adj().coeffRef(n) += exp_x.coeff(n - 1) * rolling_adjoint_sum;
     }
     arena_x.adj().coeffRef(0) += rolling_adjoint_sum + y.adj().coeff(0);
   });
-
   return y;
 }
 
@@ -71,10 +63,11 @@ inline auto ordered_constrain(T&& x) {
  */
 template <typename VarVec, require_var_col_vector_t<VarVec>* = nullptr>
 auto ordered_constrain(VarVec&& x, scalar_type_t<VarVec>& lp) {
-  if (x.size() > 1) {
-    lp += sum(x.tail(x.size() - 1));
+  auto&& x_ref = to_ref(std::forward<VarVec>(x));
+  if (x_ref.size() > 1) {
+    lp += sum(x_ref.tail(x_ref.size() - 1));
   }
-  return ordered_constrain(std::forward<VarVec>(x));
+  return ordered_constrain(std::forward<decltype(x_ref)>(x_ref));
 }
 
 }  // namespace math

--- a/stan/math/rev/constraint/ordered_constrain.hpp
+++ b/stan/math/rev/constraint/ordered_constrain.hpp
@@ -63,11 +63,11 @@ inline auto ordered_constrain(T&& x) {
  */
 template <typename VarVec, require_var_col_vector_t<VarVec>* = nullptr>
 auto ordered_constrain(VarVec&& x, scalar_type_t<VarVec>& lp) {
-  auto&& x_ref = to_ref(std::forward<VarVec>(x));
+  auto&& x_ref = to_ref(x);
   if (x_ref.size() > 1) {
     lp += sum(x_ref.tail(x_ref.size() - 1));
   }
-  return ordered_constrain(std::forward<decltype(x_ref)>(x_ref));
+  return ordered_constrain(x_ref);
 }
 
 }  // namespace math

--- a/stan/math/rev/constraint/positive_ordered_constrain.hpp
+++ b/stan/math/rev/constraint/positive_ordered_constrain.hpp
@@ -43,7 +43,6 @@ inline auto positive_ordered_constrain(const T& x) {
   }
 
   arena_t<ret_type> y = y_val;
-
   reverse_pass_callback([arena_x, exp_x, y]() mutable {
     const size_t N = arena_x.size();
     double rolling_adjoint_sum = 0.0;

--- a/stan/math/rev/constraint/simplex_constrain.hpp
+++ b/stan/math/rev/constraint/simplex_constrain.hpp
@@ -28,11 +28,11 @@ namespace math {
  * @return Simplex of dimensionality K
  */
 template <typename T, require_rev_col_vector_t<T>* = nullptr>
-inline auto simplex_constrain(const T& y) {
+inline auto simplex_constrain(T&& y) {
   using ret_type = plain_type_t<T>;
 
   size_t N = y.size();
-  arena_t<T> arena_y = y;
+  arena_t<T> arena_y = std::forward<T>(y);
   arena_t<Eigen::VectorXd> arena_z(N);
   Eigen::VectorXd x_val(N + 1);
 
@@ -48,7 +48,7 @@ inline auto simplex_constrain(const T& y) {
   arena_t<ret_type> arena_x = x_val;
 
   if (unlikely(N == 0)) {
-    return ret_type(arena_x);
+    return arena_x;
   }
 
   reverse_pass_callback([arena_y, arena_x, arena_z]() mutable {
@@ -65,7 +65,7 @@ inline auto simplex_constrain(const T& y) {
     }
   });
 
-  return ret_type(arena_x);
+  return arena_x;
 }
 
 /**
@@ -82,11 +82,11 @@ inline auto simplex_constrain(const T& y) {
  * @return Simplex of dimensionality N + 1.
  */
 template <typename T, require_rev_col_vector_t<T>* = nullptr>
-auto simplex_constrain(const T& y, scalar_type_t<T>& lp) {
+auto simplex_constrain(T&& y, scalar_type_t<T>& lp) {
   using ret_type = plain_type_t<T>;
 
   size_t N = y.size();
-  arena_t<T> arena_y = y;
+  arena_t<T> arena_y = std::forward<T>(y);
   arena_t<Eigen::VectorXd> arena_z(N);
   Eigen::VectorXd x_val(N + 1);
 
@@ -106,7 +106,7 @@ auto simplex_constrain(const T& y, scalar_type_t<T>& lp) {
   arena_t<ret_type> arena_x = x_val;
 
   if (unlikely(N == 0)) {
-    return ret_type(arena_x);
+    return arena_x;
   }
 
   reverse_pass_callback([arena_y, arena_x, arena_z, lp]() mutable {
@@ -128,7 +128,7 @@ auto simplex_constrain(const T& y, scalar_type_t<T>& lp) {
     }
   });
 
-  return ret_type(arena_x);
+  return arena_x;
 }
 
 }  // namespace math

--- a/stan/math/rev/constraint/unit_vector_constrain.hpp
+++ b/stan/math/rev/constraint/unit_vector_constrain.hpp
@@ -27,12 +27,12 @@ namespace math {
  * @return Unit length vector of dimension K
  **/
 template <typename T, require_rev_col_vector_t<T>* = nullptr>
-inline auto unit_vector_constrain(const T& y) {
+inline auto unit_vector_constrain(T&& y) {
   using ret_type = return_var_matrix_t<T>;
   check_nonzero_size("unit_vector", "y", y);
 
-  arena_t<T> arena_y = y;
-  arena_t<promote_scalar_t<double, T>> arena_y_val = arena_y.val();
+  arena_t<T> arena_y = std::forward<T>(y);
+  auto arena_y_val = to_arena(arena_y.val());
 
   const double r = arena_y_val.norm();
   arena_t<ret_type> res = arena_y_val / r;
@@ -58,9 +58,9 @@ inline auto unit_vector_constrain(const T& y) {
  * @param lp Log probability reference to increment.
  **/
 template <typename T, require_eigen_col_vector_vt<is_var, T>* = nullptr>
-inline auto unit_vector_constrain(const T& y, var& lp) {
-  const auto& y_ref = to_ref(y);
-  auto x = unit_vector_constrain(y_ref);
+inline auto unit_vector_constrain(T&& y, var& lp) {
+  auto&& y_ref = to_ref(std::forward<T>(y));
+  auto x = unit_vector_constrain(std::forward<decltype(y_ref)>(y_ref));
   lp -= 0.5 * dot_self(y_ref);
   return x;
 }
@@ -76,8 +76,8 @@ inline auto unit_vector_constrain(const T& y, var& lp) {
  * @param lp Log probability reference to increment.
  **/
 template <typename T, require_var_col_vector_t<T>* = nullptr>
-inline auto unit_vector_constrain(const T& y, var& lp) {
-  auto x = unit_vector_constrain(y);
+inline auto unit_vector_constrain(T&& y, var& lp) {
+  auto x = unit_vector_constrain(std::forward<T>(y));
   lp -= 0.5 * dot_self(y);
   return x;
 }

--- a/stan/math/rev/constraint/unit_vector_constrain.hpp
+++ b/stan/math/rev/constraint/unit_vector_constrain.hpp
@@ -44,7 +44,7 @@ inline auto unit_vector_constrain(T&& y) {
                               / (r * r * r));
   });
 
-  return ret_type(res);
+  return res;
 }
 
 /**
@@ -60,8 +60,8 @@ inline auto unit_vector_constrain(T&& y) {
 template <typename T, require_eigen_col_vector_vt<is_var, T>* = nullptr>
 inline auto unit_vector_constrain(T&& y, var& lp) {
   auto&& y_ref = to_ref(std::forward<T>(y));
-  auto x = unit_vector_constrain(std::forward<decltype(y_ref)>(y_ref));
-  lp -= 0.5 * dot_self(y_ref);
+  auto x = unit_vector_constrain(y_ref);
+  lp -= 0.5 * dot_self(std::forward<decltype(y_ref)>(y_ref));
   return x;
 }
 
@@ -77,8 +77,8 @@ inline auto unit_vector_constrain(T&& y, var& lp) {
  **/
 template <typename T, require_var_col_vector_t<T>* = nullptr>
 inline auto unit_vector_constrain(T&& y, var& lp) {
-  auto x = unit_vector_constrain(std::forward<T>(y));
-  lp -= 0.5 * dot_self(y);
+  auto x = unit_vector_constrain(y);
+  lp -= 0.5 * dot_self(std::forward<T>(y));
   return x;
 }
 

--- a/stan/math/rev/fun/append_col.hpp
+++ b/stan/math/rev/fun/append_col.hpp
@@ -35,24 +35,24 @@ template <typename T1, typename T2, require_any_var_matrix_t<T1, T2>* = nullptr>
 inline auto append_col(const T1& A, const T2& B) {
   check_size_match("append_col", "columns of A", A.rows(), "columns of B",
                    B.rows());
-  if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_A = A;
-    arena_t<promote_scalar_t<var, T2>> arena_B = B;
+  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+    arena_t<T1> arena_A = A;
+    arena_t<T2> arena_B = B;
     return make_callback_var(
         append_col(value_of(arena_A), value_of(arena_B)),
         [arena_A, arena_B](auto& vi) mutable {
           arena_A.adj() += vi.adj().leftCols(arena_A.cols());
           arena_B.adj() += vi.adj().rightCols(arena_B.cols());
         });
-  } else if (!is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_A = A;
+  } else if constexpr (!is_constant_v<T1>) {
+    arena_t<T1> arena_A = A;
     return make_callback_var(append_col(value_of(arena_A), value_of(B)),
                              [arena_A](auto& vi) mutable {
                                arena_A.adj()
                                    += vi.adj().leftCols(arena_A.cols());
                              });
   } else {
-    arena_t<promote_scalar_t<var, T2>> arena_B = B;
+    arena_t<T2> arena_B = B;
     return make_callback_var(append_col(value_of(A), value_of(arena_B)),
                              [arena_B](auto& vi) mutable {
                                arena_B.adj()
@@ -79,21 +79,21 @@ template <typename Scal, typename RowVec,
           require_stan_scalar_t<Scal>* = nullptr,
           require_t<is_eigen_row_vector<RowVec>>* = nullptr>
 inline auto append_col(const Scal& A, const var_value<RowVec>& B) {
-  if (!is_constant<Scal>::value && !is_constant<RowVec>::value) {
+  if constexpr(!is_constant_v<Scal> && !is_constant_v<RowVec>) {
     var arena_A = A;
-    arena_t<promote_scalar_t<var, RowVec>> arena_B = B;
+    arena_t<RowVec> arena_B = B;
     return make_callback_var(append_col(value_of(arena_A), value_of(arena_B)),
                              [arena_A, arena_B](auto& vi) mutable {
                                arena_A.adj() += vi.adj().coeff(0);
                                arena_B.adj() += vi.adj().tail(arena_B.size());
                              });
-  } else if (!is_constant<Scal>::value) {
+  } else if constexpr (!is_constant_v<Scal>) {
     var arena_A = A;
     return make_callback_var(
         append_col(value_of(arena_A), value_of(B)),
         [arena_A](auto& vi) mutable { arena_A.adj() += vi.adj().coeff(0); });
   } else {
-    arena_t<promote_scalar_t<var, RowVec>> arena_B = B;
+    arena_t<RowVec> arena_B = B;
     return make_callback_var(append_col(value_of(A), value_of(arena_B)),
                              [arena_B](auto& vi) mutable {
                                arena_B.adj() += vi.adj().tail(arena_B.size());
@@ -119,8 +119,8 @@ template <typename RowVec, typename Scal,
           require_t<is_eigen_row_vector<RowVec>>* = nullptr,
           require_stan_scalar_t<Scal>* = nullptr>
 inline auto append_col(const var_value<RowVec>& A, const Scal& B) {
-  if (!is_constant<RowVec>::value && !is_constant<Scal>::value) {
-    arena_t<promote_scalar_t<var, RowVec>> arena_A = A;
+  if constexpr (!is_constant_v<RowVec> && !is_constant_v<Scal>) {
+    arena_t<RowVec> arena_A = A;
     var arena_B = B;
     return make_callback_var(append_col(value_of(arena_A), value_of(arena_B)),
                              [arena_A, arena_B](auto& vi) mutable {
@@ -128,8 +128,8 @@ inline auto append_col(const var_value<RowVec>& A, const Scal& B) {
                                arena_B.adj()
                                    += vi.adj().coeff(vi.adj().size() - 1);
                              });
-  } else if (!is_constant<RowVec>::value) {
-    arena_t<promote_scalar_t<var, RowVec>> arena_A = A;
+  } else if constexpr (!is_constant_v<RowVec>) {
+    arena_t<RowVec> arena_A = A;
     return make_callback_var(append_col(value_of(arena_A), value_of(B)),
                              [arena_A](auto& vi) mutable {
                                arena_A.adj() += vi.adj().head(arena_A.size());

--- a/stan/math/rev/fun/append_col.hpp
+++ b/stan/math/rev/fun/append_col.hpp
@@ -35,7 +35,7 @@ template <typename T1, typename T2, require_any_var_matrix_t<T1, T2>* = nullptr>
 inline auto append_col(const T1& A, const T2& B) {
   check_size_match("append_col", "columns of A", A.rows(), "columns of B",
                    B.rows());
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     arena_t<T1> arena_A = A;
     arena_t<T2> arena_B = B;
     return make_callback_var(
@@ -44,7 +44,7 @@ inline auto append_col(const T1& A, const T2& B) {
           arena_A.adj() += vi.adj().leftCols(arena_A.cols());
           arena_B.adj() += vi.adj().rightCols(arena_B.cols());
         });
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     arena_t<T1> arena_A = A;
     return make_callback_var(append_col(value_of(arena_A), value_of(B)),
                              [arena_A](auto& vi) mutable {
@@ -79,7 +79,7 @@ template <typename Scal, typename RowVec,
           require_stan_scalar_t<Scal>* = nullptr,
           require_t<is_eigen_row_vector<RowVec>>* = nullptr>
 inline auto append_col(const Scal& A, const var_value<RowVec>& B) {
-  if constexpr (!is_constant_v<Scal> && !is_constant_v<RowVec>) {
+  if constexpr (is_autodiffable_v<Scal, RowVec>) {
     var arena_A = A;
     arena_t<RowVec> arena_B = B;
     return make_callback_var(append_col(value_of(arena_A), value_of(arena_B)),
@@ -87,7 +87,7 @@ inline auto append_col(const Scal& A, const var_value<RowVec>& B) {
                                arena_A.adj() += vi.adj().coeff(0);
                                arena_B.adj() += vi.adj().tail(arena_B.size());
                              });
-  } else if constexpr (!is_constant_v<Scal>) {
+  } else if constexpr (is_autodiffable_v<Scal>) {
     var arena_A = A;
     return make_callback_var(
         append_col(value_of(arena_A), value_of(B)),
@@ -119,7 +119,7 @@ template <typename RowVec, typename Scal,
           require_t<is_eigen_row_vector<RowVec>>* = nullptr,
           require_stan_scalar_t<Scal>* = nullptr>
 inline auto append_col(const var_value<RowVec>& A, const Scal& B) {
-  if constexpr (!is_constant_v<RowVec> && !is_constant_v<Scal>) {
+  if constexpr (is_autodiffable_v<RowVec, Scal>) {
     arena_t<RowVec> arena_A = A;
     var arena_B = B;
     return make_callback_var(append_col(value_of(arena_A), value_of(arena_B)),
@@ -128,7 +128,7 @@ inline auto append_col(const var_value<RowVec>& A, const Scal& B) {
                                arena_B.adj()
                                    += vi.adj().coeff(vi.adj().size() - 1);
                              });
-  } else if constexpr (!is_constant_v<RowVec>) {
+  } else if constexpr (is_autodiffable_v<RowVec>) {
     arena_t<RowVec> arena_A = A;
     return make_callback_var(append_col(value_of(arena_A), value_of(B)),
                              [arena_A](auto& vi) mutable {

--- a/stan/math/rev/fun/append_col.hpp
+++ b/stan/math/rev/fun/append_col.hpp
@@ -79,7 +79,7 @@ template <typename Scal, typename RowVec,
           require_stan_scalar_t<Scal>* = nullptr,
           require_t<is_eigen_row_vector<RowVec>>* = nullptr>
 inline auto append_col(const Scal& A, const var_value<RowVec>& B) {
-  if constexpr(!is_constant_v<Scal> && !is_constant_v<RowVec>) {
+  if constexpr (!is_constant_v<Scal> && !is_constant_v<RowVec>) {
     var arena_A = A;
     arena_t<RowVec> arena_B = B;
     return make_callback_var(append_col(value_of(arena_A), value_of(arena_B)),

--- a/stan/math/rev/fun/append_row.hpp
+++ b/stan/math/rev/fun/append_row.hpp
@@ -33,24 +33,24 @@ template <typename T1, typename T2, require_any_var_matrix_t<T1, T2>* = nullptr>
 inline auto append_row(const T1& A, const T2& B) {
   check_size_match("append_row", "columns of A", A.cols(), "columns of B",
                    B.cols());
-  if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_A = A;
-    arena_t<promote_scalar_t<var, T2>> arena_B = B;
+  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+    arena_t<T1> arena_A = A;
+    arena_t<T2> arena_B = B;
     return make_callback_var(
         append_row(value_of(arena_A), value_of(arena_B)),
         [arena_A, arena_B](auto& vi) mutable {
           arena_A.adj() += vi.adj().topRows(arena_A.rows());
           arena_B.adj() += vi.adj().bottomRows(arena_B.rows());
         });
-  } else if (!is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_A = A;
+  } else if constexpr (!is_constant_v<T1>) {
+    arena_t<T1> arena_A = A;
     return make_callback_var(append_row(value_of(arena_A), value_of(B)),
                              [arena_A](auto& vi) mutable {
                                arena_A.adj()
                                    += vi.adj().topRows(arena_A.rows());
                              });
   } else {
-    arena_t<promote_scalar_t<var, T2>> arena_B = B;
+    arena_t<T2> arena_B = B;
     return make_callback_var(append_row(value_of(A), value_of(arena_B)),
                              [arena_B](auto& vi) mutable {
                                arena_B.adj()
@@ -76,21 +76,21 @@ template <typename Scal, typename ColVec,
           require_stan_scalar_t<Scal>* = nullptr,
           require_t<is_eigen_col_vector<ColVec>>* = nullptr>
 inline auto append_row(const Scal& A, const var_value<ColVec>& B) {
-  if (!is_constant<Scal>::value && !is_constant<ColVec>::value) {
+  if constexpr (!is_constant_v<Scal> && !is_constant_v<ColVec>) {
     var arena_A = A;
-    arena_t<promote_scalar_t<var, ColVec>> arena_B = B;
+    arena_t<ColVec> arena_B = B;
     return make_callback_var(append_row(value_of(arena_A), value_of(arena_B)),
                              [arena_A, arena_B](auto& vi) mutable {
                                arena_A.adj() += vi.adj().coeff(0);
                                arena_B.adj() += vi.adj().tail(arena_B.size());
                              });
-  } else if (!is_constant<Scal>::value) {
+  } else if constexpr (!is_constant_v<Scal>) {
     var arena_A = A;
     return make_callback_var(
         append_row(value_of(arena_A), value_of(B)),
         [arena_A](auto& vi) mutable { arena_A.adj() += vi.adj().coeff(0); });
   } else {
-    arena_t<promote_scalar_t<var, ColVec>> arena_B = B;
+    arena_t<ColVec> arena_B = B;
     return make_callback_var(append_row(value_of(A), value_of(arena_B)),
                              [arena_B](auto& vi) mutable {
                                arena_B.adj() += vi.adj().tail(arena_B.size());
@@ -115,8 +115,8 @@ template <typename ColVec, typename Scal,
           require_t<is_eigen_col_vector<ColVec>>* = nullptr,
           require_stan_scalar_t<Scal>* = nullptr>
 inline auto append_row(const var_value<ColVec>& A, const Scal& B) {
-  if (!is_constant<ColVec>::value && !is_constant<Scal>::value) {
-    arena_t<promote_scalar_t<var, ColVec>> arena_A = A;
+  if constexpr (!is_constant_v<ColVec> && !is_constant_v<Scal>) {
+    arena_t<ColVec> arena_A = A;
     var arena_B = B;
     return make_callback_var(append_row(value_of(arena_A), value_of(arena_B)),
                              [arena_A, arena_B](auto& vi) mutable {
@@ -124,14 +124,14 @@ inline auto append_row(const var_value<ColVec>& A, const Scal& B) {
                                arena_B.adj()
                                    += vi.adj().coeff(vi.adj().size() - 1);
                              });
-  } else if (!is_constant<ColVec>::value) {
-    arena_t<promote_scalar_t<var, ColVec>> arena_A = A;
+  } else if constexpr (!is_constant_v<ColVec>) {
+    arena_t<ColVec> arena_A = A;
     return make_callback_var(append_row(value_of(arena_A), value_of(B)),
                              [arena_A](auto& vi) mutable {
                                arena_A.adj() += vi.adj().head(arena_A.size());
                              });
   } else {
-    arena_t<promote_scalar_t<var, Scal>> arena_B = B;
+    arena_t<Scal> arena_B = B;
     return make_callback_var(append_row(value_of(A), value_of(arena_B)),
                              [arena_B](auto& vi) mutable {
                                arena_B.adj()

--- a/stan/math/rev/fun/append_row.hpp
+++ b/stan/math/rev/fun/append_row.hpp
@@ -33,7 +33,7 @@ template <typename T1, typename T2, require_any_var_matrix_t<T1, T2>* = nullptr>
 inline auto append_row(const T1& A, const T2& B) {
   check_size_match("append_row", "columns of A", A.cols(), "columns of B",
                    B.cols());
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     arena_t<T1> arena_A = A;
     arena_t<T2> arena_B = B;
     return make_callback_var(
@@ -42,7 +42,7 @@ inline auto append_row(const T1& A, const T2& B) {
           arena_A.adj() += vi.adj().topRows(arena_A.rows());
           arena_B.adj() += vi.adj().bottomRows(arena_B.rows());
         });
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     arena_t<T1> arena_A = A;
     return make_callback_var(append_row(value_of(arena_A), value_of(B)),
                              [arena_A](auto& vi) mutable {
@@ -76,7 +76,7 @@ template <typename Scal, typename ColVec,
           require_stan_scalar_t<Scal>* = nullptr,
           require_t<is_eigen_col_vector<ColVec>>* = nullptr>
 inline auto append_row(const Scal& A, const var_value<ColVec>& B) {
-  if constexpr (!is_constant_v<Scal> && !is_constant_v<ColVec>) {
+  if constexpr (is_autodiffable_v<Scal, ColVec>) {
     var arena_A = A;
     arena_t<ColVec> arena_B = B;
     return make_callback_var(append_row(value_of(arena_A), value_of(arena_B)),
@@ -84,7 +84,7 @@ inline auto append_row(const Scal& A, const var_value<ColVec>& B) {
                                arena_A.adj() += vi.adj().coeff(0);
                                arena_B.adj() += vi.adj().tail(arena_B.size());
                              });
-  } else if constexpr (!is_constant_v<Scal>) {
+  } else if constexpr (is_autodiffable_v<Scal>) {
     var arena_A = A;
     return make_callback_var(
         append_row(value_of(arena_A), value_of(B)),
@@ -115,7 +115,7 @@ template <typename ColVec, typename Scal,
           require_t<is_eigen_col_vector<ColVec>>* = nullptr,
           require_stan_scalar_t<Scal>* = nullptr>
 inline auto append_row(const var_value<ColVec>& A, const Scal& B) {
-  if constexpr (!is_constant_v<ColVec> && !is_constant_v<Scal>) {
+  if constexpr (is_autodiffable_v<ColVec, Scal>) {
     arena_t<ColVec> arena_A = A;
     var arena_B = B;
     return make_callback_var(append_row(value_of(arena_A), value_of(arena_B)),
@@ -124,7 +124,7 @@ inline auto append_row(const var_value<ColVec>& A, const Scal& B) {
                                arena_B.adj()
                                    += vi.adj().coeff(vi.adj().size() - 1);
                              });
-  } else if constexpr (!is_constant_v<ColVec>) {
+  } else if constexpr (is_autodiffable_v<ColVec>) {
     arena_t<ColVec> arena_A = A;
     return make_callback_var(append_row(value_of(arena_A), value_of(B)),
                              [arena_A](auto& vi) mutable {

--- a/stan/math/rev/fun/atan2.hpp
+++ b/stan/math/rev/fun/atan2.hpp
@@ -148,21 +148,18 @@ inline auto atan2(const Scalar& a, const VarMat& b) {
   arena_t<VarMat> arena_b = b;
   if constexpr (!is_constant_v<Scalar> && !is_constant_v<VarMat>) {
     auto atan2_val = atan2(a.val(), arena_b.val());
-    auto a_sq_plus_b_sq
-        = to_arena((a.val() * a.val())
-                   + (arena_b.val().array() * arena_b.val().array()));
+    auto a_sq_plus_b_sq = to_arena(
+        (a.val() * a.val()) + (arena_b.val().array() * arena_b.val().array()));
     return make_callback_var(
         atan2(a.val(), arena_b.val()),
         [a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
-          a.adj()
-              += (vi.adj().array() * arena_b.val().array() / a_sq_plus_b_sq)
-                     .sum();
-          arena_b.adj().array()
-              += -vi.adj().array() * a.val() / a_sq_plus_b_sq;
+          a.adj() += (vi.adj().array() * arena_b.val().array() / a_sq_plus_b_sq)
+                         .sum();
+          arena_b.adj().array() += -vi.adj().array() * a.val() / a_sq_plus_b_sq;
         });
   } else if constexpr (!is_constant_v<Scalar>) {
-    auto a_sq_plus_b_sq = to_arena((a.val() * a.val())
-                                   + (arena_b.array() * arena_b.array()));
+    auto a_sq_plus_b_sq
+        = to_arena((a.val() * a.val()) + (arena_b.array() * arena_b.array()));
     return make_callback_var(
         atan2(a.val(), arena_b),
         [a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
@@ -170,13 +167,13 @@ inline auto atan2(const Scalar& a, const VarMat& b) {
               += (vi.adj().array() * arena_b.array() / a_sq_plus_b_sq).sum();
         });
   } else if constexpr (!is_constant_v<VarMat>) {
-    auto a_sq_plus_b_sq = to_arena(
-        (a * a) + (arena_b.val().array() * arena_b.val().array()));
-    return make_callback_var(
-        atan2(a, arena_b.val()),
-        [a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
-          arena_b.adj().array() += -vi.adj().array() * a / a_sq_plus_b_sq;
-        });
+    auto a_sq_plus_b_sq
+        = to_arena((a * a) + (arena_b.val().array() * arena_b.val().array()));
+    return make_callback_var(atan2(a, arena_b.val()),
+                             [a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
+                               arena_b.adj().array()
+                                   += -vi.adj().array() * a / a_sq_plus_b_sq;
+                             });
   }
 }
 
@@ -187,29 +184,27 @@ inline auto atan2(const VarMat& a, const Scalar& b) {
   arena_t<VarMat> arena_a = a;
   if constexpr (!is_constant_v<VarMat> && !is_constant_v<Scalar>) {
     auto atan2_val = atan2(arena_a.val(), b.val());
-    auto a_sq_plus_b_sq
-        = to_arena((arena_a.val().array() * arena_a.val().array())
-                   + (b.val() * b.val()));
+    auto a_sq_plus_b_sq = to_arena(
+        (arena_a.val().array() * arena_a.val().array()) + (b.val() * b.val()));
     return make_callback_var(
         atan2(arena_a.val(), b.val()),
         [arena_a, b, a_sq_plus_b_sq](auto& vi) mutable {
-          arena_a.adj().array()
-              += vi.adj().array() * b.val() / a_sq_plus_b_sq;
+          arena_a.adj().array() += vi.adj().array() * b.val() / a_sq_plus_b_sq;
           b.adj()
               += -(vi.adj().array() * arena_a.val().array() / a_sq_plus_b_sq)
                       .sum();
         });
   } else if constexpr (!is_constant_v<VarMat>) {
-    auto a_sq_plus_b_sq = to_arena(
-        (arena_a.val().array() * arena_a.val().array()) + (b * b));
-    return make_callback_var(
-        atan2(arena_a.val(), b),
-        [arena_a, b, a_sq_plus_b_sq](auto& vi) mutable {
-          arena_a.adj().array() += vi.adj().array() * b / a_sq_plus_b_sq;
-        });
+    auto a_sq_plus_b_sq
+        = to_arena((arena_a.val().array() * arena_a.val().array()) + (b * b));
+    return make_callback_var(atan2(arena_a.val(), b),
+                             [arena_a, b, a_sq_plus_b_sq](auto& vi) mutable {
+                               arena_a.adj().array()
+                                   += vi.adj().array() * b / a_sq_plus_b_sq;
+                             });
   } else if constexpr (!is_constant_v<Scalar>) {
-    auto a_sq_plus_b_sq = to_arena((arena_a.array() * arena_a.array())
-                                   + (b.val() * b.val()));
+    auto a_sq_plus_b_sq
+        = to_arena((arena_a.array() * arena_a.array()) + (b.val() * b.val()));
     return make_callback_var(
         atan2(arena_a, b.val()),
         [arena_a, b, a_sq_plus_b_sq](auto& vi) mutable {

--- a/stan/math/rev/fun/atan2.hpp
+++ b/stan/math/rev/fun/atan2.hpp
@@ -101,9 +101,9 @@ template <typename Mat1, typename Mat2,
           require_any_var_matrix_t<Mat1, Mat2>* = nullptr,
           require_all_matrix_t<Mat1, Mat2>* = nullptr>
 inline auto atan2(const Mat1& a, const Mat2& b) {
-  if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
-    arena_t<promote_scalar_t<var, Mat1>> arena_a = a;
-    arena_t<promote_scalar_t<var, Mat2>> arena_b = b;
+  arena_t<Mat1> arena_a = a;
+  arena_t<Mat2> arena_b = b;
+  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
     auto atan2_val = atan2(arena_a.val(), arena_b.val());
     auto a_sq_plus_b_sq
         = to_arena((arena_a.val().array() * arena_a.val().array())
@@ -116,9 +116,7 @@ inline auto atan2(const Mat1& a, const Mat2& b) {
           arena_b.adj().array()
               += -vi.adj().array() * arena_a.val().array() / a_sq_plus_b_sq;
         });
-  } else if (!is_constant<Mat1>::value) {
-    arena_t<promote_scalar_t<var, Mat1>> arena_a = a;
-    arena_t<promote_scalar_t<double, Mat2>> arena_b = value_of(b);
+  } else if constexpr (!is_constant_v<Mat1>) {
     auto a_sq_plus_b_sq
         = to_arena((arena_a.val().array() * arena_a.val().array())
                    + (arena_b.array() * arena_b.array()));
@@ -129,9 +127,7 @@ inline auto atan2(const Mat1& a, const Mat2& b) {
           arena_a.adj().array()
               += vi.adj().array() * arena_b.array() / a_sq_plus_b_sq;
         });
-  } else if (!is_constant<Mat2>::value) {
-    arena_t<promote_scalar_t<double, Mat1>> arena_a = value_of(a);
-    arena_t<promote_scalar_t<var, Mat2>> arena_b = b;
+  } else if constexpr (!is_constant_v<Mat2>) {
     auto a_sq_plus_b_sq
         = to_arena((arena_a.array() * arena_a.array())
                    + (arena_b.val().array() * arena_b.val().array()));
@@ -149,44 +145,37 @@ template <typename Scalar, typename VarMat,
           require_var_matrix_t<VarMat>* = nullptr,
           require_stan_scalar_t<Scalar>* = nullptr>
 inline auto atan2(const Scalar& a, const VarMat& b) {
-  if (!is_constant<Scalar>::value && !is_constant<VarMat>::value) {
-    var arena_a = a;
-    arena_t<promote_scalar_t<var, VarMat>> arena_b = b;
-    auto atan2_val = atan2(arena_a.val(), arena_b.val());
+  arena_t<VarMat> arena_b = b;
+  if constexpr (!is_constant_v<Scalar> && !is_constant_v<VarMat>) {
+    auto atan2_val = atan2(a.val(), arena_b.val());
     auto a_sq_plus_b_sq
-        = to_arena((arena_a.val() * arena_a.val())
+        = to_arena((a.val() * a.val())
                    + (arena_b.val().array() * arena_b.val().array()));
     return make_callback_var(
-        atan2(arena_a.val(), arena_b.val()),
-        [arena_a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
-          arena_a.adj()
+        atan2(a.val(), arena_b.val()),
+        [a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
+          a.adj()
               += (vi.adj().array() * arena_b.val().array() / a_sq_plus_b_sq)
                      .sum();
           arena_b.adj().array()
-              += -vi.adj().array() * arena_a.val() / a_sq_plus_b_sq;
+              += -vi.adj().array() * a.val() / a_sq_plus_b_sq;
         });
-  } else if (!is_constant<Scalar>::value) {
-    var arena_a = a;
-    arena_t<promote_scalar_t<double, VarMat>> arena_b = value_of(b);
-    auto a_sq_plus_b_sq = to_arena((arena_a.val() * arena_a.val())
+  } else if constexpr (!is_constant_v<Scalar>) {
+    auto a_sq_plus_b_sq = to_arena((a.val() * a.val())
                                    + (arena_b.array() * arena_b.array()));
-
     return make_callback_var(
-        atan2(arena_a.val(), arena_b),
-        [arena_a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
-          arena_a.adj()
+        atan2(a.val(), arena_b),
+        [a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
+          a.adj()
               += (vi.adj().array() * arena_b.array() / a_sq_plus_b_sq).sum();
         });
-  } else if (!is_constant<VarMat>::value) {
-    double arena_a = value_of(a);
-    arena_t<promote_scalar_t<var, VarMat>> arena_b = b;
+  } else if constexpr (!is_constant_v<VarMat>) {
     auto a_sq_plus_b_sq = to_arena(
-        (arena_a * arena_a) + (arena_b.val().array() * arena_b.val().array()));
-
+        (a * a) + (arena_b.val().array() * arena_b.val().array()));
     return make_callback_var(
-        atan2(arena_a, arena_b.val()),
-        [arena_a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
-          arena_b.adj().array() += -vi.adj().array() * arena_a / a_sq_plus_b_sq;
+        atan2(a, arena_b.val()),
+        [a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
+          arena_b.adj().array() += -vi.adj().array() * a / a_sq_plus_b_sq;
         });
   }
 }
@@ -195,43 +184,36 @@ template <typename VarMat, typename Scalar,
           require_var_matrix_t<VarMat>* = nullptr,
           require_stan_scalar_t<Scalar>* = nullptr>
 inline auto atan2(const VarMat& a, const Scalar& b) {
-  if (!is_constant<VarMat>::value && !is_constant<Scalar>::value) {
-    arena_t<promote_scalar_t<var, VarMat>> arena_a = a;
-    var arena_b = b;
-    auto atan2_val = atan2(arena_a.val(), arena_b.val());
+  arena_t<VarMat> arena_a = a;
+  if constexpr (!is_constant_v<VarMat> && !is_constant_v<Scalar>) {
+    auto atan2_val = atan2(arena_a.val(), b.val());
     auto a_sq_plus_b_sq
         = to_arena((arena_a.val().array() * arena_a.val().array())
-                   + (arena_b.val() * arena_b.val()));
+                   + (b.val() * b.val()));
     return make_callback_var(
-        atan2(arena_a.val(), arena_b.val()),
-        [arena_a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
+        atan2(arena_a.val(), b.val()),
+        [arena_a, b, a_sq_plus_b_sq](auto& vi) mutable {
           arena_a.adj().array()
-              += vi.adj().array() * arena_b.val() / a_sq_plus_b_sq;
-          arena_b.adj()
+              += vi.adj().array() * b.val() / a_sq_plus_b_sq;
+          b.adj()
               += -(vi.adj().array() * arena_a.val().array() / a_sq_plus_b_sq)
                       .sum();
         });
-  } else if (!is_constant<VarMat>::value) {
-    arena_t<promote_scalar_t<var, VarMat>> arena_a = a;
-    double arena_b = value_of(b);
+  } else if constexpr (!is_constant_v<VarMat>) {
     auto a_sq_plus_b_sq = to_arena(
-        (arena_a.val().array() * arena_a.val().array()) + (arena_b * arena_b));
-
+        (arena_a.val().array() * arena_a.val().array()) + (b * b));
     return make_callback_var(
-        atan2(arena_a.val(), arena_b),
-        [arena_a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
-          arena_a.adj().array() += vi.adj().array() * arena_b / a_sq_plus_b_sq;
+        atan2(arena_a.val(), b),
+        [arena_a, b, a_sq_plus_b_sq](auto& vi) mutable {
+          arena_a.adj().array() += vi.adj().array() * b / a_sq_plus_b_sq;
         });
-  } else if (!is_constant<Scalar>::value) {
-    arena_t<promote_scalar_t<double, VarMat>> arena_a = value_of(a);
-    var arena_b = b;
+  } else if constexpr (!is_constant_v<Scalar>) {
     auto a_sq_plus_b_sq = to_arena((arena_a.array() * arena_a.array())
-                                   + (arena_b.val() * arena_b.val()));
-
+                                   + (b.val() * b.val()));
     return make_callback_var(
-        atan2(arena_a, arena_b.val()),
-        [arena_a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
-          arena_b.adj()
+        atan2(arena_a, b.val()),
+        [arena_a, b, a_sq_plus_b_sq](auto& vi) mutable {
+          b.adj()
               += -(vi.adj().array() * arena_a.array() / a_sq_plus_b_sq).sum();
         });
   }

--- a/stan/math/rev/fun/atan2.hpp
+++ b/stan/math/rev/fun/atan2.hpp
@@ -146,7 +146,8 @@ template <typename Scalar, typename VarMat,
           require_stan_scalar_t<Scalar>* = nullptr>
 inline auto atan2(const Scalar& a, const VarMat& b) {
   arena_t<VarMat> arena_b = b;
-  if constexpr (is_autodiffable_v<Scalar, VarMat> && is_autodiffable_v<VarMat>) {
+  if constexpr (is_autodiffable_v<Scalar,
+                                  VarMat> && is_autodiffable_v<VarMat>) {
     auto atan2_val = atan2(a.val(), arena_b.val());
     auto a_sq_plus_b_sq = to_arena(
         (a.val() * a.val()) + (arena_b.val().array() * arena_b.val().array()));

--- a/stan/math/rev/fun/atan2.hpp
+++ b/stan/math/rev/fun/atan2.hpp
@@ -103,7 +103,7 @@ template <typename Mat1, typename Mat2,
 inline auto atan2(const Mat1& a, const Mat2& b) {
   arena_t<Mat1> arena_a = a;
   arena_t<Mat2> arena_b = b;
-  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
+  if constexpr (is_autodiffable_v<Mat1, Mat2>) {
     auto atan2_val = atan2(arena_a.val(), arena_b.val());
     auto a_sq_plus_b_sq
         = to_arena((arena_a.val().array() * arena_a.val().array())
@@ -116,7 +116,7 @@ inline auto atan2(const Mat1& a, const Mat2& b) {
           arena_b.adj().array()
               += -vi.adj().array() * arena_a.val().array() / a_sq_plus_b_sq;
         });
-  } else if constexpr (!is_constant_v<Mat1>) {
+  } else if constexpr (is_autodiffable_v<Mat1>) {
     auto a_sq_plus_b_sq
         = to_arena((arena_a.val().array() * arena_a.val().array())
                    + (arena_b.array() * arena_b.array()));
@@ -127,7 +127,7 @@ inline auto atan2(const Mat1& a, const Mat2& b) {
           arena_a.adj().array()
               += vi.adj().array() * arena_b.array() / a_sq_plus_b_sq;
         });
-  } else if constexpr (!is_constant_v<Mat2>) {
+  } else if constexpr (is_autodiffable_v<Mat2>) {
     auto a_sq_plus_b_sq
         = to_arena((arena_a.array() * arena_a.array())
                    + (arena_b.val().array() * arena_b.val().array()));
@@ -146,7 +146,7 @@ template <typename Scalar, typename VarMat,
           require_stan_scalar_t<Scalar>* = nullptr>
 inline auto atan2(const Scalar& a, const VarMat& b) {
   arena_t<VarMat> arena_b = b;
-  if constexpr (!is_constant_v<Scalar> && !is_constant_v<VarMat>) {
+  if constexpr (is_autodiffable_v<Scalar, VarMat> && is_autodiffable_v<VarMat>) {
     auto atan2_val = atan2(a.val(), arena_b.val());
     auto a_sq_plus_b_sq = to_arena(
         (a.val() * a.val()) + (arena_b.val().array() * arena_b.val().array()));
@@ -157,7 +157,7 @@ inline auto atan2(const Scalar& a, const VarMat& b) {
                          .sum();
           arena_b.adj().array() += -vi.adj().array() * a.val() / a_sq_plus_b_sq;
         });
-  } else if constexpr (!is_constant_v<Scalar>) {
+  } else if constexpr (is_autodiffable_v<Scalar>) {
     auto a_sq_plus_b_sq
         = to_arena((a.val() * a.val()) + (arena_b.array() * arena_b.array()));
     return make_callback_var(
@@ -166,7 +166,7 @@ inline auto atan2(const Scalar& a, const VarMat& b) {
           a.adj()
               += (vi.adj().array() * arena_b.array() / a_sq_plus_b_sq).sum();
         });
-  } else if constexpr (!is_constant_v<VarMat>) {
+  } else if constexpr (is_autodiffable_v<VarMat>) {
     auto a_sq_plus_b_sq
         = to_arena((a * a) + (arena_b.val().array() * arena_b.val().array()));
     return make_callback_var(atan2(a, arena_b.val()),
@@ -182,7 +182,7 @@ template <typename VarMat, typename Scalar,
           require_stan_scalar_t<Scalar>* = nullptr>
 inline auto atan2(const VarMat& a, const Scalar& b) {
   arena_t<VarMat> arena_a = a;
-  if constexpr (!is_constant_v<VarMat> && !is_constant_v<Scalar>) {
+  if constexpr (is_autodiffable_v<VarMat, Scalar>) {
     auto atan2_val = atan2(arena_a.val(), b.val());
     auto a_sq_plus_b_sq = to_arena(
         (arena_a.val().array() * arena_a.val().array()) + (b.val() * b.val()));
@@ -194,7 +194,7 @@ inline auto atan2(const VarMat& a, const Scalar& b) {
               += -(vi.adj().array() * arena_a.val().array() / a_sq_plus_b_sq)
                       .sum();
         });
-  } else if constexpr (!is_constant_v<VarMat>) {
+  } else if constexpr (is_autodiffable_v<VarMat>) {
     auto a_sq_plus_b_sq
         = to_arena((arena_a.val().array() * arena_a.val().array()) + (b * b));
     return make_callback_var(atan2(arena_a.val(), b),
@@ -202,7 +202,7 @@ inline auto atan2(const VarMat& a, const Scalar& b) {
                                arena_a.adj().array()
                                    += vi.adj().array() * b / a_sq_plus_b_sq;
                              });
-  } else if constexpr (!is_constant_v<Scalar>) {
+  } else if constexpr (is_autodiffable_v<Scalar>) {
     auto a_sq_plus_b_sq
         = to_arena((arena_a.array() * arena_a.array()) + (b.val() * b.val()));
     return make_callback_var(

--- a/stan/math/rev/fun/atan2.hpp
+++ b/stan/math/rev/fun/atan2.hpp
@@ -103,21 +103,20 @@ template <typename Mat1, typename Mat2,
 inline auto atan2(Mat1&& a, Mat2&& b) {
   arena_t<Mat1> arena_a = std::forward<Mat1>(a);
   arena_t<Mat2> arena_b = std::forward<Mat2>(b);
-    auto a_sq_plus_b_sq
-        = to_arena(value_of(arena_a).array().square()
-                   + value_of(arena_b).array().square());
-    return make_callback_var(
-        atan2(arena_a.val(), arena_b.val()),
-        [arena_a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
-          if constexpr (is_autodiffable_v<Mat1>) {
-            arena_a.adj().array()
-                += vi.adj().array() * value_of(arena_b).array() / a_sq_plus_b_sq;
-          }
-          if constexpr (is_autodiffable_v<Mat2>) {
-            arena_b.adj().array()
-                += -vi.adj().array() * value_of(arena_a).array() / a_sq_plus_b_sq;
-          }
-        });
+  auto a_sq_plus_b_sq = to_arena(value_of(arena_a).array().square()
+                                 + value_of(arena_b).array().square());
+  return make_callback_var(
+      atan2(arena_a.val(), arena_b.val()),
+      [arena_a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
+        if constexpr (is_autodiffable_v<Mat1>) {
+          arena_a.adj().array()
+              += vi.adj().array() * value_of(arena_b).array() / a_sq_plus_b_sq;
+        }
+        if constexpr (is_autodiffable_v<Mat2>) {
+          arena_b.adj().array()
+              += -vi.adj().array() * value_of(arena_a).array() / a_sq_plus_b_sq;
+        }
+      });
 }
 
 template <typename Scalar, typename VarMat,
@@ -125,19 +124,21 @@ template <typename Scalar, typename VarMat,
           require_stan_scalar_t<Scalar>* = nullptr>
 inline auto atan2(Scalar a, VarMat&& b) {
   arena_t<VarMat> arena_b = std::forward<VarMat>(b);
-  auto a_sq_plus_b_sq = to_arena(
-      square(value_of(a)) + (value_of(arena_b).array().square()));
-    return make_callback_var(
-        atan2(value_of(a), value_of(arena_b)),
-        [a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
-          if constexpr (is_autodiffable_v<Scalar>) {
-            a.adj() += (vi.adj().array() * value_of(arena_b).array() / a_sq_plus_b_sq)
-                          .sum();
-          }
-          if constexpr (is_autodiffable_v<VarMat>) {
-            arena_b.adj().array() += -vi.adj().array() * value_of(a) / a_sq_plus_b_sq;
-          }
-        });
+  auto a_sq_plus_b_sq
+      = to_arena(square(value_of(a)) + (value_of(arena_b).array().square()));
+  return make_callback_var(
+      atan2(value_of(a), value_of(arena_b)),
+      [a, arena_b, a_sq_plus_b_sq](auto& vi) mutable {
+        if constexpr (is_autodiffable_v<Scalar>) {
+          a.adj()
+              += (vi.adj().array() * value_of(arena_b).array() / a_sq_plus_b_sq)
+                     .sum();
+        }
+        if constexpr (is_autodiffable_v<VarMat>) {
+          arena_b.adj().array()
+              += -vi.adj().array() * value_of(a) / a_sq_plus_b_sq;
+        }
+      });
 }
 
 template <typename VarMat, typename Scalar,
@@ -145,19 +146,21 @@ template <typename VarMat, typename Scalar,
           require_stan_scalar_t<Scalar>* = nullptr>
 inline auto atan2(VarMat&& a, Scalar b) {
   arena_t<VarMat> arena_a = std::forward<VarMat>(a);
-  auto a_sq_plus_b_sq = to_arena(value_of(arena_a).array().square() + square(value_of(b)));
-    return make_callback_var(
-        atan2(value_of(arena_a), value_of(b)),
-        [arena_a, b, a_sq_plus_b_sq](auto& vi) mutable {
+  auto a_sq_plus_b_sq
+      = to_arena(value_of(arena_a).array().square() + square(value_of(b)));
+  return make_callback_var(
+      atan2(value_of(arena_a), value_of(b)),
+      [arena_a, b, a_sq_plus_b_sq](auto& vi) mutable {
         if constexpr (is_autodiffable_v<VarMat>) {
-          arena_a.adj().array() += vi.adj().array() * value_of(b) / a_sq_plus_b_sq;
+          arena_a.adj().array()
+              += vi.adj().array() * value_of(b) / a_sq_plus_b_sq;
         }
         if constexpr (is_autodiffable_v<Scalar>) {
-          b.adj()
-              += -(vi.adj().array() * value_of(arena_a).array() / a_sq_plus_b_sq)
-                      .sum();
+          b.adj() += -(vi.adj().array() * value_of(arena_a).array()
+                       / a_sq_plus_b_sq)
+                          .sum();
         }
-        });
+      });
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/beta.hpp
+++ b/stan/math/rev/fun/beta.hpp
@@ -103,7 +103,7 @@ template <typename Mat1, typename Mat2,
 inline auto beta(const Mat1& a, const Mat2& b) {
   arena_t<Mat1> arena_a = a;
   arena_t<Mat2> arena_b = b;
-  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
+  if constexpr (is_autodiffable_v<Mat1, Mat2>) {
     auto beta_val = beta(arena_a.val(), arena_b.val());
     auto digamma_ab
         = to_arena(digamma(arena_a.val().array() + arena_b.val().array()));
@@ -116,7 +116,7 @@ inline auto beta(const Mat1& a, const Mat2& b) {
           arena_b.adj().array()
               += adj_val * (digamma(arena_b.val().array()) - digamma_ab);
         });
-  } else if constexpr (!is_constant_v<Mat1>) {
+  } else if constexpr (is_autodiffable_v<Mat1>) {
     auto digamma_ab
         = to_arena(digamma(arena_a.val()).array()
                    - digamma(arena_a.val().array() + arena_b.array()));
@@ -126,7 +126,7 @@ inline auto beta(const Mat1& a, const Mat2& b) {
                                                         * digamma_ab
                                                         * vi.val().array();
                              });
-  } else if constexpr (!is_constant_v<Mat2>) {
+  } else if constexpr (is_autodiffable_v<Mat2>) {
     auto beta_val = beta(arena_a, arena_b.val());
     auto digamma_ab
         = to_arena((digamma(arena_b.val()).array()
@@ -145,7 +145,7 @@ template <typename Scalar, typename VarMat,
 inline auto beta(const Scalar& a, const VarMat& b) {
   auto arena_a = a;
   arena_t<VarMat> arena_b = b;
-  if constexpr (!is_constant_v<Scalar> && !is_constant_v<VarMat>) {
+  if constexpr (is_autodiffable_v<Scalar, VarMat>) {
     auto beta_val = beta(arena_a.val(), arena_b.val());
     auto digamma_ab = to_arena(digamma(arena_a.val() + arena_b.val().array()));
     return make_callback_var(
@@ -157,7 +157,7 @@ inline auto beta(const Scalar& a, const VarMat& b) {
           arena_b.adj().array()
               += adj_val * (digamma(arena_b.val().array()) - digamma_ab);
         });
-  } else if constexpr (!is_constant_v<Scalar>) {
+  } else if constexpr (is_autodiffable_v<Scalar>) {
     auto digamma_ab = to_arena(digamma(arena_a.val())
                                - digamma(arena_a.val() + arena_b.array()));
     return make_callback_var(
@@ -166,7 +166,7 @@ inline auto beta(const Scalar& a, const VarMat& b) {
           arena_a.adj()
               += (vi.adj().array() * digamma_ab * vi.val().array()).sum();
         });
-  } else if constexpr (!is_constant_v<VarMat>) {
+  } else if constexpr (is_autodiffable_v<VarMat>) {
     auto beta_val = beta(arena_a, arena_b.val());
     auto digamma_ab = to_arena((digamma(arena_b.val()).array()
                                 - digamma(arena_a + arena_b.val().array()))
@@ -183,7 +183,7 @@ template <typename VarMat, typename Scalar,
 inline auto beta(const VarMat& a, const Scalar& b) {
   arena_t<VarMat> arena_a = a;
   auto arena_b = b;
-  if constexpr (!is_constant_v<VarMat> && !is_constant_v<Scalar>) {
+  if constexpr (is_autodiffable_v<VarMat, Scalar>) {
     auto beta_val = beta(arena_a.val(), arena_b.val());
     auto digamma_ab = to_arena(digamma(arena_a.val().array() + arena_b.val()));
     return make_callback_var(
@@ -195,7 +195,7 @@ inline auto beta(const VarMat& a, const Scalar& b) {
           arena_b.adj()
               += (adj_val * (digamma(arena_b.val()) - digamma_ab)).sum();
         });
-  } else if constexpr (!is_constant_v<VarMat>) {
+  } else if constexpr (is_autodiffable_v<VarMat>) {
     auto digamma_ab = to_arena(digamma(arena_a.val()).array()
                                - digamma(arena_a.val().array() + arena_b));
     return make_callback_var(
@@ -203,7 +203,7 @@ inline auto beta(const VarMat& a, const Scalar& b) {
           arena_a.adj().array()
               += vi.adj().array() * digamma_ab * vi.val().array();
         });
-  } else if constexpr (!is_constant_v<Scalar>) {
+  } else if constexpr (is_autodiffable_v<Scalar>) {
     auto beta_val = beta(arena_a, arena_b.val());
     auto digamma_ab = to_arena(
         (digamma(arena_b.val()) - digamma(arena_a.array() + arena_b.val()))

--- a/stan/math/rev/fun/beta.hpp
+++ b/stan/math/rev/fun/beta.hpp
@@ -101,9 +101,9 @@ template <typename Mat1, typename Mat2,
           require_any_var_matrix_t<Mat1, Mat2>* = nullptr,
           require_all_matrix_t<Mat1, Mat2>* = nullptr>
 inline auto beta(const Mat1& a, const Mat2& b) {
-  if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
-    arena_t<promote_scalar_t<var, Mat1>> arena_a = a;
-    arena_t<promote_scalar_t<var, Mat2>> arena_b = b;
+  arena_t<Mat1> arena_a = a;
+  arena_t<Mat2> arena_b = b;
+  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
     auto beta_val = beta(arena_a.val(), arena_b.val());
     auto digamma_ab
         = to_arena(digamma(arena_a.val().array() + arena_b.val().array()));
@@ -116,9 +116,7 @@ inline auto beta(const Mat1& a, const Mat2& b) {
           arena_b.adj().array()
               += adj_val * (digamma(arena_b.val().array()) - digamma_ab);
         });
-  } else if (!is_constant<Mat1>::value) {
-    arena_t<promote_scalar_t<var, Mat1>> arena_a = a;
-    arena_t<promote_scalar_t<double, Mat2>> arena_b = value_of(b);
+  } else if constexpr (!is_constant_v<Mat1>) {
     auto digamma_ab
         = to_arena(digamma(arena_a.val()).array()
                    - digamma(arena_a.val().array() + arena_b.array()));
@@ -128,9 +126,7 @@ inline auto beta(const Mat1& a, const Mat2& b) {
                                                         * digamma_ab
                                                         * vi.val().array();
                              });
-  } else if (!is_constant<Mat2>::value) {
-    arena_t<promote_scalar_t<double, Mat1>> arena_a = value_of(a);
-    arena_t<promote_scalar_t<var, Mat2>> arena_b = b;
+  } else if constexpr (!is_constant_v<Mat2>) {
     auto beta_val = beta(arena_a, arena_b.val());
     auto digamma_ab
         = to_arena((digamma(arena_b.val()).array()
@@ -147,9 +143,9 @@ template <typename Scalar, typename VarMat,
           require_var_matrix_t<VarMat>* = nullptr,
           require_stan_scalar_t<Scalar>* = nullptr>
 inline auto beta(const Scalar& a, const VarMat& b) {
-  if (!is_constant<Scalar>::value && !is_constant<VarMat>::value) {
-    var arena_a = a;
-    arena_t<promote_scalar_t<var, VarMat>> arena_b = b;
+  auto arena_a = a;
+  arena_t<VarMat> arena_b = b;
+  if constexpr (!is_constant_v<Scalar> && !is_constant_v<VarMat>) {
     auto beta_val = beta(arena_a.val(), arena_b.val());
     auto digamma_ab = to_arena(digamma(arena_a.val() + arena_b.val().array()));
     return make_callback_var(
@@ -161,9 +157,7 @@ inline auto beta(const Scalar& a, const VarMat& b) {
           arena_b.adj().array()
               += adj_val * (digamma(arena_b.val().array()) - digamma_ab);
         });
-  } else if (!is_constant<Scalar>::value) {
-    var arena_a = a;
-    arena_t<promote_scalar_t<double, VarMat>> arena_b = value_of(b);
+  } else if constexpr (!is_constant_v<Scalar>) {
     auto digamma_ab = to_arena(digamma(arena_a.val())
                                - digamma(arena_a.val() + arena_b.array()));
     return make_callback_var(
@@ -172,9 +166,7 @@ inline auto beta(const Scalar& a, const VarMat& b) {
           arena_a.adj()
               += (vi.adj().array() * digamma_ab * vi.val().array()).sum();
         });
-  } else if (!is_constant<VarMat>::value) {
-    double arena_a = value_of(a);
-    arena_t<promote_scalar_t<var, VarMat>> arena_b = b;
+  } else if constexpr (!is_constant_v<VarMat>) {
     auto beta_val = beta(arena_a, arena_b.val());
     auto digamma_ab = to_arena((digamma(arena_b.val()).array()
                                 - digamma(arena_a + arena_b.val().array()))
@@ -189,9 +181,9 @@ template <typename VarMat, typename Scalar,
           require_var_matrix_t<VarMat>* = nullptr,
           require_stan_scalar_t<Scalar>* = nullptr>
 inline auto beta(const VarMat& a, const Scalar& b) {
-  if (!is_constant<VarMat>::value && !is_constant<Scalar>::value) {
-    arena_t<promote_scalar_t<var, VarMat>> arena_a = a;
-    var arena_b = b;
+  arena_t<VarMat> arena_a = a;
+  auto arena_b = b;
+  if constexpr (!is_constant_v<VarMat> && !is_constant_v<Scalar>) {
     auto beta_val = beta(arena_a.val(), arena_b.val());
     auto digamma_ab = to_arena(digamma(arena_a.val().array() + arena_b.val()));
     return make_callback_var(
@@ -203,9 +195,7 @@ inline auto beta(const VarMat& a, const Scalar& b) {
           arena_b.adj()
               += (adj_val * (digamma(arena_b.val()) - digamma_ab)).sum();
         });
-  } else if (!is_constant<VarMat>::value) {
-    arena_t<promote_scalar_t<var, VarMat>> arena_a = a;
-    double arena_b = value_of(b);
+  } else if constexpr (!is_constant_v<VarMat>) {
     auto digamma_ab = to_arena(digamma(arena_a.val()).array()
                                - digamma(arena_a.val().array() + arena_b));
     return make_callback_var(
@@ -213,9 +203,7 @@ inline auto beta(const VarMat& a, const Scalar& b) {
           arena_a.adj().array()
               += vi.adj().array() * digamma_ab * vi.val().array();
         });
-  } else if (!is_constant<Scalar>::value) {
-    arena_t<promote_scalar_t<double, VarMat>> arena_a = value_of(a);
-    var arena_b = b;
+  } else if constexpr (!is_constant_v<Scalar>) {
     auto beta_val = beta(arena_a, arena_b.val());
     auto digamma_ab = to_arena(
         (digamma(arena_b.val()) - digamma(arena_a.array() + arena_b.val()))

--- a/stan/math/rev/fun/cholesky_decompose.hpp
+++ b/stan/math/rev/fun/cholesky_decompose.hpp
@@ -153,7 +153,7 @@ inline auto cholesky_decompose(const EigMat& A) {
     internal::initialize_return(L, L_A, dummy);
     reverse_pass_callback(internal::cholesky_lambda(L_A, L, arena_A));
   }
-  return plain_type_t<EigMat>(L);
+  return L;
 }
 
 /**

--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -68,7 +68,7 @@ inline auto columns_dot_product(Mat1&& v1, Mat2&& v2) {
 
   arena_t<Mat1> arena_v1 = std::forward<Mat1>(v1);
   arena_t<Mat2> arena_v2 = std::forward<Mat2>(v2);
-  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
+  if constexpr (is_autodiffable_v<Mat1, Mat2>) {
     return_t res
         = (arena_v1.val().array() * arena_v2.val().array()).colwise().sum();
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
@@ -84,7 +84,7 @@ inline auto columns_dot_product(Mat1&& v1, Mat2&& v2) {
       }
     });
     return res;
-  } else if constexpr (!is_constant_v<Mat2>) {
+  } else if constexpr (is_autodiffable_v<Mat2>) {
     return_t res = (arena_v1.array() * arena_v2.val().array()).colwise().sum();
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if constexpr (is_var_matrix<Mat2>::value) {

--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -31,11 +31,11 @@ namespace math {
 template <
     typename Mat1, typename Mat2, require_all_eigen_t<Mat1, Mat2>* = nullptr,
     require_any_eigen_vt<is_var, Mat1, Mat2>* = nullptr,
-    require_vt_complex<Mat1>* = nullptr, require_vt_complex<Mat2>* = nullptr>
+    require_any_vt_complex<Mat1, Mat2>* = nullptr>
 inline Eigen::Matrix<return_type_t<Mat1, Mat2>, 1, Mat1::ColsAtCompileTime>
 columns_dot_product(const Mat1& v1, const Mat2& v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
-  Eigen::Matrix<var, 1, Mat1::ColsAtCompileTime> ret(1, v1.cols());
+  Eigen::Matrix<return_type_t<Mat1, Mat2>, 1, Mat1::ColsAtCompileTime> ret(1, v1.cols());
   for (size_type j = 0; j < v1.cols(); ++j) {
     ret.coeffRef(j) = dot_product(v1.col(j), v2.col(j));
   }
@@ -56,8 +56,7 @@ columns_dot_product(const Mat1& v1, const Mat2& v2) {
  */
 template <typename Mat1, typename Mat2,
           require_all_matrix_t<Mat1, Mat2>* = nullptr,
-          require_not_st_complex<Mat1>* = nullptr,
-          require_not_st_complex<Mat2>* = nullptr>
+          require_not_any_vt_complex<Mat1, Mat2>* = nullptr>
 inline auto columns_dot_product(Mat1&& v1, Mat2&& v2) {
   check_matching_sizes("columns_dot_product", "v1", v1, "v2", v2);
   using inner_return_t = decltype(

--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -17,6 +17,35 @@ namespace math {
 /**
  * Returns the dot product of columns of the specified matrices.
  *
+ * @tparam Mat1 type of the first matrix (must be derived from \c
+ * Eigen::MatrixBase)
+ * @tparam Mat2 type of the second matrix (must be derived from \c
+ * Eigen::MatrixBase)
+ *
+ * @param v1 Matrix of first vectors.
+ * @param v2 Matrix of second vectors.
+ * @return Dot product of the vectors.
+ * @throw std::domain_error If the vectors are not the same
+ * size or if they are both not vector dimensioned.
+ */
+template <typename Mat1, typename Mat2,
+          require_all_eigen_t<Mat1, Mat2>* = nullptr,
+          require_any_eigen_vt<is_var, Mat1, Mat2>* = nullptr,
+          require_vt_complex<Mat1>* = nullptr,
+          require_vt_complex<Mat2>* = nullptr>
+inline Eigen::Matrix<return_type_t<Mat1, Mat2>, 1, Mat1::ColsAtCompileTime>
+columns_dot_product(const Mat1& v1, const Mat2& v2) {
+  check_matching_sizes("dot_product", "v1", v1, "v2", v2);
+  Eigen::Matrix<var, 1, Mat1::ColsAtCompileTime> ret(1, v1.cols());
+  for (size_type j = 0; j < v1.cols(); ++j) {
+    ret.coeffRef(j) = dot_product(v1.col(j), v2.col(j));
+  }
+  return ret;
+}
+
+/**
+ * Returns the dot product of columns of the specified matrices.
+ *
  * @tparam Mat1 type of the first matrix
  * @tparam Mat2 type of the second matrix
  *
@@ -27,7 +56,9 @@ namespace math {
  * size or if they are both not vector dimensioned.
  */
 template <typename Mat1, typename Mat2,
-          require_all_matrix_t<Mat1, Mat2>* = nullptr>
+          require_all_matrix_t<Mat1, Mat2>* = nullptr,
+          require_not_st_complex<Mat1>* = nullptr,
+          require_not_st_complex<Mat2>* = nullptr>
 inline auto columns_dot_product(Mat1&& v1, Mat2&& v2) {
   check_matching_sizes("columns_dot_product", "v1", v1, "v2", v2);
   using inner_return_t = decltype(

--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -31,8 +31,7 @@ namespace math {
 template <typename Mat1, typename Mat2,
           require_all_eigen_t<Mat1, Mat2>* = nullptr,
           require_any_eigen_vt<is_var, Mat1, Mat2>* = nullptr>
-inline Eigen::Matrix<return_type_t<Mat1, Mat2>, 1, Mat1::ColsAtCompileTime>
-columns_dot_product(const Mat1& v1, const Mat2& v2) {
+inline auto columns_dot_product(const Mat1& v1, const Mat2& v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
   Eigen::Matrix<var, 1, Mat1::ColsAtCompileTime> ret(1, v1.cols());
   for (size_type j = 0; j < v1.cols(); ++j) {
@@ -61,54 +60,42 @@ columns_dot_product(const Mat1& v1, const Mat2& v2) {
 template <typename Mat1, typename Mat2,
           require_all_matrix_t<Mat1, Mat2>* = nullptr,
           require_any_var_matrix_t<Mat1, Mat2>* = nullptr>
-inline auto columns_dot_product(const Mat1& v1, const Mat2& v2) {
+inline auto columns_dot_product(Mat1&& v1, Mat2&& v2) {
   check_matching_sizes("columns_dot_product", "v1", v1, "v2", v2);
   using inner_return_t = decltype(
       (value_of(v1).array() * value_of(v2).array()).colwise().sum().matrix());
   using return_t = return_var_matrix_t<inner_return_t, Mat1, Mat2>;
 
-  if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
-    arena_t<promote_scalar_t<var, Mat1>> arena_v1 = v1;
-    arena_t<promote_scalar_t<var, Mat2>> arena_v2 = v2;
-
+  arena_t<Mat1> arena_v1 = std::forward<Mat1>(v1);
+  arena_t<Mat2> arena_v2 = std::forward<Mat2>(v2);
+  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
     return_t res
         = (arena_v1.val().array() * arena_v2.val().array()).colwise().sum();
-
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
-      if (is_var_matrix<Mat1>::value) {
+      if constexpr (is_var_matrix<Mat1>::value) {
         arena_v1.adj().noalias() += arena_v2.val() * res.adj().asDiagonal();
       } else {
         arena_v1.adj() += arena_v2.val() * res.adj().asDiagonal();
       }
-      if (is_var_matrix<Mat2>::value) {
+      if constexpr (is_var_matrix<Mat2>::value) {
         arena_v2.adj().noalias() += arena_v1.val() * res.adj().asDiagonal();
       } else {
         arena_v2.adj() += arena_v1.val() * res.adj().asDiagonal();
       }
     });
-
     return res;
-  } else if (!is_constant<Mat2>::value) {
-    arena_t<promote_scalar_t<double, Mat1>> arena_v1 = value_of(v1);
-    arena_t<promote_scalar_t<var, Mat2>> arena_v2 = v2;
-
+  } else if constexpr (!is_constant_v<Mat2>) {
     return_t res = (arena_v1.array() * arena_v2.val().array()).colwise().sum();
-
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
-      if (is_var_matrix<Mat2>::value) {
+      if constexpr (is_var_matrix<Mat2>::value) {
         arena_v2.adj().noalias() += arena_v1 * res.adj().asDiagonal();
       } else {
         arena_v2.adj() += arena_v1 * res.adj().asDiagonal();
       }
     });
-
     return res;
   } else {
-    arena_t<promote_scalar_t<var, Mat1>> arena_v1 = v1;
-    arena_t<promote_scalar_t<double, Mat2>> arena_v2 = value_of(v2);
-
     return_t res = (arena_v1.val().array() * arena_v2.array()).colwise().sum();
-
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat2>::value) {
         arena_v1.adj().noalias() += arena_v2 * res.adj().asDiagonal();
@@ -116,7 +103,6 @@ inline auto columns_dot_product(const Mat1& v1, const Mat2& v2) {
         arena_v1.adj() += arena_v2 * res.adj().asDiagonal();
       }
     });
-
     return res;
   }
 }

--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -28,14 +28,15 @@ namespace math {
  * @throw std::domain_error If the vectors are not the same
  * size or if they are both not vector dimensioned.
  */
-template <
-    typename Mat1, typename Mat2, require_all_eigen_t<Mat1, Mat2>* = nullptr,
-    require_any_eigen_vt<is_var, Mat1, Mat2>* = nullptr,
-    require_any_vt_complex<Mat1, Mat2>* = nullptr>
+template <typename Mat1, typename Mat2,
+          require_all_eigen_t<Mat1, Mat2>* = nullptr,
+          require_any_eigen_vt<is_var, Mat1, Mat2>* = nullptr,
+          require_any_vt_complex<Mat1, Mat2>* = nullptr>
 inline Eigen::Matrix<return_type_t<Mat1, Mat2>, 1, Mat1::ColsAtCompileTime>
 columns_dot_product(const Mat1& v1, const Mat2& v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
-  Eigen::Matrix<return_type_t<Mat1, Mat2>, 1, Mat1::ColsAtCompileTime> ret(1, v1.cols());
+  Eigen::Matrix<return_type_t<Mat1, Mat2>, 1, Mat1::ColsAtCompileTime> ret(
+      1, v1.cols());
   for (size_type j = 0; j < v1.cols(); ++j) {
     ret.coeffRef(j) = dot_product(v1.col(j), v2.col(j));
   }

--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -56,7 +56,8 @@ columns_dot_product(const Mat1& v1, const Mat2& v2) {
  */
 template <typename Mat1, typename Mat2,
           require_all_matrix_t<Mat1, Mat2>* = nullptr,
-          require_not_any_vt_complex<Mat1, Mat2>* = nullptr>
+          require_not_any_vt_complex<Mat1, Mat2>* = nullptr,
+          require_any_st_var<Mat1, Mat2>* = nullptr>
 inline auto columns_dot_product(Mat1&& v1, Mat2&& v2) {
   check_matching_sizes("columns_dot_product", "v1", v1, "v2", v2);
   using inner_return_t = decltype(

--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -36,7 +36,9 @@ inline auto columns_dot_product(Mat1&& v1, Mat2&& v2) {
   arena_t<Mat1> arena_v1 = std::forward<Mat1>(v1);
   arena_t<Mat2> arena_v2 = std::forward<Mat2>(v2);
   arena_t<return_t> res
-        = (value_of(arena_v1).array() * value_of(arena_v2).array()).colwise().sum();
+      = (value_of(arena_v1).array() * value_of(arena_v2).array())
+            .colwise()
+            .sum();
   reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
     if constexpr (is_autodiffable_v<Mat1>) {
       if constexpr (is_var_matrix<Mat1>::value) {

--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -28,11 +28,10 @@ namespace math {
  * @throw std::domain_error If the vectors are not the same
  * size or if they are both not vector dimensioned.
  */
-template <typename Mat1, typename Mat2,
-          require_all_eigen_t<Mat1, Mat2>* = nullptr,
-          require_any_eigen_vt<is_var, Mat1, Mat2>* = nullptr,
-          require_vt_complex<Mat1>* = nullptr,
-          require_vt_complex<Mat2>* = nullptr>
+template <
+    typename Mat1, typename Mat2, require_all_eigen_t<Mat1, Mat2>* = nullptr,
+    require_any_eigen_vt<is_var, Mat1, Mat2>* = nullptr,
+    require_vt_complex<Mat1>* = nullptr, require_vt_complex<Mat2>* = nullptr>
 inline Eigen::Matrix<return_type_t<Mat1, Mat2>, 1, Mat1::ColsAtCompileTime>
 columns_dot_product(const Mat1& v1, const Mat2& v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);

--- a/stan/math/rev/fun/csr_matrix_times_vector.hpp
+++ b/stan/math/rev/fun/csr_matrix_times_vector.hpp
@@ -182,15 +182,15 @@ inline auto csr_matrix_times_vector(int m, int n, const T1& w,
                  [](auto&& x) { return x - 1; });
   using sparse_var_value_t
       = var_value<Eigen::SparseMatrix<double, Eigen::RowMajor>>;
-  if (!is_constant<T2>::value && !is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T2>> b_arena = b;
+  if constexpr (!is_constant_v<T2> && !is_constant_v<T1>) {
+    arena_t<T2> b_arena = b;
     sparse_var_value_t w_mat_arena
         = to_soa_sparse_matrix<Eigen::RowMajor>(m, n, w, u_arena, v_arena);
     arena_t<return_t> res = w_mat_arena.val() * value_of(b_arena);
     stan::math::internal::make_csr_adjoint(res, w_mat_arena, b_arena);
     return return_t(res);
-  } else if (!is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T2>> b_arena = b;
+  } else if constexpr (!is_constant_v<T2>) {
+    arena_t<T2> b_arena = b;
     auto w_val_arena = to_arena(value_of(w));
     sparse_val_mat w_val_mat(m, n, w_val_arena.size(), u_arena.data(),
                              v_arena.data(), w_val_arena.data());

--- a/stan/math/rev/fun/csr_matrix_times_vector.hpp
+++ b/stan/math/rev/fun/csr_matrix_times_vector.hpp
@@ -182,14 +182,14 @@ inline auto csr_matrix_times_vector(int m, int n, const T1& w,
                  [](auto&& x) { return x - 1; });
   using sparse_var_value_t
       = var_value<Eigen::SparseMatrix<double, Eigen::RowMajor>>;
-  if constexpr (!is_constant_v<T2> && !is_constant_v<T1>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     arena_t<T2> b_arena = b;
     sparse_var_value_t w_mat_arena
         = to_soa_sparse_matrix<Eigen::RowMajor>(m, n, w, u_arena, v_arena);
     arena_t<return_t> res = w_mat_arena.val() * value_of(b_arena);
     stan::math::internal::make_csr_adjoint(res, w_mat_arena, b_arena);
     return return_t(res);
-  } else if constexpr (!is_constant_v<T2>) {
+  } else if constexpr (is_autodiffable_v<T2>) {
     arena_t<T2> b_arena = b;
     auto w_val_arena = to_arena(value_of(w));
     sparse_val_mat w_val_mat(m, n, w_val_arena.size(), u_arena.data(),

--- a/stan/math/rev/fun/cumulative_sum.hpp
+++ b/stan/math/rev/fun/cumulative_sum.hpp
@@ -32,7 +32,7 @@ inline auto cumulative_sum(const EigVec& x) {
   using return_t = return_var_matrix_t<EigVec>;
   arena_t<return_t> res = cumulative_sum(x_arena.val()).eval();
   if (unlikely(x.size() == 0)) {
-    return return_t(res);
+    return arena_t<return_t>(res);
   }
   reverse_pass_callback([x_arena, res]() mutable {
     for (Eigen::Index i = x_arena.size() - 1; i > 0; --i) {
@@ -41,7 +41,7 @@ inline auto cumulative_sum(const EigVec& x) {
     }
     x_arena.adj().coeffRef(0) += res.adj().coeffRef(0);
   });
-  return return_t(res);
+  return res;
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/cumulative_sum.hpp
+++ b/stan/math/rev/fun/cumulative_sum.hpp
@@ -32,7 +32,7 @@ inline auto cumulative_sum(const EigVec& x) {
   using return_t = return_var_matrix_t<EigVec>;
   arena_t<return_t> res = cumulative_sum(x_arena.val()).eval();
   if (unlikely(x.size() == 0)) {
-    return arena_t<return_t>(res);
+    return res;
   }
   reverse_pass_callback([x_arena, res]() mutable {
     for (Eigen::Index i = x_arena.size() - 1; i > 0; --i) {

--- a/stan/math/rev/fun/diag_post_multiply.hpp
+++ b/stan/math/rev/fun/diag_post_multiply.hpp
@@ -31,20 +31,20 @@ inline auto diag_post_multiply(T1&& m1, T2&& m2) {
 
   arena_t<T1> arena_m1 = std::forward<T1>(m1);
   arena_t<T2> arena_m2 = std::forward<T2>(m2);
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     arena_t<ret_type> ret(arena_m1.val() * arena_m2.val().asDiagonal());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m2.adj() += arena_m1.val().cwiseProduct(ret.adj()).colwise().sum();
       arena_m1.adj() += ret.adj() * arena_m2.val().asDiagonal();
     });
     return ret;
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     arena_t<ret_type> ret(arena_m1.val() * arena_m2.asDiagonal());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m1.adj() += ret.adj() * arena_m2.val().asDiagonal();
     });
     return ret;
-  } else if constexpr (!is_constant_v<T2>) {
+  } else if constexpr (is_autodiffable_v<T2>) {
     arena_t<ret_type> ret(arena_m1 * arena_m2.val().asDiagonal());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m2.adj() += arena_m1.val().cwiseProduct(ret.adj()).colwise().sum();

--- a/stan/math/rev/fun/diag_post_multiply.hpp
+++ b/stan/math/rev/fun/diag_post_multiply.hpp
@@ -23,37 +23,33 @@ namespace math {
 template <typename T1, typename T2, require_matrix_t<T1>* = nullptr,
           require_vector_t<T2>* = nullptr,
           require_any_st_var<T1, T2>* = nullptr>
-auto diag_post_multiply(const T1& m1, const T2& m2) {
+inline auto diag_post_multiply(T1&& m1, T2&& m2) {
   check_size_match("diag_post_multiply", "m2.size()", m2.size(), "m1.cols()",
                    m1.cols());
   using inner_ret_type = decltype(value_of(m1) * value_of(m2).asDiagonal());
   using ret_type = return_var_matrix_t<inner_ret_type, T1, T2>;
 
-  if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_m1 = m1;
-    arena_t<promote_scalar_t<var, T2>> arena_m2 = m2;
+  arena_t<T1> arena_m1 = std::forward<T1>(m1);
+  arena_t<T2> arena_m2 = std::forward<T2>(m2);
+  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
     arena_t<ret_type> ret(arena_m1.val() * arena_m2.val().asDiagonal());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m2.adj() += arena_m1.val().cwiseProduct(ret.adj()).colwise().sum();
       arena_m1.adj() += ret.adj() * arena_m2.val().asDiagonal();
     });
-    return ret_type(ret);
-  } else if (!is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_m1 = m1;
-    arena_t<promote_scalar_t<double, T2>> arena_m2 = value_of(m2);
+    return ret;
+  } else if constexpr (!is_constant_v<T1>) {
     arena_t<ret_type> ret(arena_m1.val() * arena_m2.asDiagonal());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m1.adj() += ret.adj() * arena_m2.val().asDiagonal();
     });
-    return ret_type(ret);
-  } else if (!is_constant<T2>::value) {
-    arena_t<promote_scalar_t<double, T1>> arena_m1 = value_of(m1);
-    arena_t<promote_scalar_t<var, T2>> arena_m2 = m2;
+    return ret;
+  } else if constexpr (!is_constant_v<T2>) {
     arena_t<ret_type> ret(arena_m1 * arena_m2.val().asDiagonal());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m2.adj() += arena_m1.val().cwiseProduct(ret.adj()).colwise().sum();
     });
-    return ret_type(ret);
+    return ret;
   }
 }
 

--- a/stan/math/rev/fun/diag_pre_multiply.hpp
+++ b/stan/math/rev/fun/diag_pre_multiply.hpp
@@ -30,20 +30,20 @@ inline auto diag_pre_multiply(T1&& m1, T2&& m2) {
   using ret_type = return_var_matrix_t<inner_ret_type, T1, T2>;
   arena_t<T1> arena_m1 = std::forward<T1>(m1);
   arena_t<T2> arena_m2 = std::forward<T2>(m2);
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     arena_t<ret_type> ret(arena_m1.val().asDiagonal() * arena_m2.val());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m1.adj() += arena_m2.val().cwiseProduct(ret.adj()).rowwise().sum();
       arena_m2.adj() += arena_m1.val().asDiagonal() * ret.adj();
     });
     return ret;
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     arena_t<ret_type> ret(arena_m1.val().asDiagonal() * arena_m2);
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m1.adj() += arena_m2.val().cwiseProduct(ret.adj()).rowwise().sum();
     });
     return ret;
-  } else if constexpr (!is_constant_v<T2>) {
+  } else if constexpr (is_autodiffable_v<T2>) {
     arena_t<ret_type> ret(arena_m1.asDiagonal() * arena_m2.val());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m2.adj() += arena_m1.val().asDiagonal() * ret.adj();

--- a/stan/math/rev/fun/diag_pre_multiply.hpp
+++ b/stan/math/rev/fun/diag_pre_multiply.hpp
@@ -23,36 +23,32 @@ namespace math {
 template <typename T1, typename T2, require_vector_t<T1>* = nullptr,
           require_matrix_t<T2>* = nullptr,
           require_any_st_var<T1, T2>* = nullptr>
-auto diag_pre_multiply(const T1& m1, const T2& m2) {
+inline auto diag_pre_multiply(T1&& m1, T2&& m2) {
   check_size_match("diag_pre_multiply", "m1.size()", m1.size(), "m2.rows()",
                    m2.rows());
   using inner_ret_type = decltype(value_of(m1).asDiagonal() * value_of(m2));
   using ret_type = return_var_matrix_t<inner_ret_type, T1, T2>;
-  if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_m1 = m1;
-    arena_t<promote_scalar_t<var, T2>> arena_m2 = m2;
+  arena_t<T1> arena_m1 = std::forward<T1>(m1);
+  arena_t<T2> arena_m2 = std::forward<T2>(m2);
+  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
     arena_t<ret_type> ret(arena_m1.val().asDiagonal() * arena_m2.val());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m1.adj() += arena_m2.val().cwiseProduct(ret.adj()).rowwise().sum();
       arena_m2.adj() += arena_m1.val().asDiagonal() * ret.adj();
     });
-    return ret_type(ret);
-  } else if (!is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_m1 = m1;
-    arena_t<promote_scalar_t<double, T2>> arena_m2 = value_of(m2);
+    return ret;
+  } else if constexpr (!is_constant_v<T1>) {
     arena_t<ret_type> ret(arena_m1.val().asDiagonal() * arena_m2);
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m1.adj() += arena_m2.val().cwiseProduct(ret.adj()).rowwise().sum();
     });
-    return ret_type(ret);
-  } else if (!is_constant<T2>::value) {
-    arena_t<promote_scalar_t<double, T1>> arena_m1 = value_of(m1);
-    arena_t<promote_scalar_t<var, T2>> arena_m2 = m2;
+    return ret;
+  } else if constexpr (!is_constant_v<T2>) {
     arena_t<ret_type> ret(arena_m1.asDiagonal() * arena_m2.val());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m2.adj() += arena_m1.val().asDiagonal() * ret.adj();
     });
-    return ret_type(ret);
+    return ret;
   }
 }
 

--- a/stan/math/rev/fun/dot_product.hpp
+++ b/stan/math/rev/fun/dot_product.hpp
@@ -43,7 +43,7 @@ inline var dot_product(T1&& v1, T2&& v2) {
   }
   arena_t<T1> v1_arena = std::forward<T1>(v1);
   arena_t<T2> v2_arena = std::forward<T2>(v2);
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     return make_callback_var(
         v1_arena.val().dot(v2_arena.val()),
         [v1_arena, v2_arena](const auto& vi) mutable {
@@ -53,7 +53,7 @@ inline var dot_product(T1&& v1, T2&& v2) {
             v2_arena.adj().coeffRef(i) += res_adj * v1_arena.val().coeff(i);
           }
         });
-  } else if constexpr (!is_constant_v<T2>) {
+  } else if constexpr (is_autodiffable_v<T2>) {
     return make_callback_var(v1_arena.dot(v2_arena.val()),
                              [v1_arena, v2_arena](const auto& vi) mutable {
                                v2_arena.adj().array()

--- a/stan/math/rev/fun/dot_product.hpp
+++ b/stan/math/rev/fun/dot_product.hpp
@@ -35,16 +35,15 @@ template <typename T1, typename T2, require_all_vector_t<T1, T2>* = nullptr,
           require_not_complex_t<return_type_t<T1, T2>>* = nullptr,
           require_all_not_std_vector_t<T1, T2>* = nullptr,
           require_any_st_var<T1, T2>* = nullptr>
-inline var dot_product(const T1& v1, const T2& v2) {
+inline var dot_product(T1&& v1, T2&& v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
 
   if (v1.size() == 0) {
     return 0.0;
   }
-
-  if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T1>> v1_arena = v1;
-    arena_t<promote_scalar_t<var, T2>> v2_arena = v2;
+  arena_t<T1> v1_arena = std::forward<T1>(v1);
+  arena_t<T2> v2_arena = std::forward<T2>(v2);
+  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
     return make_callback_var(
         v1_arena.val().dot(v2_arena.val()),
         [v1_arena, v2_arena](const auto& vi) mutable {
@@ -54,21 +53,17 @@ inline var dot_product(const T1& v1, const T2& v2) {
             v2_arena.adj().coeffRef(i) += res_adj * v1_arena.val().coeff(i);
           }
         });
-  } else if (!is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T2>> v2_arena = v2;
-    arena_t<promote_scalar_t<double, T1>> v1_val_arena = value_of(v1);
-    return make_callback_var(v1_val_arena.dot(v2_arena.val()),
-                             [v1_val_arena, v2_arena](const auto& vi) mutable {
+  } else if constexpr (!is_constant_v<T2>) {
+    return make_callback_var(v1_arena.dot(v2_arena.val()),
+                             [v1_arena, v2_arena](const auto& vi) mutable {
                                v2_arena.adj().array()
-                                   += vi.adj() * v1_val_arena.array();
+                                   += vi.adj() * v1_arena.array();
                              });
   } else {
-    arena_t<promote_scalar_t<var, T1>> v1_arena = v1;
-    arena_t<promote_scalar_t<double, T2>> v2_val_arena = value_of(v2);
-    return make_callback_var(v1_arena.val().dot(v2_val_arena),
-                             [v1_arena, v2_val_arena](const auto& vi) mutable {
+    return make_callback_var(v1_arena.val().dot(v2_arena.val()),
+                             [v1_arena, v2_arena](const auto& vi) mutable {
                                v1_arena.adj().array()
-                                   += vi.adj() * v2_val_arena.array();
+                                   += vi.adj() * v2_arena.val().array();
                              });
   }
 }

--- a/stan/math/rev/fun/eigendecompose_sym.hpp
+++ b/stan/math/rev/fun/eigendecompose_sym.hpp
@@ -60,8 +60,7 @@ inline auto eigendecompose_sym(const T& m) {
     arena_m.adj() += value_adj + vector_adj;
   });
 
-  return std::make_tuple(std::move(eigenvecs),
-                         std::move(eigenvals));
+  return std::make_tuple(std::move(eigenvecs), std::move(eigenvals));
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/eigenvectors_sym.hpp
+++ b/stan/math/rev/fun/eigenvectors_sym.hpp
@@ -36,10 +36,11 @@ inline auto eigenvectors_sym(const T& m) {
 
   reverse_pass_callback([arena_m, eigenvals, eigenvecs]() mutable {
     const auto p = arena_m.val().cols();
-    arena_t<Eigen::MatrixXd> f = (1
-                         / (eigenvals.rowwise().replicate(p).transpose()
-                            - eigenvals.rowwise().replicate(p))
-                               .array());
+    arena_t<Eigen::MatrixXd> f
+        = (1
+           / (eigenvals.rowwise().replicate(p).transpose()
+              - eigenvals.rowwise().replicate(p))
+                 .array());
     f.diagonal().setZero();
     arena_m.adj()
         += eigenvecs.val_op()

--- a/stan/math/rev/fun/eigenvectors_sym.hpp
+++ b/stan/math/rev/fun/eigenvectors_sym.hpp
@@ -47,7 +47,7 @@ inline auto eigenvectors_sym(const T& m) {
            * eigenvecs.val_op().transpose();
   });
 
-  return return_t(eigenvecs);
+  return eigenvecs;
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/eigenvectors_sym.hpp
+++ b/stan/math/rev/fun/eigenvectors_sym.hpp
@@ -25,7 +25,7 @@ template <typename T, require_rev_matrix_t<T>* = nullptr>
 inline auto eigenvectors_sym(const T& m) {
   using return_t = return_var_matrix_t<T>;
   if (unlikely(m.size() == 0)) {
-    return return_t(Eigen::MatrixXd(0, 0));
+    return arena_t<return_t>(Eigen::MatrixXd(0, 0));
   }
   check_symmetric("eigenvectors_sym", "m", m);
 
@@ -36,7 +36,7 @@ inline auto eigenvectors_sym(const T& m) {
 
   reverse_pass_callback([arena_m, eigenvals, eigenvecs]() mutable {
     const auto p = arena_m.val().cols();
-    Eigen::MatrixXd f = (1
+    arena_t<Eigen::MatrixXd> f = (1
                          / (eigenvals.rowwise().replicate(p).transpose()
                             - eigenvals.rowwise().replicate(p))
                                .array());

--- a/stan/math/rev/fun/elt_divide.hpp
+++ b/stan/math/rev/fun/elt_divide.hpp
@@ -31,7 +31,7 @@ inline auto elt_divide(Mat1&& m1, Mat2&& m2) {
   using ret_type = return_var_matrix_t<inner_ret_type, Mat1, Mat2>;
   arena_t<Mat1> arena_m1 = std::forward<Mat1>(m1);
   arena_t<Mat2> arena_m2 = std::forward<Mat2>(m2);
-  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
+  if constexpr (is_autodiffable_v<Mat1, Mat2>) {
     arena_t<ret_type> ret(arena_m1.val().array() / arena_m2.val().array());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       for (Eigen::Index j = 0; j < arena_m2.cols(); ++j) {
@@ -44,13 +44,13 @@ inline auto elt_divide(Mat1&& m1, Mat2&& m2) {
       }
     });
     return ret;
-  } else if constexpr (!is_constant_v<Mat1>) {
+  } else if constexpr (is_autodiffable_v<Mat1>) {
     arena_t<ret_type> ret(arena_m1.val().array() / arena_m2.array());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m1.adj().array() += ret.adj().array() / arena_m2.array();
     });
     return ret;
-  } else if constexpr (!is_constant_v<Mat2>) {
+  } else if constexpr (is_autodiffable_v<Mat2>) {
     arena_t<ret_type> ret(arena_m1.array() / arena_m2.val().array());
     reverse_pass_callback([ret, arena_m2, arena_m1]() mutable {
       arena_m2.adj().array()
@@ -79,7 +79,7 @@ inline auto elt_divide(Scal s, Mat&& m) {
 
   reverse_pass_callback([m, s, res]() mutable {
     m.adj().array() -= res.val().array() * res.adj().array() / m.val().array();
-    if constexpr (!is_constant_v<Scal>) {
+    if constexpr (is_autodiffable_v<Scal>) {
       s.adj() += (res.adj().array() / m.val().array()).sum();
     }
   });

--- a/stan/math/rev/fun/elt_divide.hpp
+++ b/stan/math/rev/fun/elt_divide.hpp
@@ -74,7 +74,8 @@ inline auto elt_divide(Mat1&& m1, Mat2&& m2) {
 template <typename Scal, typename Mat, require_stan_scalar_t<Scal>* = nullptr,
           require_var_matrix_t<Mat>* = nullptr>
 inline auto elt_divide(Scal s, Mat&& m) {
-  arena_t<plain_type_t<Mat>> res = value_of(s) / std::forward<Mat>(m).val().array();
+  arena_t<plain_type_t<Mat>> res
+      = value_of(s) / std::forward<Mat>(m).val().array();
 
   reverse_pass_callback([m, s, res]() mutable {
     m.adj().array() -= res.val().array() * res.adj().array() / m.val().array();

--- a/stan/math/rev/fun/elt_multiply.hpp
+++ b/stan/math/rev/fun/elt_multiply.hpp
@@ -25,13 +25,13 @@ namespace math {
 template <typename Mat1, typename Mat2,
           require_all_matrix_t<Mat1, Mat2>* = nullptr,
           require_any_rev_matrix_t<Mat1, Mat2>* = nullptr>
-auto elt_multiply(const Mat1& m1, const Mat2& m2) {
+inline auto elt_multiply(Mat1&& m1, Mat2&& m2) {
   check_matching_dims("elt_multiply", "m1", m1, "m2", m2);
   using inner_ret_type = decltype(value_of(m1).cwiseProduct(value_of(m2)));
   using ret_type = return_var_matrix_t<inner_ret_type, Mat1, Mat2>;
-  if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
-    arena_t<promote_scalar_t<var, Mat1>> arena_m1 = m1;
-    arena_t<promote_scalar_t<var, Mat2>> arena_m2 = m2;
+  arena_t<Mat1> arena_m1 = std::forward<Mat1>(m1);
+  arena_t<Mat2> arena_m2 = std::forward<Mat2>(m2);
+  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
     arena_t<ret_type> ret(arena_m1.val().cwiseProduct(arena_m2.val()));
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       for (Eigen::Index j = 0; j < arena_m2.cols(); ++j) {
@@ -42,23 +42,19 @@ auto elt_multiply(const Mat1& m1, const Mat2& m2) {
         }
       }
     });
-    return ret_type(ret);
-  } else if (!is_constant<Mat1>::value) {
-    arena_t<promote_scalar_t<var, Mat1>> arena_m1 = m1;
-    arena_t<promote_scalar_t<double, Mat2>> arena_m2 = value_of(m2);
+    return ret;
+  } else if constexpr (!is_constant_v<Mat1>) {
     arena_t<ret_type> ret(arena_m1.val().cwiseProduct(arena_m2));
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       arena_m1.adj().array() += arena_m2.array() * ret.adj().array();
     });
-    return ret_type(ret);
-  } else if (!is_constant<Mat2>::value) {
-    arena_t<promote_scalar_t<double, Mat1>> arena_m1 = value_of(m1);
-    arena_t<promote_scalar_t<var, Mat2>> arena_m2 = m2;
+    return ret;
+  } else if constexpr (!is_constant_v<Mat2>) {
     arena_t<ret_type> ret(arena_m1.cwiseProduct(arena_m2.val()));
     reverse_pass_callback([ret, arena_m2, arena_m1]() mutable {
       arena_m2.adj().array() += arena_m1.array() * ret.adj().array();
     });
-    return ret_type(ret);
+    return ret;
   }
 }
 

--- a/stan/math/rev/fun/fft.hpp
+++ b/stan/math/rev/fun/fft.hpp
@@ -45,7 +45,8 @@ inline auto fft(const V& x) {
   }
 
   arena_t<V> arena_v = x;
-  arena_t<plain_type_t<V>> res = fft(to_complex(arena_v.real().val(), arena_v.imag().val()));
+  arena_t<plain_type_t<V>> res
+      = fft(to_complex(arena_v.real().val(), arena_v.imag().val()));
 
   reverse_pass_callback([arena_v, res]() mutable {
     auto adj_inv_fft = inv_fft(to_complex(res.real().adj(), res.imag().adj()));

--- a/stan/math/rev/fun/fft.hpp
+++ b/stan/math/rev/fun/fft.hpp
@@ -39,13 +39,13 @@ namespace math {
  */
 template <typename V, require_eigen_vector_vt<is_complex, V>* = nullptr,
           require_var_t<base_type_t<value_type_t<V>>>* = nullptr>
-inline plain_type_t<V> fft(const V& x) {
+inline auto fft(const V& x) {
   if (unlikely(x.size() <= 1)) {
-    return plain_type_t<V>(x);
+    return arena_t<plain_type_t<V>>(x);
   }
 
   arena_t<V> arena_v = x;
-  arena_t<V> res = fft(to_complex(arena_v.real().val(), arena_v.imag().val()));
+  arena_t<plain_type_t<V>> res = fft(to_complex(arena_v.real().val(), arena_v.imag().val()));
 
   reverse_pass_callback([arena_v, res]() mutable {
     auto adj_inv_fft = inv_fft(to_complex(res.real().adj(), res.imag().adj()));
@@ -54,7 +54,7 @@ inline plain_type_t<V> fft(const V& x) {
     arena_v.imag().adj() += adj_inv_fft.imag();
   });
 
-  return plain_type_t<V>(res);
+  return res;
 }
 
 /**
@@ -84,13 +84,13 @@ inline plain_type_t<V> fft(const V& x) {
  */
 template <typename V, require_eigen_vector_vt<is_complex, V>* = nullptr,
           require_var_t<base_type_t<value_type_t<V>>>* = nullptr>
-inline plain_type_t<V> inv_fft(const V& y) {
+inline auto inv_fft(const V& y) {
   if (unlikely(y.size() <= 1)) {
-    return plain_type_t<V>(y);
+    return arena_t<plain_type_t<V>>(y);
   }
 
   arena_t<V> arena_v = y;
-  arena_t<V> res
+  arena_t<plain_type_t<V>> res
       = inv_fft(to_complex(arena_v.real().val(), arena_v.imag().val()));
 
   reverse_pass_callback([arena_v, res]() mutable {
@@ -100,7 +100,7 @@ inline plain_type_t<V> inv_fft(const V& y) {
     arena_v.real().adj() += adj_fft.real();
     arena_v.imag().adj() += adj_fft.imag();
   });
-  return plain_type_t<V>(res);
+  return res;
 }
 
 /**
@@ -120,7 +120,7 @@ inline plain_type_t<V> inv_fft(const V& y) {
  */
 template <typename M, require_eigen_dense_dynamic_vt<is_complex, M>* = nullptr,
           require_var_t<base_type_t<value_type_t<M>>>* = nullptr>
-inline plain_type_t<M> fft2(const M& x) {
+inline auto fft2(const M& x) {
   arena_t<M> arena_v = x;
   arena_t<M> res = fft2(to_complex(arena_v.real().val(), arena_v.imag().val()));
 
@@ -131,7 +131,7 @@ inline plain_type_t<M> fft2(const M& x) {
     arena_v.imag().adj() += adj_inv_fft.imag();
   });
 
-  return plain_type_t<M>(res);
+  return res;
 }
 
 /**
@@ -152,7 +152,7 @@ inline plain_type_t<M> fft2(const M& x) {
  */
 template <typename M, require_eigen_dense_dynamic_vt<is_complex, M>* = nullptr,
           require_var_t<base_type_t<value_type_t<M>>>* = nullptr>
-inline plain_type_t<M> inv_fft2(const M& y) {
+inline auto inv_fft2(const M& y) {
   arena_t<M> arena_v = y;
   arena_t<M> res
       = inv_fft2(to_complex(arena_v.real().val(), arena_v.imag().val()));
@@ -164,7 +164,7 @@ inline plain_type_t<M> inv_fft2(const M& y) {
     arena_v.real().adj() += adj_fft.real();
     arena_v.imag().adj() += adj_fft.imag();
   });
-  return plain_type_t<M>(res);
+  return res;
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/fma.hpp
+++ b/stan/math/rev/fun/fma.hpp
@@ -201,8 +201,8 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_stan_scalar_v<T1> && is_matrix_v<T2>
-                         && is_matrix_v<T3>) {
+    } else if constexpr (is_stan_scalar_v<
+                             T1> && is_matrix_v<T2> && is_matrix_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
         arena_x.adj() += (ret.adj().array() * value_of(arena_y).array()).sum();
       }
@@ -212,8 +212,8 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_matrix_v<T1> && is_stan_scalar_v<T2>
-                         && is_matrix_v<T3>) {
+    } else if constexpr (is_matrix_v<
+                             T1> && is_stan_scalar_v<T2> && is_matrix_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
         arena_x.adj().array() += ret.adj().array() * value_of(arena_y);
       }
@@ -223,8 +223,8 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_stan_scalar_v<T1> && is_stan_scalar_v<T2>
-                         && is_matrix_v<T3>) {
+    } else if constexpr (is_stan_scalar_v<
+                             T1> && is_stan_scalar_v<T2> && is_matrix_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
         arena_x.adj() += (ret.adj().array() * value_of(arena_y)).sum();
       }
@@ -234,8 +234,8 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_matrix_v<T1> && is_matrix_v<T2>
-                         && is_stan_scalar_v<T3>) {
+    } else if constexpr (is_matrix_v<
+                             T1> && is_matrix_v<T2> && is_stan_scalar_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
         arena_x.adj().array() += ret.adj().array() * value_of(arena_y).array();
       }
@@ -245,8 +245,8 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj() += ret.adj().sum();
       }
-    } else if constexpr (is_stan_scalar_v<T1> && is_matrix_v<T2>
-                         && is_stan_scalar_v<T3>) {
+    } else if constexpr (is_stan_scalar_v<
+                             T1> && is_matrix_v<T2> && is_stan_scalar_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
         arena_x.adj() += (ret.adj().array() * value_of(arena_y).array()).sum();
       }
@@ -256,8 +256,8 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj() += ret.adj().sum();
       }
-    } else if constexpr (is_matrix_v<T1> && is_stan_scalar_v<T2>
-                         && is_stan_scalar_v<T3>) {
+    } else if constexpr (
+        is_matrix_v<T1> && is_stan_scalar_v<T2> && is_stan_scalar_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
         arena_x.adj().array() += ret.adj().array() * value_of(arena_y);
       }

--- a/stan/math/rev/fun/fma.hpp
+++ b/stan/math/rev/fun/fma.hpp
@@ -191,80 +191,74 @@ namespace internal {
 template <typename T1, typename T2, typename T3, typename T4>
 inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
   return [arena_x, arena_y, arena_z, ret]() mutable {
-    if constexpr (is_matrix_v<T1> && is_matrix_v<T2> && is_matrix_v<T3>) {
-      if constexpr (!is_constant_v<T1>) {
+    if constexpr (is_matrix_v<T1, T2, T3>) {
+      if constexpr (is_autodiffable_v<T1>) {
         arena_x.adj().array() += ret.adj().array() * value_of(arena_y).array();
       }
-      if constexpr (!is_constant_v<T2>) {
+      if constexpr (is_autodiffable_v<T2>) {
         arena_y.adj().array() += ret.adj().array() * value_of(arena_x).array();
       }
-      if constexpr (!is_constant_v<T3>) {
+      if constexpr (is_autodiffable_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_stan_scalar_v<
-                             T1> && is_matrix_v<T2> && is_matrix_v<T3>) {
-      if constexpr (!is_constant_v<T1>) {
+    } else if constexpr (is_stan_scalar_v<T1> && is_matrix_v<T2, T3>) {
+      if constexpr (is_autodiffable_v<T1>) {
         arena_x.adj() += (ret.adj().array() * value_of(arena_y).array()).sum();
       }
-      if constexpr (!is_constant_v<T2>) {
+      if constexpr (is_autodiffable_v<T2>) {
         arena_y.adj().array() += ret.adj().array() * value_of(arena_x);
       }
-      if constexpr (!is_constant_v<T3>) {
+      if constexpr (is_autodiffable_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_matrix_v<
-                             T1> && is_stan_scalar_v<T2> && is_matrix_v<T3>) {
-      if constexpr (!is_constant_v<T1>) {
+    } else if constexpr (is_matrix_v<T1, T3> && is_stan_scalar_v<T2>) {
+      if constexpr (is_autodiffable_v<T1>) {
         arena_x.adj().array() += ret.adj().array() * value_of(arena_y);
       }
-      if constexpr (!is_constant_v<T2>) {
+      if constexpr (is_autodiffable_v<T2>) {
         arena_y.adj() += (ret.adj().array() * value_of(arena_x).array()).sum();
       }
-      if constexpr (!is_constant_v<T3>) {
+      if constexpr (is_autodiffable_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_stan_scalar_v<
-                             T1> && is_stan_scalar_v<T2> && is_matrix_v<T3>) {
-      if constexpr (!is_constant_v<T1>) {
+    } else if constexpr (is_stan_scalar_v<T1, T2> && is_matrix_v<T3>) {
+      if constexpr (is_autodiffable_v<T1>) {
         arena_x.adj() += (ret.adj().array() * value_of(arena_y)).sum();
       }
-      if constexpr (!is_constant_v<T2>) {
+      if constexpr (is_autodiffable_v<T2>) {
         arena_y.adj() += (ret.adj().array() * value_of(arena_x)).sum();
       }
-      if constexpr (!is_constant_v<T3>) {
+      if constexpr (is_autodiffable_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_matrix_v<
-                             T1> && is_matrix_v<T2> && is_stan_scalar_v<T3>) {
-      if constexpr (!is_constant_v<T1>) {
+    } else if constexpr (is_matrix_v<T1, T2> && is_stan_scalar_v<T3>) {
+      if constexpr (is_autodiffable_v<T1>) {
         arena_x.adj().array() += ret.adj().array() * value_of(arena_y).array();
       }
-      if constexpr (!is_constant_v<T2>) {
+      if constexpr (is_autodiffable_v<T2>) {
         arena_y.adj().array() += ret.adj().array() * value_of(arena_x).array();
       }
-      if constexpr (!is_constant_v<T3>) {
+      if constexpr (is_autodiffable_v<T3>) {
         arena_z.adj() += ret.adj().sum();
       }
-    } else if constexpr (is_stan_scalar_v<
-                             T1> && is_matrix_v<T2> && is_stan_scalar_v<T3>) {
-      if constexpr (!is_constant_v<T1>) {
+    } else if constexpr (is_stan_scalar_v<T1, T3> && is_matrix_v<T2>) {
+      if constexpr (is_autodiffable_v<T1>) {
         arena_x.adj() += (ret.adj().array() * value_of(arena_y).array()).sum();
       }
-      if constexpr (!is_constant_v<T2>) {
+      if constexpr (is_autodiffable_v<T2>) {
         arena_y.adj().array() += ret.adj().array() * value_of(arena_x);
       }
-      if constexpr (!is_constant_v<T3>) {
+      if constexpr (is_autodiffable_v<T3>) {
         arena_z.adj() += ret.adj().sum();
       }
-    } else if constexpr (
-        is_matrix_v<T1> && is_stan_scalar_v<T2> && is_stan_scalar_v<T3>) {
-      if constexpr (!is_constant_v<T1>) {
+    } else if constexpr (is_matrix_v<T1> && is_stan_scalar_v<T2, T3>) {
+      if constexpr (is_autodiffable_v<T1>) {
         arena_x.adj().array() += ret.adj().array() * value_of(arena_y);
       }
-      if constexpr (!is_constant_v<T2>) {
+      if constexpr (is_autodiffable_v<T2>) {
         arena_y.adj() += (ret.adj().array() * value_of(arena_x).array()).sum();
       }
-      if constexpr (!is_constant_v<T3>) {
+      if constexpr (is_autodiffable_v<T3>) {
         arena_z.adj() += ret.adj().sum();
       }
     }

--- a/stan/math/rev/fun/fma.hpp
+++ b/stan/math/rev/fun/fma.hpp
@@ -205,10 +205,12 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     auto&& y_arr = as_array_or_scalar(arena_y);
     auto&& z_arr = as_array_or_scalar(arena_z);
     if constexpr (!is_constant_v<T1>) {
-      x_arr.adj() += conditional_sum<is_stan_scalar_v<T1>>(ret.adj().array() * value_of(y_arr));
+      x_arr.adj() += conditional_sum<is_stan_scalar_v<T1>>(ret.adj().array()
+                                                           * value_of(y_arr));
     }
     if constexpr (!is_constant_v<T2>) {
-      y_arr.adj() += conditional_sum<is_stan_scalar_v<T2>>(ret.adj().array() * value_of(x_arr));
+      y_arr.adj() += conditional_sum<is_stan_scalar_v<T2>>(ret.adj().array()
+                                                           * value_of(x_arr));
     }
     if constexpr (!is_constant_v<T3>) {
       z_arr.adj() += conditional_sum<is_stan_scalar_v<T3>>(ret.adj().array());

--- a/stan/math/rev/fun/fma.hpp
+++ b/stan/math/rev/fun/fma.hpp
@@ -201,8 +201,8 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_stan_scalar_v<
-                             T1> && is_matrix_v<T2> && is_matrix_v<T3>) {
+    } else if constexpr (is_stan_scalar_v<T1> && is_matrix_v<T2>
+                         && is_matrix_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
         arena_x.adj() += (ret.adj().array() * value_of(arena_y).array()).sum();
       }
@@ -212,8 +212,8 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_matrix_v<
-                             T1> && is_stan_scalar_v<T2> && is_matrix_v<T3>) {
+    } else if constexpr (is_matrix_v<T1> && is_stan_scalar_v<T2>
+                         && is_matrix_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
         arena_x.adj().array() += ret.adj().array() * value_of(arena_y);
       }
@@ -223,8 +223,8 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_stan_scalar_v<
-                             T1> && is_stan_scalar_v<T2> && is_matrix_v<T3>) {
+    } else if constexpr (is_stan_scalar_v<T1> && is_stan_scalar_v<T2>
+                         && is_matrix_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
         arena_x.adj() += (ret.adj().array() * value_of(arena_y)).sum();
       }
@@ -234,8 +234,8 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_matrix_v<
-                             T1> && is_matrix_v<T2> && is_stan_scalar_v<T3>) {
+    } else if constexpr (is_matrix_v<T1> && is_matrix_v<T2>
+                         && is_stan_scalar_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
         arena_x.adj().array() += ret.adj().array() * value_of(arena_y).array();
       }
@@ -245,8 +245,8 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj() += ret.adj().sum();
       }
-    } else if constexpr (is_stan_scalar_v<
-                             T1> && is_matrix_v<T2> && is_stan_scalar_v<T3>) {
+    } else if constexpr (is_stan_scalar_v<T1> && is_matrix_v<T2>
+                         && is_stan_scalar_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
         arena_x.adj() += (ret.adj().array() * value_of(arena_y).array()).sum();
       }
@@ -256,8 +256,8 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj() += ret.adj().sum();
       }
-    } else if constexpr (
-        is_matrix_v<T1> && is_stan_scalar_v<T2> && is_stan_scalar_v<T3>) {
+    } else if constexpr (is_matrix_v<T1> && is_stan_scalar_v<T2>
+                         && is_stan_scalar_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
         arena_x.adj().array() += ret.adj().array() * value_of(arena_y);
       }

--- a/stan/math/rev/fun/fma.hpp
+++ b/stan/math/rev/fun/fma.hpp
@@ -193,90 +193,82 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
   return [arena_x, arena_y, arena_z, ret]() mutable {
     if constexpr (is_matrix_v<T1> && is_matrix_v<T2> && is_matrix_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
-        arena_x.adj().array()
-            += ret.adj().array() * value_of(arena_y).array();          
+        arena_x.adj().array() += ret.adj().array() * value_of(arena_y).array();
       }
       if constexpr (!is_constant_v<T2>) {
-        arena_y.adj().array()
-            += ret.adj().array() * value_of(arena_x).array();
+        arena_y.adj().array() += ret.adj().array() * value_of(arena_x).array();
       }
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_stan_scalar_v<T1> && is_matrix_v<T2> && is_matrix_v<T3>) {
+    } else if constexpr (is_stan_scalar_v<
+                             T1> && is_matrix_v<T2> && is_matrix_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
-        arena_x.adj()
-            += (ret.adj().array() * value_of(arena_y).array()).sum();
+        arena_x.adj() += (ret.adj().array() * value_of(arena_y).array()).sum();
       }
       if constexpr (!is_constant_v<T2>) {
-        arena_y.adj().array()
-            += ret.adj().array() * value_of(arena_x);
+        arena_y.adj().array() += ret.adj().array() * value_of(arena_x);
       }
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_matrix_v<T1> && is_stan_scalar_v<T2> && is_matrix_v<T3>) {
+    } else if constexpr (is_matrix_v<
+                             T1> && is_stan_scalar_v<T2> && is_matrix_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
-        arena_x.adj().array()
-            += ret.adj().array() * value_of(arena_y);
+        arena_x.adj().array() += ret.adj().array() * value_of(arena_y);
       }
       if constexpr (!is_constant_v<T2>) {
-        arena_y.adj()
-            += (ret.adj().array() * value_of(arena_x).array()).sum();
+        arena_y.adj() += (ret.adj().array() * value_of(arena_x).array()).sum();
       }
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_stan_scalar_v<T1> && is_stan_scalar_v<T2> && is_matrix_v<T3>) {
+    } else if constexpr (is_stan_scalar_v<
+                             T1> && is_stan_scalar_v<T2> && is_matrix_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
-        arena_x.adj()
-            += (ret.adj().array() * value_of(arena_y)).sum();
+        arena_x.adj() += (ret.adj().array() * value_of(arena_y)).sum();
       }
       if constexpr (!is_constant_v<T2>) {
-        arena_y.adj()
-            += (ret.adj().array() * value_of(arena_x)).sum();
+        arena_y.adj() += (ret.adj().array() * value_of(arena_x)).sum();
       }
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj().array() += ret.adj().array();
       }
-    } else if constexpr (is_matrix_v<T1> && is_matrix_v<T2> && is_stan_scalar_v<T3>) {
+    } else if constexpr (is_matrix_v<
+                             T1> && is_matrix_v<T2> && is_stan_scalar_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
-        arena_x.adj().array()
-            += ret.adj().array() * value_of(arena_y).array();
+        arena_x.adj().array() += ret.adj().array() * value_of(arena_y).array();
       }
       if constexpr (!is_constant_v<T2>) {
-        arena_y.adj().array()
-            += ret.adj().array() * value_of(arena_x).array();
+        arena_y.adj().array() += ret.adj().array() * value_of(arena_x).array();
       }
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj() += ret.adj().sum();
       }
-    } else if constexpr (is_stan_scalar_v<T1> && is_matrix_v<T2> && is_stan_scalar_v<T3>) {
+    } else if constexpr (is_stan_scalar_v<
+                             T1> && is_matrix_v<T2> && is_stan_scalar_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
-        arena_x.adj()
-            += (ret.adj().array() * value_of(arena_y).array()).sum();
+        arena_x.adj() += (ret.adj().array() * value_of(arena_y).array()).sum();
       }
       if constexpr (!is_constant_v<T2>) {
-        arena_y.adj().array()
-            += ret.adj().array() * value_of(arena_x);
+        arena_y.adj().array() += ret.adj().array() * value_of(arena_x);
       }
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj() += ret.adj().sum();
       }
-    } else if constexpr (is_matrix_v<T1> && is_stan_scalar_v<T2> && is_stan_scalar_v<T3>) {
+    } else if constexpr (
+        is_matrix_v<T1> && is_stan_scalar_v<T2> && is_stan_scalar_v<T3>) {
       if constexpr (!is_constant_v<T1>) {
-        arena_x.adj().array()
-            += ret.adj().array() * value_of(arena_y);
+        arena_x.adj().array() += ret.adj().array() * value_of(arena_y);
       }
       if constexpr (!is_constant_v<T2>) {
-        arena_y.adj()
-            += (ret.adj().array() * value_of(arena_x).array()).sum();
+        arena_y.adj() += (ret.adj().array() * value_of(arena_x).array()).sum();
       }
       if constexpr (!is_constant_v<T3>) {
         arena_z.adj() += ret.adj().sum();
       }
     }
-};
+  };
 }
 
 }  // namespace internal

--- a/stan/math/rev/fun/gp_exp_quad_cov.hpp
+++ b/stan/math/rev/fun/gp_exp_quad_cov.hpp
@@ -61,7 +61,7 @@ inline Eigen::Matrix<var, -1, -1> gp_exp_quad_cov(const std::vector<T_x>& x,
     size_t j_size = j_end - jb;
     cov.diagonal().segment(jb, j_size)
         = Eigen::VectorXd::Constant(j_size, sigma_sq);
-    if constexpr (!is_constant_v<T_sigma>) {
+    if constexpr (is_autodiffable_v<T_sigma>) {
       cov_diag.segment(jb, j_size) = cov.diagonal().segment(jb, j_size);
     }
     for (size_t ib = jb; ib < x_size; ib += block_size) {
@@ -86,11 +86,11 @@ inline Eigen::Matrix<var, -1, -1> gp_exp_quad_cov(const std::vector<T_x>& x,
           double prod_add
               = cov_l_tri_lin.coeff(pos).val() * cov_l_tri_lin.coeff(pos).adj();
           adjl += prod_add * sq_dists_lin.coeff(pos);
-          if constexpr (!is_constant_v<T_sigma>) {
+          if constexpr (is_autodiffable_v<T_sigma>) {
             adjsigma += prod_add;
           }
         }
-        if constexpr (!is_constant_v<T_sigma>) {
+        if constexpr (is_autodiffable_v<T_sigma>) {
           adjsigma += (cov_diag.val().array() * cov_diag.adj().array()).sum();
           sigma.adj() += adjsigma * 2 / value_of(sigma);
         }

--- a/stan/math/rev/fun/gp_exp_quad_cov.hpp
+++ b/stan/math/rev/fun/gp_exp_quad_cov.hpp
@@ -61,7 +61,7 @@ inline Eigen::Matrix<var, -1, -1> gp_exp_quad_cov(const std::vector<T_x>& x,
     size_t j_size = j_end - jb;
     cov.diagonal().segment(jb, j_size)
         = Eigen::VectorXd::Constant(j_size, sigma_sq);
-    if (!is_constant<T_sigma>::value) {
+    if constexpr (!is_constant_v<T_sigma>) {
       cov_diag.segment(jb, j_size) = cov.diagonal().segment(jb, j_size);
     }
     for (size_t ib = jb; ib < x_size; ib += block_size) {
@@ -86,13 +86,13 @@ inline Eigen::Matrix<var, -1, -1> gp_exp_quad_cov(const std::vector<T_x>& x,
           double prod_add
               = cov_l_tri_lin.coeff(pos).val() * cov_l_tri_lin.coeff(pos).adj();
           adjl += prod_add * sq_dists_lin.coeff(pos);
-          if (!is_constant<T_sigma>::value) {
+          if constexpr (!is_constant_v<T_sigma>) {
             adjsigma += prod_add;
           }
         }
-        if (!is_constant<T_sigma>::value) {
+        if constexpr (!is_constant_v<T_sigma>) {
           adjsigma += (cov_diag.val().array() * cov_diag.adj().array()).sum();
-          adjoint_of(sigma) += adjsigma * 2 / value_of(sigma);
+          sigma.adj() += adjsigma * 2 / value_of(sigma);
         }
         double l_val = value_of(length_scale);
         length_scale.adj() += adjl / (l_val * l_val * l_val);

--- a/stan/math/rev/fun/gp_periodic_cov.hpp
+++ b/stan/math/rev/fun/gp_periodic_cov.hpp
@@ -75,7 +75,7 @@ inline Eigen::Matrix<var, Eigen::Dynamic, Eigen::Dynamic> gp_periodic_cov(
     cov.diagonal().segment(jb, j_size)
         = Eigen::VectorXd::Constant(j_size, sigma_sq);
 
-    if (!is_constant<T_sigma>::value) {
+    if constexpr (!is_constant_v<T_sigma>) {
       cov_diag.segment(jb, j_size) = cov.diagonal().segment(jb, j_size);
     }
     for (size_t ib = jb; ib < x_size; ib += block_size) {
@@ -114,9 +114,9 @@ inline Eigen::Matrix<var, Eigen::Dynamic, Eigen::Dynamic> gp_periodic_cov(
       double dist = dists_lin.coeff(pos);
       adjp += prod_add * sin(two_pi_div_p * dist) * dist;
     }
-    if (!is_constant<T_sigma>::value) {
+    if constexpr (!is_constant_v<T_sigma>) {
       adjsigma += (cov_diag.val().array() * cov_diag.adj().array()).sum();
-      adjoint_of(sigma) += adjsigma * 2 / value_of(sigma);
+      sigma.adj() += adjsigma * 2 / value_of(sigma);
     }
     double l_sq = square(l_val);
     l.adj() += adjl * 4 / (l_sq * l_val);

--- a/stan/math/rev/fun/gp_periodic_cov.hpp
+++ b/stan/math/rev/fun/gp_periodic_cov.hpp
@@ -75,7 +75,7 @@ inline Eigen::Matrix<var, Eigen::Dynamic, Eigen::Dynamic> gp_periodic_cov(
     cov.diagonal().segment(jb, j_size)
         = Eigen::VectorXd::Constant(j_size, sigma_sq);
 
-    if constexpr (!is_constant_v<T_sigma>) {
+    if constexpr (is_autodiffable_v<T_sigma>) {
       cov_diag.segment(jb, j_size) = cov.diagonal().segment(jb, j_size);
     }
     for (size_t ib = jb; ib < x_size; ib += block_size) {
@@ -114,7 +114,7 @@ inline Eigen::Matrix<var, Eigen::Dynamic, Eigen::Dynamic> gp_periodic_cov(
       double dist = dists_lin.coeff(pos);
       adjp += prod_add * sin(two_pi_div_p * dist) * dist;
     }
-    if constexpr (!is_constant_v<T_sigma>) {
+    if constexpr (is_autodiffable_v<T_sigma>) {
       adjsigma += (cov_diag.val().array() * cov_diag.adj().array()).sum();
       sigma.adj() += adjsigma * 2 / value_of(sigma);
     }

--- a/stan/math/rev/fun/hypergeometric_1F0.hpp
+++ b/stan/math/rev/fun/hypergeometric_1F0.hpp
@@ -36,11 +36,11 @@ var hypergeometric_1f0(const Ta& a, const Tz& z) {
   double z_val = value_of(z);
   double rtn = hypergeometric_1f0(a_val, z_val);
   return make_callback_var(rtn, [rtn, a, z, a_val, z_val](auto& vi) mutable {
-    if (!is_constant_all<Ta>::value) {
-      forward_as<var>(a).adj() += vi.adj() * -rtn * log1m(z_val);
+    if constexpr (!is_constant_all<Ta>::value) {
+      a.adj() += vi.adj() * -rtn * log1m(z_val);
     }
-    if (!is_constant_all<Tz>::value) {
-      forward_as<var>(z).adj() += vi.adj() * rtn * a_val * inv(1 - z_val);
+    if constexpr (!is_constant_all<Tz>::value) {
+      z.adj() += vi.adj() * rtn * a_val * inv(1 - z_val);
     }
   });
 }

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -43,17 +43,17 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
       [a1, a2, b, z](auto& vi) mutable {
         auto grad_tuple = grad_2F1(a1, a2, b, z);
 
-        if (!is_constant<Ta1>::value) {
-          forward_as<var>(a1).adj() += vi.adj() * std::get<0>(grad_tuple);
+        if constexpr (!is_constant_v<Ta1>) {
+          a1.adj() += vi.adj() * std::get<0>(grad_tuple);
         }
-        if (!is_constant<Ta2>::value) {
-          forward_as<var>(a2).adj() += vi.adj() * std::get<1>(grad_tuple);
+        if constexpr (!is_constant_v<Ta2>) {
+          a2.adj() += vi.adj() * std::get<1>(grad_tuple);
         }
-        if (!is_constant<Tb>::value) {
-          forward_as<var>(b).adj() += vi.adj() * std::get<2>(grad_tuple);
+        if constexpr (!is_constant_v<Tb>) {
+          b.adj() += vi.adj() * std::get<2>(grad_tuple);
         }
-        if (!is_constant<Tz>::value) {
-          forward_as<var>(z).adj() += vi.adj() * std::get<3>(grad_tuple);
+        if constexpr (!is_constant_v<Tz>) {
+          z.adj() += vi.adj() * std::get<3>(grad_tuple);
         }
       });
 }

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -38,24 +38,23 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   double b_dbl = value_of(b);
   double z_dbl = value_of(z);
 
-  return make_callback_var(
-      hypergeometric_2F1(a1_dbl, a2_dbl, b_dbl, z_dbl),
-      [a1, a2, b, z](auto& vi) mutable {
-        auto grad_tuple = grad_2F1(a1, a2, b, z);
+  return make_callback_var(hypergeometric_2F1(a1_dbl, a2_dbl, b_dbl, z_dbl),
+                           [a1, a2, b, z](auto& vi) mutable {
+                             auto grad_tuple = grad_2F1(a1, a2, b, z);
 
-        if constexpr (!is_constant_v<Ta1>) {
-          a1.adj() += vi.adj() * std::get<0>(grad_tuple);
-        }
-        if constexpr (!is_constant_v<Ta2>) {
-          a2.adj() += vi.adj() * std::get<1>(grad_tuple);
-        }
-        if constexpr (!is_constant_v<Tb>) {
-          b.adj() += vi.adj() * std::get<2>(grad_tuple);
-        }
-        if constexpr (!is_constant_v<Tz>) {
-          z.adj() += vi.adj() * std::get<3>(grad_tuple);
-        }
-      });
+                             if constexpr (!is_constant_v<Ta1>) {
+                               a1.adj() += vi.adj() * std::get<0>(grad_tuple);
+                             }
+                             if constexpr (!is_constant_v<Ta2>) {
+                               a2.adj() += vi.adj() * std::get<1>(grad_tuple);
+                             }
+                             if constexpr (!is_constant_v<Tb>) {
+                               b.adj() += vi.adj() * std::get<2>(grad_tuple);
+                             }
+                             if constexpr (!is_constant_v<Tz>) {
+                               z.adj() += vi.adj() * std::get<3>(grad_tuple);
+                             }
+                           });
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -42,16 +42,16 @@ inline return_type_t<Ta1, Ta1, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
                            [a1, a2, b, z](auto& vi) mutable {
                              auto grad_tuple = grad_2F1(a1, a2, b, z);
 
-                             if constexpr (!is_constant_v<Ta1>) {
+                             if constexpr (is_autodiffable_v<Ta1>) {
                                a1.adj() += vi.adj() * std::get<0>(grad_tuple);
                              }
-                             if constexpr (!is_constant_v<Ta2>) {
+                             if constexpr (is_autodiffable_v<Ta2>) {
                                a2.adj() += vi.adj() * std::get<1>(grad_tuple);
                              }
-                             if constexpr (!is_constant_v<Tb>) {
+                             if constexpr (is_autodiffable_v<Tb>) {
                                b.adj() += vi.adj() * std::get<2>(grad_tuple);
                              }
-                             if constexpr (!is_constant_v<Tz>) {
+                             if constexpr (is_autodiffable_v<Tz>) {
                                z.adj() += vi.adj() * std::get<3>(grad_tuple);
                              }
                            });

--- a/stan/math/rev/fun/hypergeometric_pFq.hpp
+++ b/stan/math/rev/fun/hypergeometric_pFq.hpp
@@ -22,8 +22,7 @@ namespace math {
  * @return Generalized hypergeometric function
  */
 template <typename Ta, typename Tb, typename Tz,
-          bool grad_a = !is_constant_v<Ta>,
-          bool grad_b = !is_constant_v<Tb>,
+          bool grad_a = !is_constant_v<Ta>, bool grad_b = !is_constant_v<Tb>,
           bool grad_z = !is_constant_v<Tz>,
           require_all_matrix_t<Ta, Tb>* = nullptr,
           require_return_type_t<is_var, Ta, Tb, Tz>* = nullptr>

--- a/stan/math/rev/fun/hypergeometric_pFq.hpp
+++ b/stan/math/rev/fun/hypergeometric_pFq.hpp
@@ -22,30 +22,27 @@ namespace math {
  * @return Generalized hypergeometric function
  */
 template <typename Ta, typename Tb, typename Tz,
-          bool grad_a = !is_constant<Ta>::value,
-          bool grad_b = !is_constant<Tb>::value,
-          bool grad_z = !is_constant<Tz>::value,
+          bool grad_a = !is_constant_v<Ta>,
+          bool grad_b = !is_constant_v<Tb>,
+          bool grad_z = !is_constant_v<Tz>,
           require_all_matrix_t<Ta, Tb>* = nullptr,
           require_return_type_t<is_var, Ta, Tb, Tz>* = nullptr>
-inline var hypergeometric_pFq(const Ta& a, const Tb& b, const Tz& z) {
-  arena_t<Ta> arena_a = a;
-  arena_t<Tb> arena_b = b;
+inline var hypergeometric_pFq(Ta&& a, Tb&& b, const Tz& z) {
+  arena_t<Ta> arena_a = std::forward<Ta>(a);
+  arena_t<Tb> arena_b = std::forward<Tb>(b);
   auto pfq_val = hypergeometric_pFq(a.val(), b.val(), value_of(z));
   return make_callback_var(
       pfq_val, [arena_a, arena_b, z, pfq_val](auto& vi) mutable {
         auto grad_tuple = grad_pFq<grad_a, grad_b, grad_z>(
             pfq_val, arena_a.val(), arena_b.val(), value_of(z));
-        if (grad_a) {
-          forward_as<promote_scalar_t<var, Ta>>(arena_a).adj()
-              += vi.adj() * std::get<0>(grad_tuple);
+        if constexpr (grad_a) {
+          arena_a.adj() += vi.adj() * std::get<0>(grad_tuple);
         }
-        if (grad_b) {
-          forward_as<promote_scalar_t<var, Tb>>(arena_b).adj()
-              += vi.adj() * std::get<1>(grad_tuple);
+        if constexpr (grad_b) {
+          arena_b.adj() += vi.adj() * std::get<1>(grad_tuple);
         }
-        if (grad_z) {
-          forward_as<promote_scalar_t<var, Tz>>(z).adj()
-              += vi.adj() * std::get<2>(grad_tuple);
+        if constexpr (grad_z) {
+          z.adj() += vi.adj() * std::get<2>(grad_tuple);
         }
       });
 }

--- a/stan/math/rev/fun/hypergeometric_pFq.hpp
+++ b/stan/math/rev/fun/hypergeometric_pFq.hpp
@@ -22,8 +22,8 @@ namespace math {
  * @return Generalized hypergeometric function
  */
 template <typename Ta, typename Tb, typename Tz,
-          bool grad_a = !is_constant_v<Ta>, bool grad_b = !is_constant_v<Tb>,
-          bool grad_z = !is_constant_v<Tz>,
+          bool grad_a = is_autodiffable_v<Ta>, bool grad_b = is_autodiffable_v<Tb>,
+          bool grad_z = is_autodiffable_v<Tz>,
           require_all_matrix_t<Ta, Tb>* = nullptr,
           require_return_type_t<is_var, Ta, Tb, Tz>* = nullptr>
 inline var hypergeometric_pFq(Ta&& a, Tb&& b, const Tz& z) {

--- a/stan/math/rev/fun/hypergeometric_pFq.hpp
+++ b/stan/math/rev/fun/hypergeometric_pFq.hpp
@@ -21,11 +21,11 @@ namespace math {
  * @param[in] z Scalar z argument
  * @return Generalized hypergeometric function
  */
-template <typename Ta, typename Tb, typename Tz,
-          bool grad_a = is_autodiffable_v<Ta>, bool grad_b = is_autodiffable_v<Tb>,
-          bool grad_z = is_autodiffable_v<Tz>,
-          require_all_matrix_t<Ta, Tb>* = nullptr,
-          require_return_type_t<is_var, Ta, Tb, Tz>* = nullptr>
+template <
+    typename Ta, typename Tb, typename Tz, bool grad_a = is_autodiffable_v<Ta>,
+    bool grad_b = is_autodiffable_v<Tb>, bool grad_z = is_autodiffable_v<Tz>,
+    require_all_matrix_t<Ta, Tb>* = nullptr,
+    require_return_type_t<is_var, Ta, Tb, Tz>* = nullptr>
 inline var hypergeometric_pFq(Ta&& a, Tb&& b, const Tz& z) {
   arena_t<Ta> arena_a = std::forward<Ta>(a);
   arena_t<Tb> arena_b = std::forward<Tb>(b);

--- a/stan/math/rev/fun/inv_inc_beta.hpp
+++ b/stan/math/rev/fun/inv_inc_beta.hpp
@@ -96,8 +96,7 @@ inline var inv_inc_beta(const T1& a, const T2& b, const T3& p) {
     }
 
     if constexpr (!is_constant_all<T3>::value) {
-      p.adj()
-          += vi.adj() * exp(one_m_b * log1m_w + one_m_a * log_w + lbeta_ab);
+      p.adj() += vi.adj() * exp(one_m_b * log1m_w + one_m_a * log_w + lbeta_ab);
     }
   });
 }

--- a/stan/math/rev/fun/inv_inc_beta.hpp
+++ b/stan/math/rev/fun/inv_inc_beta.hpp
@@ -70,7 +70,7 @@ inline var inv_inc_beta(const T1& a, const T2& b, const T3& p) {
     double lbeta_ab = lbeta(a_val, b_val);
     double digamma_apb = digamma(a_val + b_val);
 
-    if (!is_constant_all<T1>::value) {
+    if constexpr (!is_constant_all<T1>::value) {
       double da1 = exp(one_m_b * log1m_w + one_m_a * log_w);
       double da2
           = a_val * log_w + 2 * lgamma(a_val)
@@ -79,10 +79,10 @@ inline var inv_inc_beta(const T1& a, const T2& b, const T3& p) {
       double da3 = inc_beta(a_val, b_val, w) * exp(lbeta_ab)
                    * (log_w - digamma(a_val) + digamma_apb);
 
-      forward_as<var>(a).adj() += vi.adj() * da1 * (exp(da2) - da3);
+      a.adj() += vi.adj() * da1 * (exp(da2) - da3);
     }
 
-    if (!is_constant_all<T2>::value) {
+    if constexpr (!is_constant_all<T2>::value) {
       double db1 = (w - 1) * exp(-b_val * log1m_w + one_m_a * log_w);
       double db2 = 2 * lgamma(b_val)
                    + log(hypergeometric_3F2({b_val, b_val, one_m_a}, {bp1, bp1},
@@ -92,11 +92,11 @@ inline var inv_inc_beta(const T1& a, const T2& b, const T3& p) {
       double db3 = inc_beta(b_val, a_val, one_m_w) * exp(lbeta_ab)
                    * (log1m_w - digamma(b_val) + digamma_apb);
 
-      forward_as<var>(b).adj() += vi.adj() * db1 * (exp(db2) - db3);
+      b.adj() += vi.adj() * db1 * (exp(db2) - db3);
     }
 
-    if (!is_constant_all<T3>::value) {
-      forward_as<var>(p).adj()
+    if constexpr (!is_constant_all<T3>::value) {
+      p.adj()
           += vi.adj() * exp(one_m_b * log1m_w + one_m_a * log_w + lbeta_ab);
     }
   });

--- a/stan/math/rev/fun/inverse.hpp
+++ b/stan/math/rev/fun/inverse.hpp
@@ -25,7 +25,7 @@ inline auto inverse(const T& m) {
 
   using ret_type = return_var_matrix_t<T>;
   if (unlikely(m.size() == 0)) {
-    return ret_type(m);
+    return arena_t<ret_type>(m);
   }
 
   arena_t<T> arena_m = m;
@@ -36,7 +36,7 @@ inline auto inverse(const T& m) {
     arena_m.adj() -= res_val.transpose() * res.adj_op() * res_val.transpose();
   });
 
-  return ret_type(res);
+  return res;
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/lmultiply.hpp
+++ b/stan/math/rev/fun/lmultiply.hpp
@@ -103,10 +103,9 @@ template <typename T1, typename T2, require_all_matrix_t<T1, T2>* = nullptr,
           require_any_var_matrix_t<T1, T2>* = nullptr>
 inline auto lmultiply(const T1& a, const T2& b) {
   check_matching_dims("lmultiply", "a", a, "b", b);
-  if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_a = a;
-    arena_t<promote_scalar_t<var, T2>> arena_b = b;
-
+  arena_t<T1> arena_a = a;
+  arena_t<T2> arena_b = b;
+  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
     return make_callback_var(
         lmultiply(arena_a.val(), arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -115,10 +114,7 @@ inline auto lmultiply(const T1& a, const T2& b) {
           arena_b.adj().array() += res.adj().array() * arena_a.val().array()
                                    / arena_b.val().array();
         });
-  } else if (!is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_a = a;
-    arena_t<promote_scalar_t<double, T2>> arena_b = value_of(b);
-
+  } else if constexpr (!is_constant_v<T1>) {
     return make_callback_var(lmultiply(arena_a.val(), arena_b),
                              [arena_a, arena_b](const auto& res) mutable {
                                arena_a.adj().array()
@@ -126,9 +122,6 @@ inline auto lmultiply(const T1& a, const T2& b) {
                                       * arena_b.val().array().log();
                              });
   } else {
-    arena_t<promote_scalar_t<double, T1>> arena_a = value_of(a);
-    arena_t<promote_scalar_t<var, T2>> arena_b = b;
-
     return make_callback_var(lmultiply(arena_a, arena_b.val()),
                              [arena_a, arena_b](const auto& res) mutable {
                                arena_b.adj().array() += res.adj().array()
@@ -151,11 +144,9 @@ template <typename T1, typename T2, require_var_matrix_t<T1>* = nullptr,
           require_stan_scalar_t<T2>* = nullptr>
 inline auto lmultiply(const T1& a, const T2& b) {
   using std::log;
-
-  if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_a = a;
-    var arena_b = b;
-
+  arena_t<T1> arena_a = a;
+  auto arena_b = b;
+  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
     return make_callback_var(
         lmultiply(arena_a.val(), arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -163,18 +154,13 @@ inline auto lmultiply(const T1& a, const T2& b) {
           arena_b.adj() += (res.adj().array() * arena_a.val().array()).sum()
                            / arena_b.val();
         });
-  } else if (!is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_a = a;
-
+  } else if constexpr (!is_constant_v<T1>) {
     return make_callback_var(lmultiply(arena_a.val(), value_of(b)),
                              [arena_a, b](const auto& res) mutable {
                                arena_a.adj().array()
                                    += res.adj().array() * log(value_of(b));
                              });
   } else {
-    arena_t<promote_scalar_t<double, T1>> arena_a = value_of(a);
-    var arena_b = b;
-
     return make_callback_var(
         lmultiply(arena_a, arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -196,10 +182,9 @@ inline auto lmultiply(const T1& a, const T2& b) {
 template <typename T1, typename T2, require_stan_scalar_t<T1>* = nullptr,
           require_var_matrix_t<T2>* = nullptr>
 inline auto lmultiply(const T1& a, const T2& b) {
-  if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    var arena_a = a;
-    arena_t<promote_scalar_t<var, T2>> arena_b = b;
-
+  auto arena_a = a;
+  arena_t<T2> arena_b = b;
+  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
     return make_callback_var(
         lmultiply(arena_a.val(), arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -208,10 +193,7 @@ inline auto lmultiply(const T1& a, const T2& b) {
           arena_b.adj().array()
               += arena_a.val() * res.adj().array() / arena_b.val().array();
         });
-  } else if (!is_constant<T1>::value) {
-    var arena_a = a;
-    arena_t<promote_scalar_t<double, T2>> arena_b = value_of(b);
-
+  } else if constexpr (!is_constant_v<T1>) {
     return make_callback_var(
         lmultiply(arena_a.val(), arena_b),
         [arena_a, arena_b](const auto& res) mutable {
@@ -219,8 +201,6 @@ inline auto lmultiply(const T1& a, const T2& b) {
               += (res.adj().array() * arena_b.val().array().log()).sum();
         });
   } else {
-    arena_t<promote_scalar_t<var, T2>> arena_b = b;
-
     return make_callback_var(lmultiply(value_of(a), arena_b.val()),
                              [a, arena_b](const auto& res) mutable {
                                arena_b.adj().array() += value_of(a)

--- a/stan/math/rev/fun/lmultiply.hpp
+++ b/stan/math/rev/fun/lmultiply.hpp
@@ -105,7 +105,7 @@ inline auto lmultiply(const T1& a, const T2& b) {
   check_matching_dims("lmultiply", "a", a, "b", b);
   arena_t<T1> arena_a = a;
   arena_t<T2> arena_b = b;
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     return make_callback_var(
         lmultiply(arena_a.val(), arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -114,7 +114,7 @@ inline auto lmultiply(const T1& a, const T2& b) {
           arena_b.adj().array() += res.adj().array() * arena_a.val().array()
                                    / arena_b.val().array();
         });
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     return make_callback_var(lmultiply(arena_a.val(), arena_b),
                              [arena_a, arena_b](const auto& res) mutable {
                                arena_a.adj().array()
@@ -146,7 +146,7 @@ inline auto lmultiply(const T1& a, const T2& b) {
   using std::log;
   arena_t<T1> arena_a = a;
   auto arena_b = b;
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     return make_callback_var(
         lmultiply(arena_a.val(), arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -154,7 +154,7 @@ inline auto lmultiply(const T1& a, const T2& b) {
           arena_b.adj() += (res.adj().array() * arena_a.val().array()).sum()
                            / arena_b.val();
         });
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     return make_callback_var(lmultiply(arena_a.val(), value_of(b)),
                              [arena_a, b](const auto& res) mutable {
                                arena_a.adj().array()
@@ -184,7 +184,7 @@ template <typename T1, typename T2, require_stan_scalar_t<T1>* = nullptr,
 inline auto lmultiply(const T1& a, const T2& b) {
   auto arena_a = a;
   arena_t<T2> arena_b = b;
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     return make_callback_var(
         lmultiply(arena_a.val(), arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -193,7 +193,7 @@ inline auto lmultiply(const T1& a, const T2& b) {
           arena_b.adj().array()
               += arena_a.val() * res.adj().array() / arena_b.val().array();
         });
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     return make_callback_var(
         lmultiply(arena_a.val(), arena_b),
         [arena_a, arena_b](const auto& res) mutable {

--- a/stan/math/rev/fun/log_mix.hpp
+++ b/stan/math/rev/fun/log_mix.hpp
@@ -106,15 +106,15 @@ inline return_type_t<T_theta, T_lambda1, T_lambda2> log_mix(
     one_m_t_prod_exp_lam2_m_lam1 = 1.0 - value_of(theta);
   }
 
-  if (!is_constant_all<T_theta>::value) {
+  if constexpr (!is_constant_all<T_theta>::value) {
     partials<0>(ops_partials)[0]
         = one_m_exp_lam2_m_lam1 * one_d_t_plus_one_m_t_prod_exp_lam2_m_lam1;
   }
-  if (!is_constant_all<T_lambda1>::value) {
+  if constexpr (!is_constant_all<T_lambda1>::value) {
     partials<1>(ops_partials)[0]
         = theta_double * one_d_t_plus_one_m_t_prod_exp_lam2_m_lam1;
   }
-  if (!is_constant_all<T_lambda2>::value) {
+  if constexpr (!is_constant_all<T_lambda2>::value) {
     partials<2>(ops_partials)[0] = one_m_t_prod_exp_lam2_m_lam1
                                    * one_d_t_plus_one_m_t_prod_exp_lam2_m_lam1;
   }

--- a/stan/math/rev/fun/log_sum_exp.hpp
+++ b/stan/math/rev/fun/log_sum_exp.hpp
@@ -66,8 +66,8 @@ inline var log_sum_exp(double a, const var& b) {
  */
 template <typename T, require_eigen_st<is_var, T>* = nullptr,
           require_not_var_matrix_t<T>* = nullptr>
-inline var log_sum_exp(const T& v) {
-  arena_t<decltype(v)> arena_v = v;
+inline var log_sum_exp(T&& v) {
+  arena_t<decltype(v)> arena_v = std::forward<T>(v);
   arena_t<decltype(v.val())> arena_v_val = arena_v.val();
   var res = log_sum_exp(arena_v_val);
 

--- a/stan/math/rev/fun/mdivide_left.hpp
+++ b/stan/math/rev/fun/mdivide_left.hpp
@@ -38,7 +38,7 @@ inline auto mdivide_left(T1&& A, T2&& B) {
     return arena_t<ret_type>(ret_val_type(0, B.cols()));
   }
 
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     arena_t<T1> arena_A = std::forward<T1>(A);
     arena_t<T2> arena_B = std::forward<T2>(B);
 
@@ -58,7 +58,7 @@ inline auto mdivide_left(T1&& A, T2&& B) {
     });
 
     return res;
-  } else if constexpr (!is_constant_v<T2>) {
+  } else if constexpr (is_autodiffable_v<T2>) {
     arena_t<T2> arena_B = std::forward<T2>(B);
 
     auto hqr_A_ptr = make_chainable_ptr(value_of(A).householderQr());

--- a/stan/math/rev/fun/mdivide_left.hpp
+++ b/stan/math/rev/fun/mdivide_left.hpp
@@ -46,12 +46,13 @@ inline auto mdivide_left(T1&& A, T2&& B) {
     arena_t<ret_type> res = hqr_A_ptr->solve(arena_B.val());
     reverse_pass_callback([arena_A, arena_B, hqr_A_ptr, res]() mutable {
       using T2_t = std::decay_t<T2>;
-      arena_t<Eigen::Matrix<double, T2_t::RowsAtCompileTime, T2_t::ColsAtCompileTime>> adjB
-          = hqr_A_ptr->householderQ()
-            * hqr_A_ptr->matrixQR()
-                  .template triangularView<Eigen::Upper>()
-                  .transpose()
-                  .solve(res.adj());
+      arena_t<Eigen::Matrix<double, T2_t::RowsAtCompileTime,
+                            T2_t::ColsAtCompileTime>>
+          adjB = hqr_A_ptr->householderQ()
+                 * hqr_A_ptr->matrixQR()
+                       .template triangularView<Eigen::Upper>()
+                       .transpose()
+                       .solve(res.adj());
       arena_A.adj() -= adjB * res.val_op().transpose();
       arena_B.adj() += adjB;
     });

--- a/stan/math/rev/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/fun/mdivide_left_ldlt.hpp
@@ -35,7 +35,7 @@ inline auto mdivide_left_ldlt(LDLT_factor<T1>& A, T2&& B) {
     return arena_t<ret_type>(ret_val_type(0, B.cols()));
   }
 
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     arena_t<T2> arena_B = std::forward<T2>(B);
     arena_t<T1> arena_A = A.matrix();
     arena_t<ret_type> res = A.ldlt().solve(arena_B.val());
@@ -49,7 +49,7 @@ inline auto mdivide_left_ldlt(LDLT_factor<T1>& A, T2&& B) {
     });
 
     return res;
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     arena_t<T1> arena_A = A.matrix();
     arena_t<ret_type> res = A.ldlt().solve(std::forward<T2>(B));
     const auto* ldlt_ptr = make_chainable_ptr(A.ldlt());

--- a/stan/math/rev/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/fun/mdivide_left_ldlt.hpp
@@ -25,8 +25,8 @@ namespace math {
 template <typename T1, typename T2, require_all_matrix_t<T1, T2>* = nullptr,
           require_any_st_var<T1, T2>* = nullptr>
 inline auto mdivide_left_ldlt(LDLT_factor<T1>& A, T2&& B) {
-  using ret_val_type
-      = Eigen::Matrix<double, Eigen::Dynamic, std::decay_t<T2>::ColsAtCompileTime>;
+  using ret_val_type = Eigen::Matrix<double, Eigen::Dynamic,
+                                     std::decay_t<T2>::ColsAtCompileTime>;
   using ret_type = promote_var_matrix_t<ret_val_type, T1, T2>;
 
   check_multiplicable("mdivide_left_ldlt", "A", A.matrix().val(), "B", B);

--- a/stan/math/rev/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/fun/mdivide_left_ldlt.hpp
@@ -24,20 +24,20 @@ namespace math {
  */
 template <typename T1, typename T2, require_all_matrix_t<T1, T2>* = nullptr,
           require_any_st_var<T1, T2>* = nullptr>
-inline auto mdivide_left_ldlt(LDLT_factor<T1>& A, const T2& B) {
+inline auto mdivide_left_ldlt(LDLT_factor<T1>& A, T2&& B) {
   using ret_val_type
-      = Eigen::Matrix<double, Eigen::Dynamic, T2::ColsAtCompileTime>;
+      = Eigen::Matrix<double, Eigen::Dynamic, std::decay_t<T2>::ColsAtCompileTime>;
   using ret_type = promote_var_matrix_t<ret_val_type, T1, T2>;
 
   check_multiplicable("mdivide_left_ldlt", "A", A.matrix().val(), "B", B);
 
   if (A.matrix().size() == 0) {
-    return ret_type(ret_val_type(0, B.cols()));
+    return arena_t<ret_type>(ret_val_type(0, B.cols()));
   }
 
-  if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T2>> arena_B = B;
-    arena_t<promote_scalar_t<var, T1>> arena_A = A.matrix();
+  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+    arena_t<T2> arena_B = std::forward<T2>(B);
+    arena_t<T1> arena_A = A.matrix();
     arena_t<ret_type> res = A.ldlt().solve(arena_B.val());
     const auto* ldlt_ptr = make_chainable_ptr(A.ldlt());
 
@@ -48,19 +48,19 @@ inline auto mdivide_left_ldlt(LDLT_factor<T1>& A, const T2& B) {
       arena_B.adj() += adjB;
     });
 
-    return ret_type(res);
-  } else if (!is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_A = A.matrix();
-    arena_t<ret_type> res = A.ldlt().solve(value_of(B));
+    return res;
+  } else if constexpr (!is_constant_v<T1>) {
+    arena_t<T1> arena_A = A.matrix();
+    arena_t<ret_type> res = A.ldlt().solve(std::forward<T2>(B));
     const auto* ldlt_ptr = make_chainable_ptr(A.ldlt());
 
     reverse_pass_callback([arena_A, ldlt_ptr, res]() mutable {
       arena_A.adj() -= ldlt_ptr->solve(res.adj()) * res.val_op().transpose();
     });
 
-    return ret_type(res);
+    return res;
   } else {
-    arena_t<promote_scalar_t<var, T2>> arena_B = B;
+    arena_t<T2> arena_B = std::forward<T2>(B);
     arena_t<ret_type> res = A.ldlt().solve(arena_B.val());
     const auto* ldlt_ptr = make_chainable_ptr(A.ldlt());
 
@@ -68,7 +68,7 @@ inline auto mdivide_left_ldlt(LDLT_factor<T1>& A, const T2& B) {
       arena_B.adj() += ldlt_ptr->solve(res.adj());
     });
 
-    return ret_type(res);
+    return res;
   }
 }
 

--- a/stan/math/rev/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/fun/mdivide_left_spd.hpp
@@ -268,7 +268,7 @@ inline auto mdivide_left_spd(T1 &&A, T2 &&B) {
 
   check_multiplicable("mdivide_left_spd", "A", A, "B", B);
 
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     arena_t<T1> arena_A = std::forward<T1>(A);
     arena_t<T2> arena_B = std::forward<T2>(B);
 
@@ -298,7 +298,7 @@ inline auto mdivide_left_spd(T1 &&A, T2 &&B) {
     });
 
     return res;
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     arena_t<T1> arena_A = std::forward<T1>(A);
 
     check_symmetric("mdivide_left_spd", "A", arena_A.val());

--- a/stan/math/rev/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/fun/mdivide_left_spd.hpp
@@ -26,9 +26,9 @@ namespace math {
  * @throws std::domain_error if A is not square or B does not have
  * as many rows as A has columns.
  */
-template <typename T1, typename T2, require_all_matrix_t<T1, T2> * = nullptr,
-  require_any_st_var<T1, T2>* = nullptr>
-inline auto mdivide_left_spd(T1 &&A, T2 &&B) {
+template <typename T1, typename T2, require_all_matrix_t<T1, T2>* = nullptr,
+          require_any_st_var<T1, T2>* = nullptr>
+inline auto mdivide_left_spd(T1&& A, T2&& B) {
   using ret_val_type = plain_type_t<decltype(value_of(A) * value_of(B))>;
   using ret_type = return_var_matrix_t<ret_val_type, T1, T2>;
   if (A.size() == 0) {

--- a/stan/math/rev/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/fun/mdivide_left_spd.hpp
@@ -258,7 +258,7 @@ mdivide_left_spd(const EigMat1 &A, const EigMat2 &b) {
  */
 template <typename T1, typename T2, require_all_matrix_t<T1, T2> * = nullptr,
           require_any_var_matrix_t<T1, T2> * = nullptr>
-inline auto mdivide_left_spd(T1&& A, T2&& B) {
+inline auto mdivide_left_spd(T1 &&A, T2 &&B) {
   using ret_val_type = plain_type_t<decltype(value_of(A) * value_of(B))>;
   using ret_type = var_value<ret_val_type>;
 
@@ -284,7 +284,9 @@ inline auto mdivide_left_spd(T1&& A, T2&& B) {
 
     reverse_pass_callback([arena_A, arena_B, arena_A_llt, res]() mutable {
       using T2_t = std::decay_t<T2>;
-      arena_t<Eigen::Matrix<double, T2_t::RowsAtCompileTime, T2_t::ColsAtCompileTime>> adjB = res.adj().eval();
+      arena_t<Eigen::Matrix<double, T2_t::RowsAtCompileTime,
+                            T2_t::ColsAtCompileTime>>
+          adjB = res.adj().eval();
 
       arena_A_llt.template triangularView<Eigen::Lower>().solveInPlace(adjB);
       arena_A_llt.template triangularView<Eigen::Lower>()
@@ -311,7 +313,9 @@ inline auto mdivide_left_spd(T1&& A, T2&& B) {
 
     reverse_pass_callback([arena_A, arena_A_llt, res]() mutable {
       using T2_t = std::decay_t<T2>;
-      arena_t<Eigen::Matrix<double, T2_t::RowsAtCompileTime, T2_t::ColsAtCompileTime>> adjB = res.adj().eval();
+      arena_t<Eigen::Matrix<double, T2_t::RowsAtCompileTime,
+                            T2_t::ColsAtCompileTime>>
+          adjB = res.adj().eval();
 
       arena_A_llt.template triangularView<Eigen::Lower>().solveInPlace(adjB);
       arena_A_llt.template triangularView<Eigen::Lower>()
@@ -338,7 +342,9 @@ inline auto mdivide_left_spd(T1&& A, T2&& B) {
 
     reverse_pass_callback([arena_B, arena_A_llt, res]() mutable {
       using T2_t = std::decay_t<T2>;
-      arena_t<Eigen::Matrix<double, T2_t::RowsAtCompileTime, T2_t::ColsAtCompileTime>> adjB =res.adj().eval();
+      arena_t<Eigen::Matrix<double, T2_t::RowsAtCompileTime,
+                            T2_t::ColsAtCompileTime>>
+          adjB = res.adj().eval();
 
       arena_A_llt.template triangularView<Eigen::Lower>().solveInPlace(adjB);
       arena_A_llt.template triangularView<Eigen::Lower>()

--- a/stan/math/rev/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/fun/mdivide_left_spd.hpp
@@ -12,240 +12,10 @@
 
 namespace stan {
 namespace math {
-namespace internal {
-
-template <int R1, int C1, int R2, int C2>
-class mdivide_left_spd_alloc : public chainable_alloc {
- public:
-  virtual ~mdivide_left_spd_alloc() {}
-
-  Eigen::LLT<Eigen::Matrix<double, R1, C1>> llt_;
-  Eigen::Matrix<double, R2, C2> C_;
-};
-
-template <int R1, int C1, int R2, int C2>
-class mdivide_left_spd_vv_vari : public vari {
- public:
-  int M_;  // A.rows() = A.cols() = B.rows()
-  int N_;  // B.cols()
-  vari **variRefA_;
-  vari **variRefB_;
-  vari **variRefC_;
-  mdivide_left_spd_alloc<R1, C1, R2, C2> *alloc_;
-
-  mdivide_left_spd_vv_vari(const Eigen::Matrix<var, R1, C1> &A,
-                           const Eigen::Matrix<var, R2, C2> &B)
-      : vari(0.0),
-        M_(A.rows()),
-        N_(B.cols()),
-        variRefA_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * A.rows()
-                                                       * A.cols()))),
-        variRefB_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
-                                                       * B.cols()))),
-        variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
-                                                       * B.cols()))),
-        alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
-    Eigen::Map<matrix_vi>(variRefA_, M_, M_) = A.vi();
-    Eigen::Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
-    alloc_->C_ = B.val();
-    alloc_->llt_ = A.val().llt();
-    check_pos_definite("mdivide_left_spd", "A", alloc_->llt_);
-    alloc_->llt_.solveInPlace(alloc_->C_);
-
-    Eigen::Map<matrix_vi>(variRefC_, M_, N_)
-        = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
-  }
-
-  virtual void chain() {
-    matrix_d adjB = Eigen::Map<matrix_vi>(variRefC_, M_, N_).adj();
-    alloc_->llt_.solveInPlace(adjB);
-    Eigen::Map<matrix_vi>(variRefA_, M_, M_).adj()
-        -= adjB * alloc_->C_.transpose();
-    Eigen::Map<matrix_vi>(variRefB_, M_, N_).adj() += adjB;
-  }
-};
-
-template <int R1, int C1, int R2, int C2>
-class mdivide_left_spd_dv_vari : public vari {
- public:
-  int M_;  // A.rows() = A.cols() = B.rows()
-  int N_;  // B.cols()
-  vari **variRefB_;
-  vari **variRefC_;
-  mdivide_left_spd_alloc<R1, C1, R2, C2> *alloc_;
-
-  mdivide_left_spd_dv_vari(const Eigen::Matrix<double, R1, C1> &A,
-                           const Eigen::Matrix<var, R2, C2> &B)
-      : vari(0.0),
-        M_(A.rows()),
-        N_(B.cols()),
-        variRefB_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
-                                                       * B.cols()))),
-        variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
-                                                       * B.cols()))),
-        alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
-    alloc_->C_ = B.val();
-    Eigen::Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
-    alloc_->llt_ = A.llt();
-    check_pos_definite("mdivide_left_spd", "A", alloc_->llt_);
-    alloc_->llt_.solveInPlace(alloc_->C_);
-
-    Eigen::Map<matrix_vi>(variRefC_, M_, N_)
-        = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
-  }
-
-  virtual void chain() {
-    matrix_d adjB = Eigen::Map<matrix_vi>(variRefC_, M_, N_).adj();
-    alloc_->llt_.solveInPlace(adjB);
-    Eigen::Map<matrix_vi>(variRefB_, M_, N_).adj() += adjB;
-  }
-};
-
-template <int R1, int C1, int R2, int C2>
-class mdivide_left_spd_vd_vari : public vari {
- public:
-  int M_;  // A.rows() = A.cols() = B.rows()
-  int N_;  // B.cols()
-  vari **variRefA_;
-  vari **variRefC_;
-  mdivide_left_spd_alloc<R1, C1, R2, C2> *alloc_;
-
-  mdivide_left_spd_vd_vari(const Eigen::Matrix<var, R1, C1> &A,
-                           const Eigen::Matrix<double, R2, C2> &B)
-      : vari(0.0),
-        M_(A.rows()),
-        N_(B.cols()),
-        variRefA_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * A.rows()
-                                                       * A.cols()))),
-        variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
-                                                       * B.cols()))),
-        alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
-    Eigen::Map<matrix_vi>(variRefA_, M_, M_) = A.vi();
-    alloc_->llt_ = A.val().llt();
-    check_pos_definite("mdivide_left_spd", "A", alloc_->llt_);
-    alloc_->C_ = alloc_->llt_.solve(B);
-
-    Eigen::Map<matrix_vi>(variRefC_, M_, N_)
-        = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
-  }
-
-  virtual void chain() {
-    matrix_d adjC = Eigen::Map<matrix_vi>(variRefC_, M_, N_).adj();
-    Eigen::Map<matrix_vi>(variRefA_, M_, M_).adj()
-        -= alloc_->llt_.solve(adjC * alloc_->C_.transpose());
-  }
-};
-}  // namespace internal
-
-template <
-    typename EigMat1, typename EigMat2,
-    require_all_eigen_matrix_base_vt<is_var, EigMat1, EigMat2> * = nullptr>
-inline Eigen::Matrix<var, EigMat1::RowsAtCompileTime,
-                     EigMat2::ColsAtCompileTime>
-mdivide_left_spd(const EigMat1 &A, const EigMat2 &b) {
-  constexpr int R1 = EigMat1::RowsAtCompileTime;
-  constexpr int C1 = EigMat1::ColsAtCompileTime;
-  constexpr int R2 = EigMat2::RowsAtCompileTime;
-  constexpr int C2 = EigMat2::ColsAtCompileTime;
-  static constexpr const char *function = "mdivide_left_spd";
-  check_multiplicable(function, "A", A, "b", b);
-  const auto &A_ref = to_ref(A);
-  check_symmetric(function, "A", A_ref);
-  check_not_nan(function, "A", A_ref);
-  if (A.size() == 0) {
-    return {0, b.cols()};
-  }
-
-  // NOTE: this is not a memory leak, this vari is used in the
-  // expression graph to evaluate the adjoint, but is not needed
-  // for the returned matrix.  Memory will be cleaned up with the
-  // arena allocator.
-  internal::mdivide_left_spd_vv_vari<R1, C1, R2, C2> *baseVari
-      = new internal::mdivide_left_spd_vv_vari<R1, C1, R2, C2>(A_ref, b);
-
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-  res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
-  return res;
-}
-
-template <typename EigMat1, typename EigMat2,
-          require_eigen_matrix_base_vt<is_var, EigMat1> * = nullptr,
-          require_eigen_matrix_base_vt<std::is_arithmetic, EigMat2> * = nullptr>
-inline Eigen::Matrix<var, EigMat1::RowsAtCompileTime,
-                     EigMat2::ColsAtCompileTime>
-mdivide_left_spd(const EigMat1 &A, const EigMat2 &b) {
-  constexpr int R1 = EigMat1::RowsAtCompileTime;
-  constexpr int C1 = EigMat1::ColsAtCompileTime;
-  constexpr int R2 = EigMat2::RowsAtCompileTime;
-  constexpr int C2 = EigMat2::ColsAtCompileTime;
-  static constexpr const char *function = "mdivide_left_spd";
-  check_multiplicable(function, "A", A, "b", b);
-  const auto &A_ref = to_ref(A);
-  check_symmetric(function, "A", A_ref);
-  check_not_nan(function, "A", A_ref);
-  if (A.size() == 0) {
-    return {0, b.cols()};
-  }
-
-  // NOTE: this is not a memory leak, this vari is used in the
-  // expression graph to evaluate the adjoint, but is not needed
-  // for the returned matrix.  Memory will be cleaned up with the
-  // arena allocator.
-  internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2> *baseVari
-      = new internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2>(A_ref, b);
-
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-  res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
-  return res;
-}
-
-template <typename EigMat1, typename EigMat2,
-          require_eigen_matrix_base_vt<std::is_arithmetic, EigMat1> * = nullptr,
-          require_eigen_matrix_base_vt<is_var, EigMat2> * = nullptr>
-inline Eigen::Matrix<var, EigMat1::RowsAtCompileTime,
-                     EigMat2::ColsAtCompileTime>
-mdivide_left_spd(const EigMat1 &A, const EigMat2 &b) {
-  constexpr int R1 = EigMat1::RowsAtCompileTime;
-  constexpr int C1 = EigMat1::ColsAtCompileTime;
-  constexpr int R2 = EigMat2::RowsAtCompileTime;
-  constexpr int C2 = EigMat2::ColsAtCompileTime;
-  static constexpr const char *function = "mdivide_left_spd";
-  check_multiplicable(function, "A", A, "b", b);
-  const auto &A_ref = to_ref(A);
-  check_symmetric(function, "A", A_ref);
-  check_not_nan(function, "A", A_ref);
-  if (A.size() == 0) {
-    return {0, b.cols()};
-  }
-
-  // NOTE: this is not a memory leak, this vari is used in the
-  // expression graph to evaluate the adjoint, but is not needed
-  // for the returned matrix.  Memory will be cleaned up with the
-  // arena allocator.
-  internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2> *baseVari
-      = new internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2>(A_ref, b);
-
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-  res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
-
-  return res;
-}
-
 /**
  * Returns the solution of the system Ax=B where A is symmetric positive
  * definite.
  *
- * This overload handles arguments where one of T1 or T2 are
- * `var_value<T>` where `T` is an Eigen type. The other type can
- * also be a `var_value` or it can be a matrix type that inherits
- * from EigenBase
  *
  * @tparam T1 type of the first matrix
  * @tparam T2 type of the right-hand side matrix or vector
@@ -257,37 +27,25 @@ mdivide_left_spd(const EigMat1 &A, const EigMat2 &b) {
  * as many rows as A has columns.
  */
 template <typename T1, typename T2, require_all_matrix_t<T1, T2> * = nullptr,
-          require_any_var_matrix_t<T1, T2> * = nullptr>
+  require_any_st_var<T1, T2>* = nullptr>
 inline auto mdivide_left_spd(T1 &&A, T2 &&B) {
   using ret_val_type = plain_type_t<decltype(value_of(A) * value_of(B))>;
-  using ret_type = var_value<ret_val_type>;
-
+  using ret_type = return_var_matrix_t<ret_val_type, T1, T2>;
   if (A.size() == 0) {
     return arena_t<ret_type>(ret_val_type(0, B.cols()));
   }
-
   check_multiplicable("mdivide_left_spd", "A", A, "B", B);
-
   if constexpr (is_autodiffable_v<T1, T2>) {
     arena_t<T1> arena_A = std::forward<T1>(A);
-    arena_t<T2> arena_B = std::forward<T2>(B);
-
     check_symmetric("mdivide_left_spd", "A", arena_A.val());
     check_not_nan("mdivide_left_spd", "A", arena_A.val());
-
     auto A_llt = arena_A.val().llt();
-
     check_pos_definite("mdivide_left_spd", "A", A_llt);
-
     arena_t<Eigen::MatrixXd> arena_A_llt = A_llt.matrixL();
+    arena_t<T2> arena_B = std::forward<T2>(B);
     arena_t<ret_type> res = A_llt.solve(arena_B.val());
-
     reverse_pass_callback([arena_A, arena_B, arena_A_llt, res]() mutable {
-      using T2_t = std::decay_t<T2>;
-      arena_t<Eigen::Matrix<double, T2_t::RowsAtCompileTime,
-                            T2_t::ColsAtCompileTime>>
-          adjB = res.adj().eval();
-
+      arena_t<decltype(res.adj().eval())> adjB = res.adj().eval();
       arena_A_llt.template triangularView<Eigen::Lower>().solveInPlace(adjB);
       arena_A_llt.template triangularView<Eigen::Lower>()
           .transpose()
@@ -296,27 +54,17 @@ inline auto mdivide_left_spd(T1 &&A, T2 &&B) {
       arena_A.adj() -= adjB * res.val_op().transpose();
       arena_B.adj() += adjB;
     });
-
     return res;
   } else if constexpr (is_autodiffable_v<T1>) {
     arena_t<T1> arena_A = std::forward<T1>(A);
-
     check_symmetric("mdivide_left_spd", "A", arena_A.val());
     check_not_nan("mdivide_left_spd", "A", arena_A.val());
-
     auto A_llt = arena_A.val().llt();
-
     check_pos_definite("mdivide_left_spd", "A", A_llt);
-
     arena_t<Eigen::MatrixXd> arena_A_llt = A_llt.matrixL();
-    arena_t<ret_type> res = A_llt.solve(value_of(B));
-
+    arena_t<ret_type> res = A_llt.solve(B);
     reverse_pass_callback([arena_A, arena_A_llt, res]() mutable {
-      using T2_t = std::decay_t<T2>;
-      arena_t<Eigen::Matrix<double, T2_t::RowsAtCompileTime,
-                            T2_t::ColsAtCompileTime>>
-          adjB = res.adj().eval();
-
+      arena_t<decltype(res.adj().eval())> adjB = res.adj().eval();
       arena_A_llt.template triangularView<Eigen::Lower>().solveInPlace(adjB);
       arena_A_llt.template triangularView<Eigen::Lower>()
           .transpose()
@@ -324,36 +72,24 @@ inline auto mdivide_left_spd(T1 &&A, T2 &&B) {
 
       arena_A.adj() -= adjB * res.val().transpose().eval();
     });
-
     return res;
   } else {
-    const auto &A_ref = to_ref(value_of(A));
-    arena_t<T2> arena_B = std::forward<T2>(B);
-
+    auto&& A_ref = to_ref(A);
     check_symmetric("mdivide_left_spd", "A", A_ref);
     check_not_nan("mdivide_left_spd", "A", A_ref);
-
     auto A_llt = A_ref.llt();
-
     check_pos_definite("mdivide_left_spd", "A", A_llt);
-
     arena_t<Eigen::MatrixXd> arena_A_llt = A_llt.matrixL();
+    arena_t<T2> arena_B = std::forward<T2>(B);
     arena_t<ret_type> res = A_llt.solve(arena_B.val());
-
     reverse_pass_callback([arena_B, arena_A_llt, res]() mutable {
-      using T2_t = std::decay_t<T2>;
-      arena_t<Eigen::Matrix<double, T2_t::RowsAtCompileTime,
-                            T2_t::ColsAtCompileTime>>
-          adjB = res.adj().eval();
-
+      arena_t<decltype(res.adj().eval())> adjB = res.adj().eval();
       arena_A_llt.template triangularView<Eigen::Lower>().solveInPlace(adjB);
       arena_A_llt.template triangularView<Eigen::Lower>()
           .transpose()
           .solveInPlace(adjB);
-
       arena_B.adj() += adjB;
     });
-
     return res;
   }
 }

--- a/stan/math/rev/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/fun/mdivide_left_tri.hpp
@@ -11,322 +11,9 @@
 namespace stan {
 namespace math {
 
-namespace internal {
-
-template <Eigen::UpLoType TriView, int R1, int C1, int R2, int C2>
-class mdivide_left_tri_vv_vari : public vari {
- public:
-  int M_;  // A.rows() = A.cols() = B.rows()
-  int N_;  // B.cols()
-  double *A_;
-  double *C_;
-  vari **variRefA_;
-  vari **variRefB_;
-  vari **variRefC_;
-
-  mdivide_left_tri_vv_vari(const Eigen::Matrix<var, R1, C1> &A,
-                           const Eigen::Matrix<var, R2, C2> &B)
-      : vari(0.0),
-        M_(A.rows()),
-        N_(B.cols()),
-        A_(reinterpret_cast<double *>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * A.rows()
-                                                       * A.cols()))),
-        C_(reinterpret_cast<double *>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * B.rows()
-                                                       * B.cols()))),
-        variRefA_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * A.rows()
-                                                       * (A.rows() + 1) / 2))),
-        variRefB_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
-                                                       * B.cols()))),
-        variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
-                                                       * B.cols()))) {
-    using Eigen::Map;
-
-    size_t pos = 0;
-    if (TriView == Eigen::Lower) {
-      for (size_type j = 0; j < M_; j++) {
-        for (size_type i = j; i < M_; i++) {
-          variRefA_[pos++] = A(i, j).vi_;
-        }
-      }
-    } else if (TriView == Eigen::Upper) {
-      for (size_type j = 0; j < M_; j++) {
-        for (size_type i = 0; i < j + 1; i++) {
-          variRefA_[pos++] = A(i, j).vi_;
-        }
-      }
-    }
-
-    Map<matrix_d> c_map(C_, M_, N_);
-    Map<matrix_d> a_map(A_, M_, M_);
-    a_map = A.val();
-    c_map = B.val();
-    Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
-
-    c_map = a_map.template triangularView<TriView>().solve(c_map);
-
-    Map<matrix_vi>(variRefC_, M_, N_)
-        = c_map.unaryExpr([](double x) { return new vari(x, false); });
-  }
-
-  virtual void chain() {
-    using Eigen::Map;
-    matrix_d adjA;
-    matrix_d adjB;
-
-    adjB = Map<matrix_d>(A_, M_, M_)
-               .template triangularView<TriView>()
-               .transpose()
-               .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
-    adjA = -adjB * Map<matrix_d>(C_, M_, N_).transpose();
-
-    size_t pos = 0;
-    if (TriView == Eigen::Lower) {
-      for (size_type j = 0; j < adjA.cols(); j++) {
-        for (size_type i = j; i < adjA.rows(); i++) {
-          variRefA_[pos++]->adj_ += adjA(i, j);
-        }
-      }
-    } else if (TriView == Eigen::Upper) {
-      for (size_type j = 0; j < adjA.cols(); j++) {
-        for (size_type i = 0; i < j + 1; i++) {
-          variRefA_[pos++]->adj_ += adjA(i, j);
-        }
-      }
-    }
-    Map<matrix_vi>(variRefB_, M_, N_).adj() += adjB;
-  }
-};
-
-template <Eigen::UpLoType TriView, int R1, int C1, int R2, int C2>
-class mdivide_left_tri_dv_vari : public vari {
- public:
-  int M_;  // A.rows() = A.cols() = B.rows()
-  int N_;  // B.cols()
-  double *A_;
-  double *C_;
-  vari **variRefB_;
-  vari **variRefC_;
-
-  mdivide_left_tri_dv_vari(const Eigen::Matrix<double, R1, C1> &A,
-                           const Eigen::Matrix<var, R2, C2> &B)
-      : vari(0.0),
-        M_(A.rows()),
-        N_(B.cols()),
-        A_(reinterpret_cast<double *>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * A.rows()
-                                                       * A.cols()))),
-        C_(reinterpret_cast<double *>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * B.rows()
-                                                       * B.cols()))),
-        variRefB_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
-                                                       * B.cols()))),
-        variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
-                                                       * B.cols()))) {
-    using Eigen::Map;
-
-    Map<matrix_d>(A_, M_, M_) = A;
-    Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
-    Map<matrix_d> c_map(C_, M_, N_);
-    c_map = B.val();
-
-    c_map = Map<matrix_d>(A_, M_, M_)
-                .template triangularView<TriView>()
-                .solve(c_map);
-
-    Map<matrix_vi>(variRefC_, M_, N_)
-        = c_map.unaryExpr([](double x) { return new vari(x, false); });
-  }
-
-  virtual void chain() {
-    using Eigen::Map;
-
-    Map<matrix_vi>(variRefB_, M_, N_).adj()
-        += Map<matrix_d>(A_, M_, M_)
-               .template triangularView<TriView>()
-               .transpose()
-               .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
-  }
-};
-
-template <Eigen::UpLoType TriView, int R1, int C1, int R2, int C2>
-class mdivide_left_tri_vd_vari : public vari {
- public:
-  int M_;  // A.rows() = A.cols() = B.rows()
-  int N_;  // B.cols()
-  double *A_;
-  double *C_;
-  vari **variRefA_;
-  vari **variRefC_;
-
-  mdivide_left_tri_vd_vari(const Eigen::Matrix<var, R1, C1> &A,
-                           const Eigen::Matrix<double, R2, C2> &B)
-      : vari(0.0),
-        M_(A.rows()),
-        N_(B.cols()),
-        A_(reinterpret_cast<double *>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * A.rows()
-                                                       * A.cols()))),
-        C_(reinterpret_cast<double *>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * B.rows()
-                                                       * B.cols()))),
-        variRefA_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * A.rows()
-                                                       * (A.rows() + 1) / 2))),
-        variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
-                                                       * B.cols()))) {
-    using Eigen::Map;
-    using Eigen::Matrix;
-
-    size_t pos = 0;
-    if (TriView == Eigen::Lower) {
-      for (size_type j = 0; j < M_; j++) {
-        for (size_type i = j; i < M_; i++) {
-          variRefA_[pos++] = A(i, j).vi_;
-        }
-      }
-    } else if (TriView == Eigen::Upper) {
-      for (size_type j = 0; j < M_; j++) {
-        for (size_type i = 0; i < j + 1; i++) {
-          variRefA_[pos++] = A(i, j).vi_;
-        }
-      }
-    }
-    Map<matrix_d> Ad(A_, M_, M_);
-    Map<matrix_d> Cd(C_, M_, N_);
-    Ad = A.val();
-
-    Cd = Ad.template triangularView<TriView>().solve(B);
-
-    Map<matrix_vi>(variRefC_, M_, N_)
-        = Cd.unaryExpr([](double x) { return new vari(x, false); });
-  }
-
-  virtual void chain() {
-    using Eigen::Map;
-    using Eigen::Matrix;
-    Matrix<double, R1, C1> adjA(M_, M_);
-    Matrix<double, R1, C2> adjC(M_, N_);
-
-    adjC = Map<matrix_vi>(variRefC_, M_, N_).adj();
-
-    adjA.noalias()
-        = -Map<Matrix<double, R1, C1>>(A_, M_, M_)
-               .template triangularView<TriView>()
-               .transpose()
-               .solve(adjC
-                      * Map<Matrix<double, R1, C2>>(C_, M_, N_).transpose());
-
-    size_t pos = 0;
-    if (TriView == Eigen::Lower) {
-      for (size_type j = 0; j < adjA.cols(); j++) {
-        for (size_type i = j; i < adjA.rows(); i++) {
-          variRefA_[pos++]->adj_ += adjA(i, j);
-        }
-      }
-    } else if (TriView == Eigen::Upper) {
-      for (size_type j = 0; j < adjA.cols(); j++) {
-        for (size_type i = 0; i < j + 1; i++) {
-          variRefA_[pos++]->adj_ += adjA(i, j);
-        }
-      }
-    }
-  }
-};
-}  // namespace internal
-
-template <Eigen::UpLoType TriView, typename T1, typename T2,
-          require_all_eigen_vt<is_var, T1, T2> * = nullptr>
-inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
-mdivide_left_tri(const T1 &A, const T2 &b) {
-  check_square("mdivide_left_tri", "A", A);
-  check_multiplicable("mdivide_left_tri", "A", A, "b", b);
-  if (A.rows() == 0) {
-    return {0, b.cols()};
-  }
-
-  // NOTE: this is not a memory leak, this vari is used in the
-  // expression graph to evaluate the adjoint, but is not needed
-  // for the returned matrix.  Memory will be cleaned up with the
-  // arena allocator.
-  auto *baseVari = new internal::mdivide_left_tri_vv_vari<
-      TriView, T1::RowsAtCompileTime, T1::ColsAtCompileTime,
-      T2::RowsAtCompileTime, T2::ColsAtCompileTime>(A, b);
-
-  Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime> res(
-      b.rows(), b.cols());
-  res.vi()
-      = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]), b.rows(), b.cols());
-
-  return res;
-}
-template <Eigen::UpLoType TriView, typename T1, typename T2,
-          require_eigen_vt<std::is_arithmetic, T1> * = nullptr,
-          require_eigen_vt<is_var, T2> * = nullptr>
-inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
-mdivide_left_tri(const T1 &A, const T2 &b) {
-  check_square("mdivide_left_tri", "A", A);
-  check_multiplicable("mdivide_left_tri", "A", A, "b", b);
-  if (A.rows() == 0) {
-    return {0, b.cols()};
-  }
-
-  // NOTE: this is not a memory leak, this vari is used in the
-  // expression graph to evaluate the adjoint, but is not needed
-  // for the returned matrix.  Memory will be cleaned up with the
-  // arena allocator.
-  auto *baseVari = new internal::mdivide_left_tri_dv_vari<
-      TriView, T1::RowsAtCompileTime, T1::ColsAtCompileTime,
-      T2::RowsAtCompileTime, T2::ColsAtCompileTime>(A, b);
-
-  Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime> res(
-      b.rows(), b.cols());
-  res.vi()
-      = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]), b.rows(), b.cols());
-
-  return res;
-}
-template <Eigen::UpLoType TriView, typename T1, typename T2,
-          require_eigen_vt<is_var, T1> * = nullptr,
-          require_eigen_vt<std::is_arithmetic, T2> * = nullptr>
-inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
-mdivide_left_tri(const T1 &A, const T2 &b) {
-  check_square("mdivide_left_tri", "A", A);
-  check_multiplicable("mdivide_left_tri", "A", A, "b", b);
-  if (A.rows() == 0) {
-    return {0, b.cols()};
-  }
-
-  // NOTE: this is not a memory leak, this vari is used in the
-  // expression graph to evaluate the adjoint, but is not needed
-  // for the returned matrix.  Memory will be cleaned up with the
-  // arena allocator.
-  auto *baseVari = new internal::mdivide_left_tri_vd_vari<
-      TriView, T1::RowsAtCompileTime, T1::ColsAtCompileTime,
-      T2::RowsAtCompileTime, T2::ColsAtCompileTime>(A, b);
-
-  Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime> res(
-      b.rows(), b.cols());
-  res.vi()
-      = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]), b.rows(), b.cols());
-
-  return res;
-}
-
 /**
  * Returns the solution of the system Ax=B when A is triangular.
  *
- * This overload handles arguments where one of T1 or T2 are
- * `var_value<T>` where `T` is an Eigen type. The other type can
- * also be a `var_value` or it can be a matrix type that inherits
- * from EigenBase
  *
  * @tparam TriView Specifies whether A is upper (Eigen::Upper)
  * or lower triangular (Eigen::Lower).
@@ -341,11 +28,10 @@ mdivide_left_tri(const T1 &A, const T2 &b) {
  */
 template <Eigen::UpLoType TriView, typename T1, typename T2,
           require_all_matrix_t<T1, T2> * = nullptr,
-          require_any_var_matrix_t<T1, T2> * = nullptr>
-inline auto mdivide_left_tri(const T1 &A, const T2 &B) {
+          require_any_st_var<T1, T2>* = nullptr>
+inline auto mdivide_left_tri(T1&& A, T2&& B) {
   using ret_val_type = plain_type_t<decltype(value_of(A) * value_of(B))>;
-  using ret_type = var_value<ret_val_type>;
-
+  using ret_type = return_var_matrix_t<ret_val_type, T1, T2>;
   if (A.size() == 0) {
     return arena_t<ret_type>(ret_val_type(0, B.cols()));
   }
@@ -353,57 +39,39 @@ inline auto mdivide_left_tri(const T1 &A, const T2 &B) {
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "B", B);
 
+  arena_t<T1> arena_A = std::forward<T1>(A);
   if constexpr (is_autodiffable_v<T1, T2>) {
-    arena_t<T1> arena_A = A;
-    arena_t<T2> arena_B = B;
+    arena_t<T2> arena_B = std::forward<T2>(B);
     auto arena_A_val = to_arena(arena_A.val());
-
     arena_t<ret_type> res
         = arena_A_val.template triangularView<TriView>().solve(arena_B.val());
-
     reverse_pass_callback([arena_A, arena_B, arena_A_val, res]() mutable {
-      promote_scalar_t<double, T2> adjB
+      arena_t<promote_scalar_t<double, T2>> adjB
           = arena_A_val.template triangularView<TriView>().transpose().solve(
               res.adj());
-
       arena_B.adj() += adjB;
       arena_A.adj() -= (adjB * res.val().transpose().eval())
                            .template triangularView<TriView>();
     });
-
     return res;
   } else if constexpr (is_autodiffable_v<T1>) {
-    arena_t<T1> arena_A = A;
-    auto arena_A_val = to_arena(arena_A.val());
-
+    auto arena_A_val = to_arena(std::forward<T1>(A).val());
     arena_t<ret_type> res
         = arena_A_val.template triangularView<TriView>().solve(B);
-
     reverse_pass_callback([arena_A, arena_A_val, res]() mutable {
-      promote_scalar_t<double, T2> adjB
-          = arena_A_val.template triangularView<TriView>().transpose().solve(
-              res.adj());
-
-      arena_A.adj() -= (adjB * res.val().transpose().eval())
+      arena_A.adj() -= (arena_A_val.template triangularView<TriView>().transpose().solve(
+              res.adj()) * res.val().transpose().eval())
                            .template triangularView<TriView>();
     });
-
     return res;
   } else {
-    arena_t<T1> arena_A = A;
-    arena_t<T2> arena_B = B;
-
+    arena_t<T2> arena_B = std::forward<T2>(B);
     arena_t<ret_type> res
         = arena_A.template triangularView<TriView>().solve(arena_B.val());
-
     reverse_pass_callback([arena_A, arena_B, res]() mutable {
-      promote_scalar_t<double, T2> adjB
-          = arena_A.template triangularView<TriView>().transpose().solve(
+      arena_B.adj() += arena_A.template triangularView<TriView>().transpose().solve(
               res.adj());
-
-      arena_B.adj() += adjB;
     });
-
     return res;
   }
 }

--- a/stan/math/rev/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/fun/mdivide_left_tri.hpp
@@ -27,7 +27,7 @@ namespace math {
  * as many rows as A has columns.
  */
 template <Eigen::UpLoType TriView, typename T1, typename T2,
-          require_all_matrix_t<T1, T2> * = nullptr,
+          require_all_matrix_t<T1, T2>* = nullptr,
           require_any_st_var<T1, T2>* = nullptr>
 inline auto mdivide_left_tri(T1&& A, T2&& B) {
   using ret_val_type = plain_type_t<decltype(value_of(A) * value_of(B))>;
@@ -59,9 +59,11 @@ inline auto mdivide_left_tri(T1&& A, T2&& B) {
     arena_t<ret_type> res
         = arena_A_val.template triangularView<TriView>().solve(B);
     reverse_pass_callback([arena_A, arena_A_val, res]() mutable {
-      arena_A.adj() -= (arena_A_val.template triangularView<TriView>().transpose().solve(
-              res.adj()) * res.val().transpose().eval())
-                           .template triangularView<TriView>();
+      arena_A.adj()
+          -= (arena_A_val.template triangularView<TriView>().transpose().solve(
+                  res.adj())
+              * res.val().transpose().eval())
+                 .template triangularView<TriView>();
     });
     return res;
   } else {
@@ -69,7 +71,8 @@ inline auto mdivide_left_tri(T1&& A, T2&& B) {
     arena_t<ret_type> res
         = arena_A.template triangularView<TriView>().solve(arena_B.val());
     reverse_pass_callback([arena_A, arena_B, res]() mutable {
-      arena_B.adj() += arena_A.template triangularView<TriView>().transpose().solve(
+      arena_B.adj()
+          += arena_A.template triangularView<TriView>().transpose().solve(
               res.adj());
     });
     return res;

--- a/stan/math/rev/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/fun/mdivide_left_tri.hpp
@@ -353,7 +353,7 @@ inline auto mdivide_left_tri(const T1 &A, const T2 &B) {
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "B", B);
 
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     arena_t<T1> arena_A = A;
     arena_t<T2> arena_B = B;
     auto arena_A_val = to_arena(arena_A.val());
@@ -372,7 +372,7 @@ inline auto mdivide_left_tri(const T1 &A, const T2 &B) {
     });
 
     return res;
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     arena_t<T1> arena_A = A;
     auto arena_A_val = to_arena(arena_A.val());
 

--- a/stan/math/rev/fun/multiply.hpp
+++ b/stan/math/rev/fun/multiply.hpp
@@ -28,15 +28,14 @@ template <typename T1, typename T2, require_all_matrix_t<T1, T2>* = nullptr,
           require_not_row_and_col_vector_t<T1, T2>* = nullptr>
 inline auto multiply(T1&& A, T2&& B) {
   check_multiplicable("multiply", "A", A, "B", B);
-  if (!is_constant<T2>::value && !is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_A(std::forward<T1>(A));
-    arena_t<promote_scalar_t<var, T2>> arena_B(std::forward<T2>(B));
+  arena_t<T1> arena_A(std::forward<T1>(A));
+  arena_t<T2> arena_B(std::forward<T2>(B));
+  if constexpr (!is_constant_v<T2> && !is_constant_v<T1>) {
     auto arena_A_val = to_arena(arena_A.val());
     auto arena_B_val = to_arena(arena_B.val());
     using return_t
         = return_var_matrix_t<decltype(arena_A_val * arena_B_val), T1, T2>;
     arena_t<return_t> res = arena_A_val * arena_B_val;
-
     reverse_pass_callback(
         [arena_A, arena_B, arena_A_val, arena_B_val, res]() mutable {
           if (is_var_matrix<T1>::value || is_var_matrix<T2>::value) {
@@ -49,9 +48,7 @@ inline auto multiply(T1&& A, T2&& B) {
           }
         });
     return res;
-  } else if (!is_constant<T2>::value) {
-    arena_t<promote_scalar_t<double, T1>> arena_A = value_of(A);
-    arena_t<promote_scalar_t<var, T2>> arena_B(std::forward<T2>(B));
+  } else if constexpr (!is_constant_v<T2>) {
     using return_t
         = return_var_matrix_t<decltype(arena_A * value_of(B).eval()), T1, T2>;
     arena_t<return_t> res = arena_A * arena_B.val_op();
@@ -60,8 +57,6 @@ inline auto multiply(T1&& A, T2&& B) {
     });
     return res;
   } else {
-    arena_t<promote_scalar_t<var, T1>> arena_A(std::forward<T1>(A));
-    arena_t<promote_scalar_t<double, T2>> arena_B = value_of(B);
     using return_t
         = return_var_matrix_t<decltype(value_of(arena_A).eval() * arena_B), T1,
                               T2>;
@@ -87,15 +82,14 @@ inline auto multiply(T1&& A, T2&& B) {
 template <typename T1, typename T2, require_all_matrix_t<T1, T2>* = nullptr,
           require_return_type_t<is_var, T1, T2>* = nullptr,
           require_row_and_col_vector_t<T1, T2>* = nullptr>
-inline var multiply(const T1& A, const T2& B) {
+inline var multiply(T1&& A, T2&& B) {
   check_multiplicable("multiply", "A", A, "B", B);
-  if (!is_constant<T2>::value && !is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_A = A;
-    arena_t<promote_scalar_t<var, T2>> arena_B = B;
-    arena_t<promote_scalar_t<double, T1>> arena_A_val = value_of(arena_A);
-    arena_t<promote_scalar_t<double, T2>> arena_B_val = value_of(arena_B);
+  arena_t<T1> arena_A = std::forward<T1>(A);
+  arena_t<T2> arena_B = std::forward<T2>(B);
+  if constexpr (!is_constant_v<T2> && !is_constant_v<T1>) {
+    auto arena_A_val = to_arena(value_of(arena_A));
+    auto arena_B_val = to_arena(value_of(arena_B));
     var res = arena_A_val.dot(arena_B_val);
-
     reverse_pass_callback(
         [arena_A, arena_B, arena_A_val, arena_B_val, res]() mutable {
           auto res_adj = res.adj();
@@ -103,20 +97,16 @@ inline var multiply(const T1& A, const T2& B) {
           arena_B.adj().array() += arena_A_val.transpose().array() * res_adj;
         });
     return res;
-  } else if (!is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T2>> arena_B = B;
-    arena_t<promote_scalar_t<double, T1>> arena_A_val = value_of(A);
-    var res = arena_A_val.dot(value_of(arena_B));
-    reverse_pass_callback([arena_B, arena_A_val, res]() mutable {
-      arena_B.adj().array() += arena_A_val.transpose().array() * res.adj();
+  } else if constexpr (!is_constant_v<T2>) {
+    var res = arena_A.dot(value_of(arena_B));
+    reverse_pass_callback([arena_B, arena_A, res]() mutable {
+      arena_B.adj().array() += arena_A.transpose().array() * res.adj();
     });
     return res;
   } else {
-    arena_t<promote_scalar_t<var, T1>> arena_A = A;
-    arena_t<promote_scalar_t<double, T2>> arena_B_val = value_of(B);
-    var res = value_of(arena_A).dot(arena_B_val);
-    reverse_pass_callback([arena_A, arena_B_val, res]() mutable {
-      arena_A.adj().array() += res.adj() * arena_B_val.transpose().array();
+    var res = value_of(arena_A).dot(arena_B);
+    reverse_pass_callback([arena_A, arena_B, res]() mutable {
+      arena_A.adj().array() += res.adj() * arena_B.transpose().array();
     });
     return res;
   }
@@ -138,38 +128,32 @@ template <typename T1, typename T2, require_not_matrix_t<T1>* = nullptr,
           require_return_type_t<is_var, T1, T2>* = nullptr,
           require_not_row_and_col_vector_t<T1, T2>* = nullptr>
 inline auto multiply(const T1& a, T2&& B) {
-  if (!is_constant<T2>::value && !is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T2>> arena_B(std::forward<T2>(B));
+  arena_t<T2> arena_B(std::forward<T2>(B));
+  if constexpr (!is_constant_v<T2> && !is_constant_v<T1>) {
     using return_t = return_var_matrix_t<T2, T1, T2>;
-    var av = a;
-    auto a_val = value_of(av);
-    arena_t<return_t> res = a_val * arena_B.val().array();
-    reverse_pass_callback([av, a_val, arena_B, res]() mutable {
+    arena_t<return_t> res = a.val() * arena_B.val().array();
+    reverse_pass_callback([a, arena_B, res]() mutable {
       for (Eigen::Index j = 0; j < res.cols(); ++j) {
         for (Eigen::Index i = 0; i < res.rows(); ++i) {
           const auto res_adj = res.adj().coeffRef(i, j);
-          av.adj() += res_adj * arena_B.val().coeff(i, j);
-          arena_B.adj().coeffRef(i, j) += a_val * res_adj;
+          a.adj() += res_adj * arena_B.val().coeff(i, j);
+          arena_B.adj().coeffRef(i, j) += a.val() * res_adj;
         }
       }
     });
     return res;
-  } else if (!is_constant<T2>::value) {
-    double val_a = value_of(a);
-    arena_t<promote_scalar_t<var, T2>> arena_B(std::forward<T2>(B));
+  } else if constexpr (!is_constant_v<T2>) {
     using return_t = return_var_matrix_t<T2, T1, T2>;
-    arena_t<return_t> res = val_a * arena_B.val().array();
-    reverse_pass_callback([val_a, arena_B, res]() mutable {
-      arena_B.adj().array() += val_a * res.adj().array();
+    arena_t<return_t> res = a * arena_B.val().array();
+    reverse_pass_callback([a, arena_B, res]() mutable {
+      arena_B.adj().array() += a * res.adj().array();
     });
     return res;
-  } else {
-    var av = a;
-    arena_t<promote_scalar_t<double, T2>> arena_B = value_of(B);
+  } else if constexpr (!is_constant_v<T1>) {
     using return_t = return_var_matrix_t<T2, T1, T2>;
-    arena_t<return_t> res = av.val() * arena_B.array();
-    reverse_pass_callback([av, arena_B, res]() mutable {
-      av.adj() += (res.adj().array() * arena_B.array()).sum();
+    arena_t<return_t> res = a.val() * arena_B.array();
+    reverse_pass_callback([a, arena_B, res]() mutable {
+      a.adj() += (res.adj().array() * arena_B.array()).sum();
     });
     return res;
   }

--- a/stan/math/rev/fun/multiply_log.hpp
+++ b/stan/math/rev/fun/multiply_log.hpp
@@ -102,9 +102,9 @@ template <typename T1, typename T2, require_all_matrix_t<T1, T2>* = nullptr,
           require_any_var_matrix_t<T1, T2>* = nullptr>
 inline auto multiply_log(const T1& a, const T2& b) {
   check_matching_dims("multiply_log", "a", a, "b", b);
-  if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_a = a;
-    arena_t<promote_scalar_t<var, T2>> arena_b = b;
+  arena_t<T1> arena_a = a;
+  arena_t<T2> arena_b = b;
+  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
 
     return make_callback_var(
         multiply_log(arena_a.val(), arena_b.val()),
@@ -114,10 +114,7 @@ inline auto multiply_log(const T1& a, const T2& b) {
           arena_b.adj().array() += res.adj().array() * arena_a.val().array()
                                    / arena_b.val().array();
         });
-  } else if (!is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_a = a;
-    arena_t<promote_scalar_t<double, T2>> arena_b = value_of(b);
-
+  } else if constexpr (!is_constant_v<T1>) {
     return make_callback_var(multiply_log(arena_a.val(), arena_b),
                              [arena_a, arena_b](const auto& res) mutable {
                                arena_a.adj().array()
@@ -125,9 +122,6 @@ inline auto multiply_log(const T1& a, const T2& b) {
                                       * arena_b.val().array().log();
                              });
   } else {
-    arena_t<promote_scalar_t<double, T1>> arena_a = value_of(a);
-    arena_t<promote_scalar_t<var, T2>> arena_b = b;
-
     return make_callback_var(multiply_log(arena_a, arena_b.val()),
                              [arena_a, arena_b](const auto& res) mutable {
                                arena_b.adj().array() += res.adj().array()
@@ -151,10 +145,9 @@ template <typename T1, typename T2, require_var_matrix_t<T1>* = nullptr,
 inline auto multiply_log(const T1& a, const T2& b) {
   using std::log;
 
-  if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_a = a;
-    var arena_b = b;
-
+  arena_t<T1> arena_a = a;
+  auto arena_b = b;
+  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
     return make_callback_var(
         multiply_log(arena_a.val(), arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -162,18 +155,13 @@ inline auto multiply_log(const T1& a, const T2& b) {
           arena_b.adj() += (res.adj().array() * arena_a.val().array()).sum()
                            / arena_b.val();
         });
-  } else if (!is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_a = a;
-
-    return make_callback_var(multiply_log(arena_a.val(), value_of(b)),
+  } else if constexpr (!is_constant_v<T1>) {
+    return make_callback_var(multiply_log(arena_a.val(), b),
                              [arena_a, b](const auto& res) mutable {
                                arena_a.adj().array()
-                                   += res.adj().array() * log(value_of(b));
+                                   += res.adj().array() * log(b);
                              });
   } else {
-    arena_t<promote_scalar_t<double, T1>> arena_a = value_of(a);
-    var arena_b = b;
-
     return make_callback_var(
         multiply_log(arena_a, arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -195,10 +183,9 @@ inline auto multiply_log(const T1& a, const T2& b) {
 template <typename T1, typename T2, require_stan_scalar_t<T1>* = nullptr,
           require_var_matrix_t<T2>* = nullptr>
 inline auto multiply_log(const T1& a, const T2& b) {
-  if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    var arena_a = a;
-    arena_t<promote_scalar_t<var, T2>> arena_b = b;
-
+  auto arena_a = a;
+  arena_t<T2> arena_b = b;
+  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
     return make_callback_var(
         multiply_log(arena_a.val(), arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -207,10 +194,7 @@ inline auto multiply_log(const T1& a, const T2& b) {
           arena_b.adj().array()
               += arena_a.val() * res.adj().array() / arena_b.val().array();
         });
-  } else if (!is_constant<T1>::value) {
-    var arena_a = a;
-    arena_t<promote_scalar_t<double, T2>> arena_b = value_of(b);
-
+  } else if constexpr (!is_constant_v<T1>) {
     return make_callback_var(
         multiply_log(arena_a.val(), arena_b),
         [arena_a, arena_b](const auto& res) mutable {
@@ -218,8 +202,6 @@ inline auto multiply_log(const T1& a, const T2& b) {
               += (res.adj().array() * arena_b.val().array().log()).sum();
         });
   } else {
-    arena_t<promote_scalar_t<var, T2>> arena_b = b;
-
     return make_callback_var(multiply_log(value_of(a), arena_b.val()),
                              [a, arena_b](const auto& res) mutable {
                                arena_b.adj().array() += value_of(a)

--- a/stan/math/rev/fun/multiply_log.hpp
+++ b/stan/math/rev/fun/multiply_log.hpp
@@ -105,7 +105,6 @@ inline auto multiply_log(const T1& a, const T2& b) {
   arena_t<T1> arena_a = a;
   arena_t<T2> arena_b = b;
   if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
-
     return make_callback_var(
         multiply_log(arena_a.val(), arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -156,11 +155,10 @@ inline auto multiply_log(const T1& a, const T2& b) {
                            / arena_b.val();
         });
   } else if constexpr (!is_constant_v<T1>) {
-    return make_callback_var(multiply_log(arena_a.val(), b),
-                             [arena_a, b](const auto& res) mutable {
-                               arena_a.adj().array()
-                                   += res.adj().array() * log(b);
-                             });
+    return make_callback_var(
+        multiply_log(arena_a.val(), b), [arena_a, b](const auto& res) mutable {
+          arena_a.adj().array() += res.adj().array() * log(b);
+        });
   } else {
     return make_callback_var(
         multiply_log(arena_a, arena_b.val()),

--- a/stan/math/rev/fun/multiply_log.hpp
+++ b/stan/math/rev/fun/multiply_log.hpp
@@ -104,7 +104,7 @@ inline auto multiply_log(const T1& a, const T2& b) {
   check_matching_dims("multiply_log", "a", a, "b", b);
   arena_t<T1> arena_a = a;
   arena_t<T2> arena_b = b;
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     return make_callback_var(
         multiply_log(arena_a.val(), arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -113,7 +113,7 @@ inline auto multiply_log(const T1& a, const T2& b) {
           arena_b.adj().array() += res.adj().array() * arena_a.val().array()
                                    / arena_b.val().array();
         });
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     return make_callback_var(multiply_log(arena_a.val(), arena_b),
                              [arena_a, arena_b](const auto& res) mutable {
                                arena_a.adj().array()
@@ -146,7 +146,7 @@ inline auto multiply_log(const T1& a, const T2& b) {
 
   arena_t<T1> arena_a = a;
   auto arena_b = b;
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     return make_callback_var(
         multiply_log(arena_a.val(), arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -154,7 +154,7 @@ inline auto multiply_log(const T1& a, const T2& b) {
           arena_b.adj() += (res.adj().array() * arena_a.val().array()).sum()
                            / arena_b.val();
         });
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     return make_callback_var(
         multiply_log(arena_a.val(), b), [arena_a, b](const auto& res) mutable {
           arena_a.adj().array() += res.adj().array() * log(b);
@@ -183,7 +183,7 @@ template <typename T1, typename T2, require_stan_scalar_t<T1>* = nullptr,
 inline auto multiply_log(const T1& a, const T2& b) {
   auto arena_a = a;
   arena_t<T2> arena_b = b;
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     return make_callback_var(
         multiply_log(arena_a.val(), arena_b.val()),
         [arena_a, arena_b](const auto& res) mutable {
@@ -192,7 +192,7 @@ inline auto multiply_log(const T1& a, const T2& b) {
           arena_b.adj().array()
               += arena_a.val() * res.adj().array() / arena_b.val().array();
         });
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     return make_callback_var(
         multiply_log(arena_a.val(), arena_b),
         [arena_a, arena_b](const auto& res) mutable {

--- a/stan/math/rev/fun/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/rev/fun/multiply_lower_tri_self_transpose.hpp
@@ -17,7 +17,8 @@ template <typename T, require_rev_matrix_t<T>* = nullptr>
 inline auto multiply_lower_tri_self_transpose(T&& L) {
   using ret_type = return_var_matrix_t<T>;
   if (L.size() == 0) {
-    return arena_t<ret_type>(decltype(multiply_lower_tri_self_transpose(value_of(L)))());
+    return arena_t<ret_type>(
+        decltype(multiply_lower_tri_self_transpose(value_of(L)))());
   }
 
   arena_t<T> arena_L = std::forward<T>(L);

--- a/stan/math/rev/fun/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/rev/fun/multiply_lower_tri_self_transpose.hpp
@@ -14,13 +14,13 @@ namespace stan {
 namespace math {
 
 template <typename T, require_rev_matrix_t<T>* = nullptr>
-inline auto multiply_lower_tri_self_transpose(const T& L) {
+inline auto multiply_lower_tri_self_transpose(T&& L) {
   using ret_type = return_var_matrix_t<T>;
   if (L.size() == 0) {
-    return ret_type(decltype(multiply_lower_tri_self_transpose(value_of(L)))());
+    return arena_t<ret_type>(decltype(multiply_lower_tri_self_transpose(value_of(L)))());
   }
 
-  arena_t<T> arena_L = L;
+  arena_t<T> arena_L = std::forward<T>(L);
   arena_t<promote_scalar_t<double, T>> arena_L_val
       = arena_L.val().template triangularView<Eigen::Lower>();
 
@@ -33,7 +33,7 @@ inline auto multiply_lower_tri_self_transpose(const T& L) {
                          .template triangularView<Eigen::Lower>();
   });
 
-  return ret_type(res);
+  return res;
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/norm1.hpp
+++ b/stan/math/rev/fun/norm1.hpp
@@ -20,8 +20,8 @@ namespace math {
  * @return L1 norm of v.
  */
 template <typename T, require_eigen_vector_vt<is_var, T>* = nullptr>
-inline var norm1(const T& v) {
-  arena_t<T> arena_v = v;
+inline var norm1(T&& v) {
+  arena_t<T> arena_v = std::forward<T>(v);
   var res = norm1(arena_v.val());
   reverse_pass_callback([res, arena_v]() mutable {
     arena_v.adj().array() += res.adj() * sign(arena_v.val().array());

--- a/stan/math/rev/fun/norm2.hpp
+++ b/stan/math/rev/fun/norm2.hpp
@@ -19,8 +19,8 @@ namespace math {
  * @return L2 norm of v.
  */
 template <typename T, require_eigen_vector_vt<is_var, T>* = nullptr>
-inline var norm2(const T& v) {
-  arena_t<T> arena_v = v;
+inline var norm2(T&& v) {
+  arena_t<T> arena_v = std::forward<T>(v);
   var res = norm2(arena_v.val());
   reverse_pass_callback([res, arena_v]() mutable {
     arena_v.adj().array() += res.adj() * (arena_v.val().array() / res.val());

--- a/stan/math/rev/fun/owens_t.hpp
+++ b/stan/math/rev/fun/owens_t.hpp
@@ -28,9 +28,9 @@ namespace math {
 template <typename Var1, typename Var2,
           require_all_st_var<Var1, Var2>* = nullptr,
           require_all_not_std_vector_t<Var1, Var2>* = nullptr>
-inline auto owens_t(const Var1& h, const Var2& a) {
-  auto h_arena = to_arena(h);
-  auto a_arena = to_arena(a);
+inline auto owens_t(Var1&& h, Var2&& a) {
+  auto h_arena = to_arena(std::forward<Var1>(h));
+  auto a_arena = to_arena(std::forward<Var2>(a));
   using return_type
       = return_var_matrix_t<decltype(owens_t(h_arena.val(), a_arena.val())),
                             Var1, Var2>;
@@ -47,7 +47,7 @@ inline auto owens_t(const Var1& h, const Var2& a) {
         as_array_or_scalar(ret.adj()) * exp(neg_h_sq_div_2 * one_p_a_sq)
         / (one_p_a_sq * TWO_PI));
   });
-  return return_type(ret);
+  return ret;
 }
 
 /**
@@ -65,9 +65,9 @@ inline auto owens_t(const Var1& h, const Var2& a) {
 template <typename Var, typename Arith, require_st_arithmetic<Arith>* = nullptr,
           require_all_not_std_vector_t<Var, Arith>* = nullptr,
           require_st_var<Var>* = nullptr>
-inline auto owens_t(const Var& h, const Arith& a) {
-  auto h_arena = to_arena(h);
-  auto a_arena = to_arena(a);
+inline auto owens_t(Var&& h, Arith&& a) {
+  auto h_arena = to_arena(std::forward<Var>(h));
+  auto a_arena = to_arena(std::forward<Arith>(a));
   using return_type
       = return_var_matrix_t<decltype(owens_t(h_arena.val(), a_arena)), Var,
                             Arith>;
@@ -79,7 +79,7 @@ inline auto owens_t(const Var& h, const Arith& a) {
         * erf(as_array_or_scalar(a_arena) * h_val * INV_SQRT_TWO)
         * exp(-square(h_val) * 0.5) * INV_SQRT_TWO_PI * -0.5);
   });
-  return return_type(ret);
+  return ret;
 }
 
 /**
@@ -97,9 +97,9 @@ inline auto owens_t(const Var& h, const Arith& a) {
 template <typename Arith, typename Var, require_st_arithmetic<Arith>* = nullptr,
           require_all_not_std_vector_t<Var, Arith>* = nullptr,
           require_st_var<Var>* = nullptr>
-inline auto owens_t(const Arith& h, const Var& a) {
-  auto h_arena = to_arena(h);
-  auto a_arena = to_arena(a);
+inline auto owens_t(Arith&& h, Var&& a) {
+  auto h_arena = to_arena(std::forward<Arith>(h));
+  auto a_arena = to_arena(std::forward<Var>(a));
   using return_type
       = return_var_matrix_t<decltype(owens_t(h_arena, a_arena.val())), Var,
                             Arith>;
@@ -112,7 +112,7 @@ inline auto owens_t(const Arith& h, const Var& a) {
         * exp(-0.5 * square(as_array_or_scalar(h_arena)) * one_p_a_sq)
         / (one_p_a_sq * TWO_PI));
   });
-  return return_type(ret);
+  return ret;
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/pow.hpp
+++ b/stan/math/rev/fun/pow.hpp
@@ -92,10 +92,10 @@ inline var pow(const Scal1& base, const Scal2& exponent) {
         }
         const double vi_mul = vi.adj() * vi.val();
 
-        if constexpr (!is_constant_v<Scal1>) {
+        if constexpr (is_autodiffable_v<Scal1>) {
           base.adj() += vi_mul * value_of(exponent) / value_of(base);
         }
-        if constexpr (!is_constant_v<Scal2>) {
+        if constexpr (is_autodiffable_v<Scal2>) {
           exponent.adj() += vi_mul * std::log(value_of(base));
         }
       });
@@ -140,14 +140,14 @@ inline auto pow(Mat1&& base, Mat2&& exponent) {
   reverse_pass_callback([arena_base, arena_exponent, ret]() mutable {
     const auto& are_vals_zero = to_ref(value_of(arena_base) != 0.0);
     const auto& ret_mul = to_ref(ret.adj().array() * ret.val().array());
-    if constexpr (!is_constant_v<Mat1>) {
+    if constexpr (is_autodiffable_v<Mat1>) {
       using base_var_arena_t = arena_t<base_arena_t>;
       arena_base.adj() += (are_vals_zero)
                               .select(ret_mul * value_of(arena_exponent)
                                           / value_of(arena_base),
                                       0);
     }
-    if constexpr (!is_constant_v<Mat2>) {
+    if constexpr (is_autodiffable_v<Mat2>) {
       using exp_var_arena_t = arena_t<exp_arena_t>;
       arena_exponent.adj()
           += (are_vals_zero).select(ret_mul * value_of(arena_base).log(), 0);
@@ -196,14 +196,14 @@ inline auto pow(Mat1&& base, const Scal1& exponent) {
   reverse_pass_callback([arena_base, exponent, ret]() mutable {
     const auto& are_vals_zero = to_ref(value_of(arena_base).array() != 0.0);
     const auto& ret_mul = to_ref(ret.adj().array() * ret.val().array());
-    if constexpr (!is_constant_v<Mat1>) {
+    if constexpr (is_autodiffable_v<Mat1>) {
       arena_base.adj().array()
           += (are_vals_zero)
                  .select(ret_mul * value_of(exponent)
                              / value_of(arena_base).array(),
                          0);
     }
-    if constexpr (!is_constant_v<Scal1>) {
+    if constexpr (is_autodiffable_v<Scal1>) {
       exponent.adj()
           += (are_vals_zero)
                  .select(ret_mul * value_of(arena_base).array().log(), 0)
@@ -246,12 +246,12 @@ inline auto pow(Scal1 base, Mat1&& exponent) {
       return;  // partials zero, avoids 0 & log(0)
     }
     const auto& ret_mul = to_ref(ret.adj().array() * ret.val().array());
-    if constexpr (!is_constant_v<Scal1>) {
+    if constexpr (is_autodiffable_v<Scal1>) {
       base.adj()
           += (ret_mul * value_of(arena_exponent).array() / value_of(base))
                  .sum();
     }
-    if constexpr (!is_constant_v<Mat1>) {
+    if constexpr (is_autodiffable_v<Mat1>) {
       arena_exponent.adj().array() += ret_mul * std::log(value_of(base));
     }
   });

--- a/stan/math/rev/fun/pow.hpp
+++ b/stan/math/rev/fun/pow.hpp
@@ -93,8 +93,7 @@ inline var pow(const Scal1& base, const Scal2& exponent) {
         const double vi_mul = vi.adj() * vi.val();
 
         if constexpr (!is_constant_v<Scal1>) {
-          base.adj()
-              += vi_mul * value_of(exponent) / value_of(base);
+          base.adj() += vi_mul * value_of(exponent) / value_of(base);
         }
         if constexpr (!is_constant_v<Scal2>) {
           exponent.adj() += vi_mul * std::log(value_of(base));
@@ -143,11 +142,10 @@ inline auto pow(Mat1&& base, Mat2&& exponent) {
     const auto& ret_mul = to_ref(ret.adj().array() * ret.val().array());
     if constexpr (!is_constant_v<Mat1>) {
       using base_var_arena_t = arena_t<base_arena_t>;
-      arena_base.adj()
-          += (are_vals_zero)
-                 .select(
-                     ret_mul * value_of(arena_exponent) / value_of(arena_base),
-                     0);
+      arena_base.adj() += (are_vals_zero)
+                              .select(ret_mul * value_of(arena_exponent)
+                                          / value_of(arena_base),
+                                      0);
     }
     if constexpr (!is_constant_v<Mat2>) {
       using exp_var_arena_t = arena_t<exp_arena_t>;
@@ -199,12 +197,16 @@ inline auto pow(Mat1&& base, const Scal1& exponent) {
     const auto& are_vals_zero = to_ref(value_of(arena_base).array() != 0.0);
     const auto& ret_mul = to_ref(ret.adj().array() * ret.val().array());
     if constexpr (!is_constant_v<Mat1>) {
-      arena_base.adj().array() += (are_vals_zero).select(ret_mul * value_of(exponent)
+      arena_base.adj().array()
+          += (are_vals_zero)
+                 .select(ret_mul * value_of(exponent)
                              / value_of(arena_base).array(),
                          0);
     }
     if constexpr (!is_constant_v<Scal1>) {
-      exponent.adj() += (are_vals_zero).select(ret_mul * value_of(arena_base).array().log(), 0)
+      exponent.adj()
+          += (are_vals_zero)
+                 .select(ret_mul * value_of(arena_base).array().log(), 0)
                  .sum();
     }
   });
@@ -245,7 +247,8 @@ inline auto pow(Scal1 base, Mat1&& exponent) {
     }
     const auto& ret_mul = to_ref(ret.adj().array() * ret.val().array());
     if constexpr (!is_constant_v<Scal1>) {
-      base.adj() += (ret_mul * value_of(arena_exponent).array() / value_of(base))
+      base.adj()
+          += (ret_mul * value_of(arena_exponent).array() / value_of(base))
                  .sum();
     }
     if constexpr (!is_constant_v<Mat1>) {

--- a/stan/math/rev/fun/pow.hpp
+++ b/stan/math/rev/fun/pow.hpp
@@ -141,14 +141,12 @@ inline auto pow(Mat1&& base, Mat2&& exponent) {
     const auto& are_vals_zero = to_ref(value_of(arena_base) != 0.0);
     const auto& ret_mul = to_ref(ret.adj().array() * ret.val().array());
     if constexpr (is_autodiffable_v<Mat1>) {
-      using base_var_arena_t = arena_t<base_arena_t>;
       arena_base.adj() += (are_vals_zero)
                               .select(ret_mul * value_of(arena_exponent)
                                           / value_of(arena_base),
                                       0);
     }
     if constexpr (is_autodiffable_v<Mat2>) {
-      using exp_var_arena_t = arena_t<exp_arena_t>;
       arena_exponent.adj()
           += (are_vals_zero).select(ret_mul * value_of(arena_base).log(), 0);
     }

--- a/stan/math/rev/fun/quad_form.hpp
+++ b/stan/math/rev/fun/quad_form.hpp
@@ -126,12 +126,11 @@ inline auto quad_form_impl(Mat1&& A, Mat2&& B, bool symmetric) {
   arena_t<Mat1> arena_A = std::forward<Mat1>(A);
   arena_t<Mat2> arena_B = std::forward<Mat2>(B);
   if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
-
     check_not_nan("multiply", "A", arena_A.val());
     check_not_nan("multiply", "B", arena_B.val());
 
     auto res_vals = to_arena(arena_B.val_op().transpose() * arena_A.val_op()
-                              * arena_B.val_op());
+                             * arena_B.val_op());
 
     if (symmetric) {
       res_vals += res_vals.transpose().eval();
@@ -187,8 +186,7 @@ inline auto quad_form_impl(Mat1&& A, Mat2&& B, bool symmetric) {
     check_not_nan("multiply", "A", arena_A.val());
     check_not_nan("multiply", "B", arena_B);
 
-    auto res_vals
-        = to_arena(arena_B.transpose() * arena_A.val() * arena_B);
+    auto res_vals = to_arena(arena_B.transpose() * arena_A.val() * arena_B);
 
     if (symmetric) {
       res_vals += res_vals.transpose().eval();
@@ -297,7 +295,8 @@ template <typename Mat1, typename Mat2,
           require_not_col_vector_t<Mat2>* = nullptr,
           require_any_var_matrix_t<Mat1, Mat2>* = nullptr>
 inline auto quad_form(Mat1&& A, Mat2&& B, bool symmetric = false) {
-  return internal::quad_form_impl(std::forward<Mat1>(A), std::forward<Mat2>(B), symmetric);
+  return internal::quad_form_impl(std::forward<Mat1>(A), std::forward<Mat2>(B),
+                                  symmetric);
 }
 
 /**
@@ -322,7 +321,8 @@ template <typename Mat, typename Vec, require_matrix_t<Mat>* = nullptr,
           require_col_vector_t<Vec>* = nullptr,
           require_any_var_matrix_t<Mat, Vec>* = nullptr>
 inline var quad_form(Mat&& A, Vec&& B, bool symmetric = false) {
-  return internal::quad_form_impl(std::forward<Mat>(A), std::forward<Vec>(B), symmetric)(0, 0);
+  return internal::quad_form_impl(std::forward<Mat>(A), std::forward<Vec>(B),
+                                  symmetric)(0, 0);
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/quad_form.hpp
+++ b/stan/math/rev/fun/quad_form.hpp
@@ -125,7 +125,7 @@ inline auto quad_form_impl(Mat1&& A, Mat2&& B, bool symmetric) {
 
   arena_t<Mat1> arena_A = std::forward<Mat1>(A);
   arena_t<Mat2> arena_B = std::forward<Mat2>(B);
-  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
+  if constexpr (is_autodiffable_v<Mat1, Mat2>) {
     check_not_nan("multiply", "A", arena_A.val());
     check_not_nan("multiply", "B", arena_B.val());
 
@@ -157,7 +157,7 @@ inline auto quad_form_impl(Mat1&& A, Mat2&& B, bool symmetric) {
     });
 
     return res;
-  } else if constexpr (!is_constant_v<Mat2>) {
+  } else if constexpr (is_autodiffable_v<Mat2>) {
     check_not_nan("multiply", "A", arena_A);
     check_not_nan("multiply", "B", arena_B.val());
 
@@ -182,7 +182,7 @@ inline auto quad_form_impl(Mat1&& A, Mat2&& B, bool symmetric) {
     });
 
     return res;
-  } else if constexpr (!is_constant_v<Mat1>) {
+  } else if constexpr (is_autodiffable_v<Mat1>) {
     check_not_nan("multiply", "A", arena_A.val());
     check_not_nan("multiply", "B", arena_B);
 

--- a/stan/math/rev/fun/quad_form.hpp
+++ b/stan/math/rev/fun/quad_form.hpp
@@ -114,7 +114,7 @@ class quad_form_vari : public vari {
 template <typename Mat1, typename Mat2,
           require_all_matrix_t<Mat1, Mat2>* = nullptr,
           require_any_var_matrix_t<Mat1, Mat2>* = nullptr>
-inline auto quad_form_impl(const Mat1& A, const Mat2& B, bool symmetric) {
+inline auto quad_form_impl(Mat1&& A, Mat2&& B, bool symmetric) {
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
 
@@ -123,93 +123,81 @@ inline auto quad_form_impl(const Mat1& A, const Mat2& B, bool symmetric) {
                                      * value_of(A) * value_of(B).eval()),
                             Mat1, Mat2>;
 
-  if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
-    arena_t<promote_scalar_t<var, Mat1>> arena_A = A;
-    arena_t<promote_scalar_t<var, Mat2>> arena_B = B;
+  arena_t<Mat1> arena_A = std::forward<Mat1>(A);
+  arena_t<Mat2> arena_B = std::forward<Mat2>(B);
+  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
 
-    check_not_nan("multiply", "A", value_of(arena_A));
-    check_not_nan("multiply", "B", value_of(arena_B));
+    check_not_nan("multiply", "A", arena_A.val());
+    check_not_nan("multiply", "B", arena_B.val());
 
-    auto arena_res = to_arena(value_of(arena_B).transpose() * value_of(arena_A)
-                              * value_of(arena_B));
+    auto res_vals = to_arena(arena_B.val_op().transpose() * arena_A.val_op()
+                              * arena_B.val_op());
 
     if (symmetric) {
-      arena_res += arena_res.transpose().eval();
+      res_vals += res_vals.transpose().eval();
     }
-
-    return_t res = arena_res;
-
+    arena_t<return_t> res = std::move(res_vals);
     reverse_pass_callback([arena_A, arena_B, res]() mutable {
-      auto C_adj_B_t = (res.adj() * value_of(arena_B).transpose()).eval();
+      auto C_adj_B_t = (res.adj() * arena_B.val_op().transpose()).eval();
 
-      if (is_var_matrix<Mat1>::value) {
-        arena_A.adj().noalias() += value_of(arena_B) * C_adj_B_t;
+      if constexpr (is_var_matrix<Mat1>::value) {
+        arena_A.adj().noalias() += arena_B.val_op() * C_adj_B_t;
       } else {
-        arena_A.adj() += value_of(arena_B) * C_adj_B_t;
+        arena_A.adj() += arena_B.val_op() * C_adj_B_t;
       }
 
-      if (is_var_matrix<Mat2>::value) {
+      if constexpr (is_var_matrix<Mat2>::value) {
         arena_B.adj().noalias()
-            += value_of(arena_A) * C_adj_B_t.transpose()
-               + value_of(arena_A).transpose() * value_of(arena_B) * res.adj();
+            += arena_A.val_op() * C_adj_B_t.transpose()
+               + arena_A.val_op().transpose() * arena_B.val_op() * res.adj();
       } else {
         arena_B.adj()
-            += value_of(arena_A) * C_adj_B_t.transpose()
-               + value_of(arena_A).transpose() * value_of(arena_B) * res.adj();
+            += arena_A.val_op() * C_adj_B_t.transpose()
+               + arena_A.val_op().transpose() * arena_B.val_op() * res.adj();
       }
     });
 
     return res;
-  } else if (!is_constant<Mat2>::value) {
-    arena_t<promote_scalar_t<double, Mat1>> arena_A = value_of(A);
-    arena_t<promote_scalar_t<var, Mat2>> arena_B = B;
-
+  } else if constexpr (!is_constant_v<Mat2>) {
     check_not_nan("multiply", "A", arena_A);
     check_not_nan("multiply", "B", arena_B.val());
 
-    auto arena_res
-        = to_arena(value_of(arena_B).transpose() * arena_A * value_of(arena_B));
+    auto res_vals
+        = to_arena(arena_B.val_op().transpose() * arena_A * arena_B.val_op());
 
     if (symmetric) {
-      arena_res += arena_res.transpose().eval();
+      res_vals += res_vals.transpose().eval();
     }
-
-    return_t res = arena_res;
-
+    arena_t<return_t> res = std::move(res_vals);
     reverse_pass_callback([arena_A, arena_B, res]() mutable {
-      auto C_adj_B_t = (res.adj() * value_of(arena_B).transpose());
+      auto C_adj_B_t = (res.adj() * arena_B.val_op().transpose());
 
       if (is_var_matrix<Mat2>::value) {
         arena_B.adj().noalias()
             += arena_A * C_adj_B_t.transpose()
-               + arena_A.transpose() * value_of(arena_B) * res.adj();
+               + arena_A.transpose() * arena_B.val_op() * res.adj();
       } else {
         arena_B.adj() += arena_A * C_adj_B_t.transpose()
-                         + arena_A.transpose() * value_of(arena_B) * res.adj();
+                         + arena_A.transpose() * arena_B.val_op() * res.adj();
       }
     });
 
     return res;
-  } else {
-    arena_t<promote_scalar_t<var, Mat1>> arena_A = A;
-    arena_t<promote_scalar_t<double, Mat2>> arena_B = value_of(B);
-
-    check_not_nan("multiply", "A", value_of(arena_A));
+  } else if constexpr (!is_constant_v<Mat1>) {
+    check_not_nan("multiply", "A", arena_A.val());
     check_not_nan("multiply", "B", arena_B);
 
-    auto arena_res
-        = to_arena(arena_B.transpose() * value_of(arena_A) * arena_B);
+    auto res_vals
+        = to_arena(arena_B.transpose() * arena_A.val() * arena_B);
 
     if (symmetric) {
-      arena_res += arena_res.transpose().eval();
+      res_vals += res_vals.transpose().eval();
     }
-
-    return_t res = arena_res;
-
+    arena_t<return_t> res = std::move(res_vals);
     reverse_pass_callback([arena_A, arena_B, res]() mutable {
       auto C_adj_B_t = (res.adj() * arena_B.transpose());
 
-      if (is_var_matrix<Mat1>::value) {
+      if constexpr (is_var_matrix<Mat1>::value) {
         arena_A.adj().noalias() += arena_B * C_adj_B_t;
       } else {
         arena_A.adj() += arena_B * C_adj_B_t;
@@ -308,8 +296,8 @@ template <typename Mat1, typename Mat2,
           require_all_matrix_t<Mat1, Mat2>* = nullptr,
           require_not_col_vector_t<Mat2>* = nullptr,
           require_any_var_matrix_t<Mat1, Mat2>* = nullptr>
-inline auto quad_form(const Mat1& A, const Mat2& B, bool symmetric = false) {
-  return internal::quad_form_impl(A, B, symmetric);
+inline auto quad_form(Mat1&& A, Mat2&& B, bool symmetric = false) {
+  return internal::quad_form_impl(std::forward<Mat1>(A), std::forward<Mat2>(B), symmetric);
 }
 
 /**
@@ -333,8 +321,8 @@ inline auto quad_form(const Mat1& A, const Mat2& B, bool symmetric = false) {
 template <typename Mat, typename Vec, require_matrix_t<Mat>* = nullptr,
           require_col_vector_t<Vec>* = nullptr,
           require_any_var_matrix_t<Mat, Vec>* = nullptr>
-inline var quad_form(const Mat& A, const Vec& B, bool symmetric = false) {
-  return internal::quad_form_impl(A, B, symmetric)(0, 0);
+inline var quad_form(Mat&& A, Vec&& B, bool symmetric = false) {
+  return internal::quad_form_impl(std::forward<Mat>(A), std::forward<Vec>(B), symmetric)(0, 0);
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/quad_form_sym.hpp
+++ b/stan/math/rev/fun/quad_form_sym.hpp
@@ -34,8 +34,8 @@ inline auto quad_form_sym(EigMat1&& A, EigMat2&& B) {
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   auto&& A_ref = to_ref(std::forward<EigMat1>(A));
   check_symmetric("quad_form_sym", "A", A_ref);
-  return quad_form(std::forward<decltype(A_ref)>(A_ref), std::forward<EigMat2>(B),
-                   true);
+  return quad_form(std::forward<decltype(A_ref)>(A_ref),
+                   std::forward<EigMat2>(B), true);
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/quad_form_sym.hpp
+++ b/stan/math/rev/fun/quad_form_sym.hpp
@@ -30,11 +30,11 @@ namespace math {
 template <typename EigMat1, typename EigMat2,
           require_all_eigen_t<EigMat1, EigMat2>* = nullptr,
           require_any_vt_var<EigMat1, EigMat2>* = nullptr>
-inline auto quad_form_sym(const EigMat1& A, const EigMat2& B) {
+inline auto quad_form_sym(EigMat1&& A, EigMat2&& B) {
   check_multiplicable("quad_form_sym", "A", A, "B", B);
-  const auto& A_ref = to_ref(A);
+  auto&& A_ref = to_ref(std::forward<EigMat1>(A));
   check_symmetric("quad_form_sym", "A", A_ref);
-  return quad_form(A_ref, B, true);
+  return quad_form(std::forward<EigMat1>(A_ref), std::forward<EigMat2>(B), true);
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/quad_form_sym.hpp
+++ b/stan/math/rev/fun/quad_form_sym.hpp
@@ -34,7 +34,7 @@ inline auto quad_form_sym(EigMat1&& A, EigMat2&& B) {
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   auto&& A_ref = to_ref(std::forward<EigMat1>(A));
   check_symmetric("quad_form_sym", "A", A_ref);
-  return quad_form(std::forward<EigMat1>(A_ref), std::forward<EigMat2>(B),
+  return quad_form(std::forward<decltype(A_ref)>(A_ref), std::forward<EigMat2>(B),
                    true);
 }
 

--- a/stan/math/rev/fun/quad_form_sym.hpp
+++ b/stan/math/rev/fun/quad_form_sym.hpp
@@ -34,7 +34,8 @@ inline auto quad_form_sym(EigMat1&& A, EigMat2&& B) {
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   auto&& A_ref = to_ref(std::forward<EigMat1>(A));
   check_symmetric("quad_form_sym", "A", A_ref);
-  return quad_form(std::forward<EigMat1>(A_ref), std::forward<EigMat2>(B), true);
+  return quad_form(std::forward<EigMat1>(A_ref), std::forward<EigMat2>(B),
+                   true);
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/rows_dot_product.hpp
+++ b/stan/math/rev/fun/rows_dot_product.hpp
@@ -69,7 +69,7 @@ inline auto rows_dot_product(const Mat1& v1, const Mat2& v2) {
 
   arena_t<Mat1> arena_v1 = v1;
   arena_t<Mat2> arena_v2 = v2;
-  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
+  if constexpr (is_autodiffable_v<Mat1, Mat2>) {
     return_t res
         = (arena_v1.val().array() * arena_v2.val().array()).rowwise().sum();
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
@@ -85,7 +85,7 @@ inline auto rows_dot_product(const Mat1& v1, const Mat2& v2) {
       }
     });
     return res;
-  } else if constexpr (!is_constant_v<Mat2>) {
+  } else if constexpr (is_autodiffable_v<Mat2>) {
     return_t res = (arena_v1.array() * arena_v2.val().array()).rowwise().sum();
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat2>::value) {

--- a/stan/math/rev/fun/rows_dot_product.hpp
+++ b/stan/math/rev/fun/rows_dot_product.hpp
@@ -67,13 +67,11 @@ inline auto rows_dot_product(const Mat1& v1, const Mat2& v2) {
       decltype((v1.val().array() * v2.val().array()).rowwise().sum().matrix()),
       Mat1, Mat2>;
 
-  if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
-    arena_t<promote_scalar_t<var, Mat1>> arena_v1 = v1;
-    arena_t<promote_scalar_t<var, Mat2>> arena_v2 = v2;
-
+  arena_t<Mat1> arena_v1 = v1;
+  arena_t<Mat2> arena_v2 = v2;
+  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
     return_t res
         = (arena_v1.val().array() * arena_v2.val().array()).rowwise().sum();
-
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat1>::value) {
         arena_v1.adj().noalias() += res.adj().asDiagonal() * arena_v2.val();
@@ -86,14 +84,9 @@ inline auto rows_dot_product(const Mat1& v1, const Mat2& v2) {
         arena_v2.adj() += res.adj().asDiagonal() * arena_v1.val();
       }
     });
-
     return res;
-  } else if (!is_constant<Mat2>::value) {
-    arena_t<promote_scalar_t<double, Mat1>> arena_v1 = value_of(v1);
-    arena_t<promote_scalar_t<var, Mat2>> arena_v2 = v2;
-
+  } else if constexpr (!is_constant_v<Mat2>) {
     return_t res = (arena_v1.array() * arena_v2.val().array()).rowwise().sum();
-
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat2>::value) {
         arena_v2.adj().noalias() += res.adj().asDiagonal() * arena_v1;
@@ -104,11 +97,7 @@ inline auto rows_dot_product(const Mat1& v1, const Mat2& v2) {
 
     return res;
   } else {
-    arena_t<promote_scalar_t<var, Mat1>> arena_v1 = v1;
-    arena_t<promote_scalar_t<double, Mat2>> arena_v2 = value_of(v2);
-
     return_t res = (arena_v1.val().array() * arena_v2.array()).rowwise().sum();
-
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat2>::value) {
         arena_v1.adj().noalias() += res.adj().asDiagonal() * arena_v2;
@@ -116,7 +105,6 @@ inline auto rows_dot_product(const Mat1& v1, const Mat2& v2) {
         arena_v1.adj() += res.adj().asDiagonal() * arena_v2;
       }
     });
-
     return res;
   }
 }

--- a/stan/math/rev/fun/singular_values.hpp
+++ b/stan/math/rev/fun/singular_values.hpp
@@ -20,13 +20,13 @@ namespace math {
  * @return Singular values of matrix
  */
 template <typename EigMat, require_rev_matrix_t<EigMat>* = nullptr>
-inline auto singular_values(const EigMat& m) {
+inline auto singular_values(EigMat&& m) {
   using ret_type = return_var_matrix_t<Eigen::VectorXd, EigMat>;
   if (unlikely(m.size() == 0)) {
-    return ret_type(Eigen::VectorXd(0));
+    return arena_t<ret_type>(Eigen::VectorXd(0));
   }
 
-  auto arena_m = to_arena(m);
+  auto arena_m = to_arena(std::forward<EigMat>(m));
 
   Eigen::JacobiSVD<Eigen::MatrixXd> svd(
       arena_m.val(), Eigen::ComputeThinU | Eigen::ComputeThinV);
@@ -41,7 +41,7 @@ inline auto singular_values(const EigMat& m) {
         += arena_U * singular_values.adj().asDiagonal() * arena_V.transpose();
   });
 
-  return ret_type(singular_values);
+  return singular_values;
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/softmax.hpp
+++ b/stan/math/rev/fun/softmax.hpp
@@ -25,13 +25,13 @@ namespace math {
  * @throw std::domain_error If the input vector is size 0.
  */
 template <typename Mat, require_rev_matrix_t<Mat>* = nullptr>
-inline auto softmax(const Mat& alpha) {
+inline auto softmax(Mat&& alpha) {
   using mat_plain = plain_type_t<Mat>;
   using ret_type = return_var_matrix_t<Mat>;
   if (alpha.size() == 0) {
-    return ret_type(alpha);
+    return arena_t<ret_type>(alpha);
   }
-  arena_t<mat_plain> alpha_arena = alpha;
+  arena_t<mat_plain> alpha_arena = std::forward<Mat>(alpha);
   arena_t<Eigen::VectorXd> res_val = softmax(value_of(alpha_arena));
   arena_t<ret_type> res = res_val;
 
@@ -41,7 +41,7 @@ inline auto softmax(const Mat& alpha) {
         += -res_val * res_adj.dot(res_val) + res_val.cwiseProduct(res_adj);
   });
 
-  return ret_type(res);
+  return arena_t<ret_type>(res);
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/squared_distance.hpp
+++ b/stan/math/rev/fun/squared_distance.hpp
@@ -158,7 +158,7 @@ inline var squared_distance(const T1& A, const T2& B) {
   check_matching_sizes("squared_distance", "A", A.val(), "B", B.val());
   if (unlikely(A.size() == 0)) {
     return var(0.0);
-  } 
+  }
   arena_t<T1> arena_A = A;
   arena_t<T2> arena_B = B;
   arena_t<Eigen::VectorXd> res_diff(arena_A.size());

--- a/stan/math/rev/fun/squared_distance.hpp
+++ b/stan/math/rev/fun/squared_distance.hpp
@@ -158,9 +158,9 @@ inline var squared_distance(const T1& A, const T2& B) {
   check_matching_sizes("squared_distance", "A", A.val(), "B", B.val());
   if (unlikely(A.size() == 0)) {
     return var(0.0);
-  } else if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_A = A;
-    arena_t<promote_scalar_t<var, T2>> arena_B = B;
+  } else if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+    arena_t<T1> arena_A = A;
+    arena_t<T2> arena_B = B;
     arena_t<Eigen::VectorXd> res_diff(arena_A.size());
     double res_val = 0.0;
     for (size_t i = 0; i < arena_A.size(); ++i) {
@@ -177,9 +177,9 @@ inline var squared_distance(const T1& A, const T2& B) {
             arena_B.adj().coeffRef(i) -= diff;
           }
         }));
-  } else if (!is_constant<T1>::value) {
-    arena_t<promote_scalar_t<var, T1>> arena_A = A;
-    arena_t<promote_scalar_t<double, T2>> arena_B = value_of(B);
+  } else if constexpr (!is_constant_v<T1>) {
+    arena_t<T1> arena_A = A;
+    arena_t<T2> arena_B = value_of(B);
     arena_t<Eigen::VectorXd> res_diff(arena_A.size());
     double res_val = 0.0;
     for (size_t i = 0; i < arena_A.size(); ++i) {
@@ -192,8 +192,8 @@ inline var squared_distance(const T1& A, const T2& B) {
           arena_A.adj() += 2.0 * res.adj() * res_diff;
         }));
   } else {
-    arena_t<promote_scalar_t<double, T1>> arena_A = value_of(A);
-    arena_t<promote_scalar_t<var, T2>> arena_B = B;
+    arena_t<T1> arena_A = value_of(A);
+    arena_t<T2> arena_B = B;
     arena_t<Eigen::VectorXd> res_diff(arena_A.size());
     double res_val = 0.0;
     for (size_t i = 0; i < arena_A.size(); ++i) {

--- a/stan/math/rev/fun/squared_distance.hpp
+++ b/stan/math/rev/fun/squared_distance.hpp
@@ -158,11 +158,12 @@ inline var squared_distance(const T1& A, const T2& B) {
   check_matching_sizes("squared_distance", "A", A.val(), "B", B.val());
   if (unlikely(A.size() == 0)) {
     return var(0.0);
-  } else if constexpr (is_autodiffable_v<T1, T2>) {
-    arena_t<T1> arena_A = A;
-    arena_t<T2> arena_B = B;
-    arena_t<Eigen::VectorXd> res_diff(arena_A.size());
-    double res_val = 0.0;
+  } 
+  arena_t<T1> arena_A = A;
+  arena_t<T2> arena_B = B;
+  arena_t<Eigen::VectorXd> res_diff(arena_A.size());
+  double res_val = 0.0;
+  if constexpr (is_autodiffable_v<T1, T2>) {
     for (size_t i = 0; i < arena_A.size(); ++i) {
       const double diff = arena_A.val().coeff(i) - arena_B.val().coeff(i);
       res_diff.coeffRef(i) = diff;
@@ -178,10 +179,6 @@ inline var squared_distance(const T1& A, const T2& B) {
           }
         }));
   } else if constexpr (is_autodiffable_v<T1>) {
-    arena_t<T1> arena_A = A;
-    arena_t<T2> arena_B = value_of(B);
-    arena_t<Eigen::VectorXd> res_diff(arena_A.size());
-    double res_val = 0.0;
     for (size_t i = 0; i < arena_A.size(); ++i) {
       const double diff = arena_A.val().coeff(i) - arena_B.coeff(i);
       res_diff.coeffRef(i) = diff;
@@ -192,10 +189,6 @@ inline var squared_distance(const T1& A, const T2& B) {
           arena_A.adj() += 2.0 * res.adj() * res_diff;
         }));
   } else {
-    arena_t<T1> arena_A = value_of(A);
-    arena_t<T2> arena_B = B;
-    arena_t<Eigen::VectorXd> res_diff(arena_A.size());
-    double res_val = 0.0;
     for (size_t i = 0; i < arena_A.size(); ++i) {
       const double diff = arena_A.coeff(i) - arena_B.val().coeff(i);
       res_diff.coeffRef(i) = diff;

--- a/stan/math/rev/fun/squared_distance.hpp
+++ b/stan/math/rev/fun/squared_distance.hpp
@@ -158,7 +158,7 @@ inline var squared_distance(const T1& A, const T2& B) {
   check_matching_sizes("squared_distance", "A", A.val(), "B", B.val());
   if (unlikely(A.size() == 0)) {
     return var(0.0);
-  } else if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  } else if constexpr (is_autodiffable_v<T1, T2>) {
     arena_t<T1> arena_A = A;
     arena_t<T2> arena_B = B;
     arena_t<Eigen::VectorXd> res_diff(arena_A.size());
@@ -177,7 +177,7 @@ inline var squared_distance(const T1& A, const T2& B) {
             arena_B.adj().coeffRef(i) -= diff;
           }
         }));
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     arena_t<T1> arena_A = A;
     arena_t<T2> arena_B = value_of(B);
     arena_t<Eigen::VectorXd> res_diff(arena_A.size());

--- a/stan/math/rev/fun/svd.hpp
+++ b/stan/math/rev/fun/svd.hpp
@@ -63,7 +63,8 @@ inline auto svd(EigMat&& m) {
   reverse_pass_callback([arena_m, arena_U, singular_values, arena_V, arena_Fp,
                          arena_Fm]() mutable {
     // SVD-U reverse mode
-    arena_t<Eigen::MatrixXd> UUadjT = arena_U.val_op().transpose() * arena_U.adj_op();
+    arena_t<Eigen::MatrixXd> UUadjT
+        = arena_U.val_op().transpose() * arena_U.adj_op();
     auto u_adj
         = .5 * arena_U.val_op()
               * (arena_Fp.array() * (UUadjT - UUadjT.transpose()).array())
@@ -78,7 +79,8 @@ inline auto svd(EigMat&& m) {
     auto d_adj = arena_U.val_op() * singular_values.adj().asDiagonal()
                  * arena_V.val_op().transpose();
     // SVD-V reverse mode
-    arena_t<Eigen::MatrixXd> VTVadj = arena_V.val_op().transpose() * arena_V.adj_op();
+    arena_t<Eigen::MatrixXd> VTVadj
+        = arena_V.val_op().transpose() * arena_V.adj_op();
     auto v_adj
         = 0.5 * arena_U.val_op()
               * (arena_Fm.array() * (VTVadj - VTVadj.transpose()).array())

--- a/stan/math/rev/fun/svd_U.hpp
+++ b/stan/math/rev/fun/svd_U.hpp
@@ -22,14 +22,14 @@ namespace math {
  * @return Orthogonal matrix U
  */
 template <typename EigMat, require_rev_matrix_t<EigMat>* = nullptr>
-inline auto svd_U(const EigMat& m) {
+inline auto svd_U(EigMat&& m) {
   using ret_type = return_var_matrix_t<Eigen::MatrixXd, EigMat>;
   if (unlikely(m.size() == 0)) {
-    return ret_type(Eigen::MatrixXd(0, 0));
+    return arena_t<ret_type>(Eigen::MatrixXd(0, 0));
   }
 
   const int M = std::min(m.rows(), m.cols());
-  auto arena_m = to_arena(m);
+  auto arena_m = to_arena(std::forward<EigMat>(m));
 
   Eigen::JacobiSVD<Eigen::MatrixXd> svd(
       arena_m.val(), Eigen::ComputeThinU | Eigen::ComputeThinV);
@@ -66,7 +66,7 @@ inline auto svd_U(const EigMat& m) {
                  * arena_V.transpose();
   });
 
-  return ret_type(arena_U);
+  return arena_U;
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/svd_V.hpp
+++ b/stan/math/rev/fun/svd_V.hpp
@@ -22,14 +22,14 @@ namespace math {
  * @return Orthogonal matrix V
  */
 template <typename EigMat, require_rev_matrix_t<EigMat>* = nullptr>
-inline auto svd_V(const EigMat& m) {
+inline auto svd_V(EigMat&& m) {
   using ret_type = return_var_matrix_t<Eigen::MatrixXd, EigMat>;
   if (unlikely(m.size() == 0)) {
-    return ret_type(Eigen::MatrixXd(0, 0));
+    return arena_t<ret_type>(Eigen::MatrixXd(0, 0));
   }
 
   const int M = std::min(m.rows(), m.cols());
-  auto arena_m = to_arena(m);
+  auto arena_m = to_arena(std::forward<EigMat>(m));
 
   Eigen::JacobiSVD<Eigen::MatrixXd> svd(
       arena_m.val(), Eigen::ComputeThinU | Eigen::ComputeThinV);
@@ -66,7 +66,7 @@ inline auto svd_V(const EigMat& m) {
                     - arena_V.val_op() * arena_V.val_op().transpose());
   });
 
-  return ret_type(arena_V);
+  return arena_V;
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/tcrossprod.hpp
+++ b/stan/math/rev/fun/tcrossprod.hpp
@@ -23,7 +23,9 @@ namespace math {
 template <typename T, require_rev_matrix_t<T>* = nullptr>
 inline auto tcrossprod(T&& M) {
   using ret_type = return_var_matrix_t<
-      Eigen::Matrix<double, std::decay_t<T>::RowsAtCompileTime, std::decay_t<T>::RowsAtCompileTime>, T>;
+      Eigen::Matrix<double, std::decay_t<T>::RowsAtCompileTime,
+                    std::decay_t<T>::RowsAtCompileTime>,
+      T>;
   arena_t<T> arena_M = std::forward<T>(M);
   arena_t<ret_type> res = arena_M.val_op() * arena_M.val_op().transpose();
 

--- a/stan/math/rev/fun/tcrossprod.hpp
+++ b/stan/math/rev/fun/tcrossprod.hpp
@@ -21,10 +21,10 @@ namespace math {
  * @return M times its transpose.
  */
 template <typename T, require_rev_matrix_t<T>* = nullptr>
-inline auto tcrossprod(const T& M) {
+inline auto tcrossprod(T&& M) {
   using ret_type = return_var_matrix_t<
-      Eigen::Matrix<double, T::RowsAtCompileTime, T::RowsAtCompileTime>, T>;
-  arena_t<T> arena_M = M;
+      Eigen::Matrix<double, std::decay_t<T>::RowsAtCompileTime, std::decay_t<T>::RowsAtCompileTime>, T>;
+  arena_t<T> arena_M = std::forward<T>(M);
   arena_t<ret_type> res = arena_M.val_op() * arena_M.val_op().transpose();
 
   if (likely(M.size() > 0)) {
@@ -34,7 +34,7 @@ inline auto tcrossprod(const T& M) {
     });
   }
 
-  return ret_type(res);
+  return res;
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -40,8 +40,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     return 0;
   }
 
-  if constexpr (!is_constant_v<
-                    Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
+  if constexpr (is_autodiffable_v<Ta, Tb, Td>) {
     arena_t<Ta> arena_A = A.matrix();
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = D;
@@ -62,8 +61,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if constexpr (!is_constant_v<
-                           Ta> && !is_constant_v<Tb> && is_constant_v<Td>) {
+  } else if constexpr (is_autodiffable_v<Ta, Tb> && is_constant_v<Td>) {
     arena_t<Ta> arena_A = A.matrix();
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = value_of(D);
@@ -80,8 +78,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if constexpr (!is_constant_v<
-                           Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
+  } else if constexpr (is_autodiffable_v<Ta, Td> && is_constant_v<Tb>) {
     arena_t<Ta> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
     arena_t<Td> arena_D = D;
@@ -100,8 +97,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if constexpr (!is_constant_v<
-                           Ta> && is_constant_v<Tb> && is_constant_v<Td>) {
+  } else if constexpr (is_autodiffable_v<Ta> && is_constant_v<Tb, Td>) {
     arena_t<Ta> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
     arena_t<Td> arena_D = value_of(D);
@@ -117,8 +113,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if constexpr (is_constant_v<
-                           Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<Ta> && is_autodiffable_v<Tb, Td>) {
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = D;
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
@@ -136,8 +131,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if constexpr (is_constant_v<
-                           Ta> && !is_constant_v<Tb> && is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<Ta, Td> && is_autodiffable_v<Tb>) {
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = value_of(D);
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
@@ -149,8 +143,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if constexpr (is_constant_v<
-                           Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<Ta, Tb> && is_autodiffable_v<Td>) {
     const auto& B_ref = to_ref(B);
     arena_t<Td> arena_D = D;
     auto BTAsolveB = to_arena(value_of(B_ref).transpose()
@@ -196,8 +189,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
     return 0;
   }
 
-  if constexpr (!is_constant_v<
-                    Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
+  if constexpr (is_autodiffable_v<Ta, Tb, Td>) {
     arena_t<Ta> arena_A = A.matrix();
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = D;
@@ -217,8 +209,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if constexpr (!is_constant_v<
-                           Ta> && !is_constant_v<Tb> && is_constant_v<Td>) {
+  } else if constexpr (is_autodiffable_v<Ta, Tb> && is_constant_v<Td>) {
     arena_t<Ta> arena_A = A.matrix();
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = value_of(D);
@@ -236,8 +227,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if constexpr (!is_constant_v<
-                           Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
+  } else if constexpr (is_autodiffable_v<Ta, Td> && is_constant_v<Tb>) {
     arena_t<Ta> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
     arena_t<Td> arena_D = D;
@@ -256,8 +246,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if constexpr (!is_constant_v<
-                           Ta> && is_constant_v<Tb> && is_constant_v<Td>) {
+  } else if constexpr (is_autodiffable_v<Ta> && is_constant_v<Tb, Td>) {
     arena_t<Ta> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
     arena_t<Td> arena_D = value_of(D);
@@ -274,8 +263,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if constexpr (is_constant_v<
-                           Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<Ta> && is_autodiffable_v<Tb, Td>) {
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = D;
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
@@ -292,8 +280,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if constexpr (is_constant_v<
-                           Ta> && !is_constant_v<Tb> && is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<Ta, Td> && is_autodiffable_v<Tb>) {
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = value_of(D);
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
@@ -306,8 +293,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if constexpr (is_constant_v<
-                           Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<Ta, Tb> && is_autodiffable_v<Td>) {
     const auto& B_ref = to_ref(B);
     arena_t<Td> arena_D = D;
     auto BTAsolveB = to_arena(value_of(B_ref).transpose()

--- a/stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -40,11 +40,11 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     return 0;
   }
 
-  if (!is_constant<Ta>::value && !is_constant<Tb>::value
-      && !is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Ta>> arena_A = A.matrix();
-    arena_t<promote_scalar_t<var, Tb>> arena_B = B;
-    arena_t<promote_scalar_t<var, Td>> arena_D = D;
+  if constexpr (!is_constant_v<Ta> && !is_constant_v<Tb>
+      && !is_constant_v<Td>) {
+    arena_t<Ta> arena_A = A.matrix();
+    arena_t<Tb> arena_B = B;
+    arena_t<Td> arena_D = D;
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
     auto BTAsolveB = to_arena(arena_B.val_op().transpose() * AsolveB);
 
@@ -62,11 +62,11 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if (!is_constant<Ta>::value && !is_constant<Tb>::value
-             && is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Ta>> arena_A = A.matrix();
-    arena_t<promote_scalar_t<var, Tb>> arena_B = B;
-    arena_t<promote_scalar_t<double, Td>> arena_D = value_of(D);
+  } else if constexpr (!is_constant_v<Ta> && !is_constant_v<Tb>
+             && is_constant_v<Td>) {
+    arena_t<Ta> arena_A = A.matrix();
+    arena_t<Tb> arena_B = B;
+    arena_t<Td> arena_D = value_of(D);
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
 
     var res = (arena_D * arena_B.val_op().transpose() * AsolveB).trace();
@@ -80,11 +80,11 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if (!is_constant<Ta>::value && is_constant<Tb>::value
-             && !is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Ta>> arena_A = A.matrix();
+  } else if constexpr (!is_constant_v<Ta> && is_constant_v<Tb>
+             && !is_constant_v<Td>) {
+    arena_t<Ta> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
-    arena_t<promote_scalar_t<var, Td>> arena_D = D;
+    arena_t<Td> arena_D = D;
     auto AsolveB = to_arena(A.ldlt().solve(value_of(B_ref)));
     auto BTAsolveB = to_arena(value_of(B_ref).transpose() * AsolveB);
 
@@ -100,11 +100,11 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if (!is_constant<Ta>::value && is_constant<Tb>::value
-             && is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Ta>> arena_A = A.matrix();
+  } else if constexpr (!is_constant_v<Ta> && is_constant_v<Tb>
+             && is_constant_v<Td>) {
+    arena_t<Ta> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
-    arena_t<promote_scalar_t<double, Td>> arena_D = value_of(D);
+    arena_t<Td> arena_D = value_of(D);
     auto AsolveB = to_arena(A.ldlt().solve(value_of(B_ref)));
 
     var res = (arena_D * value_of(B_ref).transpose() * AsolveB).trace();
@@ -117,10 +117,10 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if (is_constant<Ta>::value && !is_constant<Tb>::value
-             && !is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Tb>> arena_B = B;
-    arena_t<promote_scalar_t<var, Td>> arena_D = D;
+  } else if constexpr (is_constant_v<Ta> && !is_constant_v<Tb>
+             && !is_constant_v<Td>) {
+    arena_t<Tb> arena_B = B;
+    arena_t<Td> arena_D = D;
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
     auto BTAsolveB = to_arena(arena_B.val_op().transpose() * AsolveB);
 
@@ -136,10 +136,10 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if (is_constant<Ta>::value && !is_constant<Tb>::value
-             && is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Tb>> arena_B = B;
-    arena_t<promote_scalar_t<double, Td>> arena_D = value_of(D);
+  } else if constexpr (is_constant_v<Ta> && !is_constant_v<Tb>
+             && is_constant_v<Td>) {
+    arena_t<Tb> arena_B = B;
+    arena_t<Td> arena_D = value_of(D);
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
 
     var res = (arena_D * arena_B.val_op().transpose() * AsolveB).trace();
@@ -149,10 +149,10 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if (is_constant<Ta>::value && is_constant<Tb>::value
-             && !is_constant<Td>::value) {
+  } else if constexpr (is_constant_v<Ta> && is_constant_v<Tb>
+             && !is_constant_v<Td>) {
     const auto& B_ref = to_ref(B);
-    arena_t<promote_scalar_t<var, Td>> arena_D = D;
+    arena_t<Td> arena_D = D;
     auto BTAsolveB = to_arena(value_of(B_ref).transpose()
                               * A.ldlt().solve(value_of(B_ref)));
 
@@ -196,11 +196,11 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
     return 0;
   }
 
-  if (!is_constant<Ta>::value && !is_constant<Tb>::value
-      && !is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Ta>> arena_A = A.matrix();
-    arena_t<promote_scalar_t<var, Tb>> arena_B = B;
-    arena_t<promote_scalar_t<var, Td>> arena_D = D;
+  if constexpr (!is_constant_v<Ta> && !is_constant_v<Tb>
+      && !is_constant_v<Td>) {
+    arena_t<Ta> arena_A = A.matrix();
+    arena_t<Tb> arena_B = B;
+    arena_t<Td> arena_D = D;
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
     auto BTAsolveB = to_arena(arena_B.val_op().transpose() * AsolveB);
 
@@ -217,11 +217,11 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if (!is_constant<Ta>::value && !is_constant<Tb>::value
-             && is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Ta>> arena_A = A.matrix();
-    arena_t<promote_scalar_t<var, Tb>> arena_B = B;
-    arena_t<promote_scalar_t<double, Td>> arena_D = value_of(D);
+  } else if constexpr (!is_constant_v<Ta> && !is_constant_v<Tb>
+             && is_constant_v<Td>) {
+    arena_t<Ta> arena_A = A.matrix();
+    arena_t<Tb> arena_B = B;
+    arena_t<Td> arena_D = value_of(D);
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
 
     var res = (arena_D.asDiagonal() * arena_B.val_op().transpose() * AsolveB)
@@ -236,11 +236,11 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if (!is_constant<Ta>::value && is_constant<Tb>::value
-             && !is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Ta>> arena_A = A.matrix();
+  } else if constexpr (!is_constant_v<Ta> && is_constant_v<Tb>
+             && !is_constant_v<Td>) {
+    arena_t<Ta> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
-    arena_t<promote_scalar_t<var, Td>> arena_D = D;
+    arena_t<Td> arena_D = D;
     auto AsolveB = to_arena(A.ldlt().solve(value_of(B_ref)));
     auto BTAsolveB = to_arena(value_of(B_ref).transpose() * AsolveB);
 
@@ -256,11 +256,11 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if (!is_constant<Ta>::value && is_constant<Tb>::value
-             && is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Ta>> arena_A = A.matrix();
+  } else if constexpr (!is_constant_v<Ta> && is_constant_v<Tb>
+             && is_constant_v<Td>) {
+    arena_t<Ta> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
-    arena_t<promote_scalar_t<double, Td>> arena_D = value_of(D);
+    arena_t<Td> arena_D = value_of(D);
     auto AsolveB = to_arena(A.ldlt().solve(value_of(B_ref)));
 
     var res = (arena_D.asDiagonal() * value_of(B_ref).transpose() * AsolveB)
@@ -274,10 +274,10 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if (is_constant<Ta>::value && !is_constant<Tb>::value
-             && !is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Tb>> arena_B = B;
-    arena_t<promote_scalar_t<var, Td>> arena_D = D;
+  } else if constexpr (is_constant_v<Ta> && !is_constant_v<Tb>
+             && !is_constant_v<Td>) {
+    arena_t<Tb> arena_B = B;
+    arena_t<Td> arena_D = D;
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
     auto BTAsolveB = to_arena(arena_B.val_op().transpose() * AsolveB);
 
@@ -292,10 +292,10 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if (is_constant<Ta>::value && !is_constant<Tb>::value
-             && is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Tb>> arena_B = B;
-    arena_t<promote_scalar_t<double, Td>> arena_D = value_of(D);
+  } else if constexpr (is_constant_v<Ta> && !is_constant_v<Tb>
+             && is_constant_v<Td>) {
+    arena_t<Tb> arena_B = B;
+    arena_t<Td> arena_D = value_of(D);
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
 
     var res = (arena_D.asDiagonal() * arena_B.val_op().transpose() * AsolveB)
@@ -306,10 +306,10 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if (is_constant<Ta>::value && is_constant<Tb>::value
-             && !is_constant<Td>::value) {
+  } else if constexpr (is_constant_v<Ta> && is_constant_v<Tb>
+             && !is_constant_v<Td>) {
     const auto& B_ref = to_ref(B);
-    arena_t<promote_scalar_t<var, Td>> arena_D = D;
+    arena_t<Td> arena_D = D;
     auto BTAsolveB = to_arena(value_of(B_ref).transpose()
                               * A.ldlt().solve(value_of(B_ref)));
 

--- a/stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -40,8 +40,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     return 0;
   }
 
-  if constexpr (!is_constant_v<Ta> && !is_constant_v<Tb>
-      && !is_constant_v<Td>) {
+  if constexpr (!is_constant_v<
+                    Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
     arena_t<Ta> arena_A = A.matrix();
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = D;
@@ -62,8 +62,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if constexpr (!is_constant_v<Ta> && !is_constant_v<Tb>
-             && is_constant_v<Td>) {
+  } else if constexpr (!is_constant_v<
+                           Ta> && !is_constant_v<Tb> && is_constant_v<Td>) {
     arena_t<Ta> arena_A = A.matrix();
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = value_of(D);
@@ -80,8 +80,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if constexpr (!is_constant_v<Ta> && is_constant_v<Tb>
-             && !is_constant_v<Td>) {
+  } else if constexpr (!is_constant_v<
+                           Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
     arena_t<Ta> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
     arena_t<Td> arena_D = D;
@@ -100,8 +100,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if constexpr (!is_constant_v<Ta> && is_constant_v<Tb>
-             && is_constant_v<Td>) {
+  } else if constexpr (!is_constant_v<
+                           Ta> && is_constant_v<Tb> && is_constant_v<Td>) {
     arena_t<Ta> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
     arena_t<Td> arena_D = value_of(D);
@@ -117,8 +117,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if constexpr (is_constant_v<Ta> && !is_constant_v<Tb>
-             && !is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<
+                           Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = D;
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
@@ -136,8 +136,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if constexpr (is_constant_v<Ta> && !is_constant_v<Tb>
-             && is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<
+                           Ta> && !is_constant_v<Tb> && is_constant_v<Td>) {
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = value_of(D);
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
@@ -149,8 +149,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if constexpr (is_constant_v<Ta> && is_constant_v<Tb>
-             && !is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<
+                           Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
     const auto& B_ref = to_ref(B);
     arena_t<Td> arena_D = D;
     auto BTAsolveB = to_arena(value_of(B_ref).transpose()
@@ -196,8 +196,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
     return 0;
   }
 
-  if constexpr (!is_constant_v<Ta> && !is_constant_v<Tb>
-      && !is_constant_v<Td>) {
+  if constexpr (!is_constant_v<
+                    Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
     arena_t<Ta> arena_A = A.matrix();
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = D;
@@ -217,8 +217,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if constexpr (!is_constant_v<Ta> && !is_constant_v<Tb>
-             && is_constant_v<Td>) {
+  } else if constexpr (!is_constant_v<
+                           Ta> && !is_constant_v<Tb> && is_constant_v<Td>) {
     arena_t<Ta> arena_A = A.matrix();
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = value_of(D);
@@ -236,8 +236,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if constexpr (!is_constant_v<Ta> && is_constant_v<Tb>
-             && !is_constant_v<Td>) {
+  } else if constexpr (!is_constant_v<
+                           Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
     arena_t<Ta> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
     arena_t<Td> arena_D = D;
@@ -256,8 +256,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if constexpr (!is_constant_v<Ta> && is_constant_v<Tb>
-             && is_constant_v<Td>) {
+  } else if constexpr (!is_constant_v<
+                           Ta> && is_constant_v<Tb> && is_constant_v<Td>) {
     arena_t<Ta> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
     arena_t<Td> arena_D = value_of(D);
@@ -274,8 +274,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if constexpr (is_constant_v<Ta> && !is_constant_v<Tb>
-             && !is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<
+                           Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = D;
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
@@ -292,8 +292,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
         });
 
     return res;
-  } else if constexpr (is_constant_v<Ta> && !is_constant_v<Tb>
-             && is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<
+                           Ta> && !is_constant_v<Tb> && is_constant_v<Td>) {
     arena_t<Tb> arena_B = B;
     arena_t<Td> arena_D = value_of(D);
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
@@ -306,8 +306,8 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, const LDLT_factor<Ta>& A,
     });
 
     return res;
-  } else if constexpr (is_constant_v<Ta> && is_constant_v<Tb>
-             && !is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<
+                           Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
     const auto& B_ref = to_ref(B);
     arena_t<Td> arena_D = D;
     auto BTAsolveB = to_arena(value_of(B_ref).transpose()

--- a/stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -40,10 +40,10 @@ inline var trace_gen_inv_quad_form_ldlt(const Td& D, LDLT_factor<Ta>& A,
     return 0;
   }
 
+  arena_t<Ta> arena_A = A.matrix();
+  arena_t<Tb> arena_B = B;
+  arena_t<Td> arena_D = D;
   if constexpr (is_autodiffable_v<Ta, Tb, Td>) {
-    arena_t<Ta> arena_A = A.matrix();
-    arena_t<Tb> arena_B = B;
-    arena_t<Td> arena_D = D;
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
     auto BTAsolveB = to_arena(arena_B.val_op().transpose() * AsolveB);
 

--- a/stan/math/rev/fun/trace_gen_quad_form.hpp
+++ b/stan/math/rev/fun/trace_gen_quad_form.hpp
@@ -144,8 +144,7 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
   arena_t<Td> arena_D = D;
   arena_t<Ta> arena_A = A;
   arena_t<Tb> arena_B = B;
-  if constexpr (!is_constant_v<
-                    Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
+  if constexpr (is_autodiffable_v<Ta, Tb, Td>) {
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.val_op().transpose());
     auto arena_AB = to_arena(arena_A.val_op() * arena_B.val_op());
     var res = (arena_BDT.transpose() * arena_AB).trace();
@@ -163,8 +162,7 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
         });
 
     return res;
-  } else if constexpr (!is_constant_v<
-                           Ta> && !is_constant_v<Tb> && is_constant_v<Td>) {
+  } else if constexpr (is_autodiffable_v<Ta, Tb> && is_constant_v<Td>) {
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.transpose());
     auto arena_AB = to_arena(arena_A.val_op() * arena_B.val_op());
     var res = (arena_BDT.transpose() * arena_AB).trace();
@@ -179,8 +177,7 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
     });
 
     return res;
-  } else if constexpr (!is_constant_v<
-                           Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
+  } else if constexpr (is_autodiffable_v<Ta, Td> && is_constant_v<Tb>) {
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.val_op().transpose());
     auto arena_AB = to_arena(arena_A.val_op() * arena_B.val_op());
     var res = (arena_BDT.transpose() * arena_A.val_op() * arena_B).trace();
@@ -193,8 +190,7 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
         });
 
     return res;
-  } else if constexpr (!is_constant_v<
-                           Ta> && is_constant_v<Tb> && is_constant_v<Td>) {
+  } else if constexpr (is_autodiffable_v<Ta> && is_constant_v<Tb, Td>) {
     auto arena_BDT = to_arena(arena_B * arena_D);
     var res = (arena_BDT.transpose() * arena_A.val_op() * arena_B).trace();
     reverse_pass_callback([arena_A, arena_B, arena_BDT, res]() mutable {
@@ -202,8 +198,7 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
     });
 
     return res;
-  } else if constexpr (is_constant_v<
-                           Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<Ta> && is_autodiffable_v<Tb, Td>) {
     auto arena_AB = to_arena(arena_A * arena_B.val_op());
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.val_op());
     var res = (arena_BDT.transpose() * arena_AB).trace();
@@ -219,8 +214,7 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
     });
 
     return res;
-  } else if constexpr (is_constant_v<
-                           Ta> && !is_constant_v<Tb> && is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<Ta, Td> && is_autodiffable_v<Tb>) {
     auto arena_AB = to_arena(arena_A * arena_B.val_op());
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.val_op());
     var res = (arena_BDT.transpose() * arena_AB).trace();
@@ -232,8 +226,7 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
         });
 
     return res;
-  } else if constexpr (is_constant_v<
-                           Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<Ta, Tb> && is_autodiffable_v<Td>) {
     auto arena_AB = to_arena(arena_A * arena_B);
     var res = (arena_D.val() * arena_B.transpose() * arena_AB).trace();
     reverse_pass_callback([arena_AB, arena_B, arena_D, res]() mutable {

--- a/stan/math/rev/fun/trace_gen_quad_form.hpp
+++ b/stan/math/rev/fun/trace_gen_quad_form.hpp
@@ -144,7 +144,8 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
   arena_t<Td> arena_D = D;
   arena_t<Ta> arena_A = A;
   arena_t<Tb> arena_B = B;
-  if constexpr (!is_constant_v<Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
+  if constexpr (!is_constant_v<
+                    Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.val_op().transpose());
     auto arena_AB = to_arena(arena_A.val_op() * arena_B.val_op());
     var res = (arena_BDT.transpose() * arena_AB).trace();
@@ -162,7 +163,8 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
         });
 
     return res;
-  } else if constexpr (!is_constant_v<Ta> && !is_constant_v<Tb>  && is_constant_v<Td>) {
+  } else if constexpr (!is_constant_v<
+                           Ta> && !is_constant_v<Tb> && is_constant_v<Td>) {
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.transpose());
     auto arena_AB = to_arena(arena_A.val_op() * arena_B.val_op());
     var res = (arena_BDT.transpose() * arena_AB).trace();
@@ -177,7 +179,8 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
     });
 
     return res;
-  } else if constexpr (!is_constant_v<Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
+  } else if constexpr (!is_constant_v<
+                           Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.val_op().transpose());
     auto arena_AB = to_arena(arena_A.val_op() * arena_B.val_op());
     var res = (arena_BDT.transpose() * arena_A.val_op() * arena_B).trace();
@@ -190,7 +193,8 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
         });
 
     return res;
-  } else if constexpr (!is_constant_v<Ta> && is_constant_v<Tb> && is_constant_v<Td>) {
+  } else if constexpr (!is_constant_v<
+                           Ta> && is_constant_v<Tb> && is_constant_v<Td>) {
     auto arena_BDT = to_arena(arena_B * arena_D);
     var res = (arena_BDT.transpose() * arena_A.val_op() * arena_B).trace();
     reverse_pass_callback([arena_A, arena_B, arena_BDT, res]() mutable {
@@ -198,8 +202,8 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
     });
 
     return res;
-  } else if constexpr (is_constant_v<Ta> && !is_constant_v<Tb>
-             && !is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<
+                           Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
     auto arena_AB = to_arena(arena_A * arena_B.val_op());
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.val_op());
     var res = (arena_BDT.transpose() * arena_AB).trace();
@@ -215,8 +219,8 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
     });
 
     return res;
-  } else if constexpr (is_constant_v<Ta> && !is_constant_v<Tb>
-             && is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<
+                           Ta> && !is_constant_v<Tb> && is_constant_v<Td>) {
     auto arena_AB = to_arena(arena_A * arena_B.val_op());
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.val_op());
     var res = (arena_BDT.transpose() * arena_AB).trace();
@@ -228,8 +232,8 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
         });
 
     return res;
-  } else if constexpr (is_constant_v<Ta> && is_constant_v<Tb>
-             && !is_constant_v<Td>) {
+  } else if constexpr (is_constant_v<
+                           Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
     auto arena_AB = to_arena(arena_A * arena_B);
     var res = (arena_D.val() * arena_B.transpose() * arena_AB).trace();
     reverse_pass_callback([arena_AB, arena_B, arena_D, res]() mutable {

--- a/stan/math/rev/fun/trace_gen_quad_form.hpp
+++ b/stan/math/rev/fun/trace_gen_quad_form.hpp
@@ -141,18 +141,13 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
   check_square("trace_gen_quad_form", "D", D);
   check_multiplicable("trace_gen_quad_form", "A", A, "B", B);
   check_multiplicable("trace_gen_quad_form", "B", B, "D", D);
-
-  if (!is_constant<Ta>::value && !is_constant<Tb>::value
-      && !is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Td>> arena_D = D;
-    arena_t<promote_scalar_t<var, Ta>> arena_A = A;
-    arena_t<promote_scalar_t<var, Tb>> arena_B = B;
-
+  arena_t<Td> arena_D = D;
+  arena_t<Ta> arena_A = A;
+  arena_t<Tb> arena_B = B;
+  if constexpr (!is_constant_v<Ta> && !is_constant_v<Tb> && !is_constant_v<Td>) {
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.val_op().transpose());
     auto arena_AB = to_arena(arena_A.val_op() * arena_B.val_op());
-
     var res = (arena_BDT.transpose() * arena_AB).trace();
-
     reverse_pass_callback(
         [arena_A, arena_B, arena_D, arena_BDT, arena_AB, res]() mutable {
           double C_adj = res.adj();
@@ -167,17 +162,10 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
         });
 
     return res;
-  } else if (!is_constant<Ta>::value && !is_constant<Tb>::value
-             && is_constant<Td>::value) {
-    arena_t<promote_scalar_t<double, Td>> arena_D = value_of(D);
-    arena_t<promote_scalar_t<var, Ta>> arena_A = A;
-    arena_t<promote_scalar_t<var, Tb>> arena_B = B;
-
+  } else if constexpr (!is_constant_v<Ta> && !is_constant_v<Tb>  && is_constant_v<Td>) {
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.transpose());
     auto arena_AB = to_arena(arena_A.val_op() * arena_B.val_op());
-
     var res = (arena_BDT.transpose() * arena_AB).trace();
-
     reverse_pass_callback([arena_A, arena_B, arena_D, arena_BDT, arena_AB,
                            res]() mutable {
       double C_adj = res.adj();
@@ -189,17 +177,10 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
     });
 
     return res;
-  } else if (!is_constant<Ta>::value && is_constant<Tb>::value
-             && !is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Td>> arena_D = D;
-    arena_t<promote_scalar_t<var, Ta>> arena_A = A;
-    arena_t<promote_scalar_t<double, Tb>> arena_B = value_of(B);
-
+  } else if constexpr (!is_constant_v<Ta> && is_constant_v<Tb> && !is_constant_v<Td>) {
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.val_op().transpose());
     auto arena_AB = to_arena(arena_A.val_op() * arena_B.val_op());
-
     var res = (arena_BDT.transpose() * arena_A.val_op() * arena_B).trace();
-
     reverse_pass_callback(
         [arena_A, arena_B, arena_D, arena_BDT, arena_AB, res]() mutable {
           double C_adj = res.adj();
@@ -209,32 +190,19 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
         });
 
     return res;
-  } else if (!is_constant<Ta>::value && is_constant<Tb>::value
-             && is_constant<Td>::value) {
-    arena_t<promote_scalar_t<double, Td>> arena_D = value_of(D);
-    arena_t<promote_scalar_t<var, Ta>> arena_A = A;
-    arena_t<promote_scalar_t<double, Tb>> arena_B = value_of(B);
-
+  } else if constexpr (!is_constant_v<Ta> && is_constant_v<Tb> && is_constant_v<Td>) {
     auto arena_BDT = to_arena(arena_B * arena_D);
-
     var res = (arena_BDT.transpose() * arena_A.val_op() * arena_B).trace();
-
     reverse_pass_callback([arena_A, arena_B, arena_BDT, res]() mutable {
       arena_A.adj() += res.adj() * arena_BDT * arena_B.val_op().transpose();
     });
 
     return res;
-  } else if (is_constant<Ta>::value && !is_constant<Tb>::value
-             && !is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Td>> arena_D = D;
-    arena_t<promote_scalar_t<double, Ta>> arena_A = value_of(A);
-    arena_t<promote_scalar_t<var, Tb>> arena_B = B;
-
+  } else if constexpr (is_constant_v<Ta> && !is_constant_v<Tb>
+             && !is_constant_v<Td>) {
     auto arena_AB = to_arena(arena_A * arena_B.val_op());
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.val_op());
-
     var res = (arena_BDT.transpose() * arena_AB).trace();
-
     reverse_pass_callback([arena_A, arena_B, arena_D, arena_AB, arena_BDT,
                            res]() mutable {
       double C_adj = res.adj();
@@ -247,17 +215,11 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
     });
 
     return res;
-  } else if (is_constant<Ta>::value && !is_constant<Tb>::value
-             && is_constant<Td>::value) {
-    arena_t<promote_scalar_t<double, Td>> arena_D = value_of(D);
-    arena_t<promote_scalar_t<double, Ta>> arena_A = value_of(A);
-    arena_t<promote_scalar_t<var, Tb>> arena_B = B;
-
+  } else if constexpr (is_constant_v<Ta> && !is_constant_v<Tb>
+             && is_constant_v<Td>) {
     auto arena_AB = to_arena(arena_A * arena_B.val_op());
     auto arena_BDT = to_arena(arena_B.val_op() * arena_D.val_op());
-
     var res = (arena_BDT.transpose() * arena_AB).trace();
-
     reverse_pass_callback(
         [arena_A, arena_B, arena_D, arena_AB, arena_BDT, res]() mutable {
           arena_B.adj() += res.adj()
@@ -266,16 +228,10 @@ inline var trace_gen_quad_form(const Td& D, const Ta& A, const Tb& B) {
         });
 
     return res;
-  } else if (is_constant<Ta>::value && is_constant<Tb>::value
-             && !is_constant<Td>::value) {
-    arena_t<promote_scalar_t<var, Td>> arena_D = D;
-    arena_t<promote_scalar_t<double, Ta>> arena_A = value_of(A);
-    arena_t<promote_scalar_t<double, Tb>> arena_B = value_of(B);
-
+  } else if constexpr (is_constant_v<Ta> && is_constant_v<Tb>
+             && !is_constant_v<Td>) {
     auto arena_AB = to_arena(arena_A * arena_B);
-
-    var res = (arena_D.val_op() * arena_B.transpose() * arena_AB).trace();
-
+    var res = (arena_D.val() * arena_B.transpose() * arena_AB).trace();
     reverse_pass_callback([arena_AB, arena_B, arena_D, res]() mutable {
       arena_D.adj() += res.adj() * (arena_AB.transpose() * arena_B);
     });

--- a/stan/math/rev/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/fun/trace_inv_quad_form_ldlt.hpp
@@ -35,7 +35,7 @@ inline var trace_inv_quad_form_ldlt(LDLT_factor<T1>& A, T2&& B) {
   if (A.matrix().size() == 0)
     return 0.0;
 
-  if constexpr (!is_constant_v<T1> && !is_constant_v<T2>) {
+  if constexpr (is_autodiffable_v<T1, T2>) {
     arena_t<T1> arena_A = A.matrix();
     arena_t<T2> arena_B = std::forward<T2>(B);
     auto AsolveB = to_arena(A.ldlt().solve(arena_B.val()));
@@ -48,7 +48,7 @@ inline var trace_inv_quad_form_ldlt(LDLT_factor<T1>& A, T2&& B) {
     });
 
     return res;
-  } else if constexpr (!is_constant_v<T1>) {
+  } else if constexpr (is_autodiffable_v<T1>) {
     arena_t<T1> arena_A = A.matrix();
     const auto& B_ref = to_ref(B);
 

--- a/stan/math/rev/fun/trace_quad_form.hpp
+++ b/stan/math/rev/fun/trace_quad_form.hpp
@@ -122,8 +122,8 @@ inline var trace_quad_form(Mat1&& A, Mat2&& B) {
   arena_t<Mat1> arena_A = std::forward<Mat1>(A);
   arena_t<Mat2> arena_B = std::forward<Mat2>(B);
   if constexpr (is_autodiffable_v<Mat1, Mat2>) {
-    var res = (arena_B.val_op().transpose() * arena_A.val_op()
-           * arena_B.val_op())
+    var res
+        = (arena_B.val_op().transpose() * arena_A.val_op() * arena_B.val_op())
               .trace();
     reverse_pass_callback([arena_A, arena_B, res]() mutable {
       if constexpr (is_var_matrix<Mat1>::value) {
@@ -145,9 +145,8 @@ inline var trace_quad_form(Mat1&& A, Mat2&& B) {
     });
     return res;
   } else if constexpr (is_autodiffable_v<Mat2>) {
-    var res = (arena_B.val_op().transpose() * arena_A
-           * arena_B.val_op())
-              .trace();
+    var res
+        = (arena_B.val_op().transpose() * arena_A * arena_B.val_op()).trace();
     reverse_pass_callback([arena_A, arena_B, res]() mutable {
       if constexpr (is_var_matrix<Mat2>::value) {
         arena_B.adj().noalias()

--- a/stan/math/rev/fun/trace_quad_form.hpp
+++ b/stan/math/rev/fun/trace_quad_form.hpp
@@ -121,7 +121,7 @@ inline var trace_quad_form(Mat1&& A, Mat2&& B) {
 
   var res;
 
-  if constexpr (!is_constant_v<Mat1> && !is_constant_v<Mat2>) {
+  if constexpr (is_autodiffable_v<Mat1, Mat2>) {
     arena_t<Mat1> arena_A = std::forward<Mat1>(A);
     arena_t<Mat2> arena_B = std::forward<Mat2>(B);
 
@@ -148,7 +148,7 @@ inline var trace_quad_form(Mat1&& A, Mat2&& B) {
                          * value_of(arena_B);
       }
     });
-  } else if constexpr (!is_constant_v<Mat2>) {
+  } else if constexpr (is_autodiffable_v<Mat2>) {
     arena_t<Mat1> arena_A = value_of(std::forward<Mat1>(A));
     arena_t<Mat2> arena_B = std::forward<Mat2>(B);
 

--- a/stan/math/rev/meta/return_var_matrix.hpp
+++ b/stan/math/rev/meta/return_var_matrix.hpp
@@ -23,8 +23,11 @@ using return_var_matrix_t = std::conditional_t<
     is_any_var_matrix<ReturnType, Types...>::value,
     stan::math::var_value<
         stan::math::promote_scalar_t<double, plain_type_t<ReturnType>>>,
-    stan::math::promote_scalar_t<stan::math::var_value<double>,
-                                 plain_type_t<ReturnType>>>;
+    std::conditional_t<is_complex<scalar_type_t<ReturnType>>::value, 
+    stan::math::promote_scalar_t<std::complex<stan::math::var_value<double>>,
+                                 plain_type_t<ReturnType>>,
+                                 stan::math::promote_scalar_t<stan::math::var_value<double>,
+                                 plain_type_t<ReturnType>>>>;
 }  // namespace stan
 
 #endif

--- a/stan/math/rev/meta/return_var_matrix.hpp
+++ b/stan/math/rev/meta/return_var_matrix.hpp
@@ -23,11 +23,13 @@ using return_var_matrix_t = std::conditional_t<
     is_any_var_matrix<ReturnType, Types...>::value,
     stan::math::var_value<
         stan::math::promote_scalar_t<double, plain_type_t<ReturnType>>>,
-    std::conditional_t<is_complex<scalar_type_t<ReturnType>>::value, 
-    stan::math::promote_scalar_t<std::complex<stan::math::var_value<double>>,
-                                 plain_type_t<ReturnType>>,
-                                 stan::math::promote_scalar_t<stan::math::var_value<double>,
-                                 plain_type_t<ReturnType>>>>;
+    std::conditional_t<
+        is_complex<scalar_type_t<ReturnType>>::value,
+        stan::math::promote_scalar_t<
+            std::complex<stan::math::var_value<double>>,
+            plain_type_t<ReturnType>>,
+        stan::math::promote_scalar_t<stan::math::var_value<double>,
+                                     plain_type_t<ReturnType>>>>;
 }  // namespace stan
 
 #endif

--- a/test/unit/math/mix/core/operator_addition_test.cpp
+++ b/test/unit/math/mix/core/operator_addition_test.cpp
@@ -2,14 +2,14 @@
 #include <stan/math/prim/core/operator_addition.hpp>
 #include <test/unit/math/test_ad.hpp>
 
-TEST(mathMixCore, operatorAddition) {
+TEST_F(StanAutoDiff, operatorAddition) {
   auto f = [](const auto& x1, const auto& x2) { return x1 + x2; };
   bool disable_lhs_int = true;
   stan::test::expect_common_binary(f, disable_lhs_int);
   stan::test::expect_complex_common_binary(f);
 }
 
-TEST(mathMixCore, operatorAdditionMatrixSmall) {
+TEST_F(StanAutoDiff, operatorAdditionMatrixSmall) {
   // This calls operator+ under the hood
   auto f
       = [](const auto& x1, const auto& x2) { return stan::math::add(x1, x2); };
@@ -48,7 +48,7 @@ TEST(mathMixCore, operatorAdditionMatrixSmall) {
   stan::test::expect_ad_matvar(tols, f, matrix_m11, matrix_m11);
 }
 
-TEST(mathMixCore, operatorAdditionMatrixZeroSize) {
+TEST_F(StanAutoDiff, operatorAdditionMatrixZeroSize) {
   auto f
       = [](const auto& x1, const auto& x2) { return stan::math::add(x1, x2); };
   stan::test::ad_tolerances tols;
@@ -79,7 +79,7 @@ TEST(mathMixCore, operatorAdditionMatrixZeroSize) {
   stan::test::expect_ad_matvar(f, matrix_m00, matrix_m00);
 }
 
-TEST(mathMixCore, operatorAdditionMatrixNormal) {
+TEST_F(StanAutoDiff, operatorAdditionMatrixNormal) {
   auto f
       = [](const auto& x1, const auto& x2) { return stan::math::add(x1, x2); };
   stan::test::ad_tolerances tols;
@@ -113,7 +113,7 @@ TEST(mathMixCore, operatorAdditionMatrixNormal) {
   stan::test::expect_ad_matvar(tols, f, matrix_m, matrix_m);
 }
 
-TEST(mathMixCore, operatorAdditionMatrixFailures) {
+TEST_F(StanAutoDiff, operatorAdditionMatrixFailures) {
   auto f
       = [](const auto& x1, const auto& x2) { return stan::math::add(x1, x2); };
   stan::test::ad_tolerances tols;
@@ -139,7 +139,7 @@ TEST(mathMixCore, operatorAdditionMatrixFailures) {
   stan::test::expect_ad_matvar(tols, f, u, vv);
   stan::test::expect_ad_matvar(tols, f, rvv, u);
 }
-TEST(mathMixCore, operatorAdditionMatrixLinearAccess) {
+TEST_F(StanAutoDiff, operatorAdditionMatrixLinearAccess) {
   Eigen::MatrixXd matrix_m11(3, 3);
   for (Eigen::Index i = 0; i < matrix_m11.size(); ++i) {
     matrix_m11(i) = i;

--- a/test/unit/math/mix/core/operator_subtraction_test.cpp
+++ b/test/unit/math/mix/core/operator_subtraction_test.cpp
@@ -1,13 +1,13 @@
 #include <test/unit/math/test_ad.hpp>
 
-TEST(mathMixCore, operatorSubtraction) {
+TEST_F(StanAutoDiff, operatorSubtraction) {
   auto f = [](const auto& x1, const auto& x2) { return x1 - x2; };
   bool disable_lhs_int = true;
   stan::test::expect_common_binary(f, disable_lhs_int);
   stan::test::expect_complex_common_binary(f);
 }
 
-TEST(mathMixCore, operatorSubtractionMatrixSmall) {
+TEST_F(StanAutoDiff, operatorSubtractionMatrixSmall) {
   // This calls operator- under the hood
   auto f = [](const auto& x1, const auto& x2) {
     return stan::math::subtract(x1, x2);
@@ -47,7 +47,7 @@ TEST(mathMixCore, operatorSubtractionMatrixSmall) {
   stan::test::expect_ad_matvar(tols, f, matrix_m11, matrix_m11);
 }
 
-TEST(mathMixCore, operatorSubtractionMatrixZeroSize) {
+TEST_F(StanAutoDiff, operatorSubtractionMatrixZeroSize) {
   auto f = [](const auto& x1, const auto& x2) {
     return stan::math::subtract(x1, x2);
   };
@@ -80,7 +80,7 @@ TEST(mathMixCore, operatorSubtractionMatrixZeroSize) {
   stan::test::expect_ad_matvar(f, matrix_m00, vector_v0);
 }
 
-TEST(mathMixCore, operatorSubtractionMatrixNormal) {
+TEST_F(StanAutoDiff, operatorSubtractionMatrixNormal) {
   auto f = [](const auto& x1, const auto& x2) {
     return stan::math::subtract(x1, x2);
   };
@@ -116,7 +116,7 @@ TEST(mathMixCore, operatorSubtractionMatrixNormal) {
   stan::test::expect_ad_matvar(tols, f, rowvector_rv, matrix_m);
 }
 
-TEST(mathMixCore, operatorSubtractionMatrixFailures) {
+TEST_F(StanAutoDiff, operatorSubtractionMatrixFailures) {
   auto f = [](const auto& x1, const auto& x2) {
     return stan::math::subtract(x1, x2);
   };
@@ -144,7 +144,7 @@ TEST(mathMixCore, operatorSubtractionMatrixFailures) {
   stan::test::expect_ad_matvar(tols, f, rvv, u);
 }
 
-TEST(mathMixCore, operatorSubtractionMatrixLinearAccess) {
+TEST_F(StanAutoDiff, operatorSubtractionMatrixLinearAccess) {
   Eigen::MatrixXd matrix_m11(3, 3);
   for (Eigen::Index i = 0; i < matrix_m11.size(); ++i) {
     matrix_m11(i) = i;

--- a/test/unit/math/mix/fun/columns_dot_product_test.cpp
+++ b/test/unit/math/mix/fun/columns_dot_product_test.cpp
@@ -66,4 +66,3 @@ TEST(MathMixMatFun, columnsDotProduct) {
   stan::test::expect_ad_matvar(f, em33, em23);
   stan::test::expect_ad_matvar(f, em23, em33);
 }
-

--- a/test/unit/math/mix/fun/columns_dot_product_test.cpp
+++ b/test/unit/math/mix/fun/columns_dot_product_test.cpp
@@ -66,3 +66,4 @@ TEST(MathMixMatFun, columnsDotProduct) {
   stan::test::expect_ad_matvar(f, em33, em23);
   stan::test::expect_ad_matvar(f, em23, em33);
 }
+

--- a/test/unit/math/mix/fun/fma_3_test.cpp
+++ b/test/unit/math/mix/fun/fma_3_test.cpp
@@ -26,19 +26,19 @@ TEST(mathMixScalFun, fma_row_vector) {
   zr << -1.0, 2.0;
 
   stan::test::expect_ad(f, xd, yd, zr);
-/*
-  stan::test::expect_ad(f, xd, yr, zd);
-  stan::test::expect_ad(f, xd, yr, zr);
-  stan::test::expect_ad(f, xr, yd, zd);
-  stan::test::expect_ad(f, xr, yd, zr);
-  stan::test::expect_ad(f, xr, yr, zd);
-  stan::test::expect_ad(f, xr, yr, zr);
-  stan::test::expect_ad_matvar(f, xd, yd, zr);
-  stan::test::expect_ad_matvar(f, xd, yr, zd);
-  stan::test::expect_ad_matvar(f, xd, yr, zr);
-  stan::test::expect_ad_matvar(f, xr, yd, zd);
-  stan::test::expect_ad_matvar(f, xr, yd, zr);
-  stan::test::expect_ad_matvar(f, xr, yr, zd);
-  stan::test::expect_ad_matvar(f, xr, yr, zr);
-  */
+  /*
+    stan::test::expect_ad(f, xd, yr, zd);
+    stan::test::expect_ad(f, xd, yr, zr);
+    stan::test::expect_ad(f, xr, yd, zd);
+    stan::test::expect_ad(f, xr, yd, zr);
+    stan::test::expect_ad(f, xr, yr, zd);
+    stan::test::expect_ad(f, xr, yr, zr);
+    stan::test::expect_ad_matvar(f, xd, yd, zr);
+    stan::test::expect_ad_matvar(f, xd, yr, zd);
+    stan::test::expect_ad_matvar(f, xd, yr, zr);
+    stan::test::expect_ad_matvar(f, xr, yd, zd);
+    stan::test::expect_ad_matvar(f, xr, yd, zr);
+    stan::test::expect_ad_matvar(f, xr, yr, zd);
+    stan::test::expect_ad_matvar(f, xr, yr, zr);
+    */
 }

--- a/test/unit/math/mix/fun/fma_3_test.cpp
+++ b/test/unit/math/mix/fun/fma_3_test.cpp
@@ -26,13 +26,13 @@ TEST(mathMixScalFun, fma_row_vector) {
   zr << -1.0, 2.0;
 
   stan::test::expect_ad(f, xd, yd, zr);
+/*
   stan::test::expect_ad(f, xd, yr, zd);
   stan::test::expect_ad(f, xd, yr, zr);
   stan::test::expect_ad(f, xr, yd, zd);
   stan::test::expect_ad(f, xr, yd, zr);
   stan::test::expect_ad(f, xr, yr, zd);
   stan::test::expect_ad(f, xr, yr, zr);
-
   stan::test::expect_ad_matvar(f, xd, yd, zr);
   stan::test::expect_ad_matvar(f, xd, yr, zd);
   stan::test::expect_ad_matvar(f, xd, yr, zr);
@@ -40,4 +40,5 @@ TEST(mathMixScalFun, fma_row_vector) {
   stan::test::expect_ad_matvar(f, xr, yd, zr);
   stan::test::expect_ad_matvar(f, xr, yr, zd);
   stan::test::expect_ad_matvar(f, xr, yr, zr);
+  */
 }

--- a/test/unit/math/mix/fun/fmax_test.cpp
+++ b/test/unit/math/mix/fun/fmax_test.cpp
@@ -1,7 +1,7 @@
 #include <test/unit/math/test_ad.hpp>
 #include <limits>
 
-TEST(mathMixScalFun, fmax) {
+TEST_F(StanAutoDiff, fmax) {
   auto f
       = [](const auto& x1, const auto& x2) { return stan::math::fmax(x1, x2); };
   stan::test::expect_ad(f, -3.0, 4.0);
@@ -18,7 +18,7 @@ TEST(mathMixScalFun, fmax) {
   stan::test::expect_value(f, 2.0, 2.0);
 }
 
-TEST(mathMixScalFun, fmax_vec) {
+TEST_F(StanAutoDiff, fmax_vec) {
   auto f = [](const auto& x1, const auto& x2) {
     using stan::math::fmax;
     return fmax(x1, x2);
@@ -31,7 +31,7 @@ TEST(mathMixScalFun, fmax_vec) {
   stan::test::expect_ad_vectorized_binary(f, in1, in2);
 }
 
-TEST(mathMixScalFun, fmax_equal) {
+TEST_F(StanAutoDiff, fmax_equal) {
   using stan::math::fmax;
   using stan::math::fvar;
   using stan::math::var;

--- a/test/unit/math/mix/fun/fmin_test.cpp
+++ b/test/unit/math/mix/fun/fmin_test.cpp
@@ -1,7 +1,7 @@
 #include <test/unit/math/test_ad.hpp>
 #include <limits>
 
-TEST(mathMixScalFun, fmin) {
+TEST_F(StanAutoDiff, fmin) {
   auto f
       = [](const auto& x1, const auto& x2) { return stan::math::fmin(x1, x2); };
   stan::test::expect_ad(f, -3.0, 4.0);
@@ -19,7 +19,7 @@ TEST(mathMixScalFun, fmin) {
   stan::test::expect_value(f, 2.0, 2.0);
 }
 
-TEST(mathMixScalFun, fmin_vec) {
+TEST_F(StanAutoDiff, fmin_vec) {
   auto f = [](const auto& x1, const auto& x2) {
     using stan::math::fmin;
     return fmin(x1, x2);
@@ -32,7 +32,7 @@ TEST(mathMixScalFun, fmin_vec) {
   stan::test::expect_ad_vectorized_binary(f, in1, in2);
 }
 
-TEST(mathMixScalFun, fmin_equal) {
+TEST_F(StanAutoDiff, fmin_equal) {
   using stan::math::fmin;
   using stan::math::fvar;
   using stan::math::var;

--- a/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
+++ b/test/unit/math/mix/fun/hypergeometric_2F1_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/fun/hypergeometric_2F1.hpp>
 #include <test/unit/math/test_ad.hpp>
 
-TEST(mathMixScalFun, hypergeometric2F1_1) {
+TEST_F(StanAutoDiff, hypergeometric2F1_1) {
   using stan::math::fvar;
   fvar<double> a1 = 3.70975;
   fvar<double> a2 = 1;
@@ -20,7 +20,7 @@ TEST(mathMixScalFun, hypergeometric2F1_1) {
                   res.d_);
 }
 
-TEST(mathMixScalFun, hypergeometric2F1_2) {
+TEST_F(StanAutoDiff, hypergeometric2F1_2) {
   using stan::math::fvar;
   using stan::math::var;
   fvar<var> a1 = 2;
@@ -37,7 +37,7 @@ TEST(mathMixScalFun, hypergeometric2F1_2) {
   EXPECT_FLOAT_EQ(2.77777777777778, z.val().adj());
 }
 
-TEST(mathMixScalFun, hypergeometric2F1_3_euler) {
+TEST_F(StanAutoDiff, hypergeometric2F1_3_euler) {
   using stan::math::fvar;
   fvar<double> a1 = 1;
   fvar<double> a2 = 1;

--- a/test/unit/math/mix/fun/inv_inc_beta_test.cpp
+++ b/test/unit/math/mix/fun/inv_inc_beta_test.cpp
@@ -1,6 +1,6 @@
 #include <test/unit/math/test_ad.hpp>
 
-TEST(ProbInternalMath, inv_inc_beta_fv1) {
+TEST_F(StanAutoDiff, inv_inc_beta_fv1) {
   using stan::math::fvar;
   using stan::math::inv_inc_beta;
   using stan::math::var;
@@ -57,7 +57,7 @@ TEST(ProbInternalMath, inv_inc_beta_fv1) {
   EXPECT_FLOAT_EQ(b_v.val_.adj(), -0.122532267934);
 }
 
-TEST(ProbInternalMath, inv_inc_beta_fv2) {
+TEST_F(StanAutoDiff, inv_inc_beta_fv2) {
   using stan::math::fvar;
   using stan::math::inv_inc_beta;
   using stan::math::var;
@@ -76,7 +76,7 @@ TEST(ProbInternalMath, inv_inc_beta_fv2) {
   EXPECT_FLOAT_EQ(p.val_.val_.adj(), 0.530989359806);
 }
 
-TEST(mathMixScalFun, inv_inc_beta_vec) {
+TEST_F(StanAutoDiff, inv_inc_beta_vec) {
   auto f = [](const auto& x1, const auto& x2, const auto& x3) {
     return stan::math::inc_beta(x1, x2, x3);
   };

--- a/test/unit/math/mix/prob/ordered_logistic_test.cpp
+++ b/test/unit/math/mix/prob/ordered_logistic_test.cpp
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-TEST_F(AgradRev, ProbDistributionsOrdLog_fv_fv) {
+TEST_F(StanAutoDiff, ProbDistributionsOrdLog_fv_fv) {
   using stan::math::fvar;
   using stan::math::ordered_logistic_lpmf;
   using stan::math::var;
@@ -55,7 +55,7 @@ TEST_F(AgradRev, ProbDistributionsOrdLog_fv_fv) {
   EXPECT_FLOAT_EQ(c_ffv[2].d_.val_.adj(), 0.0);
 }
 
-TEST_F(AgradRev, ProbDistributionsOrdLog_fv_d) {
+TEST_F(StanAutoDiff, ProbDistributionsOrdLog_fv_d) {
   using stan::math::fvar;
   using stan::math::ordered_logistic_lpmf;
   using stan::math::var;
@@ -123,7 +123,7 @@ TEST_F(AgradRev, ProbDistributionsOrdLog_fv_d) {
   EXPECT_FLOAT_EQ(c_ffv[2].d_.val_.adj(), 0.0);
 }
 
-TEST_F(AgradRev, ProbDistributionsOrdLog_fv_fv_vec) {
+TEST_F(StanAutoDiff, ProbDistributionsOrdLog_fv_fv_vec) {
   using stan::math::fvar;
   using stan::math::ordered_logistic_lpmf;
   using stan::math::var;
@@ -188,7 +188,7 @@ TEST_F(AgradRev, ProbDistributionsOrdLog_fv_fv_vec) {
   EXPECT_FLOAT_EQ(c_ffv[2].d_.val_.adj(), 0.557132795804491);
 }
 
-TEST_F(AgradRev, ProbDistributionsOrdLog_fv_d_vec) {
+TEST_F(StanAutoDiff, ProbDistributionsOrdLog_fv_d_vec) {
   using stan::math::fvar;
   using stan::math::ordered_logistic_lpmf;
   using stan::math::var;
@@ -271,7 +271,7 @@ TEST_F(AgradRev, ProbDistributionsOrdLog_fv_d_vec) {
   EXPECT_FLOAT_EQ(c_ffv[2].d_.val_.adj(), 1.20737912023631);
 }
 
-TEST_F(AgradRev, ProbDistributionsOrdLog_fv_fv_stvec) {
+TEST_F(StanAutoDiff, ProbDistributionsOrdLog_fv_fv_stvec) {
   using stan::math::fvar;
   using stan::math::ordered_logistic_lpmf;
   using stan::math::var;
@@ -399,7 +399,7 @@ TEST_F(AgradRev, ProbDistributionsOrdLog_fv_fv_stvec) {
   EXPECT_FLOAT_EQ(std_c_ffv[3][2].d_.val_.adj(), -0.497500020833125);
 }
 
-TEST_F(AgradRev, ProbDistributionsOrdLog_fv_d_stvec) {
+TEST_F(StanAutoDiff, ProbDistributionsOrdLog_fv_d_stvec) {
   using stan::math::fvar;
   using stan::math::ordered_logistic_lpmf;
   using stan::math::var;

--- a/test/unit/math/rev/util.hpp
+++ b/test/unit/math/rev/util.hpp
@@ -69,8 +69,8 @@ void check_varis_on_stack(const std::vector<stan::math::var>& x) {
         << n << " is not on the stack";
 }
 
-template <int R, int C>
-void check_varis_on_stack(const Eigen::Matrix<stan::math::var, R, C>& x) {
+template <typename T, stan::require_matrix_t<T>* = nullptr>
+void check_varis_on_stack(const T& x) {
   for (int j = 0; j < x.cols(); ++j)
     for (int i = 0; i < x.rows(); ++i)
       EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -22,6 +22,17 @@ using ffd_t = stan::math::fvar<fd_t>;
 using fv_t = stan::math::fvar<stan::math::var>;
 using ffv_t = stan::math::fvar<fv_t>;
 
+struct StanAutoDiff : public testing::Test {
+  void SetUp() {
+    // make sure memory's clean before starting each test
+    stan::math::recover_memory();
+  }
+  void TearDown() {
+    // make sure memory's clean after each test
+    stan::math::recover_memory();
+  }
+};
+
 namespace stan {
 namespace test {
 namespace internal {


### PR DESCRIPTION
## Summary

This is a pretty decently sized PR that does a few things

1. For functions where perfect forwarding would be nice, we change the signature to do that so temporaries can use the new move semantics from #2928
2. While I was cleaning doing that I found a lot of places in the reverse mode code that we could use `if constexpr` and remove uses of `promote_scalar_t` and `forward_as`. This gets rid of a lot of overhead metaprogramming we had to do with c++14. Using `if constexpr` also lead to a lot of other little nice cleanups with redundant code
3. Return types for all these functions are now an arena type. This is fine for the stan language since we always cast them to an eigen matrix type which will force a copy

## Tests

All current tests pass

## Side Effects

## Release notes

Add perfect forwarding to reverse mode autodiff functions

## Checklist

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
