### PR TITLE
Use explicit std namespace for hypot call

### DIFF
--- a/stan/math/prim/fun/fabs.hpp
+++ b/stan/math/prim/fun/fabs.hpp
@@ -17,7 +17,7 @@ inline auto fabs(T x) {
 
 template <typename T, require_complex_t<T>* = nullptr>
 inline auto fabs(T x) {
-  return hypot(x.real(), x.imag());
+  return std::hypot(x.real(), x.imag());
 }
 
 /**


### PR DESCRIPTION
## Summary

Clang-15 on MacOS currently giving an error in the `hypot` lookup for complex `fabs`, this PR just uses the explicit namespace when calling (`std::hypot`) which ensures it is found

## Tests

N/A

## Side Effects

N/A

## Release notes

Fix compilation of `fabs` with Apple Clang 15

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
