### PR TITLE
adds check functions for stochastic row and column matrices

### DIFF
--- a/stan/math/prim/err.hpp
+++ b/stan/math/prim/err.hpp
@@ -39,6 +39,8 @@
 #include <stan/math/prim/err/check_size_match.hpp>
 #include <stan/math/prim/err/check_square.hpp>
 #include <stan/math/prim/err/check_std_vector_index.hpp>
+#include <stan/math/prim/err/check_stochastic_column.hpp>
+#include <stan/math/prim/err/check_stochastic_row.hpp>
 #include <stan/math/prim/err/check_symmetric.hpp>
 #include <stan/math/prim/err/check_unit_vector.hpp>
 #include <stan/math/prim/err/check_vector.hpp>

--- a/stan/math/prim/err/check_stochastic_column.hpp
+++ b/stan/math/prim/err/check_stochastic_column.hpp
@@ -16,10 +16,11 @@ namespace stan {
 namespace math {
 
 /**
- * Throw an exception if the specified matrix is not a column stochastic matrix. To be a
- * column stochastic matrix, all the values in each column must be greater than or equal to 0 and the values must sum to 1. A
- * valid column stochastic matrix is one where the sum of the elements by column is equal to 1.  This
- * function tests that the sum is within the tolerance specified by
+ * Throw an exception if the specified matrix is not a column stochastic matrix.
+ * To be a column stochastic matrix, all the values in each column must be
+ * greater than or equal to 0 and the values must sum to 1. A valid column
+ * stochastic matrix is one where the sum of the elements by column is equal
+ * to 1.  This function tests that the sum is within the tolerance specified by
  * `CONSTRAINT_TOLERANCE`. This function only accepts Eigen matrices, statically
  * typed vectors, not general matrices with 1 column.
  * @tparam T A type inheriting from `Eigen::EigenBase`
@@ -27,11 +28,12 @@ namespace math {
  * @param name Variable name (for error messages)
  * @param theta Matrix to test
  * @throw `std::invalid_argument` if `theta` is a 0-vector
- * @throw `std::domain_error` if the vector is not a column stochastic matrix or if any element
- * is `NaN`
+ * @throw `std::domain_error` if the vector is not a column stochastic matrix or
+ * if any element is `NaN`
  */
 template <typename T, require_matrix_t<T>* = nullptr>
-void check_stochastic_column(const char* function, const char* name, const T& theta) {
+void check_stochastic_column(const char* function, const char* name,
+                             const T& theta) {
   using std::fabs;
   check_nonzero_size(function, name, theta);
   auto&& theta_ref = to_ref(value_of_rec(theta));
@@ -42,12 +44,13 @@ void check_stochastic_column(const char* function, const char* name, const T& th
         [&]() STAN_COLD_PATH {
           std::ostringstream msg;
           msg << "is not a valid column stochastic matrix. " << name << "["
-              << std::to_string(i + stan::error_index::value) <<
-              ", " << std::to_string(i + stan::error_index::value) << "]"
+              << std::to_string(i + stan::error_index::value) << ", "
+              << std::to_string(i + stan::error_index::value) << "]"
               << " = ";
           std::string msg_str(msg.str());
-          throw_domain_error(function, name, theta_ref.coeff(i, j), msg_str.c_str(),
-                            ", but should be greater than or equal to 0");
+          throw_domain_error(function, name, theta_ref.coeff(i, j),
+                             msg_str.c_str(),
+                             ", but should be greater than or equal to 0");
         }();
       }
       vec_sum += theta_ref.coeff(i, j);
@@ -57,7 +60,8 @@ void check_stochastic_column(const char* function, const char* name, const T& th
         std::stringstream msg;
         msg << "is not a valid column stochastic matrix.";
         msg.precision(10);
-        msg << " sum(" << name << "[:, "<< std::to_string(j + 1) << "]) = " << vec_sum << ", but should be ";
+        msg << " sum(" << name << "[:, " << std::to_string(j + 1)
+            << "]) = " << vec_sum << ", but should be ";
         std::string msg_str(msg.str());
         throw_domain_error(function, name, 1.0, msg_str.c_str());
       }();
@@ -66,25 +70,27 @@ void check_stochastic_column(const char* function, const char* name, const T& th
 }
 
 /**
- * Throw an exception if the specified matrices in a standard vector are not a column stochastic matrix. To be a
- * column stochastic matrix, all the values in each column must be greater than or equal to 0 and the values must sum to 1. A
- * valid column stochastic matrix is one where the sum of the elements by column is equal to 1.  This
- * function tests that the sum is within the tolerance specified by
- * `CONSTRAINT_TOLERANCE`. This function only accepts Eigen matrices, statically
- * typed vectors, not general matrices with 1 column.
+ * Throw an exception if the specified matrices in a standard vector are not a
+ * column stochastic matrix. To be a column stochastic matrix, all the values in
+ * each column must be greater than or equal to 0 and the values must sum to 1.
+ * A valid column stochastic matrix is one where the sum of the elements by
+ * column is equal to 1.  This function tests that the sum is within the
+ * tolerance specified by `CONSTRAINT_TOLERANCE`. This function only accepts
+ * Eigen matrices, statically typed vectors, not general matrices with 1 column.
  * @tparam T A type inheriting from `Eigen::EigenBase`
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param theta Matrix to test
  * @throw `std::invalid_argument` if `theta` is a 0-vector
- * @throw `std::domain_error` if the vector's matrices are not column stochastic matrices or if any element
- * is `NaN`
+ * @throw `std::domain_error` if the vector's matrices are not column stochastic
+ * matrices or if any element is `NaN`
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
-void check_stochastic_column(const char* function, const char* name, const T& theta) {
+void check_stochastic_column(const char* function, const char* name,
+                             const T& theta) {
   for (size_t i = 0; i < theta.size(); ++i) {
     check_stochastic_column(function, internal::make_iter_name(name, i).c_str(),
-                  theta[i]);
+                            theta[i]);
   }
 }
 

--- a/stan/math/prim/err/check_stochastic_column.hpp
+++ b/stan/math/prim/err/check_stochastic_column.hpp
@@ -1,0 +1,93 @@
+#ifndef STAN_MATH_PRIM_ERR_CHECK_STOCHASTIC_COLUMN_HPP
+#define STAN_MATH_PRIM_ERR_CHECK_STOCHASTIC_COLUMN_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err/check_nonzero_size.hpp>
+#include <stan/math/prim/err/constraint_tolerance.hpp>
+#include <stan/math/prim/err/make_iter_name.hpp>
+#include <stan/math/prim/err/throw_domain_error.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of_rec.hpp>
+#include <sstream>
+#include <string>
+#include <iostream>
+namespace stan {
+namespace math {
+
+/**
+ * Throw an exception if the specified matrix is not a column stochastic matrix. To be a
+ * column stochastic matrix, all the values in each column must be greater than or equal to 0 and the values must sum to 1. A
+ * valid column stochastic matrix is one where the sum of the elements by column is equal to 1.  This
+ * function tests that the sum is within the tolerance specified by
+ * `CONSTRAINT_TOLERANCE`. This function only accepts Eigen matrices, statically
+ * typed vectors, not general matrices with 1 column.
+ * @tparam T A type inheriting from `Eigen::EigenBase`
+ * @param function Function name (for error messages)
+ * @param name Variable name (for error messages)
+ * @param theta Matrix to test
+ * @throw `std::invalid_argument` if `theta` is a 0-vector
+ * @throw `std::domain_error` if the vector is not a column stochastic matrix or if any element
+ * is `NaN`
+ */
+template <typename T, require_matrix_t<T>* = nullptr>
+void check_stochastic_column(const char* function, const char* name, const T& theta) {
+  using std::fabs;
+  check_nonzero_size(function, name, theta);
+  auto&& theta_ref = to_ref(value_of_rec(theta));
+  for (Eigen::Index j = 0; j < theta_ref.cols(); ++j) {
+    value_type_t<decltype(theta_ref)> vec_sum = 0.0;
+    for (Eigen::Index i = 0; i < theta_ref.rows(); ++i) {
+      if (!(theta_ref.coeff(i, j) >= 0)) {
+        [&]() STAN_COLD_PATH {
+          std::ostringstream msg;
+          msg << "is not a valid column stochastic matrix. " << name << "["
+              << std::to_string(i + stan::error_index::value) <<
+              ", " << std::to_string(i + stan::error_index::value) << "]"
+              << " = ";
+          std::string msg_str(msg.str());
+          throw_domain_error(function, name, theta_ref.coeff(i, j), msg_str.c_str(),
+                            ", but should be greater than or equal to 0");
+        }();
+      }
+      vec_sum += theta_ref.coeff(i, j);
+    }
+    if (!(fabs(1.0 - vec_sum) <= CONSTRAINT_TOLERANCE)) {
+      [&]() STAN_COLD_PATH {
+        std::stringstream msg;
+        msg << "is not a valid column stochastic matrix.";
+        msg.precision(10);
+        msg << " sum(" << name << "[:, "<< std::to_string(j + 1) << "]) = " << vec_sum << ", but should be ";
+        std::string msg_str(msg.str());
+        throw_domain_error(function, name, 1.0, msg_str.c_str());
+      }();
+    }
+  }
+}
+
+/**
+ * Throw an exception if the specified matrices in a standard vector are not a column stochastic matrix. To be a
+ * column stochastic matrix, all the values in each column must be greater than or equal to 0 and the values must sum to 1. A
+ * valid column stochastic matrix is one where the sum of the elements by column is equal to 1.  This
+ * function tests that the sum is within the tolerance specified by
+ * `CONSTRAINT_TOLERANCE`. This function only accepts Eigen matrices, statically
+ * typed vectors, not general matrices with 1 column.
+ * @tparam T A type inheriting from `Eigen::EigenBase`
+ * @param function Function name (for error messages)
+ * @param name Variable name (for error messages)
+ * @param theta Matrix to test
+ * @throw `std::invalid_argument` if `theta` is a 0-vector
+ * @throw `std::domain_error` if the vector's matrices are not column stochastic matrices or if any element
+ * is `NaN`
+ */
+template <typename T, require_std_vector_t<T>* = nullptr>
+void check_stochastic_column(const char* function, const char* name, const T& theta) {
+  for (size_t i = 0; i < theta.size(); ++i) {
+    check_stochastic_column(function, internal::make_iter_name(name, i).c_str(),
+                  theta[i]);
+  }
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/err/check_stochastic_row.hpp
+++ b/stan/math/prim/err/check_stochastic_row.hpp
@@ -1,0 +1,93 @@
+#ifndef STAN_MATH_PRIM_ERR_CHECK_STOCHASTIC_ROW_HPP
+#define STAN_MATH_PRIM_ERR_CHECK_STOCHASTIC_ROW_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err/check_nonzero_size.hpp>
+#include <stan/math/prim/err/constraint_tolerance.hpp>
+#include <stan/math/prim/err/make_iter_name.hpp>
+#include <stan/math/prim/err/throw_domain_error.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of_rec.hpp>
+#include <sstream>
+#include <string>
+
+namespace stan {
+namespace math {
+
+/**
+ * Throw an exception if the specified matrix is not a row stochastic matrix. To be a
+ * row stochastic matrix, all the values in each row must be greater than or equal to 0 and the values must sum to 1. A
+ * valid row stochastic matrix is one where the sum of the elements by row is equal to 1.  This
+ * function tests that the sum is within the tolerance specified by
+ * `CONSTRAINT_TOLERANCE`. This function only accepts Eigen matrices, statically
+ * typed vectors, not general matrices with 1 column.
+ * @tparam T A type inheriting from `Eigen::EigenBase`
+ * @param function Function name (for error messages)
+ * @param name Variable name (for error messages)
+ * @param theta Matrix to test
+ * @throw `std::invalid_argument` if `theta` is a 0-vector
+ * @throw `std::domain_error` if the vector is not a row stochastic matrix or if any element
+ * is `NaN`
+ */
+template <typename T, require_matrix_t<T>* = nullptr>
+void check_stochastic_row(const char* function, const char* name, const T& theta) {
+  using std::fabs;
+  check_nonzero_size(function, name, theta);
+  auto&& theta_ref = to_ref(value_of_rec(theta));
+  for (Eigen::Index i = 0; i < theta_ref.rows(); ++i) {
+    value_type_t<decltype(theta_ref)> vec_sum = 0.0;
+    for (Eigen::Index j = 0; j < theta_ref.cols(); ++j) {
+      if (!(theta_ref.coeff(i, j) >= 0)) {
+        [&]() STAN_COLD_PATH {
+          std::ostringstream msg;
+          msg << "is not a valid row stochastic matrix. " << name << "["
+              << std::to_string(i + stan::error_index::value) <<
+              ", " << std::to_string(i + stan::error_index::value) << "]"
+              << " = ";
+          std::string msg_str(msg.str());
+          throw_domain_error(function, name, theta_ref.coeff(i, j), msg_str.c_str(),
+                            ", but should be greater than or equal to 0");
+        }();
+      }
+      vec_sum += theta_ref.coeff(i, j);
+    }
+    if (!(fabs(1.0 - vec_sum) <= CONSTRAINT_TOLERANCE)) {
+      [&]() STAN_COLD_PATH {
+        std::stringstream msg;
+        msg << "is not a valid row stochastic matrix.";
+        msg.precision(10);
+        msg << " sum(" << name << "[" << std::to_string(i + 1) << ",:]) = " << vec_sum << ", but should be ";
+        std::string msg_str(msg.str());
+        throw_domain_error(function, name, 1.0, msg_str.c_str());
+      }();
+    }
+  }
+}
+
+/**
+ * Throw an exception if the specified matrices in a standard vector are not a row stochastic matrix. To be a
+ * row stochastic matrix, all the values in each row must be greater than or equal to 0 and the values must sum to 1. A
+ * valid row stochastic matrix is one where the sum of the elements by row is equal to 1.  This
+ * function tests that the sum is within the tolerance specified by
+ * `CONSTRAINT_TOLERANCE`. This function only accepts Eigen matrices, statically
+ * typed vectors, not general matrices with 1 column.
+ * @tparam T A type inheriting from `Eigen::EigenBase`
+ * @param function Function name (for error messages)
+ * @param name Variable name (for error messages)
+ * @param theta Matrix to test
+ * @throw `std::invalid_argument` if `theta` is a 0-vector
+ * @throw `std::domain_error` if the standard vector's matrices are not row stochastic matrix or if any element
+ * is `NaN`
+ */
+template <typename T, require_std_vector_t<T>* = nullptr>
+void check_stochastic_row(const char* function, const char* name, const T& theta) {
+  for (size_t i = 0; i < theta.size(); ++i) {
+    check_stochastic_row(function, internal::make_iter_name(name, i).c_str(),
+                  theta[i]);
+  }
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/err/check_stochastic_row.hpp
+++ b/stan/math/prim/err/check_stochastic_row.hpp
@@ -16,22 +16,24 @@ namespace stan {
 namespace math {
 
 /**
- * Throw an exception if the specified matrix is not a row stochastic matrix. To be a
- * row stochastic matrix, all the values in each row must be greater than or equal to 0 and the values must sum to 1. A
- * valid row stochastic matrix is one where the sum of the elements by row is equal to 1.  This
- * function tests that the sum is within the tolerance specified by
- * `CONSTRAINT_TOLERANCE`. This function only accepts Eigen matrices, statically
- * typed vectors, not general matrices with 1 column.
+ * Throw an exception if the specified matrix is not a row stochastic matrix. To
+ * be a row stochastic matrix, all the values in each row must be greater than
+ * or equal to 0 and the values must sum to 1. A valid row stochastic matrix is
+ * one where the sum of the elements by row is equal to 1.  This function tests
+ * that the sum is within the tolerance specified by `CONSTRAINT_TOLERANCE`.
+ * This function only accepts Eigen matrices, statically typed vectors, not
+ * general matrices with 1 column.
  * @tparam T A type inheriting from `Eigen::EigenBase`
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param theta Matrix to test
  * @throw `std::invalid_argument` if `theta` is a 0-vector
- * @throw `std::domain_error` if the vector is not a row stochastic matrix or if any element
- * is `NaN`
+ * @throw `std::domain_error` if the vector is not a row stochastic matrix or if
+ * any element is `NaN`
  */
 template <typename T, require_matrix_t<T>* = nullptr>
-void check_stochastic_row(const char* function, const char* name, const T& theta) {
+void check_stochastic_row(const char* function, const char* name,
+                          const T& theta) {
   using std::fabs;
   check_nonzero_size(function, name, theta);
   auto&& theta_ref = to_ref(value_of_rec(theta));
@@ -42,12 +44,13 @@ void check_stochastic_row(const char* function, const char* name, const T& theta
         [&]() STAN_COLD_PATH {
           std::ostringstream msg;
           msg << "is not a valid row stochastic matrix. " << name << "["
-              << std::to_string(i + stan::error_index::value) <<
-              ", " << std::to_string(i + stan::error_index::value) << "]"
+              << std::to_string(i + stan::error_index::value) << ", "
+              << std::to_string(i + stan::error_index::value) << "]"
               << " = ";
           std::string msg_str(msg.str());
-          throw_domain_error(function, name, theta_ref.coeff(i, j), msg_str.c_str(),
-                            ", but should be greater than or equal to 0");
+          throw_domain_error(function, name, theta_ref.coeff(i, j),
+                             msg_str.c_str(),
+                             ", but should be greater than or equal to 0");
         }();
       }
       vec_sum += theta_ref.coeff(i, j);
@@ -57,7 +60,8 @@ void check_stochastic_row(const char* function, const char* name, const T& theta
         std::stringstream msg;
         msg << "is not a valid row stochastic matrix.";
         msg.precision(10);
-        msg << " sum(" << name << "[" << std::to_string(i + 1) << ",:]) = " << vec_sum << ", but should be ";
+        msg << " sum(" << name << "[" << std::to_string(i + 1)
+            << ",:]) = " << vec_sum << ", but should be ";
         std::string msg_str(msg.str());
         throw_domain_error(function, name, 1.0, msg_str.c_str());
       }();
@@ -66,10 +70,11 @@ void check_stochastic_row(const char* function, const char* name, const T& theta
 }
 
 /**
- * Throw an exception if the specified matrices in a standard vector are not a row stochastic matrix. To be a
- * row stochastic matrix, all the values in each row must be greater than or equal to 0 and the values must sum to 1. A
- * valid row stochastic matrix is one where the sum of the elements by row is equal to 1.  This
- * function tests that the sum is within the tolerance specified by
+ * Throw an exception if the specified matrices in a standard vector are not a
+ * row stochastic matrix. To be a row stochastic matrix, all the values in each
+ * row must be greater than or equal to 0 and the values must sum to 1. A valid
+ * row stochastic matrix is one where the sum of the elements by row is equal
+ * to 1.  This function tests that the sum is within the tolerance specified by
  * `CONSTRAINT_TOLERANCE`. This function only accepts Eigen matrices, statically
  * typed vectors, not general matrices with 1 column.
  * @tparam T A type inheriting from `Eigen::EigenBase`
@@ -77,14 +82,15 @@ void check_stochastic_row(const char* function, const char* name, const T& theta
  * @param name Variable name (for error messages)
  * @param theta Matrix to test
  * @throw `std::invalid_argument` if `theta` is a 0-vector
- * @throw `std::domain_error` if the standard vector's matrices are not row stochastic matrix or if any element
- * is `NaN`
+ * @throw `std::domain_error` if the standard vector's matrices are not row
+ * stochastic matrix or if any element is `NaN`
  */
 template <typename T, require_std_vector_t<T>* = nullptr>
-void check_stochastic_row(const char* function, const char* name, const T& theta) {
+void check_stochastic_row(const char* function, const char* name,
+                          const T& theta) {
   for (size_t i = 0; i < theta.size(); ++i) {
     check_stochastic_row(function, internal::make_iter_name(name, i).c_str(),
-                  theta[i]);
+                         theta[i]);
   }
 }
 

--- a/test/unit/math/prim/err/check_stochastic_column_test.cpp
+++ b/test/unit/math/prim/err/check_stochastic_column_test.cpp
@@ -6,25 +6,29 @@
 
 TEST(ErrorHandlingMatrix, checkStochasticColumn) {
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(2, 2);
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{
+      y_vec, y_vec, y_vec};
   for (auto& y_i : y) {
     y_i << 0.5, 0.5, 0.5, 0.5;
   }
 
-  EXPECT_NO_THROW(stan::math::check_stochastic_column("checkStochasticColumn", "y", y));
+  EXPECT_NO_THROW(
+      stan::math::check_stochastic_column("checkStochasticColumn", "y", y));
 
   for (auto& y_i : y) {
     y_i(0, 1) = 0.55;
   }
-  EXPECT_THROW(stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
+      std::domain_error);
 }
 
 TEST(ErrorHandlingMatrix, checkStochasticColumn_message_negative_value) {
   std::string message;
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(3, 3);
   y_vec.setZero();
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{
+      y_vec, y_vec, y_vec};
   for (auto& y_i : y) {
     y_i(0, 0) = -0.1;
     y_i(1, 0) = 1.1;
@@ -41,10 +45,12 @@ TEST(ErrorHandlingMatrix, checkStochasticColumn_message_negative_value) {
     FAIL() << "threw the wrong error";
   }
 
-  EXPECT_TRUE(std::string::npos != message.find(" y[1] is not a valid column stochastic matrix"))
+  EXPECT_TRUE(std::string::npos
+              != message.find(" y[1] is not a valid column stochastic matrix"))
       << "Found: " << message;
 
-  EXPECT_TRUE(std::string::npos != message.find("y[1][1, 1] = -0.1")) << "Found: " << message;
+  EXPECT_TRUE(std::string::npos != message.find("y[1][1, 1] = -0.1"))
+      << "Found: " << message;
 
   for (auto& y_i : y) {
     y_i.setZero();
@@ -61,17 +67,20 @@ TEST(ErrorHandlingMatrix, checkStochasticColumn_message_negative_value) {
     FAIL() << "threw the wrong error";
   }
 
-  EXPECT_TRUE(std::string::npos != message.find(" y[1] is not a valid column stochastic matrix"))
-      << "Found: " <<  message;
+  EXPECT_TRUE(std::string::npos
+              != message.find(" y[1] is not a valid column stochastic matrix"))
+      << "Found: " << message;
 
-  EXPECT_TRUE(std::string::npos != message.find("sum(y[1][:, 1]) = 1.2")) << "Found: " <<  message;
+  EXPECT_TRUE(std::string::npos != message.find("sum(y[1][:, 1]) = 1.2"))
+      << "Found: " << message;
 }
 
 TEST(ErrorHandlingMatrix, checkStochasticColumn_message_sum) {
   std::string message;
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(10, 10);
   y_vec.setZero();
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{
+      y_vec, y_vec, y_vec};
   for (auto& y_i : y) {
     y_i(3, 0) = 0.9;
   }
@@ -85,50 +94,58 @@ TEST(ErrorHandlingMatrix, checkStochasticColumn_message_sum) {
     FAIL() << "threw the wrong error";
   }
 
-  EXPECT_TRUE(std::string::npos != message.find(" y[1] is not a valid column stochastic matrix"))
+  EXPECT_TRUE(std::string::npos
+              != message.find(" y[1] is not a valid column stochastic matrix"))
       << message;
 
-  EXPECT_TRUE(std::string::npos != message.find("sum(y[1][:, 1]) = 0.9")) << message;
+  EXPECT_TRUE(std::string::npos != message.find("sum(y[1][:, 1]) = 0.9"))
+      << message;
 }
 
 TEST(ErrorHandlingMatrix, checkStochasticColumn_message_length) {
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(0, 0);
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{
+      y_vec, y_vec, y_vec};
 
   using stan::math::check_stochastic_column;
 
-  EXPECT_THROW_MSG(check_stochastic_column("checkStochasticColumn", "y", y), std::invalid_argument,
+  EXPECT_THROW_MSG(check_stochastic_column("checkStochasticColumn", "y", y),
+                   std::invalid_argument,
                    "y[1] has size 0, but must have a non-zero size");
 }
 
 TEST(ErrorHandlingMatrix, checkStochasticColumn_nan) {
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(2, 2);
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{
+      y_vec, y_vec, y_vec};
   constexpr double nan = std::numeric_limits<double>::quiet_NaN();
   for (auto& y_i : y) {
     y_i << nan, 0.5, nan, 0.5;
   }
 
-  EXPECT_THROW(stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
+      std::domain_error);
 
   for (auto& y_i : y) {
     y_i(0, 1) = 0.55;
   }
-  EXPECT_THROW(stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
+      std::domain_error);
 
   for (auto& y_i : y) {
     y_i(0, 0) = 0.5;
     y_i(0, 1) = nan;
   }
-  EXPECT_THROW(stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
+      std::domain_error);
 
   for (auto& y_i : y) {
     y_i(0, 0) = nan;
   }
-  EXPECT_THROW(stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
+      std::domain_error);
 }
-

--- a/test/unit/math/prim/err/check_stochastic_column_test.cpp
+++ b/test/unit/math/prim/err/check_stochastic_column_test.cpp
@@ -1,0 +1,134 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <limits>
+#include <string>
+
+TEST(ErrorHandlingMatrix, checkStochasticColumn) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(2, 2);
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  for (auto& y_i : y) {
+    y_i << 0.5, 0.5, 0.5, 0.5;
+  }
+
+  EXPECT_NO_THROW(stan::math::check_stochastic_column("checkStochasticColumn", "y", y));
+
+  for (auto& y_i : y) {
+    y_i(0, 1) = 0.55;
+  }
+  EXPECT_THROW(stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
+               std::domain_error);
+}
+
+TEST(ErrorHandlingMatrix, checkStochasticColumn_message_negative_value) {
+  std::string message;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(3, 3);
+  y_vec.setZero();
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  for (auto& y_i : y) {
+    y_i(0, 0) = -0.1;
+    y_i(1, 0) = 1.1;
+    y_i(0, 1) = -0.1;
+    y_i(1, 1) = 1.1;
+  }
+
+  try {
+    stan::math::check_stochastic_column("checkStochasticColumn", "y", y);
+    FAIL() << "should have thrown";
+  } catch (std::domain_error& e) {
+    message = e.what();
+  } catch (...) {
+    FAIL() << "threw the wrong error";
+  }
+
+  EXPECT_TRUE(std::string::npos != message.find(" y[1] is not a valid column stochastic matrix"))
+      << "Found: " << message;
+
+  EXPECT_TRUE(std::string::npos != message.find("y[1][1, 1] = -0.1")) << "Found: " << message;
+
+  for (auto& y_i : y) {
+    y_i.setZero();
+    y_i(0, 0) = 0.1;
+    y_i(1, 0) = 0.1;
+    y_i(2, 0) = 1.0;
+  }
+  try {
+    stan::math::check_stochastic_column("checkStochasticColumn", "y", y);
+    FAIL() << "should have thrown";
+  } catch (std::domain_error& e) {
+    message = e.what();
+  } catch (...) {
+    FAIL() << "threw the wrong error";
+  }
+
+  EXPECT_TRUE(std::string::npos != message.find(" y[1] is not a valid column stochastic matrix"))
+      << "Found: " <<  message;
+
+  EXPECT_TRUE(std::string::npos != message.find("sum(y[1][:, 1]) = 1.2")) << "Found: " <<  message;
+}
+
+TEST(ErrorHandlingMatrix, checkStochasticColumn_message_sum) {
+  std::string message;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(10, 10);
+  y_vec.setZero();
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  for (auto& y_i : y) {
+    y_i(3, 0) = 0.9;
+  }
+
+  try {
+    stan::math::check_stochastic_column("checkStochasticColumn", "y", y);
+    FAIL() << "should have thrown";
+  } catch (std::domain_error& e) {
+    message = e.what();
+  } catch (...) {
+    FAIL() << "threw the wrong error";
+  }
+
+  EXPECT_TRUE(std::string::npos != message.find(" y[1] is not a valid column stochastic matrix"))
+      << message;
+
+  EXPECT_TRUE(std::string::npos != message.find("sum(y[1][:, 1]) = 0.9")) << message;
+}
+
+TEST(ErrorHandlingMatrix, checkStochasticColumn_message_length) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(0, 0);
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+
+  using stan::math::check_stochastic_column;
+
+  EXPECT_THROW_MSG(check_stochastic_column("checkStochasticColumn", "y", y), std::invalid_argument,
+                   "y[1] has size 0, but must have a non-zero size");
+}
+
+TEST(ErrorHandlingMatrix, checkStochasticColumn_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(2, 2);
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+  for (auto& y_i : y) {
+    y_i << nan, 0.5, nan, 0.5;
+  }
+
+  EXPECT_THROW(stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
+               std::domain_error);
+
+  for (auto& y_i : y) {
+    y_i(0, 1) = 0.55;
+  }
+  EXPECT_THROW(stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
+               std::domain_error);
+
+  for (auto& y_i : y) {
+    y_i(0, 0) = 0.5;
+    y_i(0, 1) = nan;
+  }
+  EXPECT_THROW(stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
+               std::domain_error);
+
+  for (auto& y_i : y) {
+    y_i(0, 0) = nan;
+  }
+  EXPECT_THROW(stan::math::check_stochastic_column("checkStochasticColumn", "y", y),
+               std::domain_error);
+}
+

--- a/test/unit/math/prim/err/check_stochastic_row_test.cpp
+++ b/test/unit/math/prim/err/check_stochastic_row_test.cpp
@@ -1,0 +1,134 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <limits>
+#include <string>
+
+TEST(ErrorHandlingMatrix, checkStochasticRow) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(2, 2);
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  for (auto& y_i : y) {
+    y_i << 0.5, 0.5, 0.5, 0.5;
+  }
+
+  EXPECT_NO_THROW(stan::math::check_stochastic_row("checkStochasticRow", "y", y));
+
+  for (auto& y_i : y) {
+    y_i(1, 0) = 0.55;
+  }
+  EXPECT_THROW(stan::math::check_stochastic_row("checkStochasticRow", "y", y),
+               std::domain_error);
+}
+
+TEST(ErrorHandlingMatrix, checkStochasticRow_message_negative_value) {
+  std::string message;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(3, 3);
+  y_vec.setZero();
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  for (auto& y_i : y) {
+    y_i(0, 0) = -0.1;
+    y_i(0, 1) = 1.1;
+    y_i(1, 0) = -0.1;
+    y_i(1, 1) = 1.1;
+  }
+
+  try {
+    stan::math::check_stochastic_row("checkStochasticRow", "y", y);
+    FAIL() << "should have thrown";
+  } catch (std::domain_error& e) {
+    message = e.what();
+  } catch (...) {
+    FAIL() << "threw the wrong error";
+  }
+
+  EXPECT_TRUE(std::string::npos != message.find(" y[1] is not a valid row stochastic matrix"))
+      << "Found: " << message;
+
+  EXPECT_TRUE(std::string::npos != message.find("y[1][1, 1] = -0.1")) << "Found: " << message;
+
+  for (auto& y_i : y) {
+    y_i.setZero();
+    y_i(0, 0) = 0.1;
+    y_i(0, 1) = 0.1;
+    y_i(0, 2) = 1.0;
+  }
+  try {
+    stan::math::check_stochastic_row("checkStochasticRow", "y", y);
+    FAIL() << "should have thrown";
+  } catch (std::domain_error& e) {
+    message = e.what();
+  } catch (...) {
+    FAIL() << "threw the wrong error";
+  }
+
+  EXPECT_TRUE(std::string::npos != message.find(" y[1] is not a valid row stochastic matrix"))
+      << "Found: " <<  message;
+
+  EXPECT_TRUE(std::string::npos != message.find("sum(y[1][1,:]) = 1.2")) << "Found: " <<  message;
+}
+
+TEST(ErrorHandlingMatrix, checkStochasticRow_message_sum) {
+  std::string message;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(10, 10);
+  y_vec.setZero();
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  for (auto& y_i : y) {
+    y_i(0, 3) = 0.9;
+  }
+
+  try {
+    stan::math::check_stochastic_row("checkStochasticRow", "y", y);
+    FAIL() << "should have thrown";
+  } catch (std::domain_error& e) {
+    message = e.what();
+  } catch (...) {
+    FAIL() << "threw the wrong error";
+  }
+
+  EXPECT_TRUE(std::string::npos != message.find(" y[1] is not a valid row stochastic matrix"))
+      << message;
+
+  EXPECT_TRUE(std::string::npos != message.find("sum(y[1][1,:]) = 0.9")) << message;
+}
+
+TEST(ErrorHandlingMatrix, checkStochasticRow_message_length) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(0, 0);
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+
+  using stan::math::check_stochastic_row;
+
+  EXPECT_THROW_MSG(check_stochastic_row("checkStochasticRow", "y", y), std::invalid_argument,
+                   "y[1] has size 0, but must have a non-zero size");
+}
+
+TEST(ErrorHandlingMatrix, checkStochasticRow_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(2, 2);
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+  for (auto& y_i : y) {
+    y_i << nan, nan, 0.5, 0.5;
+  }
+
+  EXPECT_THROW(stan::math::check_stochastic_row("checkStochasticRow", "y", y),
+               std::domain_error);
+
+  for (auto& y_i : y) {
+    y_i(0, 1) = 0.55;
+  }
+  EXPECT_THROW(stan::math::check_stochastic_row("checkStochasticRow", "y", y),
+               std::domain_error);
+
+  for (auto& y_i : y) {
+    y_i(0, 0) = 0.5;
+    y_i(0, 1) = nan;
+  }
+  EXPECT_THROW(stan::math::check_stochastic_row("checkStochasticRow", "y", y),
+               std::domain_error);
+
+  for (auto& y_i : y) {
+    y_i(0, 0) = nan;
+  }
+  EXPECT_THROW(stan::math::check_stochastic_row("checkStochasticRow", "y", y),
+               std::domain_error);
+}
+

--- a/test/unit/math/prim/err/check_stochastic_row_test.cpp
+++ b/test/unit/math/prim/err/check_stochastic_row_test.cpp
@@ -6,12 +6,14 @@
 
 TEST(ErrorHandlingMatrix, checkStochasticRow) {
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(2, 2);
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{
+      y_vec, y_vec, y_vec};
   for (auto& y_i : y) {
     y_i << 0.5, 0.5, 0.5, 0.5;
   }
 
-  EXPECT_NO_THROW(stan::math::check_stochastic_row("checkStochasticRow", "y", y));
+  EXPECT_NO_THROW(
+      stan::math::check_stochastic_row("checkStochasticRow", "y", y));
 
   for (auto& y_i : y) {
     y_i(1, 0) = 0.55;
@@ -24,7 +26,8 @@ TEST(ErrorHandlingMatrix, checkStochasticRow_message_negative_value) {
   std::string message;
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(3, 3);
   y_vec.setZero();
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{
+      y_vec, y_vec, y_vec};
   for (auto& y_i : y) {
     y_i(0, 0) = -0.1;
     y_i(0, 1) = 1.1;
@@ -41,10 +44,12 @@ TEST(ErrorHandlingMatrix, checkStochasticRow_message_negative_value) {
     FAIL() << "threw the wrong error";
   }
 
-  EXPECT_TRUE(std::string::npos != message.find(" y[1] is not a valid row stochastic matrix"))
+  EXPECT_TRUE(std::string::npos
+              != message.find(" y[1] is not a valid row stochastic matrix"))
       << "Found: " << message;
 
-  EXPECT_TRUE(std::string::npos != message.find("y[1][1, 1] = -0.1")) << "Found: " << message;
+  EXPECT_TRUE(std::string::npos != message.find("y[1][1, 1] = -0.1"))
+      << "Found: " << message;
 
   for (auto& y_i : y) {
     y_i.setZero();
@@ -61,17 +66,20 @@ TEST(ErrorHandlingMatrix, checkStochasticRow_message_negative_value) {
     FAIL() << "threw the wrong error";
   }
 
-  EXPECT_TRUE(std::string::npos != message.find(" y[1] is not a valid row stochastic matrix"))
-      << "Found: " <<  message;
+  EXPECT_TRUE(std::string::npos
+              != message.find(" y[1] is not a valid row stochastic matrix"))
+      << "Found: " << message;
 
-  EXPECT_TRUE(std::string::npos != message.find("sum(y[1][1,:]) = 1.2")) << "Found: " <<  message;
+  EXPECT_TRUE(std::string::npos != message.find("sum(y[1][1,:]) = 1.2"))
+      << "Found: " << message;
 }
 
 TEST(ErrorHandlingMatrix, checkStochasticRow_message_sum) {
   std::string message;
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(10, 10);
   y_vec.setZero();
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{
+      y_vec, y_vec, y_vec};
   for (auto& y_i : y) {
     y_i(0, 3) = 0.9;
   }
@@ -85,25 +93,30 @@ TEST(ErrorHandlingMatrix, checkStochasticRow_message_sum) {
     FAIL() << "threw the wrong error";
   }
 
-  EXPECT_TRUE(std::string::npos != message.find(" y[1] is not a valid row stochastic matrix"))
+  EXPECT_TRUE(std::string::npos
+              != message.find(" y[1] is not a valid row stochastic matrix"))
       << message;
 
-  EXPECT_TRUE(std::string::npos != message.find("sum(y[1][1,:]) = 0.9")) << message;
+  EXPECT_TRUE(std::string::npos != message.find("sum(y[1][1,:]) = 0.9"))
+      << message;
 }
 
 TEST(ErrorHandlingMatrix, checkStochasticRow_message_length) {
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(0, 0);
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{
+      y_vec, y_vec, y_vec};
 
   using stan::math::check_stochastic_row;
 
-  EXPECT_THROW_MSG(check_stochastic_row("checkStochasticRow", "y", y), std::invalid_argument,
+  EXPECT_THROW_MSG(check_stochastic_row("checkStochasticRow", "y", y),
+                   std::invalid_argument,
                    "y[1] has size 0, but must have a non-zero size");
 }
 
 TEST(ErrorHandlingMatrix, checkStochasticRow_nan) {
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y_vec(2, 2);
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{y_vec, y_vec, y_vec};
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> y{
+      y_vec, y_vec, y_vec};
   constexpr double nan = std::numeric_limits<double>::quiet_NaN();
   for (auto& y_i : y) {
     y_i << nan, nan, 0.5, 0.5;
@@ -131,4 +144,3 @@ TEST(ErrorHandlingMatrix, checkStochasticRow_nan) {
   EXPECT_THROW(stan::math::check_stochastic_row("checkStochasticRow", "y", y),
                std::domain_error);
 }
-


### PR DESCRIPTION
## Summary

For the stan language to allow row/col stochastic matrices in the data section we need a check function to verify that the input matrices are row/col stochastic

## Tests

Tests added to do the same checks as the `check_simplex` but over the rows and columns of the stochastic matrices. They can be run with 

```bash
./runTests.py -j12 ./test/unit/math/prim/err/ -f stochastic
```

## Release notes

Adds error checking functions for row/column stochastic matrices

## Checklist

- [x] Copyright holder: Simon's Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
