### PR TITLE
Improve finite_diff_auto with Eigen expressions

### DIFF
--- a/stan/math/prim/fun/serializer.hpp
+++ b/stan/math/prim/fun/serializer.hpp
@@ -280,9 +280,9 @@ deserializer<T> to_deserializer(const std::vector<T>& vals) {
  * @param vals values to deserialize
  * @return deserializer based on specified values
  */
-template <typename T>
-deserializer<T> to_deserializer(const Eigen::Matrix<T, -1, 1>& vals) {
-  return deserializer<T>(vals);
+template <typename T, require_eigen_vector_t<T>* = nullptr>
+deserializer<scalar_type_t<T>> to_deserializer(const T& vals) {
+  return deserializer<scalar_type_t<T>>(vals);
 }
 
 template <typename T>

--- a/stan/math/prim/functor/finite_diff_gradient_auto.hpp
+++ b/stan/math/prim/functor/finite_diff_gradient_auto.hpp
@@ -46,41 +46,30 @@ namespace math {
  * @param[out] fx function applied to argument
  * @param[out] grad_fx gradient of function at argument
  */
-template <typename F, typename VectorT,
+template <typename F, typename VectorT, typename GradVectorT,
           typename ScalarT = return_type_t<VectorT>>
-void finite_diff_gradient_auto(const F& f, const VectorT& x, ScalarT& fx,
-                               VectorT& grad_fx) {
-  VectorT x_temp(x);
+void finite_diff_gradient_auto(const F& f, VectorT&& x, ScalarT& fx,
+                               GradVectorT& grad_fx) {
+  using EigT = Eigen::Matrix<ScalarT, -1, 1>;
+  static constexpr int h_scale[6] = {3, 2, 1, -3, -2, -1};
+  static constexpr int mults[6] = {1, -9, 45, -1, 9, -45};
+
   fx = f(x);
   grad_fx.resize(x.size());
-  for (int i = 0; i < x.size(); ++i) {
+  Eigen::Map<EigT> grad_map(grad_fx.data(), grad_fx.size());
+
+  grad_map = EigT::NullaryExpr(x.size(), [&f, &x](Eigen::Index i) {
     double h = finite_diff_stepsize(value_of_rec(x[i]));
-
     ScalarT delta_f = 0;
-
-    x_temp[i] = x[i] + 3 * h;
-    delta_f += f(x_temp);
-
-    x_temp[i] = x[i] + 2 * h;
-    delta_f -= 9 * f(x_temp);
-
-    x_temp[i] = x[i] + h;
-    delta_f += 45 * f(x_temp);
-
-    x_temp[i] = x[i] + -3 * h;
-    delta_f -= f(x_temp);
-
-    x_temp[i] = x[i] + -2 * h;
-    delta_f += 9 * f(x_temp);
-
-    x_temp[i] = x[i] - h;
-    delta_f -= 45 * f(x_temp);
-
-    delta_f /= 60 * h;
-
-    x_temp[i] = x[i];
-    grad_fx[i] = delta_f;
-  }
+    for (int j = 0; j < 6; ++j) {
+      decltype(auto) x_temp
+        = EigT::NullaryExpr(x.size(), [&x, &i, &h, &j](Eigen::Index k) {
+        return k == i ? x[i] + h * h_scale[j] : x[k];
+      });
+      delta_f += f(std::forward<decltype(x_temp)>(x_temp)) * mults[j];
+    }
+    return delta_f / (60 * h);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/functor/finite_diff_gradient_auto.hpp
+++ b/stan/math/prim/functor/finite_diff_gradient_auto.hpp
@@ -62,11 +62,11 @@ void finite_diff_gradient_auto(const F& f, VectorT&& x, ScalarT& fx,
     double h = finite_diff_stepsize(value_of_rec(x[i]));
     ScalarT delta_f = 0;
     for (int j = 0; j < 6; ++j) {
-      decltype(auto) x_temp
+      auto x_temp
           = EigT::NullaryExpr(x.size(), [&x, &i, &h, &j](Eigen::Index k) {
               return k == i ? x[i] + h * h_scale[j] : x[k];
             });
-      delta_f += f(std::forward<decltype(x_temp)>(x_temp)) * mults[j];
+      delta_f += f(std::move(x_temp)) * mults[j];
     }
     return delta_f / (60 * h);
   });

--- a/stan/math/prim/functor/finite_diff_gradient_auto.hpp
+++ b/stan/math/prim/functor/finite_diff_gradient_auto.hpp
@@ -63,9 +63,9 @@ void finite_diff_gradient_auto(const F& f, VectorT&& x, ScalarT& fx,
     ScalarT delta_f = 0;
     for (int j = 0; j < 6; ++j) {
       decltype(auto) x_temp
-        = EigT::NullaryExpr(x.size(), [&x, &i, &h, &j](Eigen::Index k) {
-        return k == i ? x[i] + h * h_scale[j] : x[k];
-      });
+          = EigT::NullaryExpr(x.size(), [&x, &i, &h, &j](Eigen::Index k) {
+              return k == i ? x[i] + h * h_scale[j] : x[k];
+            });
       delta_f += f(std::forward<decltype(x_temp)>(x_temp)) * mults[j];
     }
     return delta_f / (60 * h);


### PR DESCRIPTION
## Summary

`finite_diff_gradient_auto` currently requires copying the input parameters and iteratively replacing values in the vector, requiring serial evaluation of the loop.

Rather than replacing values, we can instead use an Eigen expression to 'mask' a value at a specified index - avoiding the initial copy

## Tests

N/A - current tests should still pass

## Side Effects

N/A

## Release notes

Improved efficiency of `finite_diff_gradient_auto` 

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
