### PR TITLE
Add sum_to_zero constraint, free, and check based on ILR transform

### DIFF
--- a/stan/math/prim/constraint.hpp
+++ b/stan/math/prim/constraint.hpp
@@ -37,6 +37,8 @@
 #include <stan/math/prim/constraint/stochastic_column_free.hpp>
 #include <stan/math/prim/constraint/stochastic_row_constrain.hpp>
 #include <stan/math/prim/constraint/stochastic_row_free.hpp>
+#include <stan/math/prim/constraint/sum_to_zero_constrain.hpp>
+#include <stan/math/prim/constraint/sum_to_zero_free.hpp>
 #include <stan/math/prim/constraint/ub_constrain.hpp>
 #include <stan/math/prim/constraint/ub_free.hpp>
 #include <stan/math/prim/constraint/unit_vector_constrain.hpp>

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -14,8 +14,15 @@ namespace math {
  * Return a vector with sum zero corresponding to the specified
  * free vector.
  *
- * The sum-to-zero transform is defined using the inverse of the
- * isometric log ratio transform (ILR)
+ * The sum-to-zero transform is defined using a modified version of the
+ * the inverse of the isometric log ratio transform (ILR).
+ * See:
+ * Egozcue, Juan Jose; Pawlowsky-Glahn, Vera; Mateu-Figueras, Gloria;
+ * Barcelo-Vidal, Carles (2003), "Isometric logratio transformations for
+ * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
+ * doi:10.1023/A:1023818214614, S2CID 122844634
+ *
+ * This is a linear transform, with no Jacobian.
  *
  * @tparam Vec type of the vector
  * @param y Free vector input of dimensionality K - 1.
@@ -26,7 +33,7 @@ template <typename Vec, require_eigen_col_vector_t<Vec>* = nullptr,
 inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
   const auto N = y.size();
 
-  plain_type_t<Vec> z = Eigen::VectorXd::Zero(N+1);
+  plain_type_t<Vec> z = Eigen::VectorXd::Zero(N + 1);
   if (unlikely(N == 0)) {
     return z;
   }
@@ -36,10 +43,10 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
   typename plain_type_t<Vec>::Scalar sum_w(0);
   for (int i = N; i > 0; --i) {
     double n = i;
-    auto w = y_ref(i-1) * inv_sqrt(n * (n + 1));
+    auto w = y_ref(i - 1) * inv_sqrt(n * (n + 1));
     sum_w += w;
 
-    z.coeffRef(i-1) += sum_w;
+    z.coeffRef(i - 1) += sum_w;
     z.coeffRef(i) -= w * n;
   }
 
@@ -50,10 +57,15 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
  * Return a vector with sum zero corresponding to the specified
  * free vector.
  *
- * The sum-to-zero transform is defined such that the first K-1
- * elements are unconstrained and the last element is the negative
- * sum of those elements. This is a linear transform, with no
- * Jacobian.
+ * The sum-to-zero transform is defined using a modified version of the
+ * the inverse of the isometric log ratio transform (ILR).
+ * See:
+ * Egozcue, Juan Jose; Pawlowsky-Glahn, Vera; Mateu-Figueras, Gloria;
+ * Barcelo-Vidal, Carles (2003), "Isometric logratio transformations for
+ * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
+ * doi:10.1023/A:1023818214614, S2CID 122844634
+ *
+ * This is a linear transform, with no Jacobian.
  *
  * @tparam Vec type of the vector
  * @param y Free vector input of dimensionality K - 1.
@@ -71,10 +83,15 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y,
  * Return a vector with sum zero corresponding to the specified
  * free vector.
  *
- * The sum-to-zero transform is defined such that the first K-1
- * elements are unconstrained and the last element is the negative
- * sum of those elements. This is a linear transform, with no
- * Jacobian.
+ * The sum-to-zero transform is defined using a modified version of the
+ * the inverse of the isometric log ratio transform (ILR).
+ * See:
+ * Egozcue, Juan Jose; Pawlowsky-Glahn, Vera; Mateu-Figueras, Gloria;
+ * Barcelo-Vidal, Carles (2003), "Isometric logratio transformations for
+ * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
+ * doi:10.1023/A:1023818214614, S2CID 122844634
+ *
+ * This is a linear transform, with no Jacobian.
  *
  * @tparam Jacobian unused
  * @tparam Vec A type inheriting from `Eigen::DenseBase` or a `var_value` with
@@ -94,10 +111,15 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y,
  * Return a vector with sum zero corresponding to the specified
  * free vector.
  *
- * The sum-to-zero transform is defined such that the first K-1
- * elements are unconstrained and the last element is the negative
- * sum of those elements. This is a linear transform, with no
- * Jacobian.
+ * The sum-to-zero transform is defined using a modified version of the
+ * the inverse of the isometric log ratio transform (ILR).
+ * See:
+ * Egozcue, Juan Jose; Pawlowsky-Glahn, Vera; Mateu-Figueras, Gloria;
+ * Barcelo-Vidal, Carles (2003), "Isometric logratio transformations for
+ * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
+ * doi:10.1023/A:1023818214614, S2CID 122844634
+ *
+ * This is a linear transform, with no Jacobian. 
  *
  * @tparam Jacobian unused
  * @tparam Vec A standard vector with inner type inheriting from

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -1,0 +1,106 @@
+#ifndef STAN_MATH_PRIM_CONSTRAINT_SUM_TO_ZERO_CONSTRAIN_HPP
+#define STAN_MATH_PRIM_CONSTRAINT_SUM_TO_ZERO_CONSTRAIN_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/sum.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return a vector with sum zero corresponding to the specified
+ * free vector.
+ *
+ * The sum-to-zero transform is defined such that the first K-1
+ * elements are unconstrained and the last element is the negative
+ * sum of those elements.
+ *
+ * @tparam Vec type of the vector
+ * @param y Free vector input of dimensionality K - 1.
+ * @return Zero-sum vector of dimensionality K.
+ */
+template <typename Vec, require_eigen_vector_t<Vec>* = nullptr>
+inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
+  using T = value_type_t<Vec>;
+
+  int Km1 = y.size();
+  plain_type_t<Vec> x(Km1 + 1);
+  // copy the first Km1 elements
+  x.head(Km1) = y;
+  // set the last element to -sum(y)
+  x.coeffRef(Km1) = -sum(y);
+  return x;
+}
+
+/**
+ * Return a vector with sum zero corresponding to the specified
+ * free vector.
+ *
+ * The sum-to-zero transform is defined such that the first K-1
+ * elements are unconstrained and the last element is the negative
+ * sum of those elements. This is a linear transform, with no
+ * Jacobian.
+ *
+ * @tparam Vec type of the vector
+ * @param y Free vector input of dimensionality K - 1.
+ * @param lp unused
+ * @return Zero-sum vector of dimensionality K.
+ */
+template <typename Vec, require_eigen_vector_t<Vec>* = nullptr>
+inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y,
+                                               value_type_t<Vec>& lp) {
+  return sum_to_zero_constrain(y);
+}
+
+/**
+ * Return a vector with sum zero corresponding to the specified
+ * free vector.
+ *
+ * The sum-to-zero transform is defined such that the first K-1
+ * elements are unconstrained and the last element is the negative
+ * sum of those elements. This is a linear transform, with no
+ * Jacobian.
+ *
+ * @tparam Jacobian unused
+ * @tparam Vec A type inheriting from `Eigen::DenseBase` or a `var_value` with
+ *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
+ *  and 1 column
+ * @param[in] y free vector
+ * @param[in, out] lp unused
+ * @return Zero-sum vector of dimensionality one greater than `y`
+ */
+template <bool Jacobian, typename Vec, require_not_std_vector_t<Vec>* = nullptr>
+inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y,
+                                               return_type_t<Vec>& lp) {
+  return sum_to_zero_constrain(y);
+}
+
+/**
+ * Return a vector with sum zero corresponding to the specified
+ * free vector.
+ *
+ * The sum-to-zero transform is defined such that the first K-1
+ * elements are unconstrained and the last element is the negative
+ * sum of those elements. This is a linear transform, with no
+ * Jacobian.
+ *
+ * @tparam Jacobian unused
+ * @tparam Vec A standard vector with inner type inheriting from
+ * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
+ * `Eigen::DenseBase` with compile time dynamic rows and 1 column
+ * @param[in] y free vector
+ * @param[in, out] lp unused
+ * @return Zero-sum vectors of dimensionality one greater than `y`
+ */
+template <bool Jacobian, typename T, require_std_vector_t<T>* = nullptr>
+inline auto sum_to_zero_constrain(const T& y, return_type_t<T>& lp) {
+  return apply_vector_unary<T>::apply(
+      y, [](auto&& v) { return sum_to_zero_constrain(v); });
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/sum.hpp>
+#include <stan/math/prim/functor/apply_vector_unary.hpp>
 #include <cmath>
 
 namespace stan {
@@ -23,8 +24,6 @@ namespace math {
  */
 template <typename Vec, require_eigen_vector_t<Vec>* = nullptr>
 inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
-  using T = value_type_t<Vec>;
-
   int Km1 = y.size();
   plain_type_t<Vec> x(Km1 + 1);
   // copy the first Km1 elements

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -26,6 +26,9 @@ template <typename Vec, require_eigen_col_vector_t<Vec>* = nullptr,
           require_not_st_var<Vec>* = nullptr>
 inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
   const auto Km1 = y.size();
+  if (unlikely(Km1 == 0)) {
+    return plain_type_t<Vec>(Eigen::VectorXd{{0}});
+  }
   plain_type_t<Vec> x(Km1 + 1);
   // copy the first Km1 elements
   auto&& y_ref = to_ref(y);

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -25,9 +25,9 @@ namespace math {
  *
  * This implementation is closer to the description of the same using "pivot
  * coordinates" in
- * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
- * In: Applied Compositional Data Analysis. Springer Series in Statistics.
- * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of
+ * Compositional Data. In: Applied Compositional Data Analysis. Springer Series
+ * in Statistics. Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
  *
  * This is a linear transform, with no Jacobian.
  *
@@ -74,9 +74,9 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
  *
  * This implementation is closer to the description of the same using "pivot
  * coordinates" in
- * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
- * In: Applied Compositional Data Analysis. Springer Series in Statistics.
- * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of
+ * Compositional Data. In: Applied Compositional Data Analysis. Springer Series
+ * in Statistics. Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
  *
  * This is a linear transform, with no Jacobian.
  *
@@ -106,9 +106,9 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y,
  *
  * This implementation is closer to the description of the same using "pivot
  * coordinates" in
- * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
- * In: Applied Compositional Data Analysis. Springer Series in Statistics.
- * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of
+ * Compositional Data. In: Applied Compositional Data Analysis. Springer Series
+ * in Statistics. Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
  *
  * This is a linear transform, with no Jacobian.
  *
@@ -140,9 +140,9 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y,
  *
  * This implementation is closer to the description of the same using "pivot
  * coordinates" in
- * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
- * In: Applied Compositional Data Analysis. Springer Series in Statistics.
- * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of
+ * Compositional Data. In: Applied Compositional Data Analysis. Springer Series
+ * in Statistics. Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
  *
  * This is a linear transform, with no Jacobian.
  *

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -33,14 +33,14 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
 
   auto&& y_ref = to_ref(y);
 
-  typename plain_type_t<Vec>::Scalar total(0);
-  for (int i = N - 1; i >= 0; --i) {
-    double n = i + 1;
-    auto w = y_ref(i) * inv_sqrt(n * (n + 1));
-    total += w;
+  typename plain_type_t<Vec>::Scalar sum_w(0);
+  for (int i = N; i > 0; --i) {
+    double n = i;
+    auto w = y_ref(i-1) * inv_sqrt(n * (n + 1));
+    sum_w += w;
 
-    z.coeffRef(i) += total;
-    z.coeffRef(i + 1) -= w * n;
+    z.coeffRef(i-1) += sum_w;
+    z.coeffRef(i) -= w * n;
   }
 
   return z;

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -23,6 +23,12 @@ namespace math {
  * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
  * doi:10.1023/A:1023818214614, S2CID 122844634
  *
+ * This implementation is closer to the description of the same using "pivot
+ * coordinates" in
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
+ * In: Applied Compositional Data Analysis. Springer Series in Statistics.
+ * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
+ *
  * This is a linear transform, with no Jacobian.
  *
  * @tparam Vec type of the vector
@@ -66,6 +72,12 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
  * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
  * doi:10.1023/A:1023818214614, S2CID 122844634
  *
+ * This implementation is closer to the description of the same using "pivot
+ * coordinates" in
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
+ * In: Applied Compositional Data Analysis. Springer Series in Statistics.
+ * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
+ *
  * This is a linear transform, with no Jacobian.
  *
  * @tparam Vec type of the vector
@@ -91,6 +103,12 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y,
  * Barcelo-Vidal, Carles (2003), "Isometric logratio transformations for
  * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
  * doi:10.1023/A:1023818214614, S2CID 122844634
+ *
+ * This implementation is closer to the description of the same using "pivot
+ * coordinates" in
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
+ * In: Applied Compositional Data Analysis. Springer Series in Statistics.
+ * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
  *
  * This is a linear transform, with no Jacobian.
  *
@@ -119,6 +137,12 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y,
  * Barcelo-Vidal, Carles (2003), "Isometric logratio transformations for
  * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
  * doi:10.1023/A:1023818214614, S2CID 122844634
+ *
+ * This implementation is closer to the description of the same using "pivot
+ * coordinates" in
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
+ * In: Applied Compositional Data Analysis. Springer Series in Statistics.
+ * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
  *
  * This is a linear transform, with no Jacobian.
  *

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -25,12 +25,13 @@ namespace math {
 template <typename Vec, require_eigen_col_vector_t<Vec>* = nullptr,
           require_not_st_var<Vec>* = nullptr>
 inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
-  int Km1 = y.size();
+  const auto Km1 = y.size();
   plain_type_t<Vec> x(Km1 + 1);
   // copy the first Km1 elements
-  x.head(Km1) = y;
+  auto&& y_ref = to_ref(y);
+  x.head(Km1) = y_ref;
   // set the last element to -sum(y)
-  x.coeffRef(Km1) = -sum(y);
+  x.coeffRef(Km1) = -sum(y_ref);
   return x;
 }
 

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -24,23 +24,22 @@ namespace math {
 template <typename Vec, require_eigen_col_vector_t<Vec>* = nullptr,
           require_not_st_var<Vec>* = nullptr>
 inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
-  const auto N = y.size() + 1;
+  const auto N = y.size();
 
-  plain_type_t<Vec> x = Eigen::VectorXd::Zero(N);
-  if (unlikely(N == 1)) {
+  plain_type_t<Vec> x = Eigen::VectorXd::Zero(N+1);
+  if (unlikely(N == 0)) {
     return x;
   }
 
   auto&& y_ref = to_ref(y);
 
-  typename plain_type_t<Vec>::Scalar cumsum(0);
-  for (int i = N - 2; i >= 0; --i) {
+  typename plain_type_t<Vec>::Scalar total(0);
+  for (int i = N - 1; i >= 0; --i) {
     double n = i + 1;
     auto w = y_ref(i) * inv_sqrt(n * (n + 1));
-    cumsum += w;
+    total += w;
 
-    x.coeffRef(N - 2 - i) += cumsum;
-
+    x.coeffRef(i) += total;
     x.coeffRef(i + 1) -= w * n;
   }
 

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -83,7 +83,7 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y,
  * Return a vector with sum zero corresponding to the specified
  * free vector.
  *
- * The sum-to-zero transform is defined using a modified version of the
+ * The sum-to-zero transform is defined using a modified version of
  * the inverse of the isometric log ratio transform (ILR).
  * See:
  * Egozcue, Juan Jose; Pawlowsky-Glahn, Vera; Mateu-Figueras, Gloria;
@@ -111,7 +111,7 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y,
  * Return a vector with sum zero corresponding to the specified
  * free vector.
  *
- * The sum-to-zero transform is defined using a modified version of the
+ * The sum-to-zero transform is defined using a modified version of
  * the inverse of the isometric log ratio transform (ILR).
  * See:
  * Egozcue, Juan Jose; Pawlowsky-Glahn, Vera; Mateu-Figueras, Gloria;
@@ -119,7 +119,7 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y,
  * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
  * doi:10.1023/A:1023818214614, S2CID 122844634
  *
- * This is a linear transform, with no Jacobian. 
+ * This is a linear transform, with no Jacobian.
  *
  * @tparam Jacobian unused
  * @tparam Vec A standard vector with inner type inheriting from

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -47,9 +47,9 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
 
   auto&& y_ref = to_ref(y);
 
-  typename plain_type_t<Vec>::Scalar sum_w(0);
+  value_type_t<Vec> sum_w(0);
   for (int i = N; i > 0; --i) {
-    double n = i;
+    double n = static_cast<double>(i);
     auto w = y_ref(i - 1) * inv_sqrt(n * (n + 1));
     sum_w += w;
 

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -26,9 +26,9 @@ template <typename Vec, require_eigen_col_vector_t<Vec>* = nullptr,
 inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
   const auto N = y.size();
 
-  plain_type_t<Vec> x = Eigen::VectorXd::Zero(N+1);
+  plain_type_t<Vec> z = Eigen::VectorXd::Zero(N+1);
   if (unlikely(N == 0)) {
-    return x;
+    return z;
   }
 
   auto&& y_ref = to_ref(y);
@@ -39,11 +39,11 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
     auto w = y_ref(i) * inv_sqrt(n * (n + 1));
     total += w;
 
-    x.coeffRef(i) += total;
-    x.coeffRef(i + 1) -= w * n;
+    z.coeffRef(i) += total;
+    z.coeffRef(i + 1) -= w * n;
   }
 
-  return x;
+  return z;
 }
 
 /**

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -3,7 +3,8 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/fun/sum.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/inv_sqrt.hpp>
 #include <stan/math/prim/functor/apply_vector_unary.hpp>
 #include <cmath>
 

--- a/stan/math/prim/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_constrain.hpp
@@ -22,7 +22,8 @@ namespace math {
  * @param y Free vector input of dimensionality K - 1.
  * @return Zero-sum vector of dimensionality K.
  */
-template <typename Vec, require_eigen_vector_t<Vec>* = nullptr>
+template <typename Vec, require_eigen_col_vector_t<Vec>* = nullptr,
+          require_not_st_var<Vec>* = nullptr>
 inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
   int Km1 = y.size();
   plain_type_t<Vec> x(Km1 + 1);
@@ -47,7 +48,8 @@ inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y) {
  * @param lp unused
  * @return Zero-sum vector of dimensionality K.
  */
-template <typename Vec, require_eigen_vector_t<Vec>* = nullptr>
+template <typename Vec, require_eigen_col_vector_t<Vec>* = nullptr,
+          require_not_st_var<Vec>* = nullptr>
 inline plain_type_t<Vec> sum_to_zero_constrain(const Vec& y,
                                                value_type_t<Vec>& lp) {
   return sum_to_zero_constrain(y);

--- a/stan/math/prim/constraint/sum_to_zero_free.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_free.hpp
@@ -49,10 +49,10 @@ inline plain_type_t<Vec> sum_to_zero_free(const Vec& z) {
 
   y.coeffRef(N - 1) = -z_ref(N) * sqrt(N * (N + 1)) / N;
 
-  typename plain_type_t<Vec>::Scalar sum_w(0);
+  value_type_t<Vec> sum_w(0);
 
   for (int i = N - 2; i >= 0; --i) {
-    double n = i + 1;
+    double n = static_cast<double>(i + 1);
     auto w = y(i + 1) / sqrt((n + 1) * (n + 2));
     sum_w += w;
     y.coeffRef(i) = (sum_w - z_ref(i + 1)) * sqrt(n * (n + 1)) / n;

--- a/stan/math/prim/constraint/sum_to_zero_free.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_free.hpp
@@ -25,9 +25,9 @@ namespace math {
  *
  * This implementation is closer to the description of the same using "pivot
  * coordinates" in
- * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
- * In: Applied Compositional Data Analysis. Springer Series in Statistics.
- * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of
+ * Compositional Data. In: Applied Compositional Data Analysis. Springer Series
+ * in Statistics. Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
  *
  * @tparam ColVec a column vector type
  * @param z Vector of length K.

--- a/stan/math/prim/constraint/sum_to_zero_free.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_free.hpp
@@ -37,13 +37,14 @@ inline plain_type_t<Vec> sum_to_zero_free(const Vec& z) {
   }
 
   y.coeffRef(N - 1) = -z_ref(N) * sqrt(N * (N + 1)) / N;
-  typename plain_type_t<Vec>::Scalar total(0);
+
+  typename plain_type_t<Vec>::Scalar sum_w(0);
 
   for (int i = N - 2; i >= 0; --i) {
     double n = i + 1;
     auto w = y(i + 1) / sqrt((n + 1) * (n + 2));
-    total += w;
-    y.coeffRef(i) = (total - z_ref(i + 1)) * sqrt(n * (n + 1)) / n;
+    sum_w += w;
+    y.coeffRef(i) = (sum_w - z_ref(i + 1)) * sqrt(n * (n + 1)) / n;
   }
 
   return y;

--- a/stan/math/prim/constraint/sum_to_zero_free.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_free.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/functor/apply_vector_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/constraint/sum_to_zero_free.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_free.hpp
@@ -1,0 +1,52 @@
+#ifndef STAN_MATH_PRIM_CONSTRAINT_SUM_TO_ZERO_FREE_HPP
+#define STAN_MATH_PRIM_CONSTRAINT_SUM_TO_ZERO_FREE_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return an unconstrained vector.
+ *
+ * The sum-to-zero transform is defined such that the first K-1
+ * elements are unconstrained and the last element is the negative
+ * sum of those elements.
+ *
+ * @tparam ColVec a column vector type
+ * @param x Vector of length K.
+ * @return Free vector of length (K-1).
+ * @throw std::domain_error if x does not sum to zero
+ */
+template <typename Vec, require_eigen_vector_t<Vec>* = nullptr>
+inline plain_type_t<Vec> sum_to_zero_free(const Vec& x) {
+  const auto& x_ref = to_ref(x);
+  check_sum_to_zero("stan::math::sum_to_zero_free", "sum_to_zero variable",
+                    x_ref);
+  if (x_ref.size() == 0) {
+    return plain_type_t<Vec>(0);
+  }
+  return x_ref.head(x_ref.size() - 1);
+}
+
+/**
+ * Overload of `sum_to_zero_free()` to untransform each Eigen vector
+ * in a standard vector.
+ * @tparam T A standard vector with with a `value_type` which inherits from
+ *  `Eigen::MatrixBase` with compile time rows or columns equal to 1.
+ * @param x The standard vector to untransform.
+ */
+template <typename T, require_std_vector_t<T>* = nullptr>
+auto sum_to_zero_free(const T& x) {
+  return apply_vector_unary<T>::apply(
+      x, [](auto&& v) { return sum_to_zero_free(v); });
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/constraint/sum_to_zero_free.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_free.hpp
@@ -14,9 +14,13 @@ namespace math {
 /**
  * Return an unconstrained vector.
  *
- * The sum-to-zero transform is defined such that the first K-1
- * elements are unconstrained and the last element is the negative
- * sum of those elements.
+ * The sum-to-zero transform is defined using a modified version of the
+ * isometric log ratio transform (ILR).
+ * See:
+ * Egozcue, Juan Jose; Pawlowsky-Glahn, Vera; Mateu-Figueras, Gloria;
+ * Barcelo-Vidal, Carles (2003), "Isometric logratio transformations for
+ * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
+ * doi:10.1023/A:1023818214614, S2CID 122844634
  *
  * @tparam ColVec a column vector type
  * @param z Vector of length K.

--- a/stan/math/prim/constraint/sum_to_zero_free.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_free.hpp
@@ -23,6 +23,12 @@ namespace math {
  * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
  * doi:10.1023/A:1023818214614, S2CID 122844634
  *
+ * This implementation is closer to the description of the same using "pivot
+ * coordinates" in
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
+ * In: Applied Compositional Data Analysis. Springer Series in Statistics.
+ * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
+ *
  * @tparam ColVec a column vector type
  * @param z Vector of length K.
  * @return Free vector of length (K-1).

--- a/stan/math/prim/constraint/sum_to_zero_free.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_free.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/sqrt.hpp>
 #include <stan/math/prim/functor/apply_vector_unary.hpp>
 #include <cmath>
 

--- a/stan/math/prim/constraint/sum_to_zero_free.hpp
+++ b/stan/math/prim/constraint/sum_to_zero_free.hpp
@@ -28,9 +28,7 @@ inline plain_type_t<Vec> sum_to_zero_free(const Vec& x) {
   const auto& x_ref = to_ref(x);
   check_sum_to_zero("stan::math::sum_to_zero_free", "sum_to_zero variable",
                     x_ref);
-  if (x_ref.size() == 0) {
-    return plain_type_t<Vec>(0);
-  }
+
   return x_ref.head(x_ref.size() - 1);
 }
 

--- a/stan/math/prim/err.hpp
+++ b/stan/math/prim/err.hpp
@@ -41,6 +41,7 @@
 #include <stan/math/prim/err/check_std_vector_index.hpp>
 #include <stan/math/prim/err/check_stochastic_column.hpp>
 #include <stan/math/prim/err/check_stochastic_row.hpp>
+#include <stan/math/prim/err/check_sum_to_zero.hpp>
 #include <stan/math/prim/err/check_symmetric.hpp>
 #include <stan/math/prim/err/check_unit_vector.hpp>
 #include <stan/math/prim/err/check_vector.hpp>

--- a/stan/math/prim/err/check_sum_to_zero.hpp
+++ b/stan/math/prim/err/check_sum_to_zero.hpp
@@ -24,13 +24,17 @@ namespace math {
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param theta Vector to test
+ * @throw `std::invalid_argument` if `theta` is a 0-vector
  * @throw `std::domain_error` if the vector does not sum to zero
  */
 template <typename T, require_matrix_t<T>* = nullptr>
 void check_sum_to_zero(const char* function, const char* name, const T& theta) {
   using std::fabs;
+  // the size-zero case is technically a valid sum-to-zero vector,
+  // but it cannot be unconstrained to anything
+  check_nonzero_size(function, name, theta);
   auto&& theta_ref = to_ref(value_of_rec(theta));
-  if (!(fabs(theta_ref.sum()) <= CONSTRAINT_TOLERANCE)) {
+  if (unlikely(!(fabs(theta_ref.sum()) <= CONSTRAINT_TOLERANCE))) {
     [&]() STAN_COLD_PATH {
       std::stringstream msg;
       scalar_type_t<T> sum = theta_ref.sum();
@@ -52,6 +56,7 @@ void check_sum_to_zero(const char* function, const char* name, const T& theta) {
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param theta Vector to test.
+ * @throw `std::invalid_argument` if `theta` is a 0-vector
  * @throw `std::domain_error` if the vector does not sum to zero
  */
 template <typename T, require_std_vector_t<T>* = nullptr>

--- a/stan/math/prim/err/check_sum_to_zero.hpp
+++ b/stan/math/prim/err/check_sum_to_zero.hpp
@@ -1,0 +1,67 @@
+#ifndef STAN_MATH_PRIM_ERR_CHECK_SUM_TO_ZERO_HPP
+#define STAN_MATH_PRIM_ERR_CHECK_SUM_TO_ZERO_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err/constraint_tolerance.hpp>
+#include <stan/math/prim/err/make_iter_name.hpp>
+#include <stan/math/prim/err/throw_domain_error.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/fun/value_of_rec.hpp>
+#include <sstream>
+#include <string>
+
+namespace stan {
+namespace math {
+
+/**
+ * Throw an exception if the specified vector does not sum to 0.
+ * This function tests that the sum is within the tolerance specified by
+ * `CONSTRAINT_TOLERANCE`.
+ * This function only accepts Eigen vectors, statically
+ * typed vectors, not general matrices with 1 column.
+ * @tparam T A type inheriting from `Eigen::EigenBase`
+ * @param function Function name (for error messages)
+ * @param name Variable name (for error messages)
+ * @param theta Vector to test
+ * @throw `std::domain_error` if the vector does not sum to zero
+ */
+template <typename T, require_matrix_t<T>* = nullptr>
+void check_sum_to_zero(const char* function, const char* name, const T& theta) {
+  using std::fabs;
+  auto&& theta_ref = to_ref(value_of_rec(theta));
+  if (!(fabs(theta_ref.sum()) <= CONSTRAINT_TOLERANCE)) {
+    [&]() STAN_COLD_PATH {
+      std::stringstream msg;
+      scalar_type_t<T> sum = theta_ref.sum();
+      msg << "does not sum to zero.";
+      msg.precision(10);
+      msg << " sum(" << name << ") = " << sum << ", but should be ";
+      std::string msg_str(msg.str());
+      throw_domain_error(function, name, 0.0, msg_str.c_str());
+    }();
+  }
+}
+
+/**
+ * Throw an exception if any vector in a standard vector does not sum to 0.
+ * This function tests that the sum is within the tolerance specified by
+ * `CONSTRAINT_TOLERANCE`.
+ * @tparam T A standard vector with inner type inheriting from
+ * `Eigen::EigenBase`
+ * @param function Function name (for error messages)
+ * @param name Variable name (for error messages)
+ * @param theta Vector to test.
+ * @throw `std::domain_error` if the vector does not sum to zero
+ */
+template <typename T, require_std_vector_t<T>* = nullptr>
+void check_sum_to_zero(const char* function, const char* name, const T& theta) {
+  for (size_t i = 0; i < theta.size(); ++i) {
+    check_sum_to_zero(function, internal::make_iter_name(name, i).c_str(),
+                      theta[i]);
+  }
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/constraint.hpp
+++ b/stan/math/rev/constraint.hpp
@@ -17,6 +17,7 @@
 #include <stan/math/rev/constraint/simplex_constrain.hpp>
 #include <stan/math/rev/constraint/stochastic_column_constrain.hpp>
 #include <stan/math/rev/constraint/stochastic_row_constrain.hpp>
+#include <stan/math/rev/constraint/sum_to_zero_constrain.hpp>
 #include <stan/math/rev/constraint/unit_vector_constrain.hpp>
 #include <stan/math/rev/constraint/ub_constrain.hpp>
 

--- a/stan/math/rev/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/rev/constraint/sum_to_zero_constrain.hpp
@@ -20,7 +20,7 @@ namespace math {
  * Return a vector with sum zero corresponding to the specified
  * free vector.
  *
- * The sum-to-zero transform is defined using a modified version of the
+ * The sum-to-zero transform is defined using a modified version of
  * the inverse of the isometric log ratio transform (ILR).
  * See:
  * Egozcue, Juan Jose; Pawlowsky-Glahn, Vera; Mateu-Figueras, Gloria;
@@ -69,7 +69,7 @@ inline auto sum_to_zero_constrain(const T& y) {
  * Return a vector with sum zero corresponding to the specified
  * free vector.
  *
- * The sum-to-zero transform is defined using a modified version of the
+ * The sum-to-zero transform is defined using a modified version of
  * the inverse of the isometric log ratio transform (ILR).
  * See:
  * Egozcue, Juan Jose; Pawlowsky-Glahn, Vera; Mateu-Figueras, Gloria;
@@ -77,7 +77,7 @@ inline auto sum_to_zero_constrain(const T& y) {
  * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
  * doi:10.1023/A:1023818214614, S2CID 122844634
  *
- * This is a linear transform, with no Jacobian. 
+ * This is a linear transform, with no Jacobian.
  *
  * @tparam Vec type of the vector
  * @param y Free vector input of dimensionality K - 1.

--- a/stan/math/rev/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/rev/constraint/sum_to_zero_constrain.hpp
@@ -44,14 +44,15 @@ inline auto sum_to_zero_constrain(const T& y) {
     for (int i = 0; i < N; ++i) {
       double n = i + 1;
 
-      double u_adj = arena_z.adj()(i);
-      sum_u_adj += u_adj;
+      // adjoint of the reverse cumulative sum computed in the forward mode
+      sum_u_adj += arena_z.adj()(i);
 
-      double v_adj = -arena_z.adj()(i + 1);
+      // adjoint of the offset subtraction
+      double v_adj = -arena_z.adj()(i + 1) * n;
 
-      double w = (v_adj * n) + sum_u_adj;
+      double w_adj = v_adj + sum_u_adj;
 
-      arena_y.adj()(i) += w / sqrt(n * (n + 1));
+      arena_y.adj()(i) += w_adj / sqrt(n * (n + 1));
     }
   });
 

--- a/stan/math/rev/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/rev/constraint/sum_to_zero_constrain.hpp
@@ -39,12 +39,12 @@ namespace math {
  * @return Zero-sum vector of dimensionality K.
  */
 template <typename T, require_rev_col_vector_t<T>* = nullptr>
-inline auto sum_to_zero_constrain(const T& y) {
+inline auto sum_to_zero_constrain(T&& y) {
   using ret_type = plain_type_t<T>;
   if (unlikely(y.size() == 0)) {
     return arena_t<ret_type>(Eigen::VectorXd{{0}});
   }
-  auto arena_y = to_arena(y);
+  auto arena_y = to_arena(std::forward<T>(y));
   arena_t<ret_type> arena_z = sum_to_zero_constrain(arena_y.val());
 
   reverse_pass_callback([arena_y, arena_z]() mutable {
@@ -52,7 +52,7 @@ inline auto sum_to_zero_constrain(const T& y) {
 
     double sum_u_adj = 0;
     for (int i = 0; i < N; ++i) {
-      double n = i + 1;
+      double n = static_cast<double>(i + 1);
 
       // adjoint of the reverse cumulative sum computed in the forward mode
       sum_u_adj += arena_z.adj()(i);
@@ -95,8 +95,8 @@ inline auto sum_to_zero_constrain(const T& y) {
  * @return Zero-sum vector of dimensionality K.
  */
 template <typename T, require_rev_col_vector_t<T>* = nullptr>
-inline auto sum_to_zero_constrain(const T& y, scalar_type_t<T>& lp) {
-  return sum_to_zero_constrain(y);
+inline auto sum_to_zero_constrain(T&& y, scalar_type_t<T>& lp) {
+  return sum_to_zero_constrain(std::forward<T>(y));
 }
 
 }  // namespace math

--- a/stan/math/rev/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/rev/constraint/sum_to_zero_constrain.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/rev/core/arena_matrix.hpp>
 #include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/constraint/sum_to_zero_constrain.hpp>
 #include <cmath>
 #include <tuple>
 #include <vector>

--- a/stan/math/rev/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/rev/constraint/sum_to_zero_constrain.hpp
@@ -46,10 +46,9 @@ inline auto sum_to_zero_constrain(const T& y) {
 
   arena_x.coeffRef(N) = x_N;
 
-
   reverse_pass_callback([arena_y, arena_x, x_N, N]() mutable {
     arena_y.adj() += arena_x.adj().head(N);
-     x_N.adj() += arena_x.adj().coeff(N);
+    x_N.adj() += arena_x.adj().coeff(N);
   });
 
   return ret_type(arena_x);

--- a/stan/math/rev/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/rev/constraint/sum_to_zero_constrain.hpp
@@ -26,6 +26,12 @@ namespace math {
  * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
  * doi:10.1023/A:1023818214614, S2CID 122844634
  *
+ * This implementation is closer to the description of the same using "pivot
+ * coordinates" in
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
+ * In: Applied Compositional Data Analysis. Springer Series in Statistics.
+ * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
+ *
  * This is a linear transform, with no Jacobian.
  *
  * @tparam T type of the vector
@@ -74,6 +80,12 @@ inline auto sum_to_zero_constrain(const T& y) {
  * Barcelo-Vidal, Carles (2003), "Isometric logratio transformations for
  * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
  * doi:10.1023/A:1023818214614, S2CID 122844634
+ *
+ * This implementation is closer to the description of the same using "pivot
+ * coordinates" in
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
+ * In: Applied Compositional Data Analysis. Springer Series in Statistics.
+ * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
  *
  * This is a linear transform, with no Jacobian.
  *

--- a/stan/math/rev/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/rev/constraint/sum_to_zero_constrain.hpp
@@ -28,20 +28,15 @@ namespace math {
 template <typename T, require_rev_col_vector_t<T>* = nullptr>
 inline auto sum_to_zero_constrain(const T& y) {
   using ret_type = plain_type_t<T>;
-
   const auto N = y.size();
   if (unlikely(N == 0)) {
     return arena_t<ret_type>(Eigen::VectorXd{{0}});
   }
-  Eigen::VectorXd x_val = Eigen::VectorXd::Zero(N + 1);
   auto arena_y = to_arena(y);
-  double x_sum = -sum(arena_y.val());
-  x_val.head(N) = arena_y.val();
-  x_val(N) = x_sum;
-  arena_t<ret_type> arena_x = x_val;
-  reverse_pass_callback([arena_y, arena_x, x_sum, N]() mutable {
-    arena_y.adj().array() -= arena_x.adj_op()(N);
-    arena_y.adj() += arena_x.adj_op().head(N);
+  arena_t<ret_type> arena_x = sum_to_zero_constrain(arena_y.val());
+
+  reverse_pass_callback([arena_y, arena_x]() mutable {
+    // TODO
   });
   return arena_x;
 }

--- a/stan/math/rev/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/rev/constraint/sum_to_zero_constrain.hpp
@@ -4,11 +4,9 @@
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core/reverse_pass_callback.hpp>
 #include <stan/math/rev/core/arena_matrix.hpp>
-#include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/sqrt.hpp>
 #include <stan/math/prim/constraint/sum_to_zero_constrain.hpp>
-#include <stan/math/prim/fun/linspaced_vector.hpp>
-#include <stan/math/prim/fun/cumulative_sum.hpp>
 #include <cmath>
 #include <tuple>
 #include <vector>

--- a/stan/math/rev/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/rev/constraint/sum_to_zero_constrain.hpp
@@ -31,7 +31,7 @@ inline auto sum_to_zero_constrain(const T& y) {
 
   const auto N = y.size();
   if (unlikely(N == 0)) {
-    return ret_type(Eigen::VectorXd{{0}});
+    return arena_t<ret_type>(Eigen::VectorXd{{0}});
   }
   Eigen::VectorXd x_val = Eigen::VectorXd::Zero(N + 1);
   auto arena_y = to_arena(y);
@@ -43,7 +43,7 @@ inline auto sum_to_zero_constrain(const T& y) {
     arena_y.adj().array() -= arena_x.adj_op()(N);
     arena_y.adj() += arena_x.adj_op().head(N);
   });
-  return ret_type(arena_x);
+  return arena_x;
 }
 
 /**
@@ -61,7 +61,7 @@ inline auto sum_to_zero_constrain(const T& y) {
  * @return Zero-sum vector of dimensionality K.
  */
 template <typename T, require_rev_col_vector_t<T>* = nullptr>
-auto sum_to_zero_constrain(const T& y, scalar_type_t<T>& lp) {
+inline auto sum_to_zero_constrain(const T& y, scalar_type_t<T>& lp) {
   return sum_to_zero_constrain(y);
 }
 

--- a/stan/math/rev/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/rev/constraint/sum_to_zero_constrain.hpp
@@ -20,9 +20,15 @@ namespace math {
  * Return a vector with sum zero corresponding to the specified
  * free vector.
  *
- * The sum-to-zero transform is defined such that the first K-1
- * elements are unconstrained and the last element is the negative
- * sum of those elements.
+ * The sum-to-zero transform is defined using a modified version of the
+ * the inverse of the isometric log ratio transform (ILR).
+ * See:
+ * Egozcue, Juan Jose; Pawlowsky-Glahn, Vera; Mateu-Figueras, Gloria;
+ * Barcelo-Vidal, Carles (2003), "Isometric logratio transformations for
+ * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
+ * doi:10.1023/A:1023818214614, S2CID 122844634
+ *
+ * This is a linear transform, with no Jacobian.
  *
  * @tparam T type of the vector
  * @param y Free vector input of dimensionality K - 1.
@@ -63,10 +69,15 @@ inline auto sum_to_zero_constrain(const T& y) {
  * Return a vector with sum zero corresponding to the specified
  * free vector.
  *
- * The sum-to-zero transform is defined such that the first K-1
- * elements are unconstrained and the last element is the negative
- * sum of those elements. This is a linear transform, with no
- * Jacobian.
+ * The sum-to-zero transform is defined using a modified version of the
+ * the inverse of the isometric log ratio transform (ILR).
+ * See:
+ * Egozcue, Juan Jose; Pawlowsky-Glahn, Vera; Mateu-Figueras, Gloria;
+ * Barcelo-Vidal, Carles (2003), "Isometric logratio transformations for
+ * compositional data analysis", Mathematical Geology, 35 (3): 279–300,
+ * doi:10.1023/A:1023818214614, S2CID 122844634
+ *
+ * This is a linear transform, with no Jacobian. 
  *
  * @tparam Vec type of the vector
  * @param y Free vector input of dimensionality K - 1.

--- a/stan/math/rev/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/rev/constraint/sum_to_zero_constrain.hpp
@@ -28,9 +28,9 @@ namespace math {
  *
  * This implementation is closer to the description of the same using "pivot
  * coordinates" in
- * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
- * In: Applied Compositional Data Analysis. Springer Series in Statistics.
- * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of
+ * Compositional Data. In: Applied Compositional Data Analysis. Springer Series
+ * in Statistics. Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
  *
  * This is a linear transform, with no Jacobian.
  *
@@ -83,9 +83,9 @@ inline auto sum_to_zero_constrain(const T& y) {
  *
  * This implementation is closer to the description of the same using "pivot
  * coordinates" in
- * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of Compositional Data.
- * In: Applied Compositional Data Analysis. Springer Series in Statistics.
- * Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
+ * Filzmoser, P., Hron, K., Templ, M. (2018). Geometrical Properties of
+ * Compositional Data. In: Applied Compositional Data Analysis. Springer Series
+ * in Statistics. Springer, Cham. https://doi.org/10.1007/978-3-319-96422-5_3
  *
  * This is a linear transform, with no Jacobian.
  *

--- a/stan/math/rev/constraint/sum_to_zero_constrain.hpp
+++ b/stan/math/rev/constraint/sum_to_zero_constrain.hpp
@@ -1,0 +1,79 @@
+#ifndef STAN_MATH_REV_CONSTRAINT_SUM_TO_ZERO_CONSTRAIN_HPP
+#define STAN_MATH_REV_CONSTRAINT_SUM_TO_ZERO_CONSTRAIN_HPP
+
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/rev/core/reverse_pass_callback.hpp>
+#include <stan/math/rev/core/arena_matrix.hpp>
+#include <stan/math/rev/fun/value_of.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <cmath>
+#include <tuple>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return a vector with sum zero corresponding to the specified
+ * free vector.
+ *
+ * The sum-to-zero transform is defined such that the first K-1
+ * elements are unconstrained and the last element is the negative
+ * sum of those elements.
+ *
+ * @tparam T type of the vector
+ * @param y Free vector input of dimensionality K - 1.
+ * @return Zero-sum vector of dimensionality K.
+ */
+template <typename T, require_rev_col_vector_t<T>* = nullptr>
+inline auto sum_to_zero_constrain(const T& y) {
+  using ret_type = plain_type_t<T>;
+
+  size_t N = y.size();
+  Eigen::VectorXd x_val(N + 1);
+
+  arena_t<T> arena_y = y;
+
+  if (unlikely(N == 0)) {
+    x_val << 0;
+    return ret_type(x_val);
+  }
+
+  x_val.head(N) = y.val();
+  arena_t<ret_type> arena_x = x_val;
+
+  var x_N = -sum(y);
+
+  arena_x.coeffRef(N) = x_N;
+
+
+  reverse_pass_callback([arena_y, arena_x, x_N, N]() mutable {
+    arena_y.adj() += arena_x.adj().head(N);
+     x_N.adj() += arena_x.adj().coeff(N);
+  });
+
+  return ret_type(arena_x);
+}
+
+/**
+ * Return a vector with sum zero corresponding to the specified
+ * free vector.
+ *
+ * The sum-to-zero transform is defined such that the first K-1
+ * elements are unconstrained and the last element is the negative
+ * sum of those elements. This is a linear transform, with no
+ * Jacobian.
+ *
+ * @tparam Vec type of the vector
+ * @param y Free vector input of dimensionality K - 1.
+ * @param lp unused
+ * @return Zero-sum vector of dimensionality K.
+ */
+template <typename T, require_rev_col_vector_t<T>* = nullptr>
+auto sum_to_zero_constrain(const T& y, scalar_type_t<T>& lp) {
+  return sum_to_zero_constrain(y);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/test/unit/math/mix/constraint/sum_to_zero_constrain_test.cpp
+++ b/test/unit/math/mix/constraint/sum_to_zero_constrain_test.cpp
@@ -24,11 +24,11 @@ void expect_sum_to_zero_transform(const T& x) {
   auto f2 = [](const auto& x) { return g2(x); };
   auto f3 = [](const auto& x) { return g3(x); };
   stan::test::expect_ad(f1, x);
-//   stan::test::expect_ad_matvar(f1, x);
+  //   stan::test::expect_ad_matvar(f1, x);
   stan::test::expect_ad(f2, x);
-//   stan::test::expect_ad_matvar(f2, x);
+  //   stan::test::expect_ad_matvar(f2, x);
   stan::test::expect_ad(f3, x);
-//   stan::test::expect_ad_matvar(f3, x);
+  //   stan::test::expect_ad_matvar(f3, x);
 }
 }  // namespace sum_to_zero_constrain_test
 

--- a/test/unit/math/mix/constraint/sum_to_zero_constrain_test.cpp
+++ b/test/unit/math/mix/constraint/sum_to_zero_constrain_test.cpp
@@ -1,0 +1,58 @@
+#include <test/unit/math/test_ad.hpp>
+
+namespace sum_to_zero_constrain_test {
+template <typename T>
+T g1(const T& x) {
+  stan::scalar_type_t<T> lp = 0;
+  return stan::math::sum_to_zero_constrain<false>(x, lp);
+}
+template <typename T>
+T g2(const T& x) {
+  stan::scalar_type_t<T> lp = 0;
+  return stan::math::sum_to_zero_constrain<true>(x, lp);
+}
+template <typename T>
+typename stan::scalar_type<T>::type g3(const T& x) {
+  stan::scalar_type_t<T> lp = 0;
+  stan::math::sum_to_zero_constrain<true>(x, lp);
+  return lp;
+}
+
+template <typename T>
+void expect_sum_to_zero_transform(const T& x) {
+  auto f1 = [](const auto& x) { return g1(x); };
+  auto f2 = [](const auto& x) { return g2(x); };
+  auto f3 = [](const auto& x) { return g3(x); };
+  stan::test::expect_ad(f1, x);
+//   stan::test::expect_ad_matvar(f1, x);
+  stan::test::expect_ad(f2, x);
+//   stan::test::expect_ad_matvar(f2, x);
+  stan::test::expect_ad(f3, x);
+//   stan::test::expect_ad_matvar(f3, x);
+}
+}  // namespace sum_to_zero_constrain_test
+
+TEST(MathMixMatFun, sum_to_zeroTransform) {
+  Eigen::VectorXd v0(0);
+  sum_to_zero_constrain_test::expect_sum_to_zero_transform(v0);
+
+  Eigen::VectorXd v1(1);
+  v1 << 1;
+  sum_to_zero_constrain_test::expect_sum_to_zero_transform(v1);
+
+  Eigen::VectorXd v2(2);
+  v2 << 3, -1;
+  sum_to_zero_constrain_test::expect_sum_to_zero_transform(v2);
+
+  Eigen::VectorXd v3(3);
+  v3 << 2, 3, -1;
+  sum_to_zero_constrain_test::expect_sum_to_zero_transform(v3);
+
+  Eigen::VectorXd v4(4);
+  v4 << 2, -1, 0, -1.1;
+  sum_to_zero_constrain_test::expect_sum_to_zero_transform(v4);
+
+  Eigen::VectorXd v5(5);
+  v5 << 1, -3, 2, 0, -1;
+  sum_to_zero_constrain_test::expect_sum_to_zero_transform(v5);
+}

--- a/test/unit/math/mix/constraint/sum_to_zero_constrain_test.cpp
+++ b/test/unit/math/mix/constraint/sum_to_zero_constrain_test.cpp
@@ -24,11 +24,11 @@ void expect_sum_to_zero_transform(const T& x) {
   auto f2 = [](const auto& x) { return g2(x); };
   auto f3 = [](const auto& x) { return g3(x); };
   stan::test::expect_ad(f1, x);
-  //   stan::test::expect_ad_matvar(f1, x);
+     stan::test::expect_ad_matvar(f1, x);
   stan::test::expect_ad(f2, x);
-  //   stan::test::expect_ad_matvar(f2, x);
+     stan::test::expect_ad_matvar(f2, x);
   stan::test::expect_ad(f3, x);
-  //   stan::test::expect_ad_matvar(f3, x);
+     stan::test::expect_ad_matvar(f3, x);
 }
 }  // namespace sum_to_zero_constrain_test
 

--- a/test/unit/math/mix/constraint/sum_to_zero_constrain_test.cpp
+++ b/test/unit/math/mix/constraint/sum_to_zero_constrain_test.cpp
@@ -24,11 +24,11 @@ void expect_sum_to_zero_transform(const T& x) {
   auto f2 = [](const auto& x) { return g2(x); };
   auto f3 = [](const auto& x) { return g3(x); };
   stan::test::expect_ad(f1, x);
-     stan::test::expect_ad_matvar(f1, x);
+  stan::test::expect_ad_matvar(f1, x);
   stan::test::expect_ad(f2, x);
-     stan::test::expect_ad_matvar(f2, x);
+  stan::test::expect_ad_matvar(f2, x);
   stan::test::expect_ad(f3, x);
-     stan::test::expect_ad_matvar(f3, x);
+  stan::test::expect_ad_matvar(f3, x);
 }
 }  // namespace sum_to_zero_constrain_test
 

--- a/test/unit/math/prim/constraint/sum_to_zero_transform_test.cpp
+++ b/test/unit/math/prim/constraint/sum_to_zero_transform_test.cpp
@@ -11,6 +11,8 @@ TEST(prob_transform, sum_to_zero_rt0) {
   std::vector<Matrix<double, Dynamic, 1>> x_vec{x, x, x};
   std::vector<Matrix<double, Dynamic, 1>> y_vec
       = stan::math::sum_to_zero_constrain<false>(x_vec, lp);
+  EXPECT_NO_THROW(stan::math::check_sum_to_zero("checkSumToZero", "y", y_vec));
+
   for (auto&& y_i : y_vec) {
     EXPECT_MATRIX_FLOAT_EQ(Eigen::VectorXd::Zero(5), y_i);
   }

--- a/test/unit/math/prim/constraint/sum_to_zero_transform_test.cpp
+++ b/test/unit/math/prim/constraint/sum_to_zero_transform_test.cpp
@@ -1,0 +1,62 @@
+#include <stan/math/prim.hpp>
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+
+TEST(prob_transform, sum_to_zero_rt0) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  double lp = 0;
+  Matrix<double, Dynamic, 1> x(4);
+  x << 0.0, 0.0, 0.0, 0.0;
+  std::vector<Matrix<double, Dynamic, 1>> x_vec{x, x, x};
+  std::vector<Matrix<double, Dynamic, 1>> y_vec
+      = stan::math::sum_to_zero_constrain<false>(x_vec, lp);
+  for (auto&& y_i : y_vec) {
+    EXPECT_MATRIX_FLOAT_EQ(Eigen::VectorXd::Zero(5), y_i);
+  }
+  std::vector<Matrix<double, Dynamic, 1>> xrt
+      = stan::math::sum_to_zero_free(y_vec);
+  EXPECT_EQ(x.size() + 1, y_vec[2].size());
+  for (auto&& x_i : xrt) {
+    EXPECT_EQ(x.size(), x_i.size());
+    for (int i = 0; i < x.size(); ++i) {
+      EXPECT_NEAR(x[i], x_i[i], 1E-10);
+    }
+  }
+}
+TEST(prob_transform, sum_to_zero_rt) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  Matrix<double, Dynamic, 1> x(3);
+  x << 1.0, -1.0, 2.0;
+  Matrix<double, Dynamic, 1> y = stan::math::sum_to_zero_constrain(x);
+  EXPECT_NO_THROW(stan::math::check_sum_to_zero("checkSumToZero", "y", y));
+  Matrix<double, Dynamic, 1> xrt = stan::math::sum_to_zero_free(y);
+  EXPECT_EQ(x.size() + 1, y.size());
+  EXPECT_EQ(x.size(), xrt.size());
+  for (int i = 0; i < x.size(); ++i) {
+    EXPECT_FLOAT_EQ(x[i], xrt[i]);
+  }
+}
+TEST(prob_transform, sum_to_zero_match) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  Matrix<double, Dynamic, 1> x(3);
+  x << 1.0, -1.0, 2.0;
+  double lp = 0;
+  Matrix<double, Dynamic, 1> y = stan::math::sum_to_zero_constrain(x);
+  Matrix<double, Dynamic, 1> y2 = stan::math::sum_to_zero_constrain(x, lp);
+
+  EXPECT_EQ(4, y.size());
+  EXPECT_EQ(4, y2.size());
+  for (int i = 0; i < x.size(); ++i)
+    EXPECT_FLOAT_EQ(y[i], y2[i]);
+}
+
+TEST(prob_transform, sum_to_zero_f_exception) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  Matrix<double, Dynamic, 1> y(2);
+  y << 0.5, -0.55;
+  EXPECT_THROW(stan::math::sum_to_zero_free(y), std::domain_error);
+}

--- a/test/unit/math/prim/err/check_sum_to_zero_test.cpp
+++ b/test/unit/math/prim/err/check_sum_to_zero_test.cpp
@@ -60,7 +60,6 @@ TEST(ErrorHandlingMatrix, checkSumToZero_message_sum) {
   EXPECT_TRUE(std::string::npos != message.find("sum(y[1]) = 0.1")) << message;
 }
 
-
 TEST(ErrorHandlingMatrix, checkSumToZero_nan) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> y_vec(2);
   std::vector<Eigen::Matrix<double, Eigen::Dynamic, 1>> y{y_vec, y_vec, y_vec};

--- a/test/unit/math/prim/err/check_sum_to_zero_test.cpp
+++ b/test/unit/math/prim/err/check_sum_to_zero_test.cpp
@@ -1,0 +1,93 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <limits>
+#include <string>
+
+TEST(ErrorHandlingMatrix, checkSumToZero_edges) {
+  Eigen::Matrix<double, Eigen::Dynamic, 1> zero(0);
+
+  EXPECT_NO_THROW(
+      stan::math::check_sum_to_zero("checkSumToZero", "zero", zero));
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y_vec(1);
+  y_vec << 0.0;
+
+  EXPECT_NO_THROW(stan::math::check_sum_to_zero("checkSumToZero", "y", y_vec));
+
+  y_vec[0] = 0.1;
+  EXPECT_THROW(stan::math::check_sum_to_zero("checkSumToZero", "y", y_vec),
+               std::domain_error);
+}
+
+TEST(ErrorHandlingMatrix, checkSumToZero) {
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y_vec(2);
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, 1>> y{y_vec, y_vec, y_vec};
+  for (auto& y_i : y) {
+    y_i << 0.5, -0.5;
+  }
+
+  EXPECT_NO_THROW(stan::math::check_sum_to_zero("checkSumToZero", "y", y));
+
+  for (auto& y_i : y) {
+    y_i[0] = 0.55;
+  }
+  EXPECT_THROW(stan::math::check_sum_to_zero("checkSumToZero", "y", y),
+               std::domain_error);
+}
+
+TEST(ErrorHandlingMatrix, checkSumToZero_message_sum) {
+  std::string message;
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y_vec(100);
+  y_vec.setZero();
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, 1>> y{y_vec, y_vec, y_vec};
+  for (auto& y_i : y) {
+    y_i[13] = 0.1;
+  }
+
+  try {
+    stan::math::check_sum_to_zero("checkSumToZero", "y", y);
+    FAIL() << "should have thrown";
+  } catch (std::domain_error& e) {
+    message = e.what();
+  } catch (...) {
+    FAIL() << "threw the wrong error";
+  }
+
+  EXPECT_TRUE(std::string::npos != message.find(" y[1] does not sum to zero"))
+      << message;
+
+  EXPECT_TRUE(std::string::npos != message.find("sum(y[1]) = 0.1")) << message;
+}
+
+
+TEST(ErrorHandlingMatrix, checkSumToZero_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y_vec(2);
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, 1>> y{y_vec, y_vec, y_vec};
+  constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+  for (auto& y_i : y) {
+    y_i << nan, 0.5;
+  }
+
+  EXPECT_THROW(stan::math::check_sum_to_zero("checkSumToZero", "y", y),
+               std::domain_error);
+
+  for (auto& y_i : y) {
+    y_i[1] = 0.55;
+  }
+  EXPECT_THROW(stan::math::check_sum_to_zero("checkSumToZero", "y", y),
+               std::domain_error);
+
+  for (auto& y_i : y) {
+    y_i[0] = 0.5;
+    y_i[1] = nan;
+  }
+  EXPECT_THROW(stan::math::check_sum_to_zero("checkSumToZero", "y", y),
+               std::domain_error);
+
+  for (auto& y_i : y) {
+    y_i[0] = nan;
+  }
+  EXPECT_THROW(stan::math::check_sum_to_zero("checkSumToZero", "y", y),
+               std::domain_error);
+}

--- a/test/unit/math/prim/err/check_sum_to_zero_test.cpp
+++ b/test/unit/math/prim/err/check_sum_to_zero_test.cpp
@@ -7,8 +7,8 @@
 TEST(ErrorHandlingMatrix, checkSumToZero_edges) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> zero(0);
 
-  EXPECT_NO_THROW(
-      stan::math::check_sum_to_zero("checkSumToZero", "zero", zero));
+  EXPECT_THROW(stan::math::check_sum_to_zero("checkSumToZero", "zero", zero),
+               std::invalid_argument);
 
   Eigen::Matrix<double, Eigen::Dynamic, 1> y_vec(1);
   y_vec << 0.0;


### PR DESCRIPTION
## Summary

This is an alternative to #3099 based on the discussion in the comments there. Rather than `x[1:N-1] = y; x[N] = -sum(y)` this uses a modification of the isometric log ratio (ILR) transformation for simplexes. The implementation is based on a single for-loop, but was adapted from Sean's code that used several temporary vectors, which was adapted from [a version which used a full matrix](https://github.com/bob-carpenter/transforms/commit/8a9e14b2dd8c3710e2fab36c9c8385849b35652c)

## Tests

Added tests in the err and constraint folders, based on the existing tests for `simplex.`

In addition, I iterated on the implementation of this algorithm in Python, so I have some out-of-tree tests here: https://gist.github.com/WardBrian/aae35c65fb841f923d89cc30a3d70808

## Side Effects


## Release notes

Added `sum_to_zero_constrain`, `sum_to_zero_free`, and `check_sum_to_zero`.
## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
