### PR TITLE
Feature/issue-3107 add beta negative binomial lpmf

### DIFF
--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -25,6 +25,7 @@
 #include <stan/math/prim/prob/beta_lccdf.hpp>
 #include <stan/math/prim/prob/beta_lcdf.hpp>
 #include <stan/math/prim/prob/beta_lpdf.hpp>
+#include <stan/math/prim/prob/beta_neg_binomial_lpmf.hpp>
 #include <stan/math/prim/prob/beta_proportion_ccdf_log.hpp>
 #include <stan/math/prim/prob/beta_proportion_cdf_log.hpp>
 #include <stan/math/prim/prob/beta_proportion_lccdf.hpp>

--- a/stan/math/prim/prob/beta_neg_binomial_lpmf.hpp
+++ b/stan/math/prim/prob/beta_neg_binomial_lpmf.hpp
@@ -79,46 +79,45 @@ inline return_type_t<T_r, T_alpha, T_beta> beta_neg_binomial_lpmf(
     if constexpr (include_summand<propto>::value) {
       logp -= lgamma(n_vec[i] + 1);
     }
-    T_partials_return lbeta_denominator
-        = lbeta(r_vec.val(i), alpha_vec.val(i));
-    T_partials_return lgamma_numerator
-        = lgamma(n_vec[i] + beta_vec.val(i));
+    T_partials_return lbeta_denominator = lbeta(r_vec.val(i), alpha_vec.val(i));
+    T_partials_return lgamma_numerator = lgamma(n_vec[i] + beta_vec.val(i));
     T_partials_return lgamma_denominator = lgamma(beta_vec.val(i));
     T_partials_return lbeta_numerator
         = lbeta(n_vec[i] + r_vec.val(i), alpha_vec.val(i) + beta_vec.val(i));
     logp += lbeta_numerator + lgamma_numerator - lbeta_denominator
             - lgamma_denominator;
     if (!is_constant_all<T_r, T_alpha, T_beta>::value) {
-      T_partials_return digamma_n_r_alpha_beta
-          = digamma(n_vec[i] + r_vec.val(i) + alpha_vec.val(i)
-                          + beta_vec.val(i));
+      T_partials_return digamma_n_r_alpha_beta = digamma(
+          n_vec[i] + r_vec.val(i) + alpha_vec.val(i) + beta_vec.val(i));
 
       if constexpr (!is_constant<T_r>::value || !is_constant<T_alpha>::value) {
-        T_partials_return digamma_r_alpha = digamma(r_vec.val(i) + alpha_vec.val(i));
+        T_partials_return digamma_r_alpha
+            = digamma(r_vec.val(i) + alpha_vec.val(i));
         if constexpr (!is_constant_all<T_r>::value) {
           partials<0>(ops_partials)[i]
               += digamma(n_vec[i] + r_vec.val(i)) - digamma_n_r_alpha_beta
-                - (digamma(r_vec.val(i)) - digamma_r_alpha);
+                 - (digamma(r_vec.val(i)) - digamma_r_alpha);
         }
         if constexpr (!is_constant_all<T_alpha>::value) {
           partials<1>(ops_partials)[i]
               += -digamma_n_r_alpha_beta
-                - (digamma(alpha_vec.val(i)) - digamma_r_alpha);
+                 - (digamma(alpha_vec.val(i)) - digamma_r_alpha);
         }
       }
-      if constexpr (!is_constant<T_beta>::value || !is_constant<T_alpha>::value) {
+      if constexpr (!is_constant<T_beta>::value
+                    || !is_constant<T_alpha>::value) {
         T_partials_return digamma_alpha_beta
             = digamma(alpha_vec.val(i) + beta_vec.val(i));
         if constexpr (!is_constant_all<T_beta>::value) {
-          partials<2>(ops_partials)[i]
-              += digamma_alpha_beta - digamma_n_r_alpha_beta
-                + digamma(n_vec[i] + beta_vec.val(i)) - digamma(beta_vec.val(i));
+          partials<2>(ops_partials)[i] += digamma_alpha_beta
+                                          - digamma_n_r_alpha_beta
+                                          + digamma(n_vec[i] + beta_vec.val(i))
+                                          - digamma(beta_vec.val(i));
         }
         if constexpr (!is_constant_all<T_alpha>::value) {
           partials<1>(ops_partials)[i] += digamma_alpha_beta;
         }
       }
-
     }
   }
   return ops_partials.build(logp);

--- a/stan/math/prim/prob/beta_neg_binomial_lpmf.hpp
+++ b/stan/math/prim/prob/beta_neg_binomial_lpmf.hpp
@@ -1,0 +1,220 @@
+#ifndef STAN_MATH_PRIM_PROB_BETA_NEG_BINOMIAL_LPMF_HPP
+#define STAN_MATH_PRIM_PROB_BETA_NEG_BINOMIAL_LPMF_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/digamma.hpp>
+#include <stan/math/prim/fun/lbeta.hpp>
+#include <stan/math/prim/fun/lgamma.hpp>
+#include <stan/math/prim/fun/max_size.hpp>
+#include <stan/math/prim/fun/scalar_seq_view.hpp>
+#include <stan/math/prim/fun/size.hpp>
+#include <stan/math/prim/fun/size_zero.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/functor/partials_propagator.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup prob_dists
+ * Returns the log PMF of the Beta Negative Binomial distribution with given
+ * number of successes, prior success, and prior failure parameters.
+ * Given containers of matching sizes, returns the log sum of probabilities.
+ *
+ * @tparam T_n type of failure parameter
+ * @tparam T_r type of number of successes parameter
+ * @tparam T_alpha type of prior success parameter
+ * @tparam T_beta type of prior failure parameter
+ *
+ * @param n failure parameter
+ * @param r Number of successes parameter
+ * @param alpha prior success parameter
+ * @param beta prior failure parameter
+ * @return log probability or log sum of probabilities
+ * @throw std::domain_error if r, alpha, or beta fails to be positive
+ * @throw std::invalid_argument if container sizes mismatch
+ */
+template <bool propto, typename T_n, typename T_r, typename T_alpha,
+          typename T_beta,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_n, T_r, T_alpha, T_beta>* = nullptr>
+inline return_type_t<T_r, T_alpha, T_beta> beta_neg_binomial_lpmf(
+    const T_n& n, const T_r& r, const T_alpha& alpha, const T_beta& beta) {
+  using T_partials_return = partials_return_t<T_n, T_r, T_alpha, T_beta>;
+  using T_n_ref = ref_type_t<T_n>;
+  using T_r_ref = ref_type_t<T_r>;
+  using T_alpha_ref = ref_type_t<T_alpha>;
+  using T_beta_ref = ref_type_t<T_beta>;
+  static constexpr const char* function = "beta_neg_binomial_lpmf";
+  check_consistent_sizes(
+      function, "Failures variable", n, "Number of successes parameter", r,
+      "Prior success parameter", alpha, "Prior failure parameter", beta);
+  if (size_zero(n, r, alpha, beta)) {
+    return 0.0;
+  }
+
+  T_n_ref n_ref = n;
+  T_r_ref r_ref = r;
+  T_alpha_ref alpha_ref = alpha;
+  T_beta_ref beta_ref = beta;
+  check_nonnegative(function, "Failures variable", n_ref);
+  check_positive_finite(function, "Number of successes parameter", r_ref);
+  check_positive_finite(function, "Prior success parameter", alpha_ref);
+  check_positive_finite(function, "Prior failure parameter", beta_ref);
+
+  if (!include_summand<propto, T_r, T_alpha, T_beta>::value) {
+    return 0.0;
+  }
+
+  T_partials_return logp(0.0);
+  auto ops_partials = make_partials_propagator(r_ref, alpha_ref, beta_ref);
+
+  scalar_seq_view<T_n> n_vec(n);
+  scalar_seq_view<T_r_ref> r_vec(r_ref);
+  scalar_seq_view<T_alpha_ref> alpha_vec(alpha_ref);
+  scalar_seq_view<T_beta_ref> beta_vec(beta_ref);
+  size_t size_n = stan::math::size(n);
+  size_t size_r = stan::math::size(r);
+  size_t size_alpha = stan::math::size(alpha);
+  size_t size_beta = stan::math::size(beta);
+  size_t size_n_r = max_size(n, r);
+  size_t size_r_alpha = max_size(r, alpha);
+  size_t size_n_beta = max_size(n, beta);
+  size_t size_alpha_beta = max_size(alpha, beta);
+  size_t max_size_seq_view = max_size(n, r, alpha, beta);
+
+  VectorBuilder<include_summand<propto>::value, T_partials_return, T_n>
+      normalizing_constant(size_n);
+  for (size_t i = 0; i < size_n; i++)
+    if (include_summand<propto>::value)
+      normalizing_constant[i] = -lgamma(n_vec[i] + 1);
+
+  VectorBuilder<true, T_partials_return, T_r, T_alpha> lbeta_denominator(
+      size_r_alpha);
+  for (size_t i = 0; i < size_r_alpha; i++) {
+    lbeta_denominator[i] = lbeta(r_vec.val(i), alpha_vec.val(i));
+  }
+
+  VectorBuilder<true, T_partials_return, T_beta> lgamma_denominator(size_beta);
+  for (size_t i = 0; i < size_beta; i++) {
+    lgamma_denominator[i] = lgamma(beta_vec.val(i));
+  }
+
+  VectorBuilder<true, T_partials_return, T_n, T_beta> lgamma_numerator(
+      size_n_beta);
+  for (size_t i = 0; i < size_n_beta; i++) {
+    lgamma_numerator[i] = lgamma(n_vec[i] + beta_vec.val(i));
+  }
+
+  VectorBuilder<true, T_partials_return, T_n, T_r, T_alpha, T_beta> lbeta_diff(
+      max_size_seq_view);
+  for (size_t i = 0; i < max_size_seq_view; i++) {
+    lbeta_diff[i]
+        = lbeta(n_vec[i] + r_vec.val(i), alpha_vec.val(i) + beta_vec.val(i))
+          + lgamma_numerator[i] - lbeta_denominator[i] - lgamma_denominator[i];
+  }
+
+  // derivative w.r.t. r, alpha and beta
+
+  VectorBuilder<!is_constant_all<T_r, T_alpha, T_beta>::value,
+                T_partials_return, T_n, T_r, T_alpha, T_beta>
+      digamma_n_r_alpha_beta(max_size_seq_view);
+  if (!is_constant_all<T_r, T_alpha, T_beta>::value) {
+    for (size_t i = 0; i < max_size_seq_view; i++) {
+      digamma_n_r_alpha_beta[i] = digamma(n_vec[i] + r_vec.val(i)
+                                          + alpha_vec.val(i) + beta_vec.val(i));
+    }
+  }
+
+  VectorBuilder<!is_constant_all<T_alpha, T_beta>::value, T_partials_return,
+                T_alpha, T_beta>
+      digamma_alpha_beta(size_alpha_beta);
+  if (!is_constant_all<T_alpha, T_beta>::value) {
+    for (size_t i = 0; i < size_alpha_beta; i++) {
+      digamma_alpha_beta[i] = digamma(alpha_vec.val(i) + beta_vec.val(i));
+    }
+  }
+
+  VectorBuilder<!is_constant_all<T_r>::value, T_partials_return, T_n, T_r>
+      digamma_n_r(size_n_r);
+  if (!is_constant_all<T_r>::value) {
+    for (size_t i = 0; i < size_n_r; i++) {
+      digamma_n_r[i] = digamma(n_vec[i] + r_vec.val(i));
+    }
+  }
+
+  VectorBuilder<!is_constant_all<T_r, T_alpha>::value, T_partials_return, T_r,
+                T_alpha>
+      digamma_r_alpha(size_r_alpha);
+  if (!is_constant_all<T_r, T_alpha>::value) {
+    for (size_t i = 0; i < size_r_alpha; i++) {
+      digamma_r_alpha[i] = digamma(r_vec.val(i) + alpha_vec.val(i));
+    }
+  }
+
+  VectorBuilder<!is_constant_all<T_beta>::value, T_partials_return, T_n,
+                T_beta>
+      digamma_n_beta(size_n_beta);
+  if (!is_constant_all<T_n, T_beta>::value) {
+    for (size_t i = 0; i < size_n_beta; i++) {
+      digamma_n_beta[i] = digamma(n_vec[i] + beta_vec.val(i));
+    }
+  }
+
+  VectorBuilder<!is_constant_all<T_r>::value, T_partials_return, T_r> digamma_r(
+      size_r);
+  if (!is_constant_all<T_r>::value) {
+    for (size_t i = 0; i < size_r; i++) {
+      digamma_r[i] = digamma(r_vec.val(i));
+    }
+  }
+
+  VectorBuilder<!is_constant_all<T_alpha>::value, T_partials_return, T_alpha>
+      digamma_alpha(size_alpha);
+  if (!is_constant_all<T_alpha>::value) {
+    for (size_t i = 0; i < size_alpha; i++) {
+      digamma_alpha[i] = digamma(alpha_vec.val(i));
+    }
+  }
+
+  VectorBuilder<!is_constant_all<T_beta>::value, T_partials_return, T_beta>
+      digamma_beta(size_beta);
+  if (!is_constant_all<T_beta>::value) {
+    for (size_t i = 0; i < size_beta; i++) {
+      digamma_beta[i] = digamma(beta_vec.val(i));
+    }
+  }
+
+  for (size_t i = 0; i < max_size_seq_view; i++) {
+    if (include_summand<propto>::value)
+      logp += normalizing_constant[i];
+    logp += lbeta_diff[i];
+
+    if (!is_constant_all<T_r>::value) {
+      partials<0>(ops_partials)[i] += digamma_n_r[i] - digamma_n_r_alpha_beta[i]
+                                      - (digamma_r[i] - digamma_r_alpha[i]);
+    }
+    if (!is_constant_all<T_alpha>::value) {
+      partials<1>(ops_partials)[i] += digamma_alpha_beta[i]
+                                      - digamma_n_r_alpha_beta[i]
+                                      - (digamma_alpha[i] - digamma_r_alpha[i]);
+    }
+    if (!is_constant_all<T_beta>::value) {
+      partials<2>(ops_partials)[i] += digamma_alpha_beta[i]
+                                      - digamma_n_r_alpha_beta[i]
+                                      + digamma_n_beta[i] - digamma_beta[i];
+    }
+  }
+  return ops_partials.build(logp);
+}
+
+template <typename T_n, typename T_r, typename T_alpha, typename T_beta>
+inline return_type_t<T_r, T_alpha, T_beta> beta_neg_binomial_lpmf(
+    const T_n& n, const T_r& r, const T_alpha& alpha, const T_beta& beta) {
+  return beta_neg_binomial_lpmf<false>(n, r, alpha, beta);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/test/prob/beta_neg_binomial/beta_neg_binomial_test.hpp
+++ b/test/prob/beta_neg_binomial/beta_neg_binomial_test.hpp
@@ -1,0 +1,98 @@
+// Arguments: Ints, Doubles, Doubles, Doubles
+#include <stan/math/prim/prob/beta_neg_binomial_lpmf.hpp>
+#include <stan/math/prim/fun/lbeta.hpp>
+#include <stan/math/prim/fun/lgamma.hpp>
+
+using stan::math::var;
+using std::numeric_limits;
+using std::vector;
+
+class AgradDistributionsBetaNegBinomial : public AgradDistributionTest {
+ public:
+  void valid_values(vector<vector<double> >& parameters,
+                    vector<double>& log_prob) {
+    vector<double> param(4);
+
+    param[0] = 5;     // n
+    param[1] = 20.0;  // r
+    param[2] = 10.0;  // alpha
+    param[3] = 25.0;  // beta
+    parameters.push_back(param);
+    log_prob.push_back(-10.3681267949788);  // expected log_prob
+
+    param[0] = 10;   // n
+    param[1] = 5.5;  // r
+    param[2] = 2.5;  // alpha
+    param[3] = 0.5;  // beta
+    parameters.push_back(param);
+    log_prob.push_back(-5.166741878823932);  // expected log_prob
+  }
+
+  void invalid_values(vector<size_t>& index, vector<double>& value) {
+    // n
+    index.push_back(0U);
+    value.push_back(-1);
+
+    // r
+    index.push_back(1U);
+    value.push_back(0.0);
+
+    index.push_back(1U);
+    value.push_back(-1.0);
+
+    index.push_back(1U);
+    value.push_back(std::numeric_limits<double>::infinity());
+
+    // alpha
+    index.push_back(2U);
+    value.push_back(0.0);
+
+    index.push_back(2U);
+    value.push_back(-1.0);
+
+    index.push_back(2U);
+    value.push_back(std::numeric_limits<double>::infinity());
+
+    // beta
+    index.push_back(3U);
+    value.push_back(0.0);
+
+    index.push_back(3U);
+    value.push_back(-1.0);
+
+    index.push_back(3U);
+    value.push_back(std::numeric_limits<double>::infinity());
+  }
+
+  template <class T_n, class T_r, class T_size1, class T_size2, typename T4,
+            typename T5>
+  stan::return_type_t<T_r, T_size1, T_size2> log_prob(const T_n& n,
+                                                      const T_r& r,
+                                                      const T_size1& alpha,
+                                                      const T_size2& beta,
+                                                      const T4&, const T5&) {
+    return stan::math::beta_neg_binomial_lpmf(n, r, alpha, beta);
+  }
+
+  template <bool propto, class T_n, class T_r, class T_size1, class T_size2,
+            typename T4, typename T5>
+  stan::return_type_t<T_r, T_size1, T_size2> log_prob(const T_n& n,
+                                                      const T_r& r,
+                                                      const T_size1& alpha,
+                                                      const T_size2& beta,
+                                                      const T4&, const T5&) {
+    return stan::math::beta_neg_binomial_lpmf<propto>(n, r, alpha, beta);
+  }
+
+  template <class T_n, class T_r, class T_size1, class T_size2, typename T4,
+            typename T5>
+  stan::return_type_t<T_r, T_size1, T_size2> log_prob_function(
+      const T_n& n, const T_r& r, const T_size1& alpha, const T_size2& beta,
+      const T4&, const T5&) {
+    using stan::math::lbeta;
+    using stan::math::lgamma;
+
+    return lbeta(n + r, alpha + beta) - lbeta(r, alpha) + lgamma(n + beta)
+           - lgamma(n + 1) - lgamma(beta);
+  }
+};


### PR DESCRIPTION
## Summary

With this PR the lpmf of beta negative binomial distribution are added.
See issue https://github.com/stan-dev/math/issues/3107

Expressions involved:

PMF

$$f(n|r, \alpha ,\beta)={\frac {\Gamma (r+n)}{n!\Gamma (r)}}{\frac {\Gamma (\alpha +r)\Gamma (\beta +n)\Gamma (\alpha +\beta )}{\Gamma (\alpha +r+\beta +n)\Gamma (\alpha )\Gamma (\beta )}}$$

Partial derivatives w.r.t the three parameters

$$
\begin{aligned}
\frac{\partial \log f}{\partial r} &= \psi(n+r) - \psi(n+r+\alpha+\beta) - \psi(r) + \psi(r+\alpha) \\
\frac{\partial \log f}{\partial \alpha} &= \psi(\alpha+\beta) - \psi(n+r+\alpha+\beta) - \psi(\alpha) + \psi(r+\alpha) \\
\frac{\partial \log f}{\partial \beta} &= \psi(\alpha+\beta) - \psi(n+r+\alpha+\beta) + \psi(n+\beta) - \psi(\beta)
\end{aligned}
$$


## Tests
Test is written follow the [guide](https://mc-stan.org/math/md_doxygen_2contributor__help__pages_2adding__new__distributions.html). 

## Side Effects
No.

## Release notes
`beta_neg_binomial_lpmf` is available if merged. Allows modeling heavy-tail count data.

## Checklist

- [x] Copyright holder: Zhi Ling

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
