### PR TITLE
Fix lookup in pow test on llvm19

### DIFF
--- a/test/unit/math/mix/fun/pow_part1_test.cpp
+++ b/test/unit/math/mix/fun/pow_part1_test.cpp
@@ -5,20 +5,19 @@
 
 template <typename T>
 void expect_arith_instantiate() {
-  using stan::math::pow;
-  auto a1 = pow(T(1.0), 1);
-  auto b1 = pow(T(1.0), 1.0);
-  auto c1 = pow(1, T(1.0));
-  auto d1 = pow(1.0, T(1.0));
-  auto e1 = pow(T(1.0), T(1.0));
+  auto a1 = stan::math::pow(T(1.0), 1);
+  auto b1 = stan::math::pow(T(1.0), 1.0);
+  auto c1 = stan::math::pow(1, T(1.0));
+  auto d1 = stan::math::pow(1.0, T(1.0));
+  auto e1 = stan::math::pow(T(1.0), T(1.0));
 
-  auto a2 = pow(std::complex<T>(1.0), 1);
-  auto b2 = pow(std::complex<T>(1.0), 1.0);
-  auto c2 = pow(1, std::complex<T>(1.0));
-  auto d2 = pow(1.0, std::complex<T>(1.0));
-  auto e2 = pow(std::complex<T>(1.0), std::complex<T>(1.0));
-  auto f2 = pow(std::complex<double>(1.0), std::complex<T>(1.0));
-  auto g2 = pow(std::complex<T>(1.0), std::complex<double>(1.0));
+  auto a2 = stan::math::pow(std::complex<T>(1.0), 1);
+  auto b2 = stan::math::pow(std::complex<T>(1.0), 1.0);
+  auto c2 = stan::math::pow(1, std::complex<T>(1.0));
+  auto d2 = stan::math::pow(1.0, std::complex<T>(1.0));
+  auto e2 = stan::math::pow(std::complex<T>(1.0), std::complex<T>(1.0));
+  auto f2 = stan::math::pow(std::complex<double>(1.0), std::complex<T>(1.0));
+  auto g2 = stan::math::pow(std::complex<T>(1.0), std::complex<double>(1.0));
 }
 
 // this one's been tricky to instantiate, so test all instances
@@ -35,8 +34,7 @@ TEST(mathMixScalFun, powInstantiations) {
 
 TEST(mathMixScalFun, pow) {
   auto f = [](const auto& x1, const auto& x2) {
-    using stan::math::pow;
-    return pow(x1, x2);
+    return stan::math::pow(x1, x2);
   };
 
   stan::test::expect_ad(f, -0.4, 0.5);

--- a/test/unit/math/mix/fun/pow_part1_test.cpp
+++ b/test/unit/math/mix/fun/pow_part1_test.cpp
@@ -33,9 +33,8 @@ TEST(mathMixScalFun, powInstantiations) {
 }
 
 TEST(mathMixScalFun, pow) {
-  auto f = [](const auto& x1, const auto& x2) {
-    return stan::math::pow(x1, x2);
-  };
+  auto f
+      = [](const auto& x1, const auto& x2) { return stan::math::pow(x1, x2); };
 
   stan::test::expect_ad(f, -0.4, 0.5);
   stan::test::expect_ad(f, 0.5, 0.5);

--- a/test/unit/math/mix/fun/pow_part2_test.cpp
+++ b/test/unit/math/mix/fun/pow_part2_test.cpp
@@ -49,7 +49,6 @@ TEST(mathMixFun, complexPow) {
 }
 
 TEST(mathMixFun, powIntAmbiguityTest) {
-  using stan::math::pow;  // included to check ambiguities
   using stan::math::var;
   using std::complex;
   int i = 2;
@@ -58,35 +57,35 @@ TEST(mathMixFun, powIntAmbiguityTest) {
   complex<double> cd = 2.5;
   complex<var> cv = 2.5;
 
-  auto a1 = pow(i, i);
-  auto a2 = pow(i, d);
-  auto a3 = pow(i, v);
-  auto a4 = pow(i, cd);
-  auto a5 = pow(i, cv);
+  auto a1 = stan::math::pow(i, i);
+  auto a2 = stan::math::pow(i, d);
+  auto a3 = stan::math::pow(i, v);
+  auto a4 = stan::math::pow(i, cd);
+  auto a5 = stan::math::pow(i, cv);
 
-  auto b1 = pow(d, i);
-  auto b2 = pow(d, d);
-  auto b3 = pow(d, v);
-  auto b4 = pow(d, cd);
-  auto b5 = pow(d, cv);
+  auto b1 = stan::math::pow(d, i);
+  auto b2 = stan::math::pow(d, d);
+  auto b3 = stan::math::pow(d, v);
+  auto b4 = stan::math::pow(d, cd);
+  auto b5 = stan::math::pow(d, cv);
 
-  auto e1 = pow(v, i);
-  auto e2 = pow(v, d);
-  auto e3 = pow(v, v);
-  auto e4 = pow(v, cd);
-  auto e5 = pow(v, cv);
+  auto e1 = stan::math::pow(v, i);
+  auto e2 = stan::math::pow(v, d);
+  auto e3 = stan::math::pow(v, v);
+  auto e4 = stan::math::pow(v, cd);
+  auto e5 = stan::math::pow(v, cv);
 
-  auto c1 = pow(cd, i);
-  auto c2 = pow(cd, d);
-  auto c3 = pow(cd, v);
-  auto c4 = pow(cd, cd);
-  auto c5 = pow(cd, cv);
+  auto c1 = stan::math::pow(cd, i);
+  auto c2 = stan::math::pow(cd, d);
+  auto c3 = stan::math::pow(cd, v);
+  auto c4 = stan::math::pow(cd, cd);
+  auto c5 = stan::math::pow(cd, cv);
 
-  auto d1 = pow(cv, i);
-  auto d2 = pow(cv, d);
-  auto d3 = pow(cv, v);
-  auto d4 = pow(cv, cd);
-  auto d5 = pow(cv, cv);
+  auto d1 = stan::math::pow(cv, i);
+  auto d2 = stan::math::pow(cv, d);
+  auto d3 = stan::math::pow(cv, v);
+  auto d4 = stan::math::pow(cv, cd);
+  auto d5 = stan::math::pow(cv, cv);
 
   auto e = a1 + a2 + a3 + a4 + a5 + b1 + b2 + b3 + b4 + b5 + c1 + c2 + c3 + c4
            + c5 + d1 + d2 + d3 + d4 + d5 + e1 + e2 + e3 + e4 + e5;
@@ -96,7 +95,6 @@ TEST(mathMixFun, powIntAmbiguityTest) {
 
 TEST(mathMixFun, powIntAmbiguityTestFvar) {
   using stan::math::fvar;
-  using stan::math::pow;  // included to check ambiguities
   using std::complex;
   int i = 2;
   double d = 2.5;
@@ -104,29 +102,29 @@ TEST(mathMixFun, powIntAmbiguityTestFvar) {
   complex<double> cd = 2.5;
   complex<fvar<double>> cv = 2.5;
 
-  auto a1 = pow(i, i);
-  auto a2 = pow(i, d);
-  auto a3 = pow(i, v);
-  auto a4 = pow(i, cd);
-  auto a5 = pow(i, cv);
+  auto a1 = stan::math::pow(i, i);
+  auto a2 = stan::math::pow(i, d);
+  auto a3 = stan::math::pow(i, v);
+  auto a4 = stan::math::pow(i, cd);
+  auto a5 = stan::math::pow(i, cv);
 
-  auto b1 = pow(d, i);
-  auto b2 = pow(d, d);
-  auto b3 = pow(d, v);
-  auto b4 = pow(d, cd);
-  auto b5 = pow(d, cv);
+  auto b1 = stan::math::pow(d, i);
+  auto b2 = stan::math::pow(d, d);
+  auto b3 = stan::math::pow(d, v);
+  auto b4 = stan::math::pow(d, cd);
+  auto b5 = stan::math::pow(d, cv);
 
-  auto c1 = pow(cd, i);
-  auto c2 = pow(cd, d);
-  auto c3 = pow(cd, v);
-  auto c4 = pow(cd, cd);
-  auto c5 = pow(cd, cv);
+  auto c1 = stan::math::pow(cd, i);
+  auto c2 = stan::math::pow(cd, d);
+  auto c3 = stan::math::pow(cd, v);
+  auto c4 = stan::math::pow(cd, cd);
+  auto c5 = stan::math::pow(cd, cv);
 
-  auto d1 = pow(cv, i);
-  auto d2 = pow(cv, d);
-  auto d3 = pow(cv, v);
-  auto d4 = pow(cv, cd);
-  auto d5 = pow(cv, cv);
+  auto d1 = stan::math::pow(cv, i);
+  auto d2 = stan::math::pow(cv, d);
+  auto d3 = stan::math::pow(cv, v);
+  auto d4 = stan::math::pow(cv, cd);
+  auto d5 = stan::math::pow(cv, cv);
 
   auto e = a1 + a2 + a3 + a4 + a5 + b1 + b2 + b3 + b4 + b5 + c1 + c2 + c3 + c4
            + c5 + d1 + d2 + d3 + d4 + d5;


### PR DESCRIPTION
## Summary

I believe this should close #3106. After reading more, it looks like the issue is not triggered by any code generated by the stan compiler, just by the way this test was written. 

This probably qualifies as another example of #3006, where the compiler vendors are free to break usages of std::complex with non-builtin scalar types.

## Tests

## Side Effects

## Release notes

Fix a test compiling under LLVM19

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
