### PR TITLE
Fix pow(a,b) overload resolution under llvm19

### DIFF
--- a/stan/math/fwd/fun/pow.hpp
+++ b/stan/math/fwd/fun/pow.hpp
@@ -193,7 +193,7 @@ inline std::complex<fvar<V>> pow(const fvar<V>& x, const std::complex<T>& y) {
  * @return first argument to the power of the second argument
  */
 template <typename T, typename V, typename = require_arithmetic_t<T>>
-inline std::complex<fvar<V>> pow(T x, const std::complex<fvar<V>>& y) {
+inline std::complex<fvar<V>> pow(const T& x, const std::complex<fvar<V>>& y) {
   return internal::complex_pow(x, y);
 }
 

--- a/stan/math/prim/fun/pow.hpp
+++ b/stan/math/prim/fun/pow.hpp
@@ -59,11 +59,11 @@ inline auto pow(const T1& a, const T2& b) {
  * second argument.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
-          require_all_not_matrix_st<is_var, T1, T2>* = nullptr>
+          require_all_not_matrix_st<is_var, T1, T2>* = nullptr,
+          require_all_st_arithmetic<T1, T2>* = nullptr>
 inline auto pow(const T1& a, const T2& b) {
   return apply_scalar_binary(a, b, [](const auto& c, const auto& d) {
-    using std::pow;
-    return pow(c, d);
+    return stan::math::pow(c, d);
   });
 }
 }  // namespace math

--- a/stan/math/rev/fun/pow.hpp
+++ b/stan/math/rev/fun/pow.hpp
@@ -319,7 +319,7 @@ inline std::complex<var> pow(const std::complex<var>& x, const var& y) {
  * @return first argument to the power of the second argument
  */
 template <typename T, typename = require_arithmetic_t<T>>
-inline std::complex<var> pow(const std::complex<var>& x, T y) {
+inline std::complex<var> pow(const std::complex<var>& x, const T& y) {
   return internal::complex_pow(x, y);
 }
 
@@ -382,7 +382,7 @@ inline std::complex<var> pow(const var& x, std::complex<T> y) {
  * @return first argument to the power of the second argument
  */
 template <typename T, typename = require_arithmetic_t<T>>
-inline std::complex<var> pow(T x, const std::complex<var>& y) {
+inline std::complex<var> pow(const T& x, const std::complex<var>& y) {
   return internal::complex_pow(x, y);
 }
 
@@ -399,6 +399,26 @@ inline std::complex<var> pow(T x, const std::complex<var>& y) {
  */
 inline std::complex<var> pow(const std::complex<var>& x, int y) {
   return internal::complex_pow(x, y);
+}
+
+/**
+ * Returns the elementwise raising of the first argument to the power of the
+ * second argument.
+ *
+ * @tparam T1 type of first argument
+ * @tparam T2 type of second argument
+ * @param a first argument
+ * @param b second argument
+ * @return the elementwise raising of the first argument to the power of the
+ * second argument.
+ */
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
+          require_all_not_matrix_st<is_var, T1, T2>* = nullptr,
+          require_any_not_st_arithmetic<T1, T2>* = nullptr>
+inline auto pow(const T1& a, const T2& b) {
+  return apply_scalar_binary(a, b, [](const auto& c, const auto& d) {
+    return stan::math::pow(c, d);
+  });
 }
 
 }  // namespace math


### PR DESCRIPTION
## Summary

Closes #3106. This fixes both the test failures we were seeing in `test/unit/mix` and the model compilation that was failing. 
Two sets of changes were needed:

1. Adding `const &` to some template parameters such that our overloads are prioritized (recommended by @SteveBronder)
2. Splitting the vectorized overload between `prim/` and `rev/`

The second one here was trickier, but necessary to allow vectorized calls to see the `rev` signatures. So far as @SteveBronder and I can tell, all of the Stan Math functions that use this style of having the apply-scalar overload last in the `prim` file could end up in this situation where said overload can never resolve the `rev` specializations, if the prim file is included in any rev headers and therefore resolved first. 

## Tests
None. I plan on running the bleeding-edge pipeline on this branch before merging.

## Side Effects

Could potentially speed up the vectorized signature of `pow` as it will now use rev specializations. Could also negatively impact compile times due to the extra resolution required. 

## Release notes

Fixed some failures to compile calls to `pow` when using libc++ 19.

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
