### PR TITLE
Fix new wiener_lpdfs evaluating arguments twice

### DIFF
--- a/makefile
+++ b/makefile
@@ -87,6 +87,7 @@ doxygen:
 clean:
 	@echo '  removing generated test files'
 	@$(RM) $(wildcard test/prob/generate_tests$(EXE))
+	@$(RM) $(EXPRESSION_TESTS) $(call findfiles,test/expressions,*_test.cpp)
 	@$(RM) $(call findfiles,test/prob,*_generated_v_test.cpp)
 	@$(RM) $(call findfiles,test/prob,*_generated_vv_test.cpp)
 	@$(RM) $(call findfiles,test/prob,*_generated_fd_test.cpp)

--- a/runTests.py
+++ b/runTests.py
@@ -383,7 +383,7 @@ def checkToolchainPathWindows():
             universal_newlines=True,
         )
         out, err = p1.communicate()
-        if re.search(" |\(|\)", out):
+        if re.search(r" |\(|\)", out):
             stopErr(
                 "The RTools toolchain is installed in a path with spaces or bracket. Please reinstall to a valid path.",
                 -1,

--- a/stan/math/prim/prob/wiener5_lpdf.hpp
+++ b/stan/math/prim/prob/wiener5_lpdf.hpp
@@ -679,12 +679,12 @@ inline auto wiener_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
   if (!include_summand<propto, T_y, T_a, T_t0, T_w, T_v, T_sv>::value) {
     return ret_t(0.0);
   }
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_a_ref = ref_type_if_t<!is_constant<T_a>::value, T_a>;
-  using T_t0_ref = ref_type_if_t<!is_constant<T_t0>::value, T_t0>;
-  using T_w_ref = ref_type_if_t<!is_constant<T_w>::value, T_w>;
-  using T_v_ref = ref_type_if_t<!is_constant<T_v>::value, T_v>;
-  using T_sv_ref = ref_type_if_t<!is_constant<T_sv>::value, T_sv>;
+  using T_y_ref = ref_type_t<T_y>;
+  using T_a_ref = ref_type_t<T_a>;
+  using T_t0_ref = ref_type_t<T_t0>;
+  using T_w_ref = ref_type_t<T_w>;
+  using T_v_ref = ref_type_t<T_v>;
+  using T_sv_ref = ref_type_t<T_sv>;
 
   static constexpr const char* function_name = "wiener5_lpdf";
 
@@ -725,12 +725,12 @@ inline auto wiener_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
     return ret_t(0.0);
   }
 
-  scalar_seq_view<decltype(y_val)> y_vec(y_val);
-  scalar_seq_view<decltype(a_val)> a_vec(a_val);
-  scalar_seq_view<decltype(v_val)> v_vec(v_val);
-  scalar_seq_view<decltype(w_val)> w_vec(w_val);
-  scalar_seq_view<decltype(t0_val)> t0_vec(t0_val);
-  scalar_seq_view<decltype(sv_val)> sv_vec(sv_val);
+  scalar_seq_view<T_y_ref> y_vec(y_ref);
+  scalar_seq_view<T_a_ref> a_vec(a_ref);
+  scalar_seq_view<T_t0_ref> t0_vec(t0_ref);
+  scalar_seq_view<T_w_ref> w_vec(w_ref);
+  scalar_seq_view<T_v_ref> v_vec(v_ref);
+  scalar_seq_view<T_sv_ref> sv_vec(sv_ref);
   const size_t N_y_t0 = max_size(y, t0);
 
   for (size_t i = 0; i < N_y_t0; ++i) {

--- a/stan/math/prim/prob/wiener5_lpdf.hpp
+++ b/stan/math/prim/prob/wiener5_lpdf.hpp
@@ -725,12 +725,12 @@ inline auto wiener_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
     return ret_t(0.0);
   }
 
-  scalar_seq_view<T_y_ref> y_vec(y_ref);
-  scalar_seq_view<T_a_ref> a_vec(a_ref);
-  scalar_seq_view<T_t0_ref> t0_vec(t0_ref);
-  scalar_seq_view<T_w_ref> w_vec(w_ref);
-  scalar_seq_view<T_v_ref> v_vec(v_ref);
-  scalar_seq_view<T_sv_ref> sv_vec(sv_ref);
+  scalar_seq_view<decltype(y_val)> y_vec(y_val);
+  scalar_seq_view<decltype(a_val)> a_vec(a_val);
+  scalar_seq_view<decltype(v_val)> v_vec(v_val);
+  scalar_seq_view<decltype(w_val)> w_vec(w_val);
+  scalar_seq_view<decltype(t0_val)> t0_vec(t0_val);
+  scalar_seq_view<decltype(sv_val)> sv_vec(sv_val);
   const size_t N_y_t0 = max_size(y, t0);
 
   for (size_t i = 0; i < N_y_t0; ++i) {

--- a/stan/math/prim/prob/wiener_full_lpdf.hpp
+++ b/stan/math/prim/prob/wiener_full_lpdf.hpp
@@ -327,14 +327,14 @@ inline auto wiener_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
     return ret_t(0);
   }
 
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_a_ref = ref_type_if_t<!is_constant<T_a>::value, T_a>;
-  using T_v_ref = ref_type_if_t<!is_constant<T_v>::value, T_v>;
-  using T_w_ref = ref_type_if_t<!is_constant<T_w>::value, T_w>;
-  using T_t0_ref = ref_type_if_t<!is_constant<T_t0>::value, T_t0>;
-  using T_sv_ref = ref_type_if_t<!is_constant<T_sv>::value, T_sv>;
-  using T_sw_ref = ref_type_if_t<!is_constant<T_sw>::value, T_sw>;
-  using T_st0_ref = ref_type_if_t<!is_constant<T_st0>::value, T_st0>;
+  using T_y_ref = ref_type_t<T_y>;
+  using T_a_ref = ref_type_t<T_a>;
+  using T_v_ref = ref_type_t<T_v>;
+  using T_w_ref = ref_type_t<T_w>;
+  using T_t0_ref = ref_type_t<T_t0>;
+  using T_sv_ref = ref_type_t<T_sv>;
+  using T_sw_ref = ref_type_t<T_sw>;
+  using T_st0_ref = ref_type_t<T_st0>;
 
   using T_partials_return
       = partials_return_t<T_y, T_a, T_t0, T_w, T_v, T_sv, T_sw, T_st0>;
@@ -385,14 +385,14 @@ inline auto wiener_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
   if (N == 0) {
     return ret_t(0);
   }
-  scalar_seq_view<decltype(y_val)> y_vec(y_val);
-  scalar_seq_view<decltype(a_val)> a_vec(a_val);
-  scalar_seq_view<decltype(v_val)> v_vec(v_val);
-  scalar_seq_view<decltype(w_val)> w_vec(w_val);
-  scalar_seq_view<decltype(t0_val)> t0_vec(t0_val);
-  scalar_seq_view<decltype(sv_val)> sv_vec(sv_val);
-  scalar_seq_view<decltype(sw_val)> sw_vec(sw_val);
-  scalar_seq_view<decltype(st0_val)> st0_vec(st0_val);
+  scalar_seq_view<T_y_ref> y_vec(y_ref);
+  scalar_seq_view<T_a_ref> a_vec(a_ref);
+  scalar_seq_view<T_v_ref> v_vec(v_ref);
+  scalar_seq_view<T_w_ref> w_vec(w_ref);
+  scalar_seq_view<T_t0_ref> t0_vec(t0_ref);
+  scalar_seq_view<T_sv_ref> sv_vec(sv_ref);
+  scalar_seq_view<T_sw_ref> sw_vec(sw_ref);
+  scalar_seq_view<T_st0_ref> st0_vec(st0_ref);
   const size_t N_y_t0 = max_size(y, t0, st0);
 
   for (size_t i = 0; i < N_y_t0; ++i) {
@@ -449,6 +449,9 @@ inline auto wiener_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
   // calculate density and partials
   for (size_t i = 0; i < N; i++) {
     if (sw_vec[i] == 0 && st0_vec[i] == 0) {
+      // note: because we're delegating to wiener5_lpdf,
+      // we need to make sure is_constant is consistent between
+      // our inputs and these
       result += wiener_lpdf<propto>(y_vec[i], a_vec[i], t0_vec[i], w_vec[i],
                                     v_vec[i], sv_vec[i], precision_derivatives);
       continue;

--- a/stan/math/prim/prob/wiener_full_lpdf.hpp
+++ b/stan/math/prim/prob/wiener_full_lpdf.hpp
@@ -385,14 +385,14 @@ inline auto wiener_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
   if (N == 0) {
     return ret_t(0);
   }
-  scalar_seq_view<T_y_ref> y_vec(y_ref);
-  scalar_seq_view<T_a_ref> a_vec(a_ref);
-  scalar_seq_view<T_v_ref> v_vec(v_ref);
-  scalar_seq_view<T_w_ref> w_vec(w_ref);
-  scalar_seq_view<T_t0_ref> t0_vec(t0_ref);
-  scalar_seq_view<T_sv_ref> sv_vec(sv_ref);
-  scalar_seq_view<T_sw_ref> sw_vec(sw_ref);
-  scalar_seq_view<T_st0_ref> st0_vec(st0_ref);
+  scalar_seq_view<decltype(y_val)> y_vec(y_val);
+  scalar_seq_view<decltype(a_val)> a_vec(a_val);
+  scalar_seq_view<decltype(v_val)> v_vec(v_val);
+  scalar_seq_view<decltype(w_val)> w_vec(w_val);
+  scalar_seq_view<decltype(t0_val)> t0_vec(t0_val);
+  scalar_seq_view<decltype(sv_val)> sv_vec(sv_val);
+  scalar_seq_view<decltype(sw_val)> sw_vec(sw_val);
+  scalar_seq_view<decltype(st0_val)> st0_vec(st0_val);
   const size_t N_y_t0 = max_size(y, t0, st0);
 
   for (size_t i = 0; i < N_y_t0; ++i) {

--- a/test/generate_expression_tests.py
+++ b/test/generate_expression_tests.py
@@ -29,6 +29,9 @@ def save_tests_in_files(N_files, tests):
     for i in range(N_files):
         start = i * len(tests) // N_files
         end = (i + 1) * len(tests) // N_files
+        if start >= end:
+            # don't try to compile an empty file
+            continue
         with open(src_folder + "tests%d_test.cpp" % i, "w") as out:
             out.write("#include <test/expressions/expression_test_helpers.hpp>\n\n")
             for test in tests[start:end]:
@@ -125,5 +128,5 @@ def main(functions=(), j=1):
                     code = cg.cpp(),
                 )
             )
-    
+
     save_tests_in_files(j, tests)

--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -132,7 +132,7 @@ special_arg_values = {
     "uniform_lcdf": [None, 0.2, 0.9],
     "uniform_lpdf": [None, 0.2, 0.9],
     "uniform_rng": [0.2, 1.9, None],
-    "wiener_lpdf": [0.8, None, 0.4, None, None],
+    "wiener_lpdf": [0.8, None, 0.4, None, None, None, None, None],
 }
 
 # list of functions we do not test. These are mainly functions implemented in compiler


### PR DESCRIPTION
## Summary

Closes #3111 to allow https://github.com/stan-dev/stanc3/pull/1451

## Tests


## Side Effects

Are there any side effects that we should be aware of?

## Release notes

Fixed the new `wiener_lpdf` overloads evaluating their expression template arguments more than once

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
