### PR TITLE
add beta_neg_binomial_lccdf

### DIFF
--- a/stan/math/prim/fun/grad_F32.hpp
+++ b/stan/math/prim/fun/grad_F32.hpp
@@ -24,14 +24,20 @@ namespace math {
  * This power-series representation converges for all gradients
  * under the same conditions as the 3F2 function itself.
  *
- * @tparam T1 type of g
- * @tparam T1 type of g
- * @tparam T1 type of g
- * @tparam T1 type of g
- * @tparam T1 type of g
- * @tparam T1 type of g
- * @tparam T1 type of g
- * @tparam T1 type of g
+ * @tparam grad_a1 boolean indicating if gradient with respect to a1 is required
+ * @tparam grad_a2 boolean indicating if gradient with respect to a2 is required
+ * @tparam grad_a3 boolean indicating if gradient with respect to a3 is required
+ * @tparam grad_b1 boolean indicating if gradient with respect to b1 is required
+ * @tparam grad_b2 boolean indicating if gradient with respect to b2 is required
+ * @tparam grad_z boolean indicating if gradient with respect to z is required
+ * @tparam T1 a scalar type
+ * @tparam T2 a scalar type
+ * @tparam T3 a scalar type
+ * @tparam T4 a scalar type
+ * @tparam T5 a scalar type
+ * @tparam T6 a scalar type
+ * @tparam T7 a scalar type
+ * @tparam T8 a scalar type
  * @param[out] g g pointer to array of six values of type T, result.
  * @param[in] a1 a1 see generalized hypergeometric function definition.
  * @param[in] a2 a2 see generalized hypergeometric function definition.

--- a/stan/math/prim/fun/grad_F32.hpp
+++ b/stan/math/prim/fun/grad_F32.hpp
@@ -24,7 +24,14 @@ namespace math {
  * This power-series representation converges for all gradients
  * under the same conditions as the 3F2 function itself.
  *
- * @tparam T type of arguments and result
+ * @tparam T1 type of g
+ * @tparam T1 type of g
+ * @tparam T1 type of g
+ * @tparam T1 type of g
+ * @tparam T1 type of g
+ * @tparam T1 type of g
+ * @tparam T1 type of g
+ * @tparam T1 type of g
  * @param[out] g g pointer to array of six values of type T, result.
  * @param[in] a1 a1 see generalized hypergeometric function definition.
  * @param[in] a2 a2 see generalized hypergeometric function definition.
@@ -35,84 +42,90 @@ namespace math {
  * @param[in] precision precision of the infinite sum
  * @param[in] max_steps number of steps to take
  */
-template <typename T>
-void grad_F32(T* g, const T& a1, const T& a2, const T& a3, const T& b1,
-              const T& b2, const T& z, const T& precision = 1e-6,
+template <bool grad_a1 = true, bool grad_a2 = true, bool grad_a3 = true,
+  bool grad_b1 = true, bool grad_b2 = true, bool grad_z = true,
+  typename T1, typename T2, typename T3, typename T4, typename T5,
+  typename T6, typename T7, typename T8 = double>
+void grad_F32(T1* g, const T2& a1, const T3& a2, const T4& a3, const T5& b1,
+              const T6& b2, const T7& z, const T8& precision = 1e-6,
               int max_steps = 1e5) {
   check_3F2_converges("grad_F32", a1, a2, a3, b1, b2, z);
-
-  using std::exp;
-  using std::fabs;
-  using std::log;
 
   for (int i = 0; i < 6; ++i) {
     g[i] = 0.0;
   }
 
-  T log_g_old[6];
+  T1 log_g_old[6];
   for (auto& x : log_g_old) {
     x = NEGATIVE_INFTY;
   }
 
-  T log_t_old = 0.0;
-  T log_t_new = 0.0;
+  T1 log_t_old = 0.0;
+  T1 log_t_new = 0.0;
 
-  T log_z = log(z);
+  T7 log_z = log(z);
 
-  double log_t_new_sign = 1.0;
-  double log_t_old_sign = 1.0;
-  double log_g_old_sign[6];
+  T1 log_t_new_sign = 1.0;
+  T1 log_t_old_sign = 1.0;
+  T1 log_g_old_sign[6];
   for (int i = 0; i < 6; ++i) {
     log_g_old_sign[i] = 1.0;
   }
-
+  std::array<T1, 6> term{0};
   for (int k = 0; k <= max_steps; ++k) {
-    T p = (a1 + k) * (a2 + k) * (a3 + k) / ((b1 + k) * (b2 + k) * (1 + k));
+    T1 p = (a1 + k) * (a2 + k) * (a3 + k) / ((b1 + k) * (b2 + k) * (1 + k));
     if (p == 0) {
       return;
     }
 
     log_t_new += log(fabs(p)) + log_z;
     log_t_new_sign = p >= 0.0 ? log_t_new_sign : -log_t_new_sign;
+    if constexpr (grad_a1) {
+      term[0] = log_g_old_sign[0] * log_t_old_sign * exp(log_g_old[0] - log_t_old)
+              + inv(a1 + k);
+      log_g_old[0] = log_t_new + log(fabs(term[0]));
+      log_g_old_sign[0] = term[0] >= 0.0 ? log_t_new_sign : -log_t_new_sign;
+      g[0] += log_g_old_sign[0] * exp(log_g_old[0]);
+    }
 
-    //        g_old[0] = t_new * (g_old[0] / t_old + 1.0 / (a1 + k));
-    T term = log_g_old_sign[0] * log_t_old_sign * exp(log_g_old[0] - log_t_old)
-             + inv(a1 + k);
-    log_g_old[0] = log_t_new + log(fabs(term));
-    log_g_old_sign[0] = term >= 0.0 ? log_t_new_sign : -log_t_new_sign;
+    if constexpr (grad_a2) {
+      term[1] = log_g_old_sign[1] * log_t_old_sign * exp(log_g_old[1] - log_t_old)
+            + inv(a2 + k);
+      log_g_old[1] = log_t_new + log(fabs(term[1]));
+      log_g_old_sign[1] = term[1] >= 0.0 ? log_t_new_sign : -log_t_new_sign;
+      g[1] += log_g_old_sign[1] * exp(log_g_old[1]);
+    }
 
-    //        g_old[1] = t_new * (g_old[1] / t_old + 1.0 / (a2 + k));
-    term = log_g_old_sign[1] * log_t_old_sign * exp(log_g_old[1] - log_t_old)
-           + inv(a2 + k);
-    log_g_old[1] = log_t_new + log(fabs(term));
-    log_g_old_sign[1] = term >= 0.0 ? log_t_new_sign : -log_t_new_sign;
+    if constexpr (grad_a3) {
+      term[2] = log_g_old_sign[2] * log_t_old_sign * exp(log_g_old[2] - log_t_old)
+            + inv(a3 + k);
+      log_g_old[2] = log_t_new + log(fabs(term[2]));
+      log_g_old_sign[2] = term[2] >= 0.0 ? log_t_new_sign : -log_t_new_sign;
+      g[2] += log_g_old_sign[2] * exp(log_g_old[2]);
+    }
 
-    //        g_old[2] = t_new * (g_old[2] / t_old + 1.0 / (a3 + k));
-    term = log_g_old_sign[2] * log_t_old_sign * exp(log_g_old[2] - log_t_old)
-           + inv(a3 + k);
-    log_g_old[2] = log_t_new + log(fabs(term));
-    log_g_old_sign[2] = term >= 0.0 ? log_t_new_sign : -log_t_new_sign;
+    if constexpr (grad_b1) {
+      term[3] = log_g_old_sign[3] * log_t_old_sign * exp(log_g_old[3] - log_t_old)
+            - inv(b1 + k);
+      log_g_old[3] = log_t_new + log(fabs(term[3]));
+      log_g_old_sign[3] = term[3] >= 0.0 ? log_t_new_sign : -log_t_new_sign;
+      g[3] += log_g_old_sign[3] * exp(log_g_old[3]);
+    }
 
-    //        g_old[3] = t_new * (g_old[3] / t_old - 1.0 / (b1 + k));
-    term = log_g_old_sign[3] * log_t_old_sign * exp(log_g_old[3] - log_t_old)
-           - inv(b1 + k);
-    log_g_old[3] = log_t_new + log(fabs(term));
-    log_g_old_sign[3] = term >= 0.0 ? log_t_new_sign : -log_t_new_sign;
+    if constexpr (grad_b2) {
+      term[4] = log_g_old_sign[4] * log_t_old_sign * exp(log_g_old[4] - log_t_old)
+            - inv(b2 + k);
+      log_g_old[4] = log_t_new + log(fabs(term[4]));
+      log_g_old_sign[4] = term[4] >= 0.0 ? log_t_new_sign : -log_t_new_sign;
+      g[4] += log_g_old_sign[4] * exp(log_g_old[4]);
+    }
 
-    //        g_old[4] = t_new * (g_old[4] / t_old - 1.0 / (b2 + k));
-    term = log_g_old_sign[4] * log_t_old_sign * exp(log_g_old[4] - log_t_old)
-           - inv(b2 + k);
-    log_g_old[4] = log_t_new + log(fabs(term));
-    log_g_old_sign[4] = term >= 0.0 ? log_t_new_sign : -log_t_new_sign;
-
-    //        g_old[5] = t_new * (g_old[5] / t_old + 1.0 / z);
-    term = log_g_old_sign[5] * log_t_old_sign * exp(log_g_old[5] - log_t_old)
-           + inv(z);
-    log_g_old[5] = log_t_new + log(fabs(term));
-    log_g_old_sign[5] = term >= 0.0 ? log_t_new_sign : -log_t_new_sign;
-
-    for (int i = 0; i < 6; ++i) {
-      g[i] += log_g_old_sign[i] * exp(log_g_old[i]);
+    if constexpr (grad_z) {
+      term[5] = log_g_old_sign[5] * log_t_old_sign * exp(log_g_old[5] - log_t_old)
+            + inv(z);
+      log_g_old[5] = log_t_new + log(fabs(term[5]));
+      log_g_old_sign[5] = term[5] >= 0.0 ? log_t_new_sign : -log_t_new_sign;
+      g[5] += log_g_old_sign[5] * exp(log_g_old[5]);
     }
 
     if (log_t_new <= log(precision)) {

--- a/stan/math/prim/fun/grad_pFq.hpp
+++ b/stan/math/prim/fun/grad_pFq.hpp
@@ -89,7 +89,7 @@ template <bool calc_a = true, bool calc_b = true, bool calc_z = true,
           typename T_Rtn = return_type_t<Ta, Tb, Tz>,
           typename Ta_Rtn = promote_scalar_t<T_Rtn, plain_type_t<Ta>>,
           typename Tb_Rtn = promote_scalar_t<T_Rtn, plain_type_t<Tb>>>
-std::tuple<Ta_Rtn, Tb_Rtn, T_Rtn> grad_pFq(const TpFq& pfq_val, const Ta& a,
+inline std::tuple<Ta_Rtn, Tb_Rtn, T_Rtn> grad_pFq(const TpFq& pfq_val, const Ta& a,
                                            const Tb& b, const Tz& z,
                                            double precision = 1e-14,
                                            int max_steps = 1e6) {

--- a/stan/math/prim/fun/hypergeometric_3F2.hpp
+++ b/stan/math/prim/fun/hypergeometric_3F2.hpp
@@ -17,36 +17,33 @@ namespace stan {
 namespace math {
 namespace internal {
 template <typename Ta, typename Tb, typename Tz,
-          typename T_return = return_type_t<Ta, Tb, Tz>,
-          typename ArrayAT = Eigen::Array<scalar_type_t<Ta>, 3, 1>,
-          typename ArrayBT = Eigen::Array<scalar_type_t<Ta>, 3, 1>,
           require_all_vector_t<Ta, Tb>* = nullptr,
           require_stan_scalar_t<Tz>* = nullptr>
-T_return hypergeometric_3F2_infsum(const Ta& a, const Tb& b, const Tz& z,
+inline return_type_t<Ta, Tb, Tz> hypergeometric_3F2_infsum(const Ta& a, const Tb& b, const Tz& z,
                                    double precision = 1e-6,
                                    int max_steps = 1e5) {
-  ArrayAT a_array = as_array_or_scalar(a);
-  ArrayBT b_array = append_row(as_array_or_scalar(b), 1.0);
+  using T_return = return_type_t<Ta, Tb, Tz>;
+  Eigen::Array<scalar_type_t<Ta>, 3, 1> a_array = as_array_or_scalar(a);
+  Eigen::Array<scalar_type_t<Tb>, 3, 1> b_array = append_row(as_array_or_scalar(b), 1.0);
   check_3F2_converges("hypergeometric_3F2", a_array[0], a_array[1], a_array[2],
                       b_array[0], b_array[1], z);
 
   T_return t_acc = 1.0;
   T_return log_t = 0.0;
-  T_return log_z = log(fabs(z));
-  Eigen::ArrayXi a_signs = sign(value_of_rec(a_array));
-  Eigen::ArrayXi b_signs = sign(value_of_rec(b_array));
-  plain_type_t<decltype(a_array)> apk = a_array;
-  plain_type_t<decltype(b_array)> bpk = b_array;
+  auto log_z = log(fabs(z));
+  Eigen::Array<int, 3, 1> a_signs = sign(value_of_rec(a_array));
+  Eigen::Array<int, 3, 1> b_signs = sign(value_of_rec(b_array));
   int z_sign = sign(value_of_rec(z));
   int t_sign = z_sign * a_signs.prod() * b_signs.prod();
 
   int k = 0;
-  while (k <= max_steps && log_t >= log(precision)) {
+  const double log_precision = log(precision);
+  while (k <= max_steps && log_t >= log_precision) {
     // Replace zero values with 1 prior to taking the log so that we accumulate
     // 0.0 rather than -inf
-    const auto& abs_apk = math::fabs((apk == 0).select(1.0, apk));
-    const auto& abs_bpk = math::fabs((bpk == 0).select(1.0, bpk));
-    T_return p = sum(log(abs_apk)) - sum(log(abs_bpk));
+    const auto& abs_apk = math::fabs((a_array == 0).select(1.0, a_array));
+    const auto& abs_bpk = math::fabs((b_array == 0).select(1.0, b_array));
+    auto p = sum(log(abs_apk)) - sum(log(abs_bpk));
     if (p == NEGATIVE_INFTY) {
       return t_acc;
     }
@@ -59,10 +56,10 @@ T_return hypergeometric_3F2_infsum(const Ta& a, const Tb& b, const Tz& z,
                          "overflow hypergeometric function did not converge.");
     }
     k++;
-    apk.array() += 1.0;
-    bpk.array() += 1.0;
-    a_signs = sign(value_of_rec(apk));
-    b_signs = sign(value_of_rec(bpk));
+    a_array += 1.0;
+    b_array += 1.0;
+    a_signs = sign(value_of_rec(a_array));
+    b_signs = sign(value_of_rec(b_array));
     t_sign = a_signs.prod() * b_signs.prod() * t_sign;
   }
   if (k == max_steps) {
@@ -115,7 +112,7 @@ T_return hypergeometric_3F2_infsum(const Ta& a, const Tb& b, const Tz& z,
 template <typename Ta, typename Tb, typename Tz,
           require_all_vector_t<Ta, Tb>* = nullptr,
           require_stan_scalar_t<Tz>* = nullptr>
-auto hypergeometric_3F2(const Ta& a, const Tb& b, const Tz& z) {
+inline auto hypergeometric_3F2(const Ta& a, const Tb& b, const Tz& z) {
   check_3F2_converges("hypergeometric_3F2", a[0], a[1], a[2], b[0], b[1], z);
   // Boost's pFq throws convergence errors in some cases, fallback to naive
   // infinite-sum approach (tests pass for these)
@@ -143,7 +140,7 @@ auto hypergeometric_3F2(const Ta& a, const Tb& b, const Tz& z) {
  */
 template <typename Ta, typename Tb, typename Tz,
           require_all_stan_scalar_t<Ta, Tb, Tz>* = nullptr>
-auto hypergeometric_3F2(const std::initializer_list<Ta>& a,
+inline auto hypergeometric_3F2(const std::initializer_list<Ta>& a,
                         const std::initializer_list<Tb>& b, const Tz& z) {
   return hypergeometric_3F2(std::vector<Ta>(a), std::vector<Tb>(b), z);
 }

--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -25,6 +25,7 @@
 #include <stan/math/prim/prob/beta_lccdf.hpp>
 #include <stan/math/prim/prob/beta_lcdf.hpp>
 #include <stan/math/prim/prob/beta_lpdf.hpp>
+#include <stan/math/prim/prob/beta_neg_binomial_lccdf.hpp>
 #include <stan/math/prim/prob/beta_neg_binomial_lpmf.hpp>
 #include <stan/math/prim/prob/beta_proportion_ccdf_log.hpp>
 #include <stan/math/prim/prob/beta_proportion_cdf_log.hpp>

--- a/stan/math/prim/prob/beta_neg_binomial_lccdf.hpp
+++ b/stan/math/prim/prob/beta_neg_binomial_lccdf.hpp
@@ -1,0 +1,151 @@
+#ifndef STAN_MATH_PRIM_PROB_BETA_NEG_BINOMIAL_LCCDF_HPP
+#define STAN_MATH_PRIM_PROB_BETA_NEG_BINOMIAL_LCCDF_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/digamma.hpp>
+#include <stan/math/prim/fun/hypergeometric_3F2.hpp>
+#include <stan/math/prim/fun/grad_F32.hpp>
+#include <stan/math/prim/fun/lbeta.hpp>
+#include <stan/math/prim/fun/lgamma.hpp>
+#include <stan/math/prim/fun/max_size.hpp>
+#include <stan/math/prim/fun/scalar_seq_view.hpp>
+#include <stan/math/prim/fun/size.hpp>
+#include <stan/math/prim/fun/size_zero.hpp>
+#include <stan/math/prim/functor/partials_propagator.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/** \ingroup prob_dists
+ * Returns the log CCDF of the Beta-Negative Binomial distribution with given
+ * number of successes, prior success, and prior failure parameters.
+ * Given containers of matching sizes, returns the log sum of probabilities.
+ *
+ * @tparam T_n type of failure parameter
+ * @tparam T_r type of number of successes parameter
+ * @tparam T_alpha type of prior success parameter
+ * @tparam T_beta type of prior failure parameter
+ *
+ * @param n failure parameter
+ * @param r Number of successes parameter
+ * @param alpha prior success parameter
+ * @param beta prior failure parameter
+ * @return log probability or log sum of probabilities
+ * @throw std::domain_error if r, alpha, or beta fails to be positive
+ * @throw std::invalid_argument if container sizes mismatch
+ */
+template <typename T_n, typename T_r, typename T_alpha, typename T_beta>
+inline return_type_t<T_r, T_alpha, T_beta> beta_neg_binomial_lccdf(
+    const T_n& n, const T_r& r, const T_alpha& alpha, const T_beta& beta) {
+  using std::exp;
+  using std::log;
+  using T_partials_return = partials_return_t<T_n, T_r, T_alpha, T_beta>;
+  using T_r_ref = ref_type_t<T_r>;
+  using T_alpha_ref = ref_type_t<T_alpha>;
+  using T_beta_ref = ref_type_t<T_beta>;
+  static constexpr const char* function = "beta_neg_binomial_lccdf";
+  check_consistent_sizes(
+      function, "Failures variable", n, "Number of successes parameter", r,
+      "Prior success parameter", alpha, "Prior failure parameter", beta);
+  if (size_zero(n, r, alpha, beta)) {
+    return 0;
+  }
+
+  T_r_ref r_ref = r;
+  T_alpha_ref alpha_ref = alpha;
+  T_beta_ref beta_ref = beta;
+  check_positive_finite(function, "Number of successes parameter", r_ref);
+  check_positive_finite(function, "Prior success parameter", alpha_ref);
+  check_positive_finite(function, "Prior failure parameter", beta_ref);
+
+  T_partials_return P(0.0);
+  auto ops_partials = make_partials_propagator(r_ref, alpha_ref, beta_ref);
+
+  scalar_seq_view<T_n> n_vec(n);
+  scalar_seq_view<T_r_ref> r_vec(r_ref);
+  scalar_seq_view<T_alpha_ref> alpha_vec(alpha_ref);
+  scalar_seq_view<T_beta_ref> beta_vec(beta_ref);
+  size_t size_n = stan::math::size(n);
+  size_t max_size_seq_view = max_size(n, r, alpha, beta);
+
+  // Explicit return for extreme values
+  // The gradients are technically ill-defined, but treated as zero
+  for (size_t i = 0; i < size_n; i++) {
+    if (n_vec.val(i) < 0) {
+      return ops_partials.build(0.0);
+    }
+  }
+
+  for (size_t i = 0; i < max_size_seq_view; i++) {
+    // Explicit return for extreme values
+    // The gradients are technically ill-defined, but treated as zero
+    if (n_vec.val(i) == std::numeric_limits<int>::max()) {
+      return ops_partials.build(negative_infinity());
+    }
+    T_partials_return n_dbl = n_vec.val(i);
+    T_partials_return r_dbl = r_vec.val(i);
+    T_partials_return alpha_dbl = alpha_vec.val(i);
+    T_partials_return beta_dbl = beta_vec.val(i);
+    T_partials_return b_plus_n = beta_dbl + n_dbl;
+    T_partials_return r_plus_n = r_dbl + n_dbl;
+    T_partials_return a_plus_r = alpha_dbl + r_dbl;
+    T_partials_return one = 1;
+    T_partials_return precision = 1e-8;  // default -6, set -8 to pass all tests
+
+    T_partials_return F
+        = hypergeometric_3F2({one, b_plus_n + 1, r_plus_n + 1},
+                             {n_dbl + 2, a_plus_r + b_plus_n + 1}, one);
+    T_partials_return C = lgamma(r_plus_n + 1) + lbeta(a_plus_r, b_plus_n + 1)
+                          - lgamma(r_dbl) - lbeta(alpha_dbl, beta_dbl)
+                          - lgamma(n_dbl + 2);
+    T_partials_return ccdf = exp(C) * F;
+    T_partials_return P_i = log(ccdf);
+    P += P_i;
+
+    if (!is_constant_all<T_r, T_alpha, T_beta>::value) {
+      T_partials_return digamma_n_r_alpha_beta
+          = digamma(a_plus_r + b_plus_n + 1);
+      T_partials_return dF[6];
+      grad_F32(dF, one, b_plus_n + 1, r_plus_n + 1, n_dbl + 2,
+               a_plus_r + b_plus_n + 1, one, precision, 1e5);
+
+      if constexpr (!is_constant<T_r>::value || !is_constant<T_alpha>::value) {
+        T_partials_return digamma_r_alpha = digamma(a_plus_r);
+        if constexpr (!is_constant_all<T_r>::value) {
+          partials<0>(ops_partials)[i]
+              += digamma(r_plus_n + 1)
+                 + (digamma_r_alpha - digamma_n_r_alpha_beta)
+                 + (dF[2] + dF[4]) / F - digamma(r_dbl);
+        }
+        if constexpr (!is_constant_all<T_alpha>::value) {
+          partials<1>(ops_partials)[i] += digamma_r_alpha
+                                          - digamma_n_r_alpha_beta + dF[4] / F
+                                          - digamma(alpha_dbl);
+        }
+      }
+
+      if constexpr (!is_constant<T_alpha>::value
+                    || !is_constant<T_beta>::value) {
+        T_partials_return digamma_alpha_beta = digamma(alpha_dbl + beta_dbl);
+        if constexpr (!is_constant<T_alpha>::value) {
+          partials<1>(ops_partials)[i] += digamma_alpha_beta;
+        }
+        if constexpr (!is_constant<T_beta>::value) {
+          partials<2>(ops_partials)[i]
+              += digamma(b_plus_n + 1) - digamma_n_r_alpha_beta
+                 + (dF[1] + dF[4]) / F
+                 - (digamma(beta_dbl) - digamma_alpha_beta);
+        }
+      }
+    }
+  }
+
+  return ops_partials.build(P);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/test/prob/beta_neg_binomial/beta_neg_binomial_ccdf_log_test.hpp
+++ b/test/prob/beta_neg_binomial/beta_neg_binomial_ccdf_log_test.hpp
@@ -1,0 +1,96 @@
+// Arguments: Ints, Doubles, Doubles, Doubles
+#include <stan/math/prim/prob/beta_neg_binomial_lccdf.hpp>
+#include <stan/math/prim/fun/lbeta.hpp>
+#include <stan/math/prim/fun/lgamma.hpp>
+
+using stan::math::var;
+using std::numeric_limits;
+using std::vector;
+
+class AgradCcdfLogBetaNegBinomial : public AgradCcdfLogTest {
+ public:
+  void valid_values(vector<vector<double>>& parameters,
+                    vector<double>& ccdf_log) {
+    vector<double> param(4);
+
+    param[0] = 10;   // n
+    param[1] = 5.5;  // r
+    param[2] = 2.5;  // alpha
+    param[3] = 0.5;  // beta
+    parameters.push_back(param);
+    ccdf_log.push_back(std::log(1.0 - 0.967906252841089));  // expected ccdf_log
+  }
+
+  void invalid_values(vector<size_t>& index, vector<double>& value) {
+    // n
+
+    // r
+    index.push_back(1U);
+    value.push_back(0.0);
+
+    index.push_back(1U);
+    value.push_back(-1.0);
+
+    index.push_back(1U);
+    value.push_back(std::numeric_limits<double>::infinity());
+
+    // alpha
+    index.push_back(2U);
+    value.push_back(0.0);
+
+    index.push_back(2U);
+    value.push_back(-1.0);
+
+    index.push_back(2U);
+    value.push_back(std::numeric_limits<double>::infinity());
+
+    // beta
+    index.push_back(3U);
+    value.push_back(0.0);
+
+    index.push_back(3U);
+    value.push_back(-1.0);
+
+    index.push_back(3U);
+    value.push_back(std::numeric_limits<double>::infinity());
+  }
+
+  // BOUND INCLUDED IN ORDER FOR TEST TO PASS WITH CURRENT FRAMEWORK
+  bool has_lower_bound() { return false; }
+
+  bool has_upper_bound() { return false; }
+
+  template <typename T_n, typename T_r, typename T_size1, typename T_size2,
+            typename T4, typename T5>
+  stan::return_type_t<T_r, T_size1, T_size2> ccdf_log(const T_n& n,
+                                                      const T_r& r,
+                                                      const T_size1& alpha,
+                                                      const T_size2& beta,
+                                                      const T4&, const T5&) {
+    return stan::math::beta_neg_binomial_lccdf(n, r, alpha, beta);
+  }
+
+  template <typename T_n, typename T_r, typename T_size1, typename T_size2,
+            typename T4, typename T5>
+  stan::return_type_t<T_r, T_size1, T_size2> ccdf_log_function(
+      const T_n& n, const T_r& r, const T_size1& alpha, const T_size2& beta,
+      const T4&, const T5&) {
+    using stan::math::lbeta;
+    using stan::math::lgamma;
+    using stan::math::log1m;
+    using stan::math::log_sum_exp;
+    using std::vector;
+
+    vector<stan::return_type_t<T_r, T_size1, T_size2>> lpmf_values;
+
+    for (int i = 0; i <= n; i++) {
+      auto lpmf = lbeta(i + r, alpha + beta) - lbeta(r, alpha)
+                  + lgamma(i + beta) - lgamma(i + 1) - lgamma(beta);
+      lpmf_values.push_back(lpmf);
+    }
+
+    auto log_cdf = log_sum_exp(lpmf_values);
+
+    return log1m(exp(log_cdf));
+  }
+};

--- a/test/prob/beta_neg_binomial/beta_neg_binomial_ccdf_log_test.hpp
+++ b/test/prob/beta_neg_binomial/beta_neg_binomial_ccdf_log_test.hpp
@@ -19,6 +19,13 @@ class AgradCcdfLogBetaNegBinomial : public AgradCcdfLogTest {
     param[3] = 0.5;  // beta
     parameters.push_back(param);
     ccdf_log.push_back(std::log(1.0 - 0.967906252841089));  // expected ccdf_log
+
+    param[0] = 0;     // n
+    param[1] = 0.01;  // r
+    param[2] = 100;   // alpha
+    param[3] = 0.01;  // beta
+    parameters.push_back(param);
+    ccdf_log.push_back(std::log(1.0 - 0.999998995084973));  // expected ccdf_log
   }
 
   void invalid_values(vector<size_t>& index, vector<double>& value) {

--- a/test/prob/beta_neg_binomial/beta_neg_binomial_ccdf_log_test.hpp
+++ b/test/prob/beta_neg_binomial/beta_neg_binomial_ccdf_log_test.hpp
@@ -19,13 +19,6 @@ class AgradCcdfLogBetaNegBinomial : public AgradCcdfLogTest {
     param[3] = 0.5;  // beta
     parameters.push_back(param);
     ccdf_log.push_back(std::log(1.0 - 0.967906252841089));  // expected ccdf_log
-
-    param[0] = 0;     // n
-    param[1] = 0.01;  // r
-    param[2] = 100;   // alpha
-    param[3] = 0.01;  // beta
-    parameters.push_back(param);
-    ccdf_log.push_back(std::log(1.0 - 0.999998995084973));  // expected ccdf_log
   }
 
   void invalid_values(vector<size_t>& index, vector<double>& value) {


### PR DESCRIPTION
## Summary

With this PR the lccdf of beta negative binomial distribution are added.
See issue https://github.com/stan-dev/math/issues/3113


Expressions involved:

CCDF $C(r,\alpha,\beta)$:

$$
P(Y > y) = 1 - F(r,\alpha,\beta) = C(r,\alpha,\beta) = \frac{\Gamma (r+y +1) B(r+\alpha ,\beta +y +1) {~}_3F_2(...)}{\Gamma (r) B(\alpha ,\beta ) \Gamma (y +2)}
$$

where $F(r,\alpha,\beta)$ is CDF, we denote ${~}_3F_2(\{1,r+y +1,\beta +y +1\}; \{y +2,r+\alpha +\beta +y +1\};1)$ as $_3F_2(...)$

Partial derivatives:

$$
\begin{aligned}
\frac{\partial \log C(r,\alpha,\beta)}{\partial r} &= \psi(r+y+1) + \psi(\alpha+r) - \psi(\alpha+\beta+r+y+1) - \psi(r) + \frac{\partial \log {}_3F_2(...)}{\partial r} \\
 \frac{\partial \log C(r,\alpha,\beta)}{\partial \alpha} &= \psi(\alpha+r) - \psi(\alpha+\beta+r+y+1)  + \frac{\partial \log {}_3F_2(...)}{\partial \alpha} - \psi(\alpha) + \psi(\alpha+\beta) \\
\frac{\partial \log C(r,\alpha,\beta)}{\partial \beta} &= \psi(\beta+y+1) - \psi(\alpha+\beta+r+y+1)  + \frac{\partial \log {}_3F_2(...)}{\partial \beta} - \psi(\beta) + \psi(\alpha+\beta),
\end{aligned}
$$

where

$$
\begin{aligned}
\frac{\partial \log {}_3F_2(...)}{\partial r} &=  \frac{\partial {}_3F_2(...)}{\partial r} /  {}_3F_2(...) \\
&= \left[ _3F_2^{(\{0,1,0\},\{0,0\},0)}(...) + _3F_2^{(\{0,0,0\},\{0,1\},0)}(...) \right]  / _3F_2(...).
\end{aligned}
$$

$$
\begin{aligned}
\frac{\partial \log {}_3F_2(...)}{\partial \alpha}
&=  {}_3F_2^{(\{0,0,0\},\{0,1\},0)}(...)  / {}_3F_2(...) \\
\frac{\partial \log {}_3F_2(...)}{\partial \beta}
&= \left[ _3F_2^{(\{0,0,1\},\{0,0\},0)}(...) + _3F_2^{(\{0,0,0\},\{0,1\},0)}(...) \right]  / _3F_2(...)
\end{aligned}
$$

These can be obtained by `grad_F32`.

## Tests

Test is written follow the [guide](https://mc-stan.org/math/md_doxygen_2contributor__help__pages_2adding__new__distributions.html).

## Side Effects

`grad_F32` may have some precision issues, causing a few tests to fail. This has been resolved by increasing precision from 1e-6 to 1e-8.

## Release notes

beta_neg_binomial_lccdf is available if merged.

## Checklist

- [x] Copyright holder: Zhi Ling

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
