### PR TITLE
use eigen internal traits for getting the scalar type of a eigen type

### DIFF
--- a/stan/math/prim/meta/is_eigen.hpp
+++ b/stan/math/prim/meta/is_eigen.hpp
@@ -20,6 +20,28 @@ template <typename T>
 struct is_eigen
     : bool_constant<is_base_pointer_convertible<Eigen::EigenBase, T>::value> {};
 
+namespace internal {
+// primary template handles types that have no nested ::type member:
+template <class, class = void>
+struct has_internal_trait : std::false_type {};
+
+// specialization recognizes types that do have a nested ::type member:
+template <class T>
+struct has_internal_trait<T, std::void_t<Eigen::internal::traits<std::decay_t<T>>>>
+    : std::true_type {};
+
+// primary template handles types that have no nested ::type member:
+template <class, class = void>
+struct has_scalar_trait : std::false_type {};
+
+// specialization recognizes types that do have a nested ::type member:
+template <class T>
+struct has_scalar_trait<T, std::void_t<typename std::decay_t<T>::Scalar>>
+    : std::true_type {};
+
+}  // namespace internal
+
+
 /**
  * Template metaprogram defining the base scalar type of
  * values stored in an Eigen matrix.
@@ -28,7 +50,7 @@ struct is_eigen
  * @ingroup type_trait
  */
 template <typename T>
-struct scalar_type<T, std::enable_if_t<is_eigen<T>::value>> {
+struct scalar_type<T, std::enable_if_t<is_eigen<T>::value && internal::has_scalar_trait<T>::value>> {
   using type = scalar_type_t<typename std::decay_t<T>::Scalar>;
 };
 
@@ -40,9 +62,35 @@ struct scalar_type<T, std::enable_if_t<is_eigen<T>::value>> {
  * @ingroup type_trait
  */
 template <typename T>
-struct value_type<T, std::enable_if_t<is_eigen<T>::value>> {
+struct value_type<T, std::enable_if_t<is_eigen<T>::value && internal::has_scalar_trait<T>::value>> {
+  using type = typename std::decay_t<T>::Scalar;
+};
+
+
+/**
+ * Template metaprogram defining the base scalar type of
+ * values stored in an Eigen matrix.
+ *
+ * @tparam T type to check.
+ * @ingroup type_trait
+ */
+template <typename T>
+struct scalar_type<T, std::enable_if_t<is_eigen<T>::value && !internal::has_scalar_trait<T>::value>> {
+  using type = scalar_type_t<typename Eigen::internal::traits<std::decay_t<T>>::Scalar>;
+};
+
+/**
+ * Template metaprogram defining the type of values stored in an
+ * Eigen matrix, vector, or row vector.
+ *
+ * @tparam T type to check
+ * @ingroup type_trait
+ */
+template <typename T>
+struct value_type<T, std::enable_if_t<is_eigen<T>::value && !internal::has_scalar_trait<T>::value>> {
   using type = typename Eigen::internal::traits<std::decay_t<T>>::Scalar;
 };
+
 
 /*! \ingroup require_eigens_types */
 /*! \defgroup eigen_types eigen  */

--- a/stan/math/prim/meta/is_eigen.hpp
+++ b/stan/math/prim/meta/is_eigen.hpp
@@ -41,7 +41,7 @@ struct scalar_type<T, std::enable_if_t<is_eigen<T>::value>> {
  */
 template <typename T>
 struct value_type<T, std::enable_if_t<is_eigen<T>::value>> {
-  using type = typename std::decay_t<T>::Scalar;
+ using type = typename Eigen::internal::traits<std::decay_t<T>>::Scalar;
 };
 
 /*! \ingroup require_eigens_types */

--- a/stan/math/prim/meta/is_eigen.hpp
+++ b/stan/math/prim/meta/is_eigen.hpp
@@ -41,7 +41,7 @@ struct scalar_type<T, std::enable_if_t<is_eigen<T>::value>> {
  */
 template <typename T>
 struct value_type<T, std::enable_if_t<is_eigen<T>::value>> {
- using type = typename Eigen::internal::traits<std::decay_t<T>>::Scalar;
+  using type = typename Eigen::internal::traits<std::decay_t<T>>::Scalar;
 };
 
 /*! \ingroup require_eigens_types */

--- a/stan/math/prim/meta/is_eigen.hpp
+++ b/stan/math/prim/meta/is_eigen.hpp
@@ -27,7 +27,8 @@ struct has_internal_trait : std::false_type {};
 
 // specialization recognizes types that do have a nested ::type member:
 template <class T>
-struct has_internal_trait<T, std::void_t<Eigen::internal::traits<std::decay_t<T>>>>
+struct has_internal_trait<T,
+                          std::void_t<Eigen::internal::traits<std::decay_t<T>>>>
     : std::true_type {};
 
 // primary template handles types that have no nested ::type member:
@@ -41,7 +42,6 @@ struct has_scalar_trait<T, std::void_t<typename std::decay_t<T>::Scalar>>
 
 }  // namespace internal
 
-
 /**
  * Template metaprogram defining the base scalar type of
  * values stored in an Eigen matrix.
@@ -50,7 +50,9 @@ struct has_scalar_trait<T, std::void_t<typename std::decay_t<T>::Scalar>>
  * @ingroup type_trait
  */
 template <typename T>
-struct scalar_type<T, std::enable_if_t<is_eigen<T>::value && internal::has_scalar_trait<T>::value>> {
+struct scalar_type<T,
+                   std::enable_if_t<is_eigen<T>::value
+                                    && internal::has_scalar_trait<T>::value>> {
   using type = scalar_type_t<typename std::decay_t<T>::Scalar>;
 };
 
@@ -62,10 +64,11 @@ struct scalar_type<T, std::enable_if_t<is_eigen<T>::value && internal::has_scala
  * @ingroup type_trait
  */
 template <typename T>
-struct value_type<T, std::enable_if_t<is_eigen<T>::value && internal::has_scalar_trait<T>::value>> {
+struct value_type<T,
+                  std::enable_if_t<is_eigen<T>::value
+                                   && internal::has_scalar_trait<T>::value>> {
   using type = typename std::decay_t<T>::Scalar;
 };
-
 
 /**
  * Template metaprogram defining the base scalar type of
@@ -75,8 +78,11 @@ struct value_type<T, std::enable_if_t<is_eigen<T>::value && internal::has_scalar
  * @ingroup type_trait
  */
 template <typename T>
-struct scalar_type<T, std::enable_if_t<is_eigen<T>::value && !internal::has_scalar_trait<T>::value>> {
-  using type = scalar_type_t<typename Eigen::internal::traits<std::decay_t<T>>::Scalar>;
+struct scalar_type<T,
+                   std::enable_if_t<is_eigen<T>::value
+                                    && !internal::has_scalar_trait<T>::value>> {
+  using type = scalar_type_t<
+      typename Eigen::internal::traits<std::decay_t<T>>::Scalar>;
 };
 
 /**
@@ -87,10 +93,11 @@ struct scalar_type<T, std::enable_if_t<is_eigen<T>::value && !internal::has_scal
  * @ingroup type_trait
  */
 template <typename T>
-struct value_type<T, std::enable_if_t<is_eigen<T>::value && !internal::has_scalar_trait<T>::value>> {
+struct value_type<T,
+                  std::enable_if_t<is_eigen<T>::value
+                                   && !internal::has_scalar_trait<T>::value>> {
   using type = typename Eigen::internal::traits<std::decay_t<T>>::Scalar;
 };
-
 
 /*! \ingroup require_eigens_types */
 /*! \defgroup eigen_types eigen  */

--- a/stan/math/rev/core/arena_matrix.hpp
+++ b/stan/math/rev/core/arena_matrix.hpp
@@ -482,6 +482,7 @@ namespace internal {
 template <typename T>
 struct traits<stan::math::arena_matrix<T>> {
   using base = traits<Eigen::Map<T>>;
+  using Scalar = typename base::Scalar;
   using XprKind = typename Eigen::internal::traits<std::decay_t<T>>::XprKind;
   enum {
     PlainObjectTypeInnerSize = base::PlainObjectTypeInnerSize,

--- a/test/unit/math/prim/meta/value_type_test.cpp
+++ b/test/unit/math/prim/meta/value_type_test.cpp
@@ -1,5 +1,6 @@
-#include <stan/math/prim/meta.hpp>
 #include <test/unit/util.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <unsupported/Eigen/KroneckerProduct>
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -34,4 +35,12 @@ TEST(MathMetaPrim, value_type_matrix) {
 
   EXPECT_SAME_TYPE(Eigen::RowVectorXd,
                    value_type<std::vector<Eigen::RowVectorXd> >::type);
+}
+
+TEST(MathMetaPrim, value_type_kronecker) {
+  Eigen::Matrix<double,2,2> A;
+  const auto B = Eigen::kroneckerProduct(A, Eigen::Matrix<double,2,2>::Identity());
+  Eigen::Matrix<double,4,1> C = Eigen::Matrix<double,4,1>::Random(4, 1);
+  EXPECT_TRUE((std::is_same<double, stan::value_type_t<decltype(B)>>::value));
+  Eigen::MatrixXd D = B * C;
 }

--- a/test/unit/math/prim/meta/value_type_test.cpp
+++ b/test/unit/math/prim/meta/value_type_test.cpp
@@ -9,16 +9,16 @@ TEST(MathMetaPrim, value_type_vector) {
   using std::vector;
 
   EXPECT_SAME_TYPE(vector<double>::value_type,
-                   value_type<vector<double> >::type);
+                   value_type<vector<double>>::type);
 
   EXPECT_SAME_TYPE(vector<double>::value_type,
-                   value_type<const vector<double> >::type);
+                   value_type<const vector<double>>::type);
 
-  EXPECT_SAME_TYPE(vector<vector<int> >::value_type,
-                   value_type<vector<vector<int> > >::type);
+  EXPECT_SAME_TYPE(vector<vector<int>>::value_type,
+                   value_type<vector<vector<int>>>::type);
 
-  EXPECT_SAME_TYPE(vector<vector<int> >::value_type,
-                   value_type<const vector<vector<int> > >::type);
+  EXPECT_SAME_TYPE(vector<vector<int>>::value_type,
+                   value_type<const vector<vector<int>>>::type);
 }
 
 TEST(MathMetaPrim, value_type_matrix) {
@@ -34,13 +34,14 @@ TEST(MathMetaPrim, value_type_matrix) {
                    value_type<Eigen::RowVectorXd>::type);
 
   EXPECT_SAME_TYPE(Eigen::RowVectorXd,
-                   value_type<std::vector<Eigen::RowVectorXd> >::type);
+                   value_type<std::vector<Eigen::RowVectorXd>>::type);
 }
 
 TEST(MathMetaPrim, value_type_kronecker) {
-  Eigen::Matrix<double,2,2> A;
-  const auto B = Eigen::kroneckerProduct(A, Eigen::Matrix<double,2,2>::Identity());
-  Eigen::Matrix<double,4,1> C = Eigen::Matrix<double,4,1>::Random(4, 1);
+  Eigen::Matrix<double, 2, 2> A;
+  const auto B
+      = Eigen::kroneckerProduct(A, Eigen::Matrix<double, 2, 2>::Identity());
+  Eigen::Matrix<double, 4, 1> C = Eigen::Matrix<double, 4, 1>::Random(4, 1);
   EXPECT_TRUE((std::is_same<double, stan::value_type_t<decltype(B)>>::value));
   Eigen::MatrixXd D = B * C;
 }


### PR DESCRIPTION
## Summary

Fixes Eigen issue [2852](https://gitlab.com/libeigen/eigen/-/issues/2852) so that Eigen's kronecker product type works  with `value_type_t`

## Tests

New test in `value_type_test` to show the original error and fix

## Side Effects

No

## Release notes

Fix Eigen issue [2852](https://gitlab.com/libeigen/eigen/-/issues/2852) so that Eigen's kronecker product type works  with `value_type_t`

## Checklist

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
