### PR TITLE
Feature/issue 3121 beta neg binomial rng

### DIFF
--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -29,6 +29,7 @@
 #include <stan/math/prim/prob/beta_neg_binomial_lccdf.hpp>
 #include <stan/math/prim/prob/beta_neg_binomial_lcdf.hpp>
 #include <stan/math/prim/prob/beta_neg_binomial_lpmf.hpp>
+#include <stan/math/prim/prob/beta_neg_binomial_rng.hpp>
 #include <stan/math/prim/prob/beta_proportion_ccdf_log.hpp>
 #include <stan/math/prim/prob/beta_proportion_cdf_log.hpp>
 #include <stan/math/prim/prob/beta_proportion_lccdf.hpp>

--- a/stan/math/prim/prob/beta_neg_binomial_rng.hpp
+++ b/stan/math/prim/prob/beta_neg_binomial_rng.hpp
@@ -1,0 +1,67 @@
+#ifndef STAN_MATH_PRIM_PROB_BETA_NEG_BINOMIAL_RNG_HPP
+#define STAN_MATH_PRIM_PROB_BETA_NEG_BINOMIAL_RNG_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/prob/neg_binomial_rng.hpp>
+#include <stan/math/prim/prob/beta_rng.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup prob_dists
+ * Return a beta-negative binomial random variate with given number of
+ * successes, prior success, and prior failure parameters, using the given
+ * random number generator.
+ *
+ * r, alpha, and beta can each be a scalar or a one-dimensional container. Any
+ * non-scalar inputs must be the same size.
+ *
+ * @tparam T_r type of number of successes parameter
+ * @tparam T_alpha type of prior success parameter
+ * @tparam T_beta type of prior failure parameter
+ * @tparam RNG type of random number generator
+ *
+ * @param r (Sequence of) number of successes parameter(s)
+ * @param alpha (Sequence of) positive success parameter(s)
+ * @param beta (Sequence of) positive failure parameter(s)
+ * @param rng random number generator
+ * @return (Sequence of) beta-binomial random variate(s)
+ * @throw std::domain_error if r is negative, or alpha or beta are nonpositive
+ * @throw std::invalid_argument if non-scalar arguments are of different sizes
+ */
+template <typename T_r, typename T_alpha, typename T_beta, class RNG>
+inline typename VectorBuilder<true, int, T_r, T_alpha, T_beta>::type
+beta_neg_binomial_rng(const T_r &r, const T_alpha &alpha, const T_beta &beta,
+                      RNG &rng) {
+  using T_r_ref = ref_type_t<T_r>;
+  using T_alpha_ref = ref_type_t<T_alpha>;
+  using T_beta_ref = ref_type_t<T_beta>;
+  static constexpr const char *function = "beta_neg_binomial_rng";
+  check_consistent_sizes(function, "Number of successes parameter", r,
+                         "Prior success parameter", alpha,
+                         "Prior failure parameter", beta);
+
+  T_r_ref r_ref = r;
+  T_alpha_ref alpha_ref = alpha;
+  T_beta_ref beta_ref = beta;
+  check_positive_finite(function, "Number of successes parameter", r_ref);
+  check_positive_finite(function, "Prior success parameter", alpha_ref);
+  check_positive_finite(function, "Prior failure parameter", beta_ref);
+
+  using T_p = decltype(beta_rng(alpha_ref, beta_ref, rng));
+  T_p p = beta_rng(alpha_ref, beta_ref, rng);
+
+  scalar_seq_view<T_p> p_vec(p);
+  size_t size_p = stan::math::size(p);
+  VectorBuilder<true, double, T_p> odds_ratio_p(size_p);
+  for (size_t n = 0; n < size_p; ++n) {
+    odds_ratio_p[n] = stan::math::exp(stan::math::log(p_vec.val(n))
+                                      - stan::math::log((1 - p_vec.val(n))));
+  }
+
+  return neg_binomial_rng(r_ref, odds_ratio_p.data(), rng);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/test/unit/math/prim/prob/beta_neg_binomial_test.cpp
+++ b/test/unit/math/prim/prob/beta_neg_binomial_test.cpp
@@ -1,0 +1,55 @@
+#include <stan/math/prim.hpp>
+#include <test/unit/math/prim/prob/vector_rng_test_helper.hpp>
+#include <test/unit/math/prim/prob/VectorIntRNGTestRig.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/math/distributions.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+
+class BetaNegBinomialTestRig : public VectorIntRNGTestRig {
+ public:
+  BetaNegBinomialTestRig()
+      : VectorIntRNGTestRig(10000, 10, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+                            {1.1, 3.1, 8.1}, {1, 3, 8}, {-3.0, -2.0, 0.0},
+                            {-3, -2, 0}, {3.1, 4.1, 5.1}, {3, 4, 5},
+                            {-2.1, -0.5, 0.0}, {-3, -1, 0}, {1.1, 3.1, 8.1},
+                            {1, 3, 8}, {-3.0, -2.0, 0.0}, {-3, -2, 0}) {}
+
+  template <typename T1, typename T2, typename T3, typename T_rng>
+  auto generate_samples(const T1& N, const T2& alpha, const T3& beta,
+                        T_rng& rng) const {
+    return stan::math::beta_neg_binomial_rng(N, alpha, beta, rng);
+  }
+
+  template <typename T1>
+  double pmf(int y, T1 r, double alpha, double beta) const {
+    return std::exp(stan::math::beta_neg_binomial_lpmf(y, r, alpha, beta));
+  }
+};
+
+TEST(ProbDistributionsBetaNegBinomial, errorCheck) {
+  check_dist_throws_int_first_argument(BetaNegBinomialTestRig());
+}
+
+TEST(ProbDistributionsBetaNegBinomial, distributionCheck) {
+  check_counts_int_real_real(BetaNegBinomialTestRig());
+}
+
+TEST(ProbDistributionBetaNegBinomial, error_check) {
+  boost::random::mt19937 rng;
+  EXPECT_NO_THROW(stan::math::beta_neg_binomial_rng(4, 0.6, 2.0, rng));
+
+  EXPECT_THROW(stan::math::beta_neg_binomial_rng(-4, 0.6, 2, rng),
+               std::domain_error);
+  EXPECT_THROW(stan::math::beta_neg_binomial_rng(4, -0.6, 2, rng),
+               std::domain_error);
+  EXPECT_THROW(stan::math::beta_neg_binomial_rng(4, 0.6, -2, rng),
+               std::domain_error);
+  EXPECT_THROW(stan::math::beta_neg_binomial_rng(
+                   4, stan::math::positive_infinity(), 2, rng),
+               std::domain_error);
+  EXPECT_THROW(stan::math::beta_neg_binomial_rng(
+                   4, 0.6, stan::math::positive_infinity(), rng),
+               std::domain_error);
+}


### PR DESCRIPTION
## Summary

With this PR the rng of beta negative binomial distribution are added.
See issue #3121

Expressions involved :

for $$Y\sim \text{BNB}(r,\alpha,\beta)$$ we have

$$
  \begin{align}
  Y &\sim \text{NB}(r,p) \\
  p &\sim {\textrm {Beta}}(\alpha ,\beta ),
  \end{align}
$$

where $\text{NB}(y~|~r,p)  = \binom {y+r-1}{y} (1-p)^{y} p^{r}.$

In Stan, the negative binomial distribution is given by

$$
\text{NegBinomial}(y~|~\alpha,\beta)  = \binom{y +
\alpha - 1}{y}  \left( \frac{\beta}{\beta+1}
\right)^{\alpha}  \left( \frac{1}{\beta + 1} \right)^{y} 
$$

so

$$p = \frac{\beta}{\beta+1} \Rightarrow \beta = \frac{p}{1-p}$$

Therefore, provided $r, \alpha, \beta$, we generate $$p \sim \text{Beta}(\alpha ,\beta )$$ and then sample $Y \sim \text{NB}(r, \frac{p}{1-p})$.


## Tests

Test is written follow `test/unit/math/prim/prob/beta_binomial_test.cpp`

## Side Effects

Under more extreme paremeter combination that makes the tail of the distribution heavy, `neg_binomial_rng` might throw `domain_error` because `rng_from_gamma >= POISSON_MAX_RATE`. See https://github.com/stan-dev/math/blob/4a812be023c2b98c4ef97999985fd947cfc895fa/stan/math/prim/prob/neg_binomial_rng.hpp#L60

This is also a problem for `neg_binomial_rng` and `poisson_rng`. But due to their nature, this situation is relatively rare.

The reason behind this is that the Poisson random number generator in Boost will overflow when it exceeds the type range. Stan uses 32-bit int, so there is an upper limit. The current code includes POISSON_MAX_RATE to prevent overflow.

## Release notes
`beta_neg_binomial_rng` is available if merged.

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
