### PR TITLE
Expression tests: Fix arguments for beta_neg_binomial_rng

### DIFF
--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -75,6 +75,7 @@ special_arg_values = {
     "acosh": [1.4],
     "algebra_solver": [None, None, None, None, None, None, None, 10],
     "algebra_solver_newton": [None, None, None, None, None, None, None, 10],
+    "beta_neg_binomial_rng": [1.1, 3.1, 8.1],
     "log1m_exp": [-0.6],
     "categorical_rng": [simplex, None],
     "categorical_lpmf": [None, simplex],


### PR DESCRIPTION
## Summary

Unblocks https://github.com/stan-dev/stanc3/pull/1467

## Tests
 

## Side Effects

 

## Release notes

 

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
