### PR TITLE
Improve numerical stability of normal quantile gradients

### DIFF
--- a/stan/math/rev/fun/inv_Phi.hpp
+++ b/stan/math/rev/fun/inv_Phi.hpp
@@ -38,10 +38,8 @@ template <typename T, require_var_matrix_t<T>* = nullptr>
 inline auto inv_Phi(const T& p) {
   const auto& arena_rtn = to_arena(inv_Phi(p.val()));
   return make_callback_var(arena_rtn, [p, arena_rtn](auto& vi) mutable {
-    p.adj() += apply_scalar_binary(
-        vi.adj(), arena_rtn.val(), [](const double adj, const double rtn_val) {
-          return adj * exp(-std_normal_lpdf(rtn_val));
-        });
+    auto deriv = arena_rtn.unaryExpr([](auto x) { return exp(-std_normal_lpdf(x)); });
+    p.adj() += elt_multiply(vi.adj(), deriv);
   });
 }
 

--- a/stan/math/rev/fun/inv_Phi.hpp
+++ b/stan/math/rev/fun/inv_Phi.hpp
@@ -36,7 +36,7 @@ inline var inv_Phi(const var& p) {
  */
 template <typename T, require_var_matrix_t<T>* = nullptr>
 inline auto inv_Phi(const T& p) {
-  const auto& arena_rtn = to_arena(inv_Phi(p.val()));
+  auto arena_rtn = to_arena(inv_Phi(p.val()));
   return make_callback_var(arena_rtn, [p, arena_rtn](auto& vi) mutable {
     auto deriv
         = arena_rtn.unaryExpr([](auto x) { return exp(-std_normal_lpdf(x)); });

--- a/stan/math/rev/fun/inv_Phi.hpp
+++ b/stan/math/rev/fun/inv_Phi.hpp
@@ -37,10 +37,10 @@ template <typename T, require_var_matrix_t<T>* = nullptr>
 inline auto inv_Phi(const T& p) {
   const auto& arena_rtn = to_arena(inv_Phi(p.val()));
   return make_callback_var(arena_rtn, [p, arena_rtn](auto& vi) mutable {
-    p.adj() += apply_scalar_binary(vi.adj(), arena_rtn.val(),
-                                  [](const auto& adj, const auto& rtn_val) {
-                                    return adj * exp(-std_normal_lpdf(rtn_val));
-                                  });
+    p.adj() += apply_scalar_binary(
+        vi.adj(), arena_rtn.val(), [](const auto& adj, const auto& rtn_val) {
+          return adj * exp(-std_normal_lpdf(rtn_val));
+        });
   });
 }
 

--- a/stan/math/rev/fun/inv_Phi.hpp
+++ b/stan/math/rev/fun/inv_Phi.hpp
@@ -3,8 +3,9 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core.hpp>
-#include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/inv_Phi.hpp>
+#include <stan/math/prim/prob/std_normal_lpdf.hpp>
+#include <stan/math/prim/functor/apply_scalar_binary.hpp>
 #include <cmath>
 
 namespace stan {
@@ -19,8 +20,9 @@ namespace math {
  * @return The unit normal inverse cdf evaluated at p
  */
 inline var inv_Phi(const var& p) {
-  return make_callback_var(inv_Phi(p.val()), [p](auto& vi) mutable {
-    p.adj() += vi.adj() * SQRT_TWO_PI / std::exp(-0.5 * vi.val() * vi.val());
+  double val = inv_Phi(p.val());
+  return make_callback_var(val, [p, val](auto& vi) mutable {
+    p.adj() += vi.adj() * exp(-std_normal_lpdf(val));
   });
 }
 
@@ -33,9 +35,12 @@ inline var inv_Phi(const var& p) {
  */
 template <typename T, require_var_matrix_t<T>* = nullptr>
 inline auto inv_Phi(const T& p) {
-  return make_callback_var(inv_Phi(p.val()), [p](auto& vi) mutable {
-    p.adj().array() += vi.adj().array() * SQRT_TWO_PI
-                       / (-0.5 * vi.val().array().square()).exp();
+  const auto& arena_rtn = to_arena(inv_Phi(p.val()));
+  return make_callback_var(arena_rtn, [p, arena_rtn](auto& vi) mutable {
+    p.adj() += apply_scalar_binary(vi.adj(), arena_rtn.val(),
+                                  [](const auto& adj, const auto& rtn_val) {
+                                    return adj * exp(-std_normal_lpdf(rtn_val));
+                                  });
   });
 }
 

--- a/stan/math/rev/fun/inv_Phi.hpp
+++ b/stan/math/rev/fun/inv_Phi.hpp
@@ -38,7 +38,8 @@ template <typename T, require_var_matrix_t<T>* = nullptr>
 inline auto inv_Phi(const T& p) {
   const auto& arena_rtn = to_arena(inv_Phi(p.val()));
   return make_callback_var(arena_rtn, [p, arena_rtn](auto& vi) mutable {
-    auto deriv = arena_rtn.unaryExpr([](auto x) { return exp(-std_normal_lpdf(x)); });
+    auto deriv
+        = arena_rtn.unaryExpr([](auto x) { return exp(-std_normal_lpdf(x)); });
     p.adj() += elt_multiply(vi.adj(), deriv);
   });
 }

--- a/stan/math/rev/fun/inv_Phi.hpp
+++ b/stan/math/rev/fun/inv_Phi.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core.hpp>
+#include <stan/math/prim/fun/exp.hpp>
 #include <stan/math/prim/fun/inv_Phi.hpp>
 #include <stan/math/prim/prob/std_normal_lpdf.hpp>
 #include <stan/math/prim/functor/apply_scalar_binary.hpp>
@@ -38,7 +39,7 @@ inline auto inv_Phi(const T& p) {
   const auto& arena_rtn = to_arena(inv_Phi(p.val()));
   return make_callback_var(arena_rtn, [p, arena_rtn](auto& vi) mutable {
     p.adj() += apply_scalar_binary(
-        vi.adj(), arena_rtn.val(), [](const auto& adj, const auto& rtn_val) {
+        vi.adj(), arena_rtn.val(), [](const double adj, const double rtn_val) {
           return adj * exp(-std_normal_lpdf(rtn_val));
         });
   });

--- a/stan/math/rev/prob/std_normal_log_qf.hpp
+++ b/stan/math/rev/prob/std_normal_log_qf.hpp
@@ -21,11 +21,14 @@ template <typename T, require_stan_scalar_or_eigen_t<T>* = nullptr>
 inline auto std_normal_log_qf(const var_value<T>& log_p) {
   const auto& arena_rtn = to_arena(std_normal_log_qf(log_p.val()));
   return make_callback_var(arena_rtn, [log_p, arena_rtn](auto& vi) mutable {
-    auto deriv = apply_scalar_binary(
-        log_p.val(), arena_rtn, [](const auto& logp_val, const auto& rtn_val) {
-          return exp(logp_val - std_normal_lpdf(rtn_val));
-        });
-    log_p.adj() += elt_multiply(vi.adj(), deriv);
+    if constexpr (is_eigen<decltype(arena_rtn)>::value) {
+      auto deriv = exp(log_p.val() -  arena_rtn.unaryExpr([](auto x) { 
+        return std_normal_lpdf(x);}));
+      log_p.adj() += elt_multiply(vi.adj(), deriv);
+    } else {
+      auto deriv = exp(log_p.val() -  std_normal_lpdf(arena_rtn));
+      log_p.adj() += vi.adj() * deriv;
+    }
   });
 }
 

--- a/stan/math/rev/prob/std_normal_log_qf.hpp
+++ b/stan/math/rev/prob/std_normal_log_qf.hpp
@@ -20,11 +20,12 @@ template <typename T, require_stan_scalar_or_eigen_t<T>* = nullptr>
 inline auto std_normal_log_qf(const var_value<T>& log_p) {
   const auto& arena_rtn = to_arena(std_normal_log_qf(log_p.val()));
   return make_callback_var(arena_rtn, [log_p, arena_rtn](auto& vi) mutable {
-        log_p.adj() += apply_scalar_ternary(
-          [](const auto& adj, const auto& logp_val, const auto& rtn_val) {
-            return adj * exp(logp_val - std_normal_lpdf(rtn_val));
-          }, vi.adj(), log_p.val(), arena_rtn.val());
-      });
+    log_p.adj() += apply_scalar_ternary(
+        [](const auto& adj, const auto& logp_val, const auto& rtn_val) {
+          return adj * exp(logp_val - std_normal_lpdf(rtn_val));
+        },
+        vi.adj(), log_p.val(), arena_rtn.val());
+  });
 }
 
 }  // namespace math

--- a/stan/math/rev/prob/std_normal_log_qf.hpp
+++ b/stan/math/rev/prob/std_normal_log_qf.hpp
@@ -4,7 +4,8 @@
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/prob/std_normal_log_qf.hpp>
-#include <stan/math/prim/functor/apply_scalar_ternary.hpp>
+#include <stan/math/prim/functor/apply_scalar_binary.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
 #include <cmath>
 
 namespace stan {
@@ -20,11 +21,11 @@ template <typename T, require_stan_scalar_or_eigen_t<T>* = nullptr>
 inline auto std_normal_log_qf(const var_value<T>& log_p) {
   const auto& arena_rtn = to_arena(std_normal_log_qf(log_p.val()));
   return make_callback_var(arena_rtn, [log_p, arena_rtn](auto& vi) mutable {
-    log_p.adj() += apply_scalar_ternary(
-        [](const auto& adj, const auto& logp_val, const auto& rtn_val) {
-          return adj * exp(logp_val - std_normal_lpdf(rtn_val));
-        },
-        vi.adj(), log_p.val(), arena_rtn.val());
+    auto deriv = apply_scalar_binary(log_p.val(), arena_rtn,
+          [](const auto& logp_val, const auto& rtn_val) {
+            return exp(logp_val - std_normal_lpdf(rtn_val));
+          });
+    log_p.adj() += elt_multiply(vi.adj(), deriv);
   });
 }
 

--- a/stan/math/rev/prob/std_normal_log_qf.hpp
+++ b/stan/math/rev/prob/std_normal_log_qf.hpp
@@ -21,10 +21,10 @@ template <typename T, require_stan_scalar_or_eigen_t<T>* = nullptr>
 inline auto std_normal_log_qf(const var_value<T>& log_p) {
   const auto& arena_rtn = to_arena(std_normal_log_qf(log_p.val()));
   return make_callback_var(arena_rtn, [log_p, arena_rtn](auto& vi) mutable {
-    auto deriv = apply_scalar_binary(log_p.val(), arena_rtn,
-          [](const auto& logp_val, const auto& rtn_val) {
-            return exp(logp_val - std_normal_lpdf(rtn_val));
-          });
+    auto deriv = apply_scalar_binary(
+        log_p.val(), arena_rtn, [](const auto& logp_val, const auto& rtn_val) {
+          return exp(logp_val - std_normal_lpdf(rtn_val));
+        });
     log_p.adj() += elt_multiply(vi.adj(), deriv);
   });
 }

--- a/stan/math/rev/prob/std_normal_log_qf.hpp
+++ b/stan/math/rev/prob/std_normal_log_qf.hpp
@@ -3,9 +3,8 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core.hpp>
-#include <stan/math/prim/fun/constants.hpp>
-#include <stan/math/prim/fun/sign.hpp>
 #include <stan/math/prim/prob/std_normal_log_qf.hpp>
+#include <stan/math/prim/functor/apply_scalar_ternary.hpp>
 #include <cmath>
 
 namespace stan {
@@ -19,15 +18,12 @@ namespace math {
  */
 template <typename T, require_stan_scalar_or_eigen_t<T>* = nullptr>
 inline auto std_normal_log_qf(const var_value<T>& log_p) {
-  return make_callback_var(
-      std_normal_log_qf(log_p.val()), [log_p](auto& vi) mutable {
-        auto vi_array = as_array_or_scalar(vi.val());
-        auto vi_sign = sign(as_array_or_scalar(vi.adj()));
-
-        const auto& deriv = as_array_or_scalar(log_p).val()
-                            + log(as_array_or_scalar(vi.adj()) * vi_sign)
-                            - NEG_LOG_SQRT_TWO_PI + 0.5 * square(vi_array);
-        as_array_or_scalar(log_p).adj() += vi_sign * exp(deriv);
+  const auto& arena_rtn = to_arena(std_normal_log_qf(log_p.val()));
+  return make_callback_var(arena_rtn, [log_p, arena_rtn](auto& vi) mutable {
+        log_p.adj() += apply_scalar_ternary(
+          [](const auto& adj, const auto& logp_val, const auto& rtn_val) {
+            return adj * exp(logp_val - std_normal_lpdf(rtn_val));
+          }, vi.adj(), log_p.val(), arena_rtn.val());
       });
 }
 

--- a/stan/math/rev/prob/std_normal_log_qf.hpp
+++ b/stan/math/rev/prob/std_normal_log_qf.hpp
@@ -22,11 +22,12 @@ inline auto std_normal_log_qf(const var_value<T>& log_p) {
   const auto& arena_rtn = to_arena(std_normal_log_qf(log_p.val()));
   return make_callback_var(arena_rtn, [log_p, arena_rtn](auto& vi) mutable {
     if constexpr (is_eigen<decltype(arena_rtn)>::value) {
-      auto deriv = exp(log_p.val() -  arena_rtn.unaryExpr([](auto x) { 
-        return std_normal_lpdf(x);}));
+      auto deriv = exp(log_p.val() - arena_rtn.unaryExpr([](auto x) {
+        return std_normal_lpdf(x);
+      }));
       log_p.adj() += elt_multiply(vi.adj(), deriv);
     } else {
-      auto deriv = exp(log_p.val() -  std_normal_lpdf(arena_rtn));
+      auto deriv = exp(log_p.val() - std_normal_lpdf(arena_rtn));
       log_p.adj() += vi.adj() * deriv;
     }
   });

--- a/stan/math/rev/prob/std_normal_log_qf.hpp
+++ b/stan/math/rev/prob/std_normal_log_qf.hpp
@@ -19,7 +19,7 @@ namespace math {
  */
 template <typename T, require_stan_scalar_or_eigen_t<T>* = nullptr>
 inline auto std_normal_log_qf(const var_value<T>& log_p) {
-  const auto& arena_rtn = to_arena(std_normal_log_qf(log_p.val()));
+  auto arena_rtn = to_arena(std_normal_log_qf(log_p.val()));
   return make_callback_var(arena_rtn, [log_p, arena_rtn](auto& vi) mutable {
     if constexpr (is_eigen<decltype(arena_rtn)>::value) {
       auto deriv = exp(log_p.val() - arena_rtn.unaryExpr([](auto x) {


### PR DESCRIPTION
## Summary

This PR updates the gradient calculations for the normal quantile functions (`inv_Phi` and `std_normal_log_qf`)  to use the existing (numerically stable) standard normal density functions.

As:

$$
\frac{\text{d}}{\text{d}p} F^{-1}(p) = \frac{1}{f\left(F^{-1}(p)\right)}
$$

## Tests

N/A - tests should still pass

## Side Effects

Improved numerical stability for gradients

## Release notes

Improved the numerical stability of the gradient calculations for `inv_Phi` and `std_normal_log_qf`

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
