### PR TITLE
Re-order apply_scalar_binary signature to pass functor first

### DIFF
--- a/stan/math/fwd/fun/pow.hpp
+++ b/stan/math/fwd/fun/pow.hpp
@@ -75,7 +75,8 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_any_fvar_t<base_type_t<T1>, base_type_t<T2>>* = nullptr>
 inline auto pow(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [](const auto& c, const auto& d) { return stan::math::pow(c, d); });
+      [](const auto& c, const auto& d) { return stan::math::pow(c, d); },
+      a, b);
 }
 
 }  // namespace math

--- a/stan/math/fwd/fun/pow.hpp
+++ b/stan/math/fwd/fun/pow.hpp
@@ -75,8 +75,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_any_fvar_t<base_type_t<T1>, base_type_t<T2>>* = nullptr>
 inline auto pow(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return stan::math::pow(c, d); },
-      a, b);
+      [](const auto& c, const auto& d) { return stan::math::pow(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/fwd/functor/finite_diff.hpp
+++ b/stan/math/fwd/functor/finite_diff.hpp
@@ -45,7 +45,7 @@ template <typename FuncTangent, typename InputArg,
           require_st_fvar<InputArg>* = nullptr>
 inline auto aggregate_tangent(const FuncTangent& tangent, const InputArg& arg) {
   return sum(apply_scalar_binary(
-    [](const auto& x, const auto& y) { return x * y.d_; }, tangent, arg));
+      [](const auto& x, const auto& y) { return x * y.d_; }, tangent, arg));
 }
 }  // namespace internal
 

--- a/stan/math/fwd/functor/finite_diff.hpp
+++ b/stan/math/fwd/functor/finite_diff.hpp
@@ -45,7 +45,7 @@ template <typename FuncTangent, typename InputArg,
           require_st_fvar<InputArg>* = nullptr>
 inline auto aggregate_tangent(const FuncTangent& tangent, const InputArg& arg) {
   return sum(apply_scalar_binary(
-      tangent, arg, [](const auto& x, const auto& y) { return x * y.d_; }));
+    [](const auto& x, const auto& y) { return x * y.d_; }, tangent, arg));
 }
 }  // namespace internal
 

--- a/stan/math/prim/fun/atan2.hpp
+++ b/stan/math/prim/fun/atan2.hpp
@@ -38,7 +38,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto atan2(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return atan2(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return atan2(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/atan2.hpp
+++ b/stan/math/prim/fun/atan2.hpp
@@ -38,7 +38,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto atan2(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [](const auto& c, const auto& d) { return atan2(c, d); });
+    [](const auto& c, const auto& d) { return atan2(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/bessel_first_kind.hpp
+++ b/stan/math/prim/fun/bessel_first_kind.hpp
@@ -54,9 +54,9 @@ inline T2 bessel_first_kind(int v, const T2 z) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_not_var_matrix_t<T2>* = nullptr>
 inline auto bessel_first_kind(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
-    return bessel_first_kind(c, d);
-  });
+  return apply_scalar_binary(
+    [&](const auto& c, const auto& d) { return bessel_first_kind(c, d); },
+    a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/bessel_first_kind.hpp
+++ b/stan/math/prim/fun/bessel_first_kind.hpp
@@ -55,7 +55,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_not_var_matrix_t<T2>* = nullptr>
 inline auto bessel_first_kind(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return bessel_first_kind(c, d); },
+    [](const auto& c, const auto& d) { return bessel_first_kind(c, d); },
     a, b);
 }
 

--- a/stan/math/prim/fun/bessel_first_kind.hpp
+++ b/stan/math/prim/fun/bessel_first_kind.hpp
@@ -55,8 +55,8 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_not_var_matrix_t<T2>* = nullptr>
 inline auto bessel_first_kind(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return bessel_first_kind(c, d); },
-    a, b);
+      [](const auto& c, const auto& d) { return bessel_first_kind(c, d); }, a,
+      b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/bessel_second_kind.hpp
+++ b/stan/math/prim/fun/bessel_second_kind.hpp
@@ -55,8 +55,8 @@ inline T2 bessel_second_kind(int v, const T2 z) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto bessel_second_kind(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return bessel_second_kind(c, d); },
-    a, b);
+      [](const auto& c, const auto& d) { return bessel_second_kind(c, d); }, a,
+      b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/bessel_second_kind.hpp
+++ b/stan/math/prim/fun/bessel_second_kind.hpp
@@ -55,7 +55,7 @@ inline T2 bessel_second_kind(int v, const T2 z) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto bessel_second_kind(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return bessel_second_kind(c, d); },
+    [](const auto& c, const auto& d) { return bessel_second_kind(c, d); },
     a, b);
 }
 

--- a/stan/math/prim/fun/bessel_second_kind.hpp
+++ b/stan/math/prim/fun/bessel_second_kind.hpp
@@ -54,9 +54,9 @@ inline T2 bessel_second_kind(int v, const T2 z) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto bessel_second_kind(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
-    return bessel_second_kind(c, d);
-  });
+  return apply_scalar_binary(
+    [&](const auto& c, const auto& d) { return bessel_second_kind(c, d); },
+    a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/beta.hpp
+++ b/stan/math/prim/fun/beta.hpp
@@ -69,7 +69,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto beta(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [](const auto& c, const auto& d) { return beta(c, d); });
+    [](const auto& c, const auto& d) { return beta(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/beta.hpp
+++ b/stan/math/prim/fun/beta.hpp
@@ -69,7 +69,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto beta(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return beta(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return beta(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/binary_log_loss.hpp
+++ b/stan/math/prim/fun/binary_log_loss.hpp
@@ -45,9 +45,9 @@ inline T binary_log_loss(int y, const T& y_hat) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_not_var_matrix_t<T2>* = nullptr>
 inline auto binary_log_loss(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
-    return binary_log_loss(c, d);
-  });
+  return apply_scalar_binary(
+      [&](const auto& c, const auto& d) { return binary_log_loss(c, d); },
+      a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/binary_log_loss.hpp
+++ b/stan/math/prim/fun/binary_log_loss.hpp
@@ -46,7 +46,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_not_var_matrix_t<T2>* = nullptr>
 inline auto binary_log_loss(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      [&](const auto& c, const auto& d) { return binary_log_loss(c, d); },
+      [](const auto& c, const auto& d) { return binary_log_loss(c, d); },
       a, b);
 }
 

--- a/stan/math/prim/fun/binary_log_loss.hpp
+++ b/stan/math/prim/fun/binary_log_loss.hpp
@@ -46,8 +46,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_not_var_matrix_t<T2>* = nullptr>
 inline auto binary_log_loss(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return binary_log_loss(c, d); },
-      a, b);
+      [](const auto& c, const auto& d) { return binary_log_loss(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/binomial_coefficient_log.hpp
+++ b/stan/math/prim/fun/binomial_coefficient_log.hpp
@@ -162,9 +162,9 @@ inline return_type_t<T_n, T_k> binomial_coefficient_log(const T_n n,
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto binomial_coefficient_log(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
-    return binomial_coefficient_log(c, d);
-  });
+  return apply_scalar_binary(
+    [&](const auto& c, const auto& d) { return binomial_coefficient_log(c, d); },
+    a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/binomial_coefficient_log.hpp
+++ b/stan/math/prim/fun/binomial_coefficient_log.hpp
@@ -163,7 +163,7 @@ inline return_type_t<T_n, T_k> binomial_coefficient_log(const T_n n,
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto binomial_coefficient_log(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return binomial_coefficient_log(c, d); },
+    [](const auto& c, const auto& d) { return binomial_coefficient_log(c, d); },
     a, b);
 }
 

--- a/stan/math/prim/fun/binomial_coefficient_log.hpp
+++ b/stan/math/prim/fun/binomial_coefficient_log.hpp
@@ -163,8 +163,10 @@ inline return_type_t<T_n, T_k> binomial_coefficient_log(const T_n n,
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto binomial_coefficient_log(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return binomial_coefficient_log(c, d); },
-    a, b);
+      [](const auto& c, const auto& d) {
+        return binomial_coefficient_log(c, d);
+      },
+      a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/choose.hpp
+++ b/stan/math/prim/fun/choose.hpp
@@ -51,7 +51,7 @@ inline int choose(int n, int k) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto choose(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return choose(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return choose(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/choose.hpp
+++ b/stan/math/prim/fun/choose.hpp
@@ -51,7 +51,7 @@ inline int choose(int n, int k) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto choose(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return choose(c, d); });
+    [&](const auto& c, const auto& d) { return choose(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/choose.hpp
+++ b/stan/math/prim/fun/choose.hpp
@@ -51,7 +51,7 @@ inline int choose(int n, int k) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto choose(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return choose(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return choose(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/falling_factorial.hpp
+++ b/stan/math/prim/fun/falling_factorial.hpp
@@ -82,8 +82,8 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto falling_factorial(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return falling_factorial(c, d); },
-    a, b);
+      [](const auto& c, const auto& d) { return falling_factorial(c, d); }, a,
+      b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/falling_factorial.hpp
+++ b/stan/math/prim/fun/falling_factorial.hpp
@@ -81,9 +81,9 @@ inline return_type_t<T> falling_factorial(const T& x, int n) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto falling_factorial(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
-    return falling_factorial(c, d);
-  });
+  return apply_scalar_binary(
+    [&](const auto& c, const auto& d) { return falling_factorial(c, d); },
+    a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/falling_factorial.hpp
+++ b/stan/math/prim/fun/falling_factorial.hpp
@@ -82,7 +82,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto falling_factorial(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return falling_factorial(c, d); },
+    [](const auto& c, const auto& d) { return falling_factorial(c, d); },
     a, b);
 }
 

--- a/stan/math/prim/fun/fdim.hpp
+++ b/stan/math/prim/fun/fdim.hpp
@@ -37,7 +37,7 @@ inline double fdim(T1 x, T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto fdim(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return fdim(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return fdim(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fdim.hpp
+++ b/stan/math/prim/fun/fdim.hpp
@@ -37,7 +37,7 @@ inline double fdim(T1 x, T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto fdim(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return fdim(c, d); });
+    [&](const auto& c, const auto& d) { return fdim(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fdim.hpp
+++ b/stan/math/prim/fun/fdim.hpp
@@ -37,7 +37,7 @@ inline double fdim(T1 x, T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto fdim(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return fdim(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return fdim(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fmax.hpp
+++ b/stan/math/prim/fun/fmax.hpp
@@ -35,7 +35,7 @@ inline double fmax(T1 x, T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto fmax(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return fmax(c, d); });
+    [&](const auto& c, const auto& d) { return fmax(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fmax.hpp
+++ b/stan/math/prim/fun/fmax.hpp
@@ -35,7 +35,7 @@ inline double fmax(T1 x, T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto fmax(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return fmax(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return fmax(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fmax.hpp
+++ b/stan/math/prim/fun/fmax.hpp
@@ -35,7 +35,7 @@ inline double fmax(T1 x, T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto fmax(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return fmax(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return fmax(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fmin.hpp
+++ b/stan/math/prim/fun/fmin.hpp
@@ -35,7 +35,7 @@ inline double fmin(T1 x, T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto fmin(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return fmin(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return fmin(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fmin.hpp
+++ b/stan/math/prim/fun/fmin.hpp
@@ -35,7 +35,7 @@ inline double fmin(T1 x, T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto fmin(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return fmin(c, d); });
+    [&](const auto& c, const auto& d) { return fmin(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fmin.hpp
+++ b/stan/math/prim/fun/fmin.hpp
@@ -35,7 +35,7 @@ inline double fmin(T1 x, T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto fmin(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return fmin(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return fmin(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fmod.hpp
+++ b/stan/math/prim/fun/fmod.hpp
@@ -35,10 +35,10 @@ inline double fmod(const T1& a, const T2& b) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto fmod(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
+  return apply_scalar_binary([&](const auto& c, const auto& d) {
     using std::fmod;
     return fmod(c, d);
-  });
+  }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fmod.hpp
+++ b/stan/math/prim/fun/fmod.hpp
@@ -35,7 +35,7 @@ inline double fmod(const T1& a, const T2& b) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto fmod(const T1& a, const T2& b) {
-  return apply_scalar_binary([&](const auto& c, const auto& d) {
+  return apply_scalar_binary([](const auto& c, const auto& d) {
     using std::fmod;
     return fmod(c, d);
   }, a, b);

--- a/stan/math/prim/fun/fmod.hpp
+++ b/stan/math/prim/fun/fmod.hpp
@@ -35,10 +35,12 @@ inline double fmod(const T1& a, const T2& b) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto fmod(const T1& a, const T2& b) {
-  return apply_scalar_binary([](const auto& c, const auto& d) {
-    using std::fmod;
-    return fmod(c, d);
-  }, a, b);
+  return apply_scalar_binary(
+      [](const auto& c, const auto& d) {
+        using std::fmod;
+        return fmod(c, d);
+      },
+      a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/gamma_p.hpp
+++ b/stan/math/prim/fun/gamma_p.hpp
@@ -89,7 +89,7 @@ inline double gamma_p(double z, double a) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto gamma_p(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return gamma_p(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return gamma_p(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/gamma_p.hpp
+++ b/stan/math/prim/fun/gamma_p.hpp
@@ -89,7 +89,7 @@ inline double gamma_p(double z, double a) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto gamma_p(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return gamma_p(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return gamma_p(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/gamma_p.hpp
+++ b/stan/math/prim/fun/gamma_p.hpp
@@ -89,7 +89,7 @@ inline double gamma_p(double z, double a) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto gamma_p(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return gamma_p(c, d); });
+    [&](const auto& c, const auto& d) { return gamma_p(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/gamma_q.hpp
+++ b/stan/math/prim/fun/gamma_q.hpp
@@ -67,7 +67,7 @@ inline double gamma_q(double x, double a) { return boost::math::gamma_q(x, a); }
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto gamma_q(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return gamma_q(c, d); });
+    [&](const auto& c, const auto& d) { return gamma_q(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/gamma_q.hpp
+++ b/stan/math/prim/fun/gamma_q.hpp
@@ -67,7 +67,7 @@ inline double gamma_q(double x, double a) { return boost::math::gamma_q(x, a); }
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto gamma_q(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return gamma_q(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return gamma_q(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/gamma_q.hpp
+++ b/stan/math/prim/fun/gamma_q.hpp
@@ -67,7 +67,7 @@ inline double gamma_q(double x, double a) { return boost::math::gamma_q(x, a); }
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto gamma_q(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return gamma_q(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return gamma_q(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/hypot.hpp
+++ b/stan/math/prim/fun/hypot.hpp
@@ -41,7 +41,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
               T1, T2>* = nullptr>
 inline auto hypot(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return hypot(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return hypot(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/hypot.hpp
+++ b/stan/math/prim/fun/hypot.hpp
@@ -41,7 +41,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
               T1, T2>* = nullptr>
 inline auto hypot(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return hypot(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return hypot(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/hypot.hpp
+++ b/stan/math/prim/fun/hypot.hpp
@@ -41,7 +41,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
               T1, T2>* = nullptr>
 inline auto hypot(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return hypot(c, d); });
+    [&](const auto& c, const auto& d) { return hypot(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lbeta.hpp
+++ b/stan/math/prim/fun/lbeta.hpp
@@ -129,7 +129,7 @@ return_type_t<T1, T2> lbeta(const T1 a, const T2 b) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto lbeta(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return lbeta(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return lbeta(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lbeta.hpp
+++ b/stan/math/prim/fun/lbeta.hpp
@@ -129,7 +129,7 @@ return_type_t<T1, T2> lbeta(const T1 a, const T2 b) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto lbeta(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return lbeta(c, d); });
+    [&](const auto& c, const auto& d) { return lbeta(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lbeta.hpp
+++ b/stan/math/prim/fun/lbeta.hpp
@@ -129,7 +129,7 @@ return_type_t<T1, T2> lbeta(const T1 a, const T2 b) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto lbeta(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return lbeta(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return lbeta(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/ldexp.hpp
+++ b/stan/math/prim/fun/ldexp.hpp
@@ -38,7 +38,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
               T1, T2>* = nullptr>
 inline auto ldexp(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return ldexp(c, d); });
+    [&](const auto& c, const auto& d) { return ldexp(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/ldexp.hpp
+++ b/stan/math/prim/fun/ldexp.hpp
@@ -38,7 +38,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
               T1, T2>* = nullptr>
 inline auto ldexp(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return ldexp(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return ldexp(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/ldexp.hpp
+++ b/stan/math/prim/fun/ldexp.hpp
@@ -38,7 +38,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
               T1, T2>* = nullptr>
 inline auto ldexp(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return ldexp(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return ldexp(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lmgamma.hpp
+++ b/stan/math/prim/fun/lmgamma.hpp
@@ -72,7 +72,7 @@ inline return_type_t<T> lmgamma(int k, T x) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto lmgamma(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return lmgamma(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return lmgamma(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lmgamma.hpp
+++ b/stan/math/prim/fun/lmgamma.hpp
@@ -72,7 +72,7 @@ inline return_type_t<T> lmgamma(int k, T x) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto lmgamma(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return lmgamma(c, d); });
+    [&](const auto& c, const auto& d) { return lmgamma(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lmgamma.hpp
+++ b/stan/math/prim/fun/lmgamma.hpp
@@ -72,7 +72,7 @@ inline return_type_t<T> lmgamma(int k, T x) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto lmgamma(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return lmgamma(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return lmgamma(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lmultiply.hpp
+++ b/stan/math/prim/fun/lmultiply.hpp
@@ -45,7 +45,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto lmultiply(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return lmultiply(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return lmultiply(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lmultiply.hpp
+++ b/stan/math/prim/fun/lmultiply.hpp
@@ -45,7 +45,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto lmultiply(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return lmultiply(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return lmultiply(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lmultiply.hpp
+++ b/stan/math/prim/fun/lmultiply.hpp
@@ -45,7 +45,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto lmultiply(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return lmultiply(c, d); });
+    [&](const auto& c, const auto& d) { return lmultiply(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_diff_exp.hpp
+++ b/stan/math/prim/fun/log_diff_exp.hpp
@@ -68,7 +68,7 @@ inline return_type_t<T1, T2> log_diff_exp(const T1 x, const T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_diff_exp(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return log_diff_exp(c, d); });
+    [&](const auto& c, const auto& d) { return log_diff_exp(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_diff_exp.hpp
+++ b/stan/math/prim/fun/log_diff_exp.hpp
@@ -68,7 +68,7 @@ inline return_type_t<T1, T2> log_diff_exp(const T1 x, const T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_diff_exp(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return log_diff_exp(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return log_diff_exp(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_diff_exp.hpp
+++ b/stan/math/prim/fun/log_diff_exp.hpp
@@ -68,7 +68,7 @@ inline return_type_t<T1, T2> log_diff_exp(const T1 x, const T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_diff_exp(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return log_diff_exp(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return log_diff_exp(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_falling_factorial.hpp
+++ b/stan/math/prim/fun/log_falling_factorial.hpp
@@ -73,9 +73,9 @@ inline return_type_t<T1, T2> log_falling_factorial(const T1 x, const T2 n) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_falling_factorial(const T1& a, const T2& b) {
-  return apply_scalar_binary([](const auto& c, const auto& d) {
-    return log_falling_factorial(c, d);
-  }, a, b);
+  return apply_scalar_binary(
+      [](const auto& c, const auto& d) { return log_falling_factorial(c, d); },
+      a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_falling_factorial.hpp
+++ b/stan/math/prim/fun/log_falling_factorial.hpp
@@ -73,9 +73,9 @@ inline return_type_t<T1, T2> log_falling_factorial(const T1 x, const T2 n) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_falling_factorial(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
+  return apply_scalar_binary([&](const auto& c, const auto& d) {
     return log_falling_factorial(c, d);
-  });
+  }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_falling_factorial.hpp
+++ b/stan/math/prim/fun/log_falling_factorial.hpp
@@ -73,7 +73,7 @@ inline return_type_t<T1, T2> log_falling_factorial(const T1 x, const T2 n) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_falling_factorial(const T1& a, const T2& b) {
-  return apply_scalar_binary([&](const auto& c, const auto& d) {
+  return apply_scalar_binary([](const auto& c, const auto& d) {
     return log_falling_factorial(c, d);
   }, a, b);
 }

--- a/stan/math/prim/fun/log_inv_logit_diff.hpp
+++ b/stan/math/prim/fun/log_inv_logit_diff.hpp
@@ -53,7 +53,7 @@ inline return_type_t<T1, T2> log_inv_logit_diff(const T1& x, const T2& y) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_inv_logit_diff(const T1& a, const T2& b) {
-  return apply_scalar_binary([&](const auto& c, const auto& d) {
+  return apply_scalar_binary([](const auto& c, const auto& d) {
     return log_inv_logit_diff(c, d);
   }, a, b);
 }

--- a/stan/math/prim/fun/log_inv_logit_diff.hpp
+++ b/stan/math/prim/fun/log_inv_logit_diff.hpp
@@ -53,9 +53,9 @@ inline return_type_t<T1, T2> log_inv_logit_diff(const T1& x, const T2& y) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_inv_logit_diff(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
+  return apply_scalar_binary([&](const auto& c, const auto& d) {
     return log_inv_logit_diff(c, d);
-  });
+  }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_inv_logit_diff.hpp
+++ b/stan/math/prim/fun/log_inv_logit_diff.hpp
@@ -53,9 +53,9 @@ inline return_type_t<T1, T2> log_inv_logit_diff(const T1& x, const T2& y) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_inv_logit_diff(const T1& a, const T2& b) {
-  return apply_scalar_binary([](const auto& c, const auto& d) {
-    return log_inv_logit_diff(c, d);
-  }, a, b);
+  return apply_scalar_binary(
+      [](const auto& c, const auto& d) { return log_inv_logit_diff(c, d); }, a,
+      b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_modified_bessel_first_kind.hpp
+++ b/stan/math/prim/fun/log_modified_bessel_first_kind.hpp
@@ -233,9 +233,11 @@ inline return_type_t<T1, T2, double> log_modified_bessel_first_kind(
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_modified_bessel_first_kind(const T1& a, const T2& b) {
-  return apply_scalar_binary([](const auto& c, const auto& d) {
-    return log_modified_bessel_first_kind(c, d);
-  }, a, b);
+  return apply_scalar_binary(
+      [](const auto& c, const auto& d) {
+        return log_modified_bessel_first_kind(c, d);
+      },
+      a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_modified_bessel_first_kind.hpp
+++ b/stan/math/prim/fun/log_modified_bessel_first_kind.hpp
@@ -233,7 +233,7 @@ inline return_type_t<T1, T2, double> log_modified_bessel_first_kind(
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_modified_bessel_first_kind(const T1& a, const T2& b) {
-  return apply_scalar_binary([&](const auto& c, const auto& d) {
+  return apply_scalar_binary([](const auto& c, const auto& d) {
     return log_modified_bessel_first_kind(c, d);
   }, a, b);
 }

--- a/stan/math/prim/fun/log_modified_bessel_first_kind.hpp
+++ b/stan/math/prim/fun/log_modified_bessel_first_kind.hpp
@@ -233,9 +233,9 @@ inline return_type_t<T1, T2, double> log_modified_bessel_first_kind(
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_modified_bessel_first_kind(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
+  return apply_scalar_binary([&](const auto& c, const auto& d) {
     return log_modified_bessel_first_kind(c, d);
-  });
+  }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_rising_factorial.hpp
+++ b/stan/math/prim/fun/log_rising_factorial.hpp
@@ -71,9 +71,9 @@ inline return_type_t<T1, T2> log_rising_factorial(const T1& x, const T2& n) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_rising_factorial(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
+  return apply_scalar_binary([&](const auto& c, const auto& d) {
     return log_rising_factorial(c, d);
-  });
+  }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_rising_factorial.hpp
+++ b/stan/math/prim/fun/log_rising_factorial.hpp
@@ -71,7 +71,7 @@ inline return_type_t<T1, T2> log_rising_factorial(const T1& x, const T2& n) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_rising_factorial(const T1& a, const T2& b) {
-  return apply_scalar_binary([&](const auto& c, const auto& d) {
+  return apply_scalar_binary([](const auto& c, const auto& d) {
     return log_rising_factorial(c, d);
   }, a, b);
 }

--- a/stan/math/prim/fun/log_rising_factorial.hpp
+++ b/stan/math/prim/fun/log_rising_factorial.hpp
@@ -71,9 +71,9 @@ inline return_type_t<T1, T2> log_rising_factorial(const T1& x, const T2& n) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_rising_factorial(const T1& a, const T2& b) {
-  return apply_scalar_binary([](const auto& c, const auto& d) {
-    return log_rising_factorial(c, d);
-  }, a, b);
+  return apply_scalar_binary(
+      [](const auto& c, const auto& d) { return log_rising_factorial(c, d); },
+      a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_sum_exp.hpp
+++ b/stan/math/prim/fun/log_sum_exp.hpp
@@ -106,7 +106,7 @@ inline auto log_sum_exp(const T& x) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_sum_exp(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [](const auto& c, const auto& d) { return log_sum_exp(c, d); });
+    [](const auto& c, const auto& d) { return log_sum_exp(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_sum_exp.hpp
+++ b/stan/math/prim/fun/log_sum_exp.hpp
@@ -106,7 +106,7 @@ inline auto log_sum_exp(const T& x) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_sum_exp(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return log_sum_exp(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return log_sum_exp(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/modified_bessel_first_kind.hpp
+++ b/stan/math/prim/fun/modified_bessel_first_kind.hpp
@@ -64,9 +64,9 @@ inline double modified_bessel_first_kind(int v, int z) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto modified_bessel_first_kind(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
+  return apply_scalar_binary([&](const auto& c, const auto& d) {
     return modified_bessel_first_kind(c, d);
-  });
+  }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/modified_bessel_first_kind.hpp
+++ b/stan/math/prim/fun/modified_bessel_first_kind.hpp
@@ -64,7 +64,7 @@ inline double modified_bessel_first_kind(int v, int z) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto modified_bessel_first_kind(const T1& a, const T2& b) {
-  return apply_scalar_binary([&](const auto& c, const auto& d) {
+  return apply_scalar_binary([](const auto& c, const auto& d) {
     return modified_bessel_first_kind(c, d);
   }, a, b);
 }

--- a/stan/math/prim/fun/modified_bessel_first_kind.hpp
+++ b/stan/math/prim/fun/modified_bessel_first_kind.hpp
@@ -64,9 +64,11 @@ inline double modified_bessel_first_kind(int v, int z) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto modified_bessel_first_kind(const T1& a, const T2& b) {
-  return apply_scalar_binary([](const auto& c, const auto& d) {
-    return modified_bessel_first_kind(c, d);
-  }, a, b);
+  return apply_scalar_binary(
+      [](const auto& c, const auto& d) {
+        return modified_bessel_first_kind(c, d);
+      },
+      a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/modified_bessel_second_kind.hpp
+++ b/stan/math/prim/fun/modified_bessel_second_kind.hpp
@@ -56,9 +56,11 @@ inline T2 modified_bessel_second_kind(int v, const T2 z) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto modified_bessel_second_kind(const T1& a, const T2& b) {
-  return apply_scalar_binary([](const auto& c, const auto& d) {
-    return modified_bessel_second_kind(c, d);
-  }, a, b);
+  return apply_scalar_binary(
+      [](const auto& c, const auto& d) {
+        return modified_bessel_second_kind(c, d);
+      },
+      a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/modified_bessel_second_kind.hpp
+++ b/stan/math/prim/fun/modified_bessel_second_kind.hpp
@@ -56,9 +56,9 @@ inline T2 modified_bessel_second_kind(int v, const T2 z) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto modified_bessel_second_kind(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
+  return apply_scalar_binary([&](const auto& c, const auto& d) {
     return modified_bessel_second_kind(c, d);
-  });
+  }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/modified_bessel_second_kind.hpp
+++ b/stan/math/prim/fun/modified_bessel_second_kind.hpp
@@ -56,7 +56,7 @@ inline T2 modified_bessel_second_kind(int v, const T2 z) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto modified_bessel_second_kind(const T1& a, const T2& b) {
-  return apply_scalar_binary([&](const auto& c, const auto& d) {
+  return apply_scalar_binary([](const auto& c, const auto& d) {
     return modified_bessel_second_kind(c, d);
   }, a, b);
 }

--- a/stan/math/prim/fun/multiply_log.hpp
+++ b/stan/math/prim/fun/multiply_log.hpp
@@ -69,7 +69,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto multiply_log(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return multiply_log(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return multiply_log(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/multiply_log.hpp
+++ b/stan/math/prim/fun/multiply_log.hpp
@@ -69,7 +69,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto multiply_log(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [&](const auto& c, const auto& d) { return multiply_log(c, d); }, a, b);
+    [](const auto& c, const auto& d) { return multiply_log(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/multiply_log.hpp
+++ b/stan/math/prim/fun/multiply_log.hpp
@@ -69,7 +69,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
 inline auto multiply_log(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) { return multiply_log(c, d); });
+    [&](const auto& c, const auto& d) { return multiply_log(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/owens_t.hpp
+++ b/stan/math/prim/fun/owens_t.hpp
@@ -71,7 +71,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_and_matrix_types<T1, T2>* = nullptr>
 inline auto owens_t(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return owens_t(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return owens_t(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/owens_t.hpp
+++ b/stan/math/prim/fun/owens_t.hpp
@@ -71,7 +71,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_and_matrix_types<T1, T2>* = nullptr>
 inline auto owens_t(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [](const auto& c, const auto& d) { return owens_t(c, d); });
+    [](const auto& c, const auto& d) { return owens_t(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/pow.hpp
+++ b/stan/math/prim/fun/pow.hpp
@@ -111,7 +111,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
 inline auto pow(const T1& a, const T2& b) {
   return apply_scalar_binary(
       // Qualified pow since only Arithmetic types are accepted here
-      a, b, [](const auto& c, const auto& d) { return stan::math::pow(c, d); });
+      [](const auto& c, const auto& d) { return stan::math::pow(c, d); }, a, b);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/rising_factorial.hpp
+++ b/stan/math/prim/fun/rising_factorial.hpp
@@ -79,9 +79,9 @@ inline return_type_t<T> rising_factorial(const T& x, int n) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto rising_factorial(const T1& a, const T2& b) {
-  return apply_scalar_binary([](const auto& c, const auto& d) {
-    return rising_factorial(c, d);
-  }, a, b);
+  return apply_scalar_binary(
+      [](const auto& c, const auto& d) { return rising_factorial(c, d); }, a,
+      b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/rising_factorial.hpp
+++ b/stan/math/prim/fun/rising_factorial.hpp
@@ -79,7 +79,7 @@ inline return_type_t<T> rising_factorial(const T& x, int n) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto rising_factorial(const T1& a, const T2& b) {
-  return apply_scalar_binary([&](const auto& c, const auto& d) {
+  return apply_scalar_binary([](const auto& c, const auto& d) {
     return rising_factorial(c, d);
   }, a, b);
 }

--- a/stan/math/prim/fun/rising_factorial.hpp
+++ b/stan/math/prim/fun/rising_factorial.hpp
@@ -79,9 +79,9 @@ inline return_type_t<T> rising_factorial(const T& x, int n) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto rising_factorial(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
+  return apply_scalar_binary([&](const auto& c, const auto& d) {
     return rising_factorial(c, d);
-  });
+  }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -88,7 +88,8 @@ inline ReturnT select(const bool c, const T_true& y_true,
     return apply_scalar_binary(
         [](const auto& y_true_inner, const auto& y_false_inner) {
           return y_false_inner;
-        }, y_true, y_false);
+        },
+        y_true, y_false);
   }
 }
 
@@ -120,7 +121,8 @@ inline ReturnT select(const bool c, const T_true y_true,
     return apply_scalar_binary(
         [](const auto& y_true_inner, const auto& y_false_inner) {
           return y_true_inner;
-        }, y_true, y_false);
+        },
+        y_true, y_false);
   } else {
     return y_false;
   }

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -86,10 +86,9 @@ inline ReturnT select(const bool c, const T_true& y_true,
     return y_true;
   } else {
     return apply_scalar_binary(
-        y_true, y_false,
         [](const auto& y_true_inner, const auto& y_false_inner) {
           return y_false_inner;
-        });
+        }, y_true, y_false);
   }
 }
 
@@ -119,10 +118,9 @@ inline ReturnT select(const bool c, const T_true y_true,
                       const T_false y_false) {
   if (c) {
     return apply_scalar_binary(
-        y_true, y_false,
         [](const auto& y_true_inner, const auto& y_false_inner) {
           return y_true_inner;
-        });
+        }, y_true, y_false);
   } else {
     return y_false;
   }

--- a/stan/math/prim/fun/to_complex.hpp
+++ b/stan/math/prim/fun/to_complex.hpp
@@ -38,9 +38,9 @@ constexpr inline std::complex<stan::real_return_t<T, S>> to_complex(
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_st_stan_scalar<T1, T2>* = nullptr>
 inline auto to_complex(const T1& re, const T2& im) {
-  return apply_scalar_binary([](const auto& c, const auto& d) {
-    return stan::math::to_complex(c, d);
-  }, re, im);
+  return apply_scalar_binary(
+      [](const auto& c, const auto& d) { return stan::math::to_complex(c, d); },
+      re, im);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/to_complex.hpp
+++ b/stan/math/prim/fun/to_complex.hpp
@@ -38,7 +38,7 @@ constexpr inline std::complex<stan::real_return_t<T, S>> to_complex(
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_st_stan_scalar<T1, T2>* = nullptr>
 inline auto to_complex(const T1& re, const T2& im) {
-  return apply_scalar_binary([&](const auto& c, const auto& d) {
+  return apply_scalar_binary([](const auto& c, const auto& d) {
     return stan::math::to_complex(c, d);
   }, re, im);
 }

--- a/stan/math/prim/fun/to_complex.hpp
+++ b/stan/math/prim/fun/to_complex.hpp
@@ -38,9 +38,9 @@ constexpr inline std::complex<stan::real_return_t<T, S>> to_complex(
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_st_stan_scalar<T1, T2>* = nullptr>
 inline auto to_complex(const T1& re, const T2& im) {
-  return apply_scalar_binary(re, im, [&](const auto& c, const auto& d) {
+  return apply_scalar_binary([&](const auto& c, const auto& d) {
     return stan::math::to_complex(c, d);
-  });
+  }, re, im);
 }
 
 }  // namespace math

--- a/stan/math/prim/functor/apply_scalar_binary.hpp
+++ b/stan/math/prim/functor/apply_scalar_binary.hpp
@@ -24,17 +24,17 @@ namespace math {
  *
  * This base template function takes (and returns) scalars.
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of first argument to which functor is applied.
  * @tparam T2 Type of second argument to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to inputs.
  * @param x First input to which operation is applied.
  * @param y Second input to which operation is applied.
- * @param f functor to apply to inputs.
  * @return Scalar with result of applying functor to input.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_all_stan_scalar_t<T1, T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
   return f(x, y);
 }
 
@@ -43,17 +43,17 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
  * is used for more efficient indexing of both row- and column-major inputs
  * without separate loops.
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of first argument to which functor is applied.
  * @tparam T2 Type of second argument to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to Eigen input.
  * @param x First Eigen input to which operation is applied.
  * @param y Second Eigen input to which operation is applied.
- * @param f functor to apply to Eigen input.
  * @return Eigen object with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_all_eigen_t<T1, T2>* = nullptr>
-inline auto apply_scalar_binary(T1&& x, T2&& y, F&& f) {
+inline auto apply_scalar_binary(F&& f, T1&& x, T2&& y) {
   check_matching_dims("Binary function", "x", x, "y", y);
   return make_holder(
       [](auto& f_inner, auto& x_inner, auto& y_inner) {
@@ -66,18 +66,18 @@ inline auto apply_scalar_binary(T1&& x, T2&& y, F&& f) {
  * Specialization for use with one Eigen vector (row or column) and
  * a one-dimensional std::vector of integer types
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of first argument to which functor is applied.
  * @tparam T2 Type of second argument to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to inputs.
  * @param x Eigen input to which operation is applied.
  * @param y Integer std::vector input to which operation is applied.
- * @param f functor to apply to inputs.
  * @return Eigen object with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_eigen_vector_vt<is_stan_scalar, T1>* = nullptr,
           require_std_vector_vt<std::is_integral, T2>* = nullptr>
-inline auto apply_scalar_binary(T1&& x, T2&& y, F&& f) {
+inline auto apply_scalar_binary(F&& f, T1&& x, T2&& y) {
   check_matching_sizes("Binary function", "x", x, "y", y);
   return make_holder(
       [](auto& f_inner, auto& x_inner, auto& y_inner) {
@@ -93,18 +93,18 @@ inline auto apply_scalar_binary(T1&& x, T2&& y, F&& f) {
  * Specialization for use with a one-dimensional std::vector of integer types
  * and one Eigen vector (row or column).
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of first argument to which functor is applied.
  * @tparam T2 Type of second argument to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to inputs.
  * @param x Integer std::vector input to which operation is applied.
  * @param y Eigen input to which operation is applied.
- * @param f functor to apply to inputs.
  * @return Eigen object with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_std_vector_vt<std::is_integral, T1>* = nullptr,
           require_eigen_vector_vt<is_stan_scalar, T2>* = nullptr>
-inline auto apply_scalar_binary(T1&& x, T2&& y, F&& f) {
+inline auto apply_scalar_binary(F&& f, T1&& x, T2&& y) {
   check_matching_sizes("Binary function", "x", x, "y", y);
   return make_holder(
       [](auto& f_inner, auto& x_inner, auto& y_inner) {
@@ -120,19 +120,19 @@ inline auto apply_scalar_binary(T1&& x, T2&& y, F&& f) {
  * Specialization for use with one Eigen matrix and
  * a two-dimensional std::vector of integer types
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of first argument to which functor is applied.
  * @tparam T2 Type of second argument to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to inputs.
  * @param x Eigen matrix input to which operation is applied.
  * @param y Nested integer std::vector input to which operation is applied.
- * @param f functor to apply to inputs.
  * @return Eigen object with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_eigen_matrix_dynamic_vt<is_stan_scalar, T1>* = nullptr,
           require_std_vector_vt<is_std_vector, T2>* = nullptr,
           require_std_vector_st<std::is_integral, T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
   if (num_elements(x) != num_elements(y)) {
     std::ostringstream msg;
     msg << "Inputs to vectorized binary function must match in"
@@ -143,8 +143,8 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
   Eigen::Matrix<return_st, Eigen::Dynamic, Eigen::Dynamic> result(x.rows(),
                                                                   x.cols());
   for (size_t i = 0; i < y.size(); ++i) {
-    result.row(i) = apply_scalar_binary(x.row(i).transpose(),
-                                        as_column_vector_or_scalar(y[i]), f);
+    result.row(i) = apply_scalar_binary(f, x.row(i).transpose(),
+                                        as_column_vector_or_scalar(y[i]));
   }
   return result;
 }
@@ -153,19 +153,19 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
  * Specialization for use with a two-dimensional std::vector of integer types
  * and one Eigen matrix.
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of first argument to which functor is applied.
  * @tparam T2 Type of second argument to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to inputs.
  * @param x Nested integer std::vector input to which operation is applied.
  * @param y Eigen matrix input to which operation is applied.
- * @param f functor to apply to inputs.
  * @return Eigen object with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_std_vector_vt<is_std_vector, T1>* = nullptr,
           require_std_vector_st<std::is_integral, T1>* = nullptr,
           require_eigen_matrix_dynamic_vt<is_stan_scalar, T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
   if (num_elements(x) != num_elements(y)) {
     std::ostringstream msg;
     msg << "Inputs to vectorized binary function must match in"
@@ -176,8 +176,8 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
   Eigen::Matrix<return_st, Eigen::Dynamic, Eigen::Dynamic> result(y.rows(),
                                                                   y.cols());
   for (size_t i = 0; i < x.size(); ++i) {
-    result.row(i) = apply_scalar_binary(as_column_vector_or_scalar(x[i]),
-                                        y.row(i).transpose(), f);
+    result.row(i) = apply_scalar_binary(f, as_column_vector_or_scalar(x[i]),
+                                        y.row(i).transpose());
   }
   return result;
 }
@@ -189,17 +189,17 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
  * for the scalar to be captured and applied to each element in the Eigen
  * object.
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of Eigen object to which functor is applied.
  * @tparam T2 Type of scalar to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to Eigen and scalar inputs.
  * @param x Eigen input to which operation is applied.
  * @param y Scalar input to which operation is applied.
- * @param f functor to apply to Eigen and scalar inputs.
  * @return Eigen object with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F, require_eigen_t<T1>* = nullptr,
+template <typename F, typename T1, typename T2, require_eigen_t<T1>* = nullptr,
           require_stan_scalar_t<T2>* = nullptr>
-inline auto apply_scalar_binary(T1&& x, T2&& y, F&& f) {
+inline auto apply_scalar_binary(F&& f, T1&& x, T2&& y) {
   return make_holder(
       [](auto& f_inner, auto& x_inner, auto& y_inner) {
         return x_inner.unaryExpr(
@@ -215,17 +215,17 @@ inline auto apply_scalar_binary(T1&& x, T2&& y, F&& f) {
  * allows for the scalar to be captured and applied to each element in the
  * Eigen object.
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of scalar to which functor is applied.
  * @tparam T2 Type of Eigen object to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to Eigen and scalar inputs.
  * @param x Scalar input to which operation is applied.
  * @param y Eigen input to which operation is applied.
- * @param f functor to apply to Eigen and scalar inputs.
  * @return Eigen object with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_stan_scalar_t<T1>* = nullptr, require_eigen_t<T2>* = nullptr>
-inline auto apply_scalar_binary(T1&& x, T2&& y, F&& f) {
+inline auto apply_scalar_binary(F&& f, T1&& x, T2&& y) {
   return make_holder(
       [](auto& f_inner, auto& x_inner, auto& y_inner) {
         return y_inner.unaryExpr(
@@ -243,17 +243,17 @@ inline auto apply_scalar_binary(T1&& x, T2&& y, F&& f) {
  * return scalar types differ (e.g., functions implicitly promoting
  * integers).
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of first std::vector to which functor is applied.
  * @tparam T2 Type of second std::vector to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to std::vector inputs.
  * @param x First std::vector input to which operation is applied.
  * @param y Second std::vector input to which operation is applied.
- * @param f functor to apply to std::vector inputs.
  * @return std::vector with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_all_std_vector_vt<is_stan_scalar, T1, T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
   check_matching_sizes("Binary function", "x", x, "y", y);
   decltype(auto) x_vec = as_column_vector_or_scalar(x);
   decltype(auto) y_vec = as_column_vector_or_scalar(y);
@@ -274,18 +274,18 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
  * return scalar types differ (e.g., functions implicitly promoting
  * integers).
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of std::vector to which functor is applied.
  * @tparam T2 Type of scalar to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to std::vector and scalar inputs.
  * @param x std::vector input to which operation is applied.
  * @param y Scalar input to which operation is applied.
- * @param f functor to apply to std::vector and scalar inputs.
  * @return std::vector with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_std_vector_vt<is_stan_scalar, T1>* = nullptr,
           require_stan_scalar_t<T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
   decltype(auto) x_vec = as_column_vector_or_scalar(x);
   using T_return = std::decay_t<decltype(f(x[0], y))>;
   std::vector<T_return> result(x.size());
@@ -304,18 +304,18 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
  * return scalar types differ (e.g., functions implicitly promoting
  * integers).
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of scalar to which functor is applied.
  * @tparam T2 Type of std::vector to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to std::vector and scalar inputs.
  * @param x Scalar input to which operation is applied.
  * @param y std::vector input to which operation is applied.
- * @param f functor to apply to std::vector and scalar inputs.
  * @return std::vector with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_stan_scalar_t<T1>* = nullptr,
           require_std_vector_vt<is_stan_scalar, T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
   decltype(auto) y_vec = as_column_vector_or_scalar(y);
   using T_return = std::decay_t<decltype(f(x, y[0]))>;
   std::vector<T_return> result(y.size());
@@ -330,24 +330,24 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
  * return scalar types differ (e.g., functions implicitly promoting
  * integers).
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of first std::vector to which functor is applied.
  * @tparam T2 Type of second std::vector to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to std::vector inputs.
  * @param x First std::vector input to which operation is applied.
  * @param y Second std::vector input to which operation is applied.
- * @param f functor to apply to std::vector inputs.
  * @return std::vector with result of applying functor to inputs.
  */
 template <
-    typename T1, typename T2, typename F,
+    typename F, typename T1, typename T2,
     require_all_std_vector_vt<is_container_or_var_matrix, T1, T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
   check_matching_sizes("Binary function", "x", x, "y", y);
-  using T_return = plain_type_t<decltype(apply_scalar_binary(x[0], y[0], f))>;
+  using T_return = plain_type_t<decltype(apply_scalar_binary(f, x[0], y[0]))>;
   size_t y_size = y.size();
   std::vector<T_return> result(y_size);
   for (size_t i = 0; i < y_size; ++i) {
-    result[i] = apply_scalar_binary(x[i], y[i], f);
+    result[i] = apply_scalar_binary(f, x[i], y[i]);
   }
   return result;
 }
@@ -358,23 +358,23 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
  * where the input and return scalar types differ (e.g., functions implicitly
  * promoting integers).
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of std::vector to which functor is applied.
  * @tparam T2 Type of scalar to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to inputs.
  * @param x std::vector input to which operation is applied.
  * @param y Scalar input to which operation is applied.
- * @param f functor to apply to inputs.
  * @return std::vector with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_std_vector_vt<is_container_or_var_matrix, T1>* = nullptr,
           require_stan_scalar_t<T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
-  using T_return = plain_type_t<decltype(apply_scalar_binary(x[0], y, f))>;
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
+  using T_return = plain_type_t<decltype(apply_scalar_binary(f, x[0], y))>;
   size_t x_size = x.size();
   std::vector<T_return> result(x_size);
   for (size_t i = 0; i < x_size; ++i) {
-    result[i] = apply_scalar_binary(x[i], y, f);
+    result[i] = apply_scalar_binary(f, x[i], y);
   }
   return result;
 }
@@ -385,23 +385,23 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
  * where the input and return scalar types differ (e.g., functions implicitly
  * promoting integers).
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of scalar to which functor is applied.
  * @tparam T2 Type of std::vector to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to inputs.
  * @param x Scalar input to which operation is applied.
  * @param y std::vector input to which operation is applied.
- * @param f functor to apply to inputs.
  * @return std::vector with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_stan_scalar_t<T1>* = nullptr,
           require_std_vector_vt<is_container_or_var_matrix, T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
-  using T_return = plain_type_t<decltype(apply_scalar_binary(x, y[0], f))>;
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
+  using T_return = plain_type_t<decltype(apply_scalar_binary(f, x, y[0]))>;
   size_t y_size = y.size();
   std::vector<T_return> result(y_size);
   for (size_t i = 0; i < y_size; ++i) {
-    result[i] = apply_scalar_binary(x, y[i], f);
+    result[i] = apply_scalar_binary(f, x, y[i]);
   }
   return result;
 }

--- a/stan/math/prim/functor/apply_scalar_ternary.hpp
+++ b/stan/math/prim/functor/apply_scalar_ternary.hpp
@@ -162,7 +162,7 @@ template <typename F, typename T1, typename T2, typename T3,
 inline auto apply_scalar_ternary(const F& f, const T1& x, const T2& y,
                                  const T3& z) {
   return apply_scalar_binary(
-    [f, z](const auto& a, const auto& b) { return f(a, b, z); }, x, y);
+      [f, z](const auto& a, const auto& b) { return f(a, b, z); }, x, y);
 }
 
 /**
@@ -187,7 +187,7 @@ template <typename F, typename T1, typename T2, typename T3,
 inline auto apply_scalar_ternary(const F& f, const T1& x, const T2& y,
                                  const T3& z) {
   return apply_scalar_binary(
-    [f, y](const auto& a, const auto& c) { return f(a, y, c); }, x, z);
+      [f, y](const auto& a, const auto& c) { return f(a, y, c); }, x, z);
 }
 
 /**
@@ -212,7 +212,7 @@ template <typename F, typename T1, typename T2, typename T3,
 inline auto apply_scalar_ternary(const F& f, const T1& x, const T2& y,
                                  const T3& z) {
   return apply_scalar_binary(
-    [f, x](const auto& b, const auto& c) { return f(x, b, c); }, y, z);
+      [f, x](const auto& b, const auto& c) { return f(x, b, c); }, y, z);
 }
 
 }  // namespace math

--- a/stan/math/prim/functor/apply_scalar_ternary.hpp
+++ b/stan/math/prim/functor/apply_scalar_ternary.hpp
@@ -162,7 +162,7 @@ template <typename F, typename T1, typename T2, typename T3,
 inline auto apply_scalar_ternary(const F& f, const T1& x, const T2& y,
                                  const T3& z) {
   return apply_scalar_binary(
-      x, y, [f, z](const auto& a, const auto& b) { return f(a, b, z); });
+    [f, z](const auto& a, const auto& b) { return f(a, b, z); }, x, y);
 }
 
 /**
@@ -187,7 +187,7 @@ template <typename F, typename T1, typename T2, typename T3,
 inline auto apply_scalar_ternary(const F& f, const T1& x, const T2& y,
                                  const T3& z) {
   return apply_scalar_binary(
-      x, z, [f, y](const auto& a, const auto& c) { return f(a, y, c); });
+    [f, y](const auto& a, const auto& c) { return f(a, y, c); }, x, z);
 }
 
 /**
@@ -212,7 +212,7 @@ template <typename F, typename T1, typename T2, typename T3,
 inline auto apply_scalar_ternary(const F& f, const T1& x, const T2& y,
                                  const T3& z) {
   return apply_scalar_binary(
-      y, z, [f, x](const auto& b, const auto& c) { return f(x, b, c); });
+    [f, x](const auto& b, const auto& c) { return f(x, b, c); }, y, z);
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/pow.hpp
+++ b/stan/math/rev/fun/pow.hpp
@@ -289,7 +289,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_any_var_t<base_type_t<T1>, base_type_t<T2>>* = nullptr>
 inline auto pow(const T1& a, const T2& b) {
   return apply_scalar_binary(
-      a, b, [](const auto& c, const auto& d) { return stan::math::pow(c, d); });
+    [](const auto& c, const auto& d) { return stan::math::pow(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/pow.hpp
+++ b/stan/math/rev/fun/pow.hpp
@@ -289,7 +289,7 @@ template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_any_var_t<base_type_t<T1>, base_type_t<T2>>* = nullptr>
 inline auto pow(const T1& a, const T2& b) {
   return apply_scalar_binary(
-    [](const auto& c, const auto& d) { return stan::math::pow(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return stan::math::pow(c, d); }, a, b);
 }
 
 }  // namespace math

--- a/stan/math/rev/functor/apply_scalar_binary.hpp
+++ b/stan/math/rev/functor/apply_scalar_binary.hpp
@@ -17,18 +17,18 @@ namespace math {
  * Eigen's binaryExpr framework is used for more efficient indexing of both row-
  * and column-major inputs  without separate loops.
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of first argument to which functor is applied.
  * @tparam T2 Type of second argument to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to Matrix inputs.
  * @param x First Matrix input to which operation is applied.
  * @param y Second Matrix input to which operation is applied.
- * @param f functor to apply to Matrix inputs.
  * @return `var_value<Matrix>` with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_any_var_matrix_t<T1, T2>* = nullptr,
           require_all_matrix_t<T1, T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
   check_matching_dims("Binary function", "x", x, "y", y);
   return f(x, y);
 }
@@ -37,18 +37,18 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
  * Specialization for use with one `var_value<Eigen vector>` (row or column) and
  * a one-dimensional std::vector of integer types
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of first argument to which functor is applied.
  * @tparam T2 Type of second argument to which functor is applied.
- * @tparam F Type of functor to apply.
+ * @param f functor to apply to inputs.
  * @param x Matrix input to which operation is applied.
  * @param y Integer std::vector input to which operation is applied.
- * @param f functor to apply to inputs.
  * @return var_value<Eigen> object with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_any_var_matrix_t<T1, T2>* = nullptr,
           require_any_std_vector_vt<std::is_integral, T1, T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
   check_matching_sizes("Binary function", "x", x, "y", y);
   return f(x, y);
 }
@@ -57,21 +57,21 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
  * Specialization for use with a two-dimensional std::vector of integer types
  * and one `var_value<Matrix>`.
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of first argument to which functor is applied.
  * @tparam T2 Type of second argument to which functor is applied.
- * @tparam F Type of functor to apply.
- * @param x Either a var matrix or nested integer std::vector input to which
- * operation is applied.
- * @param x Either a var matrix or nested integer std::vector input to which
- * operation is applied.
  * @param f functor to apply to inputs.
+ * @param x Either a var matrix or nested integer std::vector input to which
+ * operation is applied.
+ * @param x Either a var matrix or nested integer std::vector input to which
+ * operation is applied.
  * @return Eigen object with result of applying functor to inputs.
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_any_std_vector_vt<is_std_vector, T1, T2>* = nullptr,
           require_any_std_vector_st<std::is_integral, T1, T2>* = nullptr,
           require_any_var_matrix_t<T1, T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
   return f(x, y);
 }
 
@@ -79,21 +79,21 @@ inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
  * Specialization for use when the one input is an `var_value<Eigen> type and
  * the other is a scalar.
  *
+ * @tparam F Type of functor to apply.
  * @tparam T1 Type of either `var_value<Matrix>` or scalar object to which
  * functor is applied.
  * @tparam T2 Type of either `var_value<Matrix>` or scalar object to which
  * functor is applied.
- * @tparam F Type of functor to apply.
- * @param x Matrix or Scalar input to which operation is applied.
- * @param x Matrix or Scalar input to which operation is applied.
  * @param f functor to apply to var matrix and scalar inputs.
+ * @param x Matrix or Scalar input to which operation is applied.
+ * @param x Matrix or Scalar input to which operation is applied.
  * @return `var_value<Matrix> object with result of applying functor to inputs.
  *
  */
-template <typename T1, typename T2, typename F,
+template <typename F, typename T1, typename T2,
           require_any_stan_scalar_t<T1, T2>* = nullptr,
           require_any_var_matrix_t<T1, T2>* = nullptr>
-inline auto apply_scalar_binary(const T1& x, const T2& y, const F& f) {
+inline auto apply_scalar_binary(const F& f, const T1& x, const T2& y) {
   return f(x, y);
 }
 

--- a/test/unit/math/prim/functor/apply_scalar_binary_test.cpp
+++ b/test/unit/math/prim/functor/apply_scalar_binary_test.cpp
@@ -7,12 +7,12 @@ TEST(MathFunctions, apply_scalar_binary_copy_scalars) {
   lambda << 0.4;
 
   const auto& y1 = stan::math::apply_scalar_binary(
-      [&](const auto& c, const auto& d) { return stan::math::gamma_q(c, d); },
+      [](const auto& c, const auto& d) { return stan::math::gamma_q(c, d); },
       n + 1, lambda);
   EXPECT_NO_THROW(stan::math::sum(y1));
 
   const auto& y2 = stan::math::apply_scalar_binary(
-      [&](const auto& d, const auto& c) { return stan::math::gamma_q(c, d); },
+      [](const auto& d, const auto& c) { return stan::math::gamma_q(c, d); },
       lambda, n + 1);
   EXPECT_NO_THROW(stan::math::sum(y2));
 }

--- a/test/unit/math/prim/functor/apply_scalar_binary_test.cpp
+++ b/test/unit/math/prim/functor/apply_scalar_binary_test.cpp
@@ -7,12 +7,12 @@ TEST(MathFunctions, apply_scalar_binary_copy_scalars) {
   lambda << 0.4;
 
   const auto& y1 = stan::math::apply_scalar_binary(
-      n + 1, lambda,
-      [&](const auto& c, const auto& d) { return stan::math::gamma_q(c, d); });
+      [&](const auto& c, const auto& d) { return stan::math::gamma_q(c, d); },
+      n + 1, lambda);
   EXPECT_NO_THROW(stan::math::sum(y1));
 
   const auto& y2 = stan::math::apply_scalar_binary(
-      lambda, n + 1,
-      [&](const auto& d, const auto& c) { return stan::math::gamma_q(c, d); });
+      [&](const auto& d, const auto& c) { return stan::math::gamma_q(c, d); },
+      lambda, n + 1);
   EXPECT_NO_THROW(stan::math::sum(y2));
 }


### PR DESCRIPTION
## Summary

The signature for `apply_scalar_binary` currently takes the functor as its last argument (i.e., `apply_scalar_binary(x, y, f)`) which is a bit of a non-standard pattern and isn't consistent with `apply_scalar_ternary`

This PR updates the signatures and function usage for `apply_scalar_binary` to take the binary functor as its first argument

## Tests

N/A - Current tests should still pass

## Side Effects

N/A

## Release notes

Updated signature for `apply_scalar_binary` to take the functor as its first argument, instead of the last

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
