### PR TITLE
Add arm64 to GHA CI and split tests across more runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,4 @@
+# Note that the workflows below use Powershell (pwsh) as they were originally written for Windows runners.
 name: Rtools & ARM64 CI
 
 on:
@@ -20,22 +21,19 @@ concurrency:
 
 jobs:
   prim-rev:
-    name: ${{ matrix.config.label }} tests (${{ matrix.config.os }})
-    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.config.label }} tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - { os: windows-latest, label: misc, tests: 'test/unit/*_test.cpp test/unit/math/*_test.cpp test/unit/math/memory' }
-          - { os: ubuntu-24.04-arm, label: misc, tests: 'test/unit/*_test.cpp test/unit/math/*_test.cpp test/unit/math/memory' }
-          - { os: windows-latest, label: prim, tests: 'test/unit/math/prim' }
-          - { os: ubuntu-24.04-arm, label: prim, tests: 'test/unit/math/prim' }
-          - { os: windows-latest, label: rev, tests: 'test/unit/math/rev' }
-          - { os: ubuntu-24.04-arm, label: rev, tests: 'test/unit/math/rev' }
-          - { os: windows-latest, label: fwd, tests: 'test/unit/math/fwd' }
-          - { os: ubuntu-24.04-arm, label: fwd, tests: 'test/unit/math/fwd' }
-          - { os: windows-latest, label: 'non-fun mix', tests: 'test/unit/math/mix/core test/unit/math/mix/meta test/unit/math/mix/*_test.cpp' }
-          - { os: ubuntu-24.04-arm, label: 'non-fun mix', tests: 'test/unit/math/mix/core test/unit/math/mix/meta test/unit/math/mix/*_test.cpp' }
+        os: [windows-latest, ubuntu-24.04-arm]
+        config: [
+          { label: misc, tests: 'test/unit/*_test.cpp test/unit/math/*_test.cpp test/unit/math/memory' },
+          { label: prim, tests: 'test/unit/math/prim' },
+          { label: rev, tests: 'test/unit/math/rev' },
+          { label: fwd, tests: 'test/unit/math/fwd' },
+          { label: 'non-fun mix', tests: 'test/unit/math/mix/core test/unit/math/mix/meta test/unit/math/mix/*_test.cpp' }
+        ]
 
     steps:
     - uses: actions/checkout@v4
@@ -77,22 +75,13 @@ jobs:
         path: '**/*_test.xml'
 
   mix-fun:
-    name: mix fun and prob tests ${{ matrix.config.group }} (${{ matrix.config.os }})
-    runs-on: ${{ matrix.config.os }}
+    name: mix fun and prob tests ${{ matrix.group }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - { os: windows-latest, group: 1 }
-          - { os: ubuntu-24.04-arm, group: 1 }
-          - { os: windows-latest, group: 2 }
-          - { os: ubuntu-24.04-arm, group: 2 }
-          - { os: windows-latest, group: 3 }
-          - { os: ubuntu-24.04-arm, group: 3 }
-          - { os: windows-latest, group: 4 }
-          - { os: ubuntu-24.04-arm, group: 4 }
-          - { os: windows-latest, group: 5 }
-          - { os: ubuntu-24.04-arm, group: 5 }
+        os: [windows-latest, ubuntu-24.04-arm]
+        group: [1, 2, 3, 4, 5]
 
     steps:
     - uses: actions/checkout@v4
@@ -128,14 +117,15 @@ jobs:
         $NumberTests = $MixFunProbTests.Length
         $FifthNumberTests = [math]::Floor($NumberTests / 5)
 
-        $MixFunProbTests1 = $MixFunProbTests[0..($FifthNumberTests - 1)]
-        $MixFunProbTests2 = $MixFunProbTests[$FifthNumberTests..(2 * $FifthNumberTests - 1)]
-        $MixFunProbTests3 = $MixFunProbTests[(2 * $FifthNumberTests)..(3 * $FifthNumberTests - 1)]
-        $MixFunProbTests4 = $MixFunProbTests[(3 * $FifthNumberTests)..(4 * $FifthNumberTests - 1)]
-        $MixFunProbTests5 = $MixFunProbTests[(4 * $FifthNumberTests)..($NumberTests - 1)]
-        $MixFunProbTestsArray = @($MixFunProbTests1, $MixFunProbTests2, $MixFunProbTests3, $MixFunProbTests4, $MixFunProbTests5)
+        $MixFunProbTestsArray = @( `
+          $MixFunProbTests[0..($FifthNumberTests - 1)], `
+          $MixFunProbTests[$FifthNumberTests..(2 * $FifthNumberTests - 1)], `
+          $MixFunProbTests[(2 * $FifthNumberTests)..(3 * $FifthNumberTests - 1)], `
+          $MixFunProbTests[(3 * $FifthNumberTests)..(4 * $FifthNumberTests - 1)], `
+          $MixFunProbTests[(4 * $FifthNumberTests)..($NumberTests - 1)] `
+        )
 
-        python runTests.py -j2 $MixFunProbTestsArray[(${{ matrix.config.group }} - 1)]
+        python runTests.py -j2 $MixFunProbTestsArray[(${{ matrix.group }} - 1)]
 
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
     name: ${{ matrix.config.label }} tests (${{ matrix.config.os }})
     runs-on: ${{ matrix.config.os }}
     strategy:
+      fail-fast: false
       matrix:
         config:
           - { os: windows-latest, label: misc, tests: 'test/unit/*_test.cpp test/unit/math/*_test.cpp test/unit/math/memory' }
@@ -79,6 +80,7 @@ jobs:
     name: mix fun and prob tests ${{ matrix.config.group }} (${{ matrix.config.os }})
     runs-on: ${{ matrix.config.os }}
     strategy:
+      fail-fast: false
       matrix:
         config:
           - { os: windows-latest, group: 1 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,10 +58,10 @@ jobs:
     - name: Run prim and rev unit tests
       shell: pwsh
       run: |
-        python runTests.py -j4 test/unit/*_test.cpp \
-                                test/unit/math/*_test.cpp \
-                                test/unit/math/prim \
-                                test/unit/math/rev \
+        python runTests.py -j4 test/unit/*_test.cpp `
+                                test/unit/math/*_test.cpp `
+                                test/unit/math/prim `
+                                test/unit/math/rev `
                                 test/unit/math/memory
 
     - name: Upload gtest_output xml
@@ -114,11 +114,11 @@ jobs:
     - name: Run fwd unit tests and all the mix tests except those in mix/fun
       shell: pwsh
       run: |
-        python runTests.py -j4 test/unit/math/fwd \
-                                test/unit/math/mix/core \
-                                test/unit/math/mix/functor \
-                                test/unit/math/mix/meta \
-                                test/unit/math/mix/prob \
+        python runTests.py -j4 test/unit/math/fwd `
+                                test/unit/math/mix/core `
+                                test/unit/math/mix/functor `
+                                test/unit/math/mix/meta `
+                                test/unit/math/mix/prob `
                                 test/unit/math/mix/*_test.cpp
 
     - name: Upload gtest_output xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
-name: Windows Rtools44
+name: Rtools & ARM64 CI
 
 on:
   pull_request:
     branches: [ develop, master ]
   push:
-    branches: [ arm64-test ]
+    branches: [ develop ]
     paths-ignore:
       - 'doygen/**'
       - 'hooks/**'
@@ -20,13 +20,21 @@ concurrency:
 
 jobs:
   prim-rev:
-    name: prim and rev tests (${{ matrix.config.os }})
+    name: (${{ matrix.config.label }}) tests (${{ matrix.config.os }})
     runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
         config:
-          - { os: windows-latest }
-          - { os: ubuntu-24.04-arm }
+          - { os: windows-latest, label: misc, tests: 'test/unit/*_test.cpp test/unit/math/*_test.cpp test/unit/math/memory' }
+          - { os: ubuntu-24.04-arm, label: misc, tests: 'test/unit/*_test.cpp test/unit/math/*_test.cpp test/unit/math/memory' }
+          - { os: windows-latest, label: prim, tests: 'test/unit/math/prim' }
+          - { os: ubuntu-24.04-arm, label: prim, tests: 'test/unit/math/prim' }
+          - { os: windows-latest, label: rev, tests: 'test/unit/math/rev' }
+          - { os: ubuntu-24.04-arm, label: rev, tests: 'test/unit/math/rev' }
+          - { os: windows-latest, label: fwd, tests: 'test/unit/math/fwd' }
+          - { os: ubuntu-24.04-arm, label: fwd, tests: 'test/unit/math/fwd' }
+          - { os: windows-latest, label: 'non-fun mix', tests: 'test/unit/math/mix/core test/unit/math/mix/meta test/unit/math/mix/prob test/unit/math/mix/*_test.cpp' }
+          - { os: ubuntu-24.04-arm, label: 'non-fun mix', tests: 'test/unit/math/mix/core test/unit/math/mix/meta test/unit/math/mix/prob test/unit/math/mix/*_test.cpp' }
 
     steps:
     - uses: actions/checkout@v4
@@ -58,11 +66,7 @@ jobs:
     - name: Run prim and rev unit tests
       shell: pwsh
       run: |
-        python runTests.py -j4 test/unit/*_test.cpp `
-                                test/unit/math/*_test.cpp `
-                                test/unit/math/prim `
-                                test/unit/math/rev `
-                                test/unit/math/memory
+        python runTests.py -j4 ${{ matrix.config.tests }}
 
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v4
@@ -71,71 +75,18 @@ jobs:
         name: gtest_outputs_xml
         path: '**/*_test.xml'
 
-  fwd-non-fun-mix:
-    name: fwd tests and non-fun mix tests (${{ matrix.config.os }})
+  mix-fun:
+    name: mix/fun tests ${{ matrix.config.group }} (${{ matrix.config.os }})
     runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
         config:
-          - { os: windows-latest }
-          - { os: ubuntu-24.04-arm }
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-
-    - uses: r-lib/actions/setup-r@v2
-      if: runner.os == 'Windows'
-      with:
-        r-version: 'release'
-        rtools-version: '44'
-
-    - name: Set path for Rtools44
-      if: runner.os == 'Windows'
-      run: echo "C:/rtools44/usr/bin;C:/rtools44/x86_64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-
-    - name: Build Math libs
-      shell: pwsh
-      run: |
-        Add-Content make\local "CPPFLAGS=-w -Wno-psabi -Wno-misleading-indentation`n"
-        make -f make/standalone math-libs -j2
-
-    - name: Add TBB to PATH
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-
-    - name: Disable running fwd/mix tests
-      shell: pwsh
-      run: echo "CXXFLAGS+= -DSTAN_MATH_TESTS_REV_ONLY" | Out-File -Append -FilePath make/local -Encoding utf8
-
-    - name: Run fwd unit tests and all the mix tests except those in mix/fun
-      shell: pwsh
-      run: |
-        python runTests.py -j4 test/unit/math/fwd `
-                                test/unit/math/mix/core `
-                                test/unit/math/mix/functor `
-                                test/unit/math/mix/meta `
-                                test/unit/math/mix/prob `
-                                test/unit/math/mix/*_test.cpp
-
-    - name: Upload gtest_output xml
-      uses: actions/upload-artifact@v4
-      if: failure()
-      with:
-        name: gtest_outputs_xml
-        path: '**/*_test.xml'
-
-  mix-fun-1:
-    name: mix/fun tests 1 (${{ matrix.config.os }})
-    runs-on: ${{ matrix.config.os }}
-    strategy:
-      matrix:
-        config:
-          - { os: windows-latest }
-          - { os: ubuntu-24.04-arm }
+          - { os: windows-latest, group: 1 }
+          - { os: ubuntu-24.04-arm, group: 1 }
+          - { os: windows-latest, group: 2 }
+          - { os: ubuntu-24.04-arm, group: 2 }
+          - { os: windows-latest, group: 3 }
+          - { os: ubuntu-24.04-arm, group: 3 }
 
     steps:
     - uses: actions/checkout@v4
@@ -169,59 +120,15 @@ jobs:
       run: |
         $MixFunTests = Get-ChildItem -Path test\unit\math\mix\fun\* -Include *.cpp | Resolve-Path -Relative
         $NumberTests = $MixFunTests.Length
-        $HalfNumberTests = [math]::Floor($NumberTests / 2)
-        python runTests.py -j2 $MixFunTests[0..$HalfNumberTests]
+        $ThirdNumberTests = [math]::Floor($NumberTests / 3)
+        $TwoThirdNumberTests = [math]::Floor(2 * $NumberTests / 3)
 
-    - name: Upload gtest_output xml
-      uses: actions/upload-artifact@v4
-      if: failure()
-      with:
-        name: gtest_outputs_xml
-        path: '**/*_test.xml'
+        $MixFunTests1 = $MixFunTests[0..($ThirdNumberTests - 1)]
+        $MixFunTests2 = $MixFunTests[$ThirdNumberTests..($TwoThirdNumberTests - 1)]
+        $MixFunTests3 = $MixFunTests[$TwoThirdNumberTests..($NumberTests - 1)]
+        $MixFunTestsArray = @($MixFunTests1, $MixFunTests2, $MixFunTests3)
 
-  mix-fun-2:
-    name: mix/fun tests 2 (${{ matrix.config.os }})
-    runs-on: ${{ matrix.config.os }}
-    strategy:
-      matrix:
-        config:
-          - { os: windows-latest }
-          - { os: ubuntu-24.04-arm }
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-
-    - uses: r-lib/actions/setup-r@v2
-      if: runner.os == 'Windows'
-      with:
-        r-version: 'release'
-        rtools-version: '44'
-
-    - name: Set path for Rtools44
-      if: runner.os == 'Windows'
-      run: echo "C:/rtools44/usr/bin;C:/rtools44/x86_64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-
-    - name: Build Math libs
-      shell: pwsh
-      run: |
-        Add-Content make\local "CPPFLAGS=-w -Wno-psabi -Wno-misleading-indentation`n"
-        make -f make/standalone math-libs -j2
-
-    - name: Add TBB to PATH
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-
-    - name: Run mix/fun unit tests
-      shell: pwsh
-      run: |
-        $MixFunTests = Get-ChildItem -Path test\unit\math\mix\fun\* -Include *.cpp | Resolve-Path -Relative
-        $NumberTests = $MixFunTests.Length
-        $HalfNumberTests = [math]::Floor($NumberTests / 2)
-        python runTests.py -j2 $MixFunTests[($HalfNumberTests + 1)..($NumberTests - 1)]
+        python runTests.py -j2 $MixFunTestsArray[(${{ matrix.config.group }} - 1)]
 
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ develop, master ]
   push:
-    branches: [ develop ]
+    branches: [ arm64-test ]
     paths-ignore:
       - 'doygen/**'
       - 'hooks/**'
@@ -20,15 +20,22 @@ concurrency:
 
 jobs:
   prim-rev:
-    name: prim and rev tests
-    runs-on: windows-latest
+    name: prim and rev tests (${{ matrix.config.os }})
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - { os: windows-latest }
+          - { os: ubuntu-24.04-arm }
 
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
+
     - uses: r-lib/actions/setup-r@v2
+      if: runner.os == 'Windows'
       with:
         r-version: 'release'
         rtools-version: '44'
@@ -38,20 +45,24 @@ jobs:
       run: echo "C:/rtools44/usr/bin;C:/rtools44/x86_64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
-      shell: powershell
+      shell: pwsh
       run: |
+        Add-Content make\local "CPPFLAGS=-w -Wno-psabi -Wno-misleading-indentation`n"
         make -f make/standalone math-libs -j2
+
     - name: Add TBB to PATH
-      shell: powershell
+      if: runner.os == 'Windows'
+      shell: pwsh
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
     - name: Run prim and rev unit tests
-      shell: powershell
+      shell: pwsh
       run: |
-        python.exe runTests.py -j2 test/unit/*_test.cpp
-        python.exe runTests.py -j2 test/unit/math/*_test.cpp
-        python.exe runTests.py -j2 test/unit/math/prim
-        python.exe runTests.py -j2 test/unit/math/rev
-        python.exe runTests.py -j2 test/unit/math/memory
+        python runTests.py -j4 test/unit/*_test.cpp \
+                                test/unit/math/*_test.cpp \
+                                test/unit/math/prim \
+                                test/unit/math/rev \
+                                test/unit/math/memory
 
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v4
@@ -61,15 +72,22 @@ jobs:
         path: '**/*_test.xml'
 
   fwd-non-fun-mix:
-    name: fwd tests and non-fun mix tests
-    runs-on: windows-latest
+    name: fwd tests and non-fun mix tests (${{ matrix.config.os }})
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - { os: windows-latest }
+          - { os: ubuntu-24.04-arm }
 
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
+
     - uses: r-lib/actions/setup-r@v2
+      if: runner.os == 'Windows'
       with:
         r-version: 'release'
         rtools-version: '44'
@@ -79,24 +97,29 @@ jobs:
       run: echo "C:/rtools44/usr/bin;C:/rtools44/x86_64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
-      shell: powershell
+      shell: pwsh
       run: |
+        Add-Content make\local "CPPFLAGS=-w -Wno-psabi -Wno-misleading-indentation`n"
         make -f make/standalone math-libs -j2
+
     - name: Add TBB to PATH
-      shell: powershell
+      if: runner.os == 'Windows'
+      shell: pwsh
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
     - name: Disable running fwd/mix tests
-      shell: powershell
+      shell: pwsh
       run: echo "CXXFLAGS+= -DSTAN_MATH_TESTS_REV_ONLY" | Out-File -Append -FilePath make/local -Encoding utf8
+
     - name: Run fwd unit tests and all the mix tests except those in mix/fun
-      shell: powershell
+      shell: pwsh
       run: |
-        python.exe runTests.py test/unit/math/fwd -j2
-        python.exe runTests.py test/unit/math/mix/core -j2
-        python.exe runTests.py test/unit/math/mix/functor -j2
-        python.exe runTests.py test/unit/math/mix/meta -j2
-        python.exe runTests.py test/unit/math/mix/prob -j2
-        python.exe runTests.py test/unit/math/mix/*_test.cpp -j2
+        python runTests.py -j4 test/unit/math/fwd \
+                                test/unit/math/mix/core \
+                                test/unit/math/mix/functor \
+                                test/unit/math/mix/meta \
+                                test/unit/math/mix/prob \
+                                test/unit/math/mix/*_test.cpp
 
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v4
@@ -106,15 +129,22 @@ jobs:
         path: '**/*_test.xml'
 
   mix-fun-1:
-    name: mix/fun tests 1
-    runs-on: windows-latest
+    name: mix/fun tests 1 (${{ matrix.config.os }})
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - { os: windows-latest }
+          - { os: ubuntu-24.04-arm }
 
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
+
     - uses: r-lib/actions/setup-r@v2
+      if: runner.os == 'Windows'
       with:
         r-version: 'release'
         rtools-version: '44'
@@ -124,19 +154,23 @@ jobs:
       run: echo "C:/rtools44/usr/bin;C:/rtools44/x86_64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
-      shell: powershell
+      shell: pwsh
       run: |
+        Add-Content make\local "CPPFLAGS=-w -Wno-psabi -Wno-misleading-indentation`n"
         make -f make/standalone math-libs -j2
+
     - name: Add TBB to PATH
-      shell: powershell
+      if: runner.os == 'Windows'
+      shell: pwsh
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
     - name: Run mix/fun unit tests
-      shell: powershell
+      shell: pwsh
       run: |
         $MixFunTests = Get-ChildItem -Path test\unit\math\mix\fun\* -Include *.cpp | Resolve-Path -Relative
         $NumberTests = $MixFunTests.Length
         $HalfNumberTests = [math]::Floor($NumberTests / 2)
-        python.exe runTests.py $MixFunTests[0..$HalfNumberTests]
+        python runTests.py -j2 $MixFunTests[0..$HalfNumberTests]
 
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v4
@@ -146,15 +180,22 @@ jobs:
         path: '**/*_test.xml'
 
   mix-fun-2:
-    name: mix/fun tests 2
-    runs-on: windows-latest
+    name: mix/fun tests 2 (${{ matrix.config.os }})
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - { os: windows-latest }
+          - { os: ubuntu-24.04-arm }
 
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
+
     - uses: r-lib/actions/setup-r@v2
+      if: runner.os == 'Windows'
       with:
         r-version: 'release'
         rtools-version: '44'
@@ -164,20 +205,23 @@ jobs:
       run: echo "C:/rtools44/usr/bin;C:/rtools44/x86_64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
-      shell: powershell
+      shell: pwsh
       run: |
-        Add-Content make\local "O=1`n"
+        Add-Content make\local "CPPFLAGS=-w -Wno-psabi -Wno-misleading-indentation`n"
         make -f make/standalone math-libs -j2
+
     - name: Add TBB to PATH
-      shell: powershell
+      if: runner.os == 'Windows'
+      shell: pwsh
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
     - name: Run mix/fun unit tests
-      shell: powershell
+      shell: pwsh
       run: |
         $MixFunTests = Get-ChildItem -Path test\unit\math\mix\fun\* -Include *.cpp | Resolve-Path -Relative
         $NumberTests = $MixFunTests.Length
         $HalfNumberTests = [math]::Floor($NumberTests / 2)
-        python.exe runTests.py $MixFunTests[($HalfNumberTests + 1)..($NumberTests - 1)]
+        python runTests.py -j2 $MixFunTests[($HalfNumberTests + 1)..($NumberTests - 1)]
 
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,8 @@ jobs:
           - { os: ubuntu-24.04-arm, group: 3 }
           - { os: windows-latest, group: 4 }
           - { os: ubuntu-24.04-arm, group: 4 }
+          - { os: windows-latest, group: 5 }
+          - { os: ubuntu-24.04-arm, group: 5 }
 
     steps:
     - uses: actions/checkout@v4
@@ -124,13 +126,14 @@ jobs:
       run: |
         $MixFunProbTests = Get-ChildItem -Path test\unit\math\mix\fun\*, test\unit\math\mix\prob\* -Include *.cpp | Resolve-Path -Relative
         $NumberTests = $MixFunProbTests.Length
-        $QuarterNumberTests = [math]::Floor($NumberTests / 4)
+        $FifthNumberTests = [math]::Floor($NumberTests / 5)
 
-        $MixFunProbTests1 = $MixFunProbTests[0..($QuarterNumberTests - 1)]
-        $MixFunProbTests2 = $MixFunProbTests[$QuarterNumberTests..(2 * $QuarterNumberTests - 1)]
-        $MixFunProbTests3 = $MixFunProbTests[(2 * $QuarterNumberTests)..(3 * $QuarterNumberTests - 1)]
-        $MixFunProbTests4 = $MixFunProbTests[(3 * $QuarterNumberTests)..($NumberTests - 1)]
-        $MixFunProbTestsArray = @($MixFunProbTests1, $MixFunProbTests2, $MixFunProbTests3, $MixFunProbTests4)
+        $MixFunProbTests1 = $MixFunProbTests[0..($FifthNumberTests - 1)]
+        $MixFunProbTests2 = $MixFunProbTests[$FifthNumberTests..(2 * $FifthNumberTests - 1)]
+        $MixFunProbTests3 = $MixFunProbTests[(2 * $FifthNumberTests)..(3 * $FifthNumberTests - 1)]
+        $MixFunProbTests4 = $MixFunProbTests[(3 * $FifthNumberTests)..(4 * $FifthNumberTests - 1)]
+        $MixFunProbTests5 = $MixFunProbTests[(4 * $FifthNumberTests)..($NumberTests - 1)]
+        $MixFunProbTestsArray = @($MixFunProbTests1, $MixFunProbTests2, $MixFunProbTests3, $MixFunProbTests4, $MixFunProbTests5)
 
         python runTests.py -j2 $MixFunProbTestsArray[(${{ matrix.config.group }} - 1)]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,8 @@ jobs:
           - { os: ubuntu-24.04-arm, group: 2 }
           - { os: windows-latest, group: 3 }
           - { os: ubuntu-24.04-arm, group: 3 }
+          - { os: windows-latest, group: 4 }
+          - { os: ubuntu-24.04-arm, group: 4 }
 
     steps:
     - uses: actions/checkout@v4
@@ -120,15 +122,15 @@ jobs:
       run: |
         $MixFunTests = Get-ChildItem -Path test\unit\math\mix\fun\* -Include *.cpp | Resolve-Path -Relative
         $NumberTests = $MixFunTests.Length
-        $ThirdNumberTests = [math]::Floor($NumberTests / 3)
-        $TwoThirdNumberTests = [math]::Floor(2 * $NumberTests / 3)
+        $QuarterNumberTests = [math]::Floor($NumberTests / 4)
 
-        $MixFunTests1 = $MixFunTests[0..($ThirdNumberTests - 1)]
-        $MixFunTests2 = $MixFunTests[$ThirdNumberTests..($TwoThirdNumberTests - 1)]
-        $MixFunTests3 = $MixFunTests[$TwoThirdNumberTests..($NumberTests - 1)]
-        $MixFunTestsArray = @($MixFunTests1, $MixFunTests2, $MixFunTests3)
+        $MixFunTests1 = $MixFunTests[0..($QuarterNumberTests - 1)]
+        $MixFunTests2 = $MixFunTests[$QuarterNumberTests..(2 * $QuarterNumberTests - 1)]
+        $MixFunTests3 = $MixFunTests[(2 * $QuarterNumberTests)..(3 * $QuarterNumberTests - 1)]
+        $MixFunTests4 = $MixFunTests[(3 * $QuarterNumberTests)..($NumberTests - 1)]
+        $MixFunTestsArray = @($MixFunTests1, $MixFunTests2, $MixFunTests3, $MixFunTests3)
 
-        python runTests.py -j2 $MixFunTestsArray[(${{ matrix.config.group }} - 1)]
+        python runTests.py $MixFunTestsArray[(${{ matrix.config.group }} - 1)]
 
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,8 @@ jobs:
           - { os: ubuntu-24.04-arm, label: rev, tests: 'test/unit/math/rev' }
           - { os: windows-latest, label: fwd, tests: 'test/unit/math/fwd' }
           - { os: ubuntu-24.04-arm, label: fwd, tests: 'test/unit/math/fwd' }
-          - { os: windows-latest, label: 'non-fun mix', tests: 'test/unit/math/mix/core test/unit/math/mix/meta test/unit/math/mix/prob test/unit/math/mix/*_test.cpp' }
-          - { os: ubuntu-24.04-arm, label: 'non-fun mix', tests: 'test/unit/math/mix/core test/unit/math/mix/meta test/unit/math/mix/prob test/unit/math/mix/*_test.cpp' }
+          - { os: windows-latest, label: 'non-fun mix', tests: 'test/unit/math/mix/core test/unit/math/mix/meta test/unit/math/mix/*_test.cpp' }
+          - { os: ubuntu-24.04-arm, label: 'non-fun mix', tests: 'test/unit/math/mix/core test/unit/math/mix/meta test/unit/math/mix/*_test.cpp' }
 
     steps:
     - uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
         path: '**/*_test.xml'
 
   mix-fun:
-    name: mix/fun tests ${{ matrix.config.group }} (${{ matrix.config.os }})
+    name: mix fun and prob tests ${{ matrix.config.group }} (${{ matrix.config.os }})
     runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
@@ -120,17 +120,17 @@ jobs:
     - name: Run mix/fun unit tests
       shell: pwsh
       run: |
-        $MixFunTests = Get-ChildItem -Path test\unit\math\mix\fun\* -Include *.cpp | Resolve-Path -Relative
-        $NumberTests = $MixFunTests.Length
+        $MixFunProbTests = Get-ChildItem -Path test\unit\math\mix\fun\*, test\unit\math\mix\prob\* -Include *.cpp | Resolve-Path -Relative
+        $NumberTests = $MixFunProbTests.Length
         $QuarterNumberTests = [math]::Floor($NumberTests / 4)
 
-        $MixFunTests1 = $MixFunTests[0..($QuarterNumberTests - 1)]
-        $MixFunTests2 = $MixFunTests[$QuarterNumberTests..(2 * $QuarterNumberTests - 1)]
-        $MixFunTests3 = $MixFunTests[(2 * $QuarterNumberTests)..(3 * $QuarterNumberTests - 1)]
-        $MixFunTests4 = $MixFunTests[(3 * $QuarterNumberTests)..($NumberTests - 1)]
-        $MixFunTestsArray = @($MixFunTests1, $MixFunTests2, $MixFunTests3, $MixFunTests3)
+        $MixFunProbTests1 = $MixFunProbTests[0..($QuarterNumberTests - 1)]
+        $MixFunProbTests2 = $MixFunProbTests[$QuarterNumberTests..(2 * $QuarterNumberTests - 1)]
+        $MixFunProbTests3 = $MixFunProbTests[(2 * $QuarterNumberTests)..(3 * $QuarterNumberTests - 1)]
+        $MixFunProbTests4 = $MixFunProbTests[(3 * $QuarterNumberTests)..($NumberTests - 1)]
+        $MixFunProbTestsArray = @($MixFunProbTests1, $MixFunProbTests2, $MixFunProbTests3, $MixFunProbTests4)
 
-        python runTests.py $MixFunTestsArray[(${{ matrix.config.group }} - 1)]
+        python runTests.py -j2 $MixFunProbTestsArray[(${{ matrix.config.group }} - 1)]
 
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   prim-rev:
-    name: (${{ matrix.config.label }}) tests (${{ matrix.config.os }})
+    name: ${{ matrix.config.label }} tests (${{ matrix.config.os }})
     runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
@@ -63,7 +63,7 @@ jobs:
       shell: pwsh
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
-    - name: Run prim and rev unit tests
+    - name: Run ${{ matrix.config.label }} unit tests
       shell: pwsh
       run: |
         python runTests.py -j4 ${{ matrix.config.tests }}

--- a/stan/math/prim/fun/owens_t.hpp
+++ b/stan/math/prim/fun/owens_t.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/functor/apply_scalar_binary.hpp>
+#include <stan/math/prim/fun/boost_policy.hpp>
 #include <boost/math/special_functions/owens_t.hpp>
 
 namespace stan {
@@ -55,7 +56,9 @@ namespace math {
  * @param a Second argument
  * @return Owen's T function applied to the arguments.
  */
-inline double owens_t(double h, double a) { return boost::math::owens_t(h, a); }
+inline double owens_t(double h, double a) {
+  return boost::math::owens_t(h, a, boost_policy_t<>());
+}
 
 /**
  * Enables the vectorized application of the owens_t


### PR DESCRIPTION
## Summary

Now that arm64 runners are available in github actions, we can add them as part of our regular CI. This will help catch issues like those fixed in #3059 - it's already identified issues with `owens_t`!

The `owens_t` function was hanging indefinitely under the arm64 runner, and this was resolved by adding our `boost_policy` definition as an argument - I'm not entirely sure why (might be another precision thing?).

I've added the runners as part of the existing Windows Rtools CI, using `pwsh` to avoid changing the current workflow in any meaningful way.

## Tests

N/A - existing tests should still pass

## Side Effects

N/A

## Release notes

Add arm64 linux to Github Actions CI

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
