### PR TITLE
Fix TBB compatibility with rtools45 on windows arm64

### DIFF
--- a/lib/tbb_2020.3/STAN_CHANGES
+++ b/lib/tbb_2020.3/STAN_CHANGES
@@ -10,6 +10,7 @@ This file documents changes done for the stan-math project
 - Support for Windows ARM64 with RTools:
   - build/Makefile.tbb
     - L94 Wrapped the use of `--version-script` export in conditional on non-WINARM64
-  - build/windows.gcc.ino
+  - build/windows.gcc.inc
     - L84 Wrapped the use of `-flifetime-dse` flag in conditional on non-WINARM64
+    - L101 Wrapped the use of `-msse` in conditional on non-WINARM64
     

--- a/lib/tbb_2020.3/build/windows.gcc.inc
+++ b/lib/tbb_2020.3/build/windows.gcc.inc
@@ -98,7 +98,11 @@ CPLUS_FLAGS += -DUSE_WINTHREAD
 CPLUS_FLAGS += -D_WIN32_WINNT=$(_WIN32_WINNT)
 
 # MinGW specific
-CPLUS_FLAGS += -DMINGW_HAS_SECURE_API=1 -D__MSVCRT_VERSION__=0x0700 -msse -mthreads
+CPLUS_FLAGS += -DMINGW_HAS_SECURE_API=1 -D__MSVCRT_VERSION__=0x0700 -mthreads
+# Unused under ARM64 and error with LLVM19+
+ifeq (, $(WINARM64))
+    CPLUS_FLAGS +=  -msse 
+endif
 
 CONLY = gcc
 debugger = gdb


### PR DESCRIPTION
## Summary

The upcoming release of RTools45 updates to LLVM19 on ARM64, which has started converting some warnings to errors. This causes the building of the TBB to fail due to passing an x86-specific flag `-msse`:

```
g++ -o concurrent_hash_map.o -c -MMD -O2 -DUSE_WINTHREAD -D_WIN32_WINNT=0x0502 -DMINGW_HAS_SECURE_API=1 -D__MSVCRT_VERSION__=0x0700 -msse -mthreads    -D__TBB_BUILD=1 -Wall -Wno-parentheses -Wno-uninitialized -Wno-non-virtual-dtor -Wno-unknown-warning-option -Wno-deprecated-copy -Wno-missing-attributes -Wno-class-memaccess -Wno-sized-deallocation   -D_UCRT -DTBB_USE_GCC_BUILTINS -DTBB_SUPPRESS_DEPRECATED_MESSAGES=1 -std=c++17  -I../tbb_2020.3/src -I../tbb_2020.3/src/rml/include -I../tbb_2020.3/include ../tbb_2020.3/src/tbb/concurrent_hash_map.cpp
clang-19: error: unsupported option '-msse' for target 'aarch64-w64-mingw32'
```

This PR updates the existing Windows ARM64 handling to also ignore this flag

## Tests

N/A

## Side Effects

N/A

## Release notes

Fixed compilation of bundled TBB under Windows ARM64 with RTools45

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
