### PR TITLE
Save some memory in simplex constrain

### DIFF
--- a/stan/math/rev/constraint/simplex_constrain.hpp
+++ b/stan/math/rev/constraint/simplex_constrain.hpp
@@ -33,35 +33,24 @@ inline auto simplex_constrain(const T& y) {
 
   size_t N = y.size();
   arena_t<T> arena_y = y;
-  arena_t<Eigen::VectorXd> arena_z(N);
-  Eigen::VectorXd x_val(N + 1);
 
-  double stick_len(1.0);
-  for (Eigen::Index k = 0; k < N; ++k) {
-    double log_N_minus_k = std::log(N - k);
-    arena_z.coeffRef(k) = inv_logit(arena_y.val().coeff(k) - log_N_minus_k);
-    x_val.coeffRef(k) = stick_len * arena_z.coeff(k);
-    stick_len -= x_val(k);
-  }
-  x_val.coeffRef(N) = stick_len;
-
-  arena_t<ret_type> arena_x = x_val;
+  arena_t<ret_type> arena_x = simplex_constrain(arena_y.val());
 
   if (unlikely(N == 0)) {
     return ret_type(arena_x);
   }
 
-  reverse_pass_callback([arena_y, arena_x, arena_z]() mutable {
+  reverse_pass_callback([arena_y, arena_x]() mutable {
     int N = arena_y.size();
     double stick_len_val = arena_x.val().coeff(N);
     double stick_len_adj = arena_x.adj().coeff(N);
     for (Eigen::Index k = N; k-- > 0;) {
+      double z_k = inv_logit(arena_y.val().coeff(k) - log(N - k));
       arena_x.adj().coeffRef(k) -= stick_len_adj;
       stick_len_val += arena_x.val().coeff(k);
-      stick_len_adj += arena_x.adj().coeff(k) * arena_z.coeff(k);
+      stick_len_adj += arena_x.adj().coeff(k) * z_k;
       double arena_z_adj = arena_x.adj().coeff(k) * stick_len_val;
-      arena_y.adj().coeffRef(k)
-          += arena_z_adj * arena_z.coeff(k) * (1.0 - arena_z.coeff(k));
+      arena_y.adj().coeffRef(k) += arena_z_adj * z_k * (1.0 - z_k);
     }
   });
 
@@ -87,29 +76,14 @@ auto simplex_constrain(const T& y, scalar_type_t<T>& lp) {
 
   size_t N = y.size();
   arena_t<T> arena_y = y;
-  arena_t<Eigen::VectorXd> arena_z(N);
-  Eigen::VectorXd x_val(N + 1);
 
-  double stick_len(1.0);
-  for (Eigen::Index k = 0; k < N; ++k) {
-    double log_N_minus_k = std::log(N - k);
-    double adj_y_k = arena_y.val().coeff(k) - log_N_minus_k;
-    arena_z.coeffRef(k) = inv_logit(adj_y_k);
-    x_val.coeffRef(k) = stick_len * arena_z.coeff(k);
-    lp += log(stick_len);
-    lp -= log1p_exp(-adj_y_k);
-    lp -= log1p_exp(adj_y_k);
-    stick_len -= x_val(k);
-  }
-  x_val.coeffRef(N) = stick_len;
-
-  arena_t<ret_type> arena_x = x_val;
+  arena_t<ret_type> arena_x = simplex_constrain(arena_y.val(), lp);
 
   if (unlikely(N == 0)) {
     return ret_type(arena_x);
   }
 
-  reverse_pass_callback([arena_y, arena_x, arena_z, lp]() mutable {
+  reverse_pass_callback([arena_y, arena_x, lp]() mutable {
     int N = arena_y.size();
     double stick_len_val = arena_x.val().coeff(N);
     double stick_len_adj = arena_x.adj().coeff(N);
@@ -118,13 +92,14 @@ auto simplex_constrain(const T& y, scalar_type_t<T>& lp) {
       stick_len_val += arena_x.val().coeff(k);
       double log_N_minus_k = std::log(N - k);
       double adj_y_k = arena_y.val().coeff(k) - log_N_minus_k;
-      arena_y.adj().coeffRef(k) -= lp.adj() * inv_logit(adj_y_k);
+      double z_k = inv_logit(adj_y_k);
+
+      arena_y.adj().coeffRef(k) -= lp.adj() * z_k;
       arena_y.adj().coeffRef(k) += lp.adj() * inv_logit(-adj_y_k);
       stick_len_adj += lp.adj() / stick_len_val;
-      stick_len_adj += arena_x.adj().coeff(k) * arena_z.coeff(k);
+      stick_len_adj += arena_x.adj().coeff(k) * z_k;
       double arena_z_adj = arena_x.adj().coeff(k) * stick_len_val;
-      arena_y.adj().coeffRef(k)
-          += arena_z_adj * arena_z.coeff(k) * (1.0 - arena_z.coeff(k));
+      arena_y.adj().coeffRef(k) += arena_z_adj * z_k * (1.0 - z_k);
     }
   });
 

--- a/stan/math/rev/constraint/stochastic_column_constrain.hpp
+++ b/stan/math/rev/constraint/stochastic_column_constrain.hpp
@@ -92,39 +92,39 @@ inline plain_type_t<T> stochastic_column_constrain(const T& y,
     return ret_type(x_val);
   }
   arena_t<change_eigen_options_t<T, Eigen::RowMajor>> arena_y = y;
-  arena_t<eigen_mat_rowmajor> arena_z(N, M);
   using arr_vec = Eigen::Array<double, 1, -1>;
   arr_vec stick_len = arr_vec::Constant(M, 1.0);
   arr_vec adj_y_k(N);
   for (Eigen::Index k = 0; k < N; ++k) {
     double log_N_minus_k = std::log(N - k);
     adj_y_k = arena_y.array().row(k).val() - log_N_minus_k;
-    arena_z.array().row(k) = inv_logit(adj_y_k);
-    x_val.array().row(k) = stick_len * arena_z.array().row(k);
+    x_val.array().row(k) = stick_len * inv_logit(adj_y_k).array();
     lp += sum(log(stick_len)) - sum(log1p_exp(-adj_y_k))
           - sum(log1p_exp(adj_y_k));
     stick_len -= x_val.array().row(k);
   }
   x_val.array().row(N) = stick_len;
   arena_t<ret_type> arena_x = x_val;
-  reverse_pass_callback([arena_y, arena_x, arena_z, lp]() mutable {
+  reverse_pass_callback([arena_y, arena_x, lp]() mutable {
     const Eigen::Index N = arena_y.rows();
     auto arena_x_arr = arena_x.array();
     auto arena_y_arr = arena_y.array();
-    auto arena_z_arr = arena_z.array();
     auto stick_len_val = arena_x.array().row(N).val().eval();
     auto stick_len_adj = arena_x.array().row(N).adj().eval();
     for (Eigen::Index k = N; k-- > 0;) {
       const double log_N_minus_k = std::log(N - k);
+      auto adj_y_k = arena_y_arr.row(k).val() - log_N_minus_k;
+      auto z_k = inv_logit(adj_y_k).eval();
+
       arena_x_arr.row(k).adj() -= stick_len_adj;
       stick_len_val += arena_x_arr.row(k).val();
-      stick_len_adj += lp.adj() / stick_len_val
-                       + arena_x_arr.row(k).adj() * arena_z_arr.row(k);
-      auto adj_y_k = arena_y_arr.row(k).val() - log_N_minus_k;
+      stick_len_adj
+          += lp.adj() / stick_len_val + arena_x_arr.row(k).adj() * z_k;
+
       auto arena_z_adj = arena_x_arr.row(k).adj() * stick_len_val;
-      arena_y_arr.row(k).adj()
-          += -(lp.adj() * inv_logit(adj_y_k)) + lp.adj() * inv_logit(-adj_y_k)
-             + arena_z_adj * arena_z_arr.row(k) * (1.0 - arena_z_arr.row(k));
+      arena_y_arr.row(k).adj() += -(lp.adj() * z_k)
+                                  + lp.adj() * inv_logit(-adj_y_k)
+                                  + arena_z_adj * z_k * (1.0 - z_k);
     }
   });
   return ret_type(arena_x);

--- a/stan/math/rev/constraint/stochastic_row_constrain.hpp
+++ b/stan/math/rev/constraint/stochastic_row_constrain.hpp
@@ -110,12 +110,11 @@ inline plain_type_t<T> stochastic_row_constrain(const T& y,
 
       arena_x_arr.col(k).adj() -= stick_len_adj;
       stick_len_val += arena_x_arr.col(k).val_op();
-      stick_len_adj += lp.adj() / stick_len_val
-                       + arena_x_arr.adj_op().col(k) * z_k;
+      stick_len_adj
+          += lp.adj() / stick_len_val + arena_x_arr.adj_op().col(k) * z_k;
       arena_y_arr.col(k).adj()
           += -(lp.adj() * z_k) + lp.adj() * inv_logit(-adj_y_k)
-             + arena_x_arr.col(k).adj_op() * stick_len_val * z_k
-                   * (1.0 - z_k);
+             + arena_x_arr.col(k).adj_op() * stick_len_val * z_k * (1.0 - z_k);
     }
   });
   return ret_type(arena_x);

--- a/stan/math/rev/constraint/stochastic_row_constrain.hpp
+++ b/stan/math/rev/constraint/stochastic_row_constrain.hpp
@@ -86,37 +86,36 @@ inline plain_type_t<T> stochastic_row_constrain(const T& y,
     return ret_type(x_val);
   }
   arena_t<T> arena_y = y;
-  arena_t<Eigen::MatrixXd> arena_z(N, M);
   Eigen::Array<double, -1, 1> stick_len = Eigen::Array<double, -1, 1>::Ones(N);
   for (Eigen::Index j = 0; j < M; ++j) {
     double log_N_minus_k = std::log(M - j);
     auto adj_y_k = arena_y.col(j).val_op().array() - log_N_minus_k;
-    arena_z.col(j).array() = inv_logit(adj_y_k);
-    x_val.col(j).array() = stick_len * arena_z.col(j).array();
+    x_val.col(j).array() = stick_len * inv_logit(adj_y_k).array();
     lp += sum(log(stick_len)) - sum(log1p_exp(-adj_y_k))
           - sum(log1p_exp(adj_y_k));
     stick_len -= x_val.col(j).array();
   }
   x_val.col(M).array() = stick_len;
   arena_t<ret_type> arena_x = x_val;
-  reverse_pass_callback([arena_y, arena_x, arena_z, lp]() mutable {
+  reverse_pass_callback([arena_y, arena_x, lp]() mutable {
     const Eigen::Index M = arena_y.cols();
     auto arena_y_arr = arena_y.array();
     auto arena_x_arr = arena_x.array();
-    auto arena_z_arr = arena_z.array();
     auto stick_len_val = arena_x_arr.col(M).val_op().eval();
     auto stick_len_adj = arena_x_arr.col(M).adj_op().eval();
     for (Eigen::Index k = M; k-- > 0;) {
       const double log_N_minus_k = std::log(M - k);
+      auto adj_y_k = arena_y_arr.col(k).val_op() - log_N_minus_k;
+      auto z_k = inv_logit(adj_y_k).eval();
+
       arena_x_arr.col(k).adj() -= stick_len_adj;
       stick_len_val += arena_x_arr.col(k).val_op();
       stick_len_adj += lp.adj() / stick_len_val
-                       + arena_x_arr.adj_op().col(k) * arena_z_arr.col(k);
-      auto adj_y_k = arena_y_arr.col(k).val_op() - log_N_minus_k;
+                       + arena_x_arr.adj_op().col(k) * z_k;
       arena_y_arr.col(k).adj()
-          += -(lp.adj() * inv_logit(adj_y_k)) + lp.adj() * inv_logit(-adj_y_k)
-             + arena_x_arr.col(k).adj_op() * stick_len_val * arena_z_arr.col(k)
-                   * (1.0 - arena_z_arr.col(k));
+          += -(lp.adj() * z_k) + lp.adj() * inv_logit(-adj_y_k)
+             + arena_x_arr.col(k).adj_op() * stick_len_val * z_k
+                   * (1.0 - z_k);
     }
   });
   return ret_type(arena_x);


### PR DESCRIPTION
## Summary

I was looking at `simplex_constrain`'s rev implementation and realized two things:

1. It duplicates the prim function for the forward pass in order to store the `z`s, but is otherwise the same
2. We are exactly re-computing each `z` in the reverse pass, anyway (at least for the version that takes `lp`)

So, some napkin math, we can save ~20% of the memory overhead of the rev implementation by just not storing these, and simplify the code by delegating the forward pass to prim.

The same is very nearly true for the stochastic matrices, except the forward pass inside the rev specialization is written in a more vectorized style than the prim one is, so it isn't a direct swap. It's still true that we are re-computing something we're also storing, so I still save the memory there, I just don't replace the forward with a call to prim.

If we want, I can move the vectorized stochastic code into prim and then do the other half of the change to rev for those functions as well.

## Tests

Existing tests pass

## Side Effects

None

## Release notes

Reduce the memory overhead of the simplex constraints in reverse mode.

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
