### PR TITLE
Update windows CI to use rtools45

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,11 +45,11 @@ jobs:
       if: runner.os == 'Windows'
       with:
         r-version: 'release'
-        rtools-version: '44'
+        rtools-version: '45'
 
-    - name: Set path for Rtools44
+    - name: Set path for Rtools45
       if: runner.os == 'Windows'
-      run: echo "C:/rtools44/usr/bin;C:/rtools44/x86_64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: echo "C:/rtools45/usr/bin;C:/rtools45/x86_64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
       shell: pwsh
@@ -93,11 +93,11 @@ jobs:
       if: runner.os == 'Windows'
       with:
         r-version: 'release'
-        rtools-version: '44'
+        rtools-version: '45'
 
-    - name: Set path for Rtools44
+    - name: Set path for Rtools45
       if: runner.os == 'Windows'
-      run: echo "C:/rtools44/usr/bin;C:/rtools44/x86_64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: echo "C:/rtools45/usr/bin;C:/rtools45/x86_64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
       shell: pwsh


### PR DESCRIPTION
## Summary

RTools45 is now available in the `setup-r` action, so we can upgrade the CI

## Tests

N/A

## Side Effects

N/A

## Release notes

Update windows CI to use rtools45

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
