### PR TITLE
Fix flaky test on windows 

### DIFF
--- a/test/unit/math/rev/fun/to_var_value_test.cpp
+++ b/test/unit/math/rev/fun/to_var_value_test.cpp
@@ -95,7 +95,7 @@ TEST(AgradRevMatrix, to_var_value_matrix_test) {
   Eigen::MatrixXd val(2, 3);
   val << 1, 2, 3, 4, 5, 6;
   Eigen::MatrixXd adj(2, 3);
-  val << 4, 5, 6, 7, 8, 9;
+  adj << 4, 5, 6, 7, 8, 9;
   Eigen::Matrix<stan::math::var, Eigen::Dynamic, Eigen::Dynamic> mat_var = val;
   stan::math::var_value<Eigen::MatrixXd> var_value
       = stan::math::to_var_value(mat_var);
@@ -109,7 +109,7 @@ TEST(AgradRevMatrix, to_var_value_vector_test) {
   Eigen::VectorXd val(3);
   val << 1, 2, 3;
   Eigen::VectorXd adj(3);
-  val << 7, 8, 9;
+  adj << 7, 8, 9;
   Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1> mat_var = val;
   stan::math::var_value<Eigen::VectorXd> var_value
       = stan::math::to_var_value(mat_var);
@@ -123,7 +123,7 @@ TEST(AgradRevMatrix, to_var_value_row_vector_test) {
   Eigen::RowVectorXd val(3);
   val << 1, 2, 3;
   Eigen::RowVectorXd adj(3);
-  val << 7, 8, 9;
+  adj << 7, 8, 9;
   Eigen::Matrix<stan::math::var, 1, Eigen::Dynamic> mat_var = val;
   stan::math::var_value<Eigen::RowVectorXd> var_value
       = stan::math::to_var_value(mat_var);


### PR DESCRIPTION
## Summary

The test file `test/unit/math/rev/fun/to_var_value_test` has been randomly failing lately. This appears to be due to the test accidentally comparing uninitialised values against each other, which is UB.

## Tests

N/A - existing tests should pass

## Side Effects

N/A

## Release notes

Fix flaky test on Windows

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
