### PR TITLE
Fixed doxygen parameters names

### DIFF
--- a/stan/math/prim/meta/holder.hpp
+++ b/stan/math/prim/meta/holder.hpp
@@ -231,8 +231,8 @@ namespace math {
  * expressions will be deleted.
  * @tparam T type of argument expression
  * @tparam Ptrs types of pointers
- * @param a argument expression
- * @param ptrs pointers to objects the constructed object will own.
+ * @param arg argument expression
+ * @param pointers pointers to objects the constructed object will own.
  * @return holder operation
  */
 template <typename T, typename... Ptrs,


### PR DESCRIPTION
## Summary

Fixes the current codebase failing Doxygen generation due to function parameter names and Doxygen parameter names being different.

## Tests

None.

## Side Effects

None.

## Release notes

Doxygen docs will be correctly generated.

## Checklist

- [x] Copyright holder: myself, tesseract241

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing
For completeness I did run all the listed tests, they passed.

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen
  No code was changed, only comments.
- [x] the new changes are tested
 No code was changed, only comments.