### PR TITLE
Use Windows ARM64 for RTools CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Download and install Rtools45
       if: runner.os == 'Windows'
       run: |
-        $ARCH = if (${{ matrix.os }} == 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
-        $RTOOLS = if (${{ matrix.os }} == 'windows-11-arm') { 'rtools45-$ARCH' } else { 'rtools45' }
+        $ARCH = if ('${{ matrix.os }}' == 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
+        $RTOOLS = if ('${{ matrix.os }}' == 'windows-11-arm') { 'rtools45-$ARCH' } else { 'rtools45' }
         Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile $RTOOLS.exe
         Start-Process -FilePath $RTOOLS.exe -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
         echo "C:/$RTOOLS/usr/bin;C:/$RTOOLS/$ARCH-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,8 +92,8 @@ jobs:
     - name: Download and install Rtools45
       if: runner.os == 'Windows'
       run: |
-        $ARCH = if (${{ matrix.os }} == 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
-        $RTOOLS = if (${{ matrix.os }} == 'windows-11-arm') { 'rtools45-$ARCH' } else { 'rtools45' }
+        $ARCH = if ('${{ matrix.os }}' == 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
+        $RTOOLS = if ('${{ matrix.os }}' == 'windows-11-arm') { 'rtools45-$ARCH' } else { 'rtools45' }
         Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile $RTOOLS.exe
         Start-Process -FilePath $RTOOLS.exe -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
         echo "C:/$RTOOLS/usr/bin;C:/$RTOOLS/$ARCH-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Add TBB to PATH
       if: runner.os == 'Windows'
       shell: pwsh
-      run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: echo "C:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Run ${{ matrix.config.label }} unit tests
       shell: pwsh
@@ -102,7 +102,7 @@ jobs:
     - name: Add TBB to PATH
       if: runner.os == 'Windows'
       shell: pwsh
-      run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: echo "C:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Run mix/fun unit tests
       shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
         Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile "$RTOOLS.exe"
         Start-Process -FilePath "$RTOOLS.exe" -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
         echo "C:/$RTOOLS/usr/bin;C:/$RTOOLS/$ARCH-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        echo "$(pwd)/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
       shell: pwsh
@@ -56,11 +57,6 @@ jobs:
         Add-Content make\local "CPPFLAGS=-w -Wno-psabi -Wno-misleading-indentation`n"
         Add-Content make\local "STAN_THREADS=true`n"
         make -f make/standalone math-libs -j2
-
-    - name: Add TBB to PATH
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: echo "$(pwd)/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Run ${{ matrix.config.label }} unit tests
       shell: pwsh
@@ -97,6 +93,7 @@ jobs:
         Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile "$RTOOLS.exe"
         Start-Process -FilePath "$RTOOLS.exe" -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
         echo "C:/$RTOOLS/usr/bin;C:/$RTOOLS/$ARCH-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        echo "$(pwd)/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
       shell: pwsh
@@ -104,11 +101,6 @@ jobs:
         Add-Content make\local "CPPFLAGS=-w -Wno-psabi -Wno-misleading-indentation`n"
         Add-Content make\local "STAN_THREADS=true`n"
         make -f make/standalone math-libs -j2
-
-    - name: Add TBB to PATH
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: echo "C:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Run mix/fun unit tests
       shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Add TBB to PATH
       if: runner.os == 'Windows'
       shell: pwsh
-      run: echo "C:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: echo "$(pwd)/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Run ${{ matrix.config.label }} unit tests
       shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ develop, master ]
   push:
-    branches: [ develop ]
+    branches: [ develop, winarm64-ci ]
     paths-ignore:
       - 'doygen/**'
       - 'hooks/**'
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-24.04-arm]
+        os: [windows-11-arm]
         config: [
           { label: misc, tests: 'test/unit/*_test.cpp test/unit/math/*_test.cpp test/unit/math/memory' },
           { label: prim, tests: 'test/unit/math/prim' },
@@ -41,15 +41,12 @@ jobs:
       with:
         python-version: '3.x'
 
-    - uses: r-lib/actions/setup-r@v2
+    - name: Download and install Rtools45
       if: runner.os == 'Windows'
-      with:
-        r-version: 'release'
-        rtools-version: '45'
-
-    - name: Set path for Rtools45
-      if: runner.os == 'Windows'
-      run: echo "C:/rtools45/usr/bin;C:/rtools45/x86_64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: |
+        Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/rtools45-aarch64.exe -OutFile rtools45-aarch64.exe
+        Start-Process -FilePath rtools45-aarch64.exe -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
+        echo "C:/rtools45-aarch64/usr/bin;C:/rtools45-aarch64/aarch64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
       shell: pwsh
@@ -80,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-24.04-arm]
+        os: [windows-11-arm]
         group: [1, 2, 3, 4, 5]
 
     steps:
@@ -89,15 +86,12 @@ jobs:
       with:
         python-version: '3.x'
 
-    - uses: r-lib/actions/setup-r@v2
+    - name: Download and install Rtools45
       if: runner.os == 'Windows'
-      with:
-        r-version: 'release'
-        rtools-version: '45'
-
-    - name: Set path for Rtools45
-      if: runner.os == 'Windows'
-      run: echo "C:/rtools45/usr/bin;C:/rtools45/x86_64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: |
+        Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/rtools45-aarch64.exe -OutFile rtools45-aarch64.exe
+        Start-Process -FilePath rtools45-aarch64.exe -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
+        echo "C:/rtools45-aarch64/usr/bin;C:/rtools45-aarch64/aarch64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
       shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-11-arm, ubuntu-24.04-arm]
+        os: [windows-11-arm, windows-latest, ubuntu-24.04-arm]
         config: [
           { label: misc, tests: 'test/unit/*_test.cpp test/unit/math/*_test.cpp test/unit/math/memory' },
           { label: prim, tests: 'test/unit/math/prim' },
@@ -44,9 +44,11 @@ jobs:
     - name: Download and install Rtools45
       if: runner.os == 'Windows'
       run: |
-        Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/rtools45-aarch64.exe -OutFile rtools45-aarch64.exe
-        Start-Process -FilePath rtools45-aarch64.exe -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
-        echo "C:/rtools45-aarch64/usr/bin;C:/rtools45-aarch64/aarch64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        $ARCH = if (${{ matrix.os }} == 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
+        $RTOOLS = if (${{ matrix.os }} == 'windows-11-arm') { 'rtools45-$ARCH' } else { 'rtools45' }
+        Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile $RTOOLS.exe
+        Start-Process -FilePath $RTOOLS.exe -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
+        echo "C:/$RTOOLS/usr/bin;C:/$RTOOLS/$ARCH-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
       shell: pwsh
@@ -78,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-11-arm, ubuntu-24.04-arm]
+        os: [windows-11-arm, windows-latest, ubuntu-24.04-arm]
         group: [1, 2, 3, 4, 5]
 
     steps:
@@ -90,9 +92,11 @@ jobs:
     - name: Download and install Rtools45
       if: runner.os == 'Windows'
       run: |
-        Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/rtools45-aarch64.exe -OutFile rtools45-aarch64.exe
-        Start-Process -FilePath rtools45-aarch64.exe -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
-        echo "C:/rtools45-aarch64/usr/bin;C:/rtools45-aarch64/aarch64-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        $ARCH = if (${{ matrix.os }} == 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
+        $RTOOLS = if (${{ matrix.os }} == 'windows-11-arm') { 'rtools45-$ARCH' } else { 'rtools45' }
+        Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile $RTOOLS.exe
+        Start-Process -FilePath $RTOOLS.exe -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
+        echo "C:/$RTOOLS/usr/bin;C:/$RTOOLS/$ARCH-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
       shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,9 @@ jobs:
       if: runner.os == 'Windows'
       run: |
         $ARCH = if ('${{ matrix.os }}' -eq 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
-        $RTOOLS = if ('${{ matrix.os }}' -eq 'windows-11-arm') { 'rtools45-$ARCH' } else { 'rtools45' }
-        Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile $RTOOLS.exe
-        Start-Process -FilePath $RTOOLS.exe -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
+        $RTOOLS = if ('${{ matrix.os }}' -eq 'windows-11-arm') { "rtools45-$ARCH" } else { 'rtools45' }
+        Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile "$RTOOLS.exe"
+        Start-Process -FilePath "$RTOOLS.exe" -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
         echo "C:/$RTOOLS/usr/bin;C:/$RTOOLS/$ARCH-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs
@@ -93,9 +93,9 @@ jobs:
       if: runner.os == 'Windows'
       run: |
         $ARCH = if ('${{ matrix.os }}' -eq 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
-        $RTOOLS = if ('${{ matrix.os }}' -eq 'windows-11-arm') { 'rtools45-$ARCH' } else { 'rtools45' }
-        Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile $RTOOLS.exe
-        Start-Process -FilePath $RTOOLS.exe -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
+        $RTOOLS = if ('${{ matrix.os }}' -eq 'windows-11-arm') { "rtools45-$ARCH" } else { 'rtools45' }
+        Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile "$RTOOLS.exe"
+        Start-Process -FilePath "$RTOOLS.exe" -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
         echo "C:/$RTOOLS/usr/bin;C:/$RTOOLS/$ARCH-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - name: Build Math libs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
       shell: pwsh
       run: |
         Add-Content make\local "CPPFLAGS=-w -Wno-psabi -Wno-misleading-indentation`n"
+        Add-Content make\local "STAN_THREADS=true`n"
         make -f make/standalone math-libs -j2
 
     - name: Add TBB to PATH
@@ -97,6 +98,7 @@ jobs:
       shell: pwsh
       run: |
         Add-Content make\local "CPPFLAGS=-w -Wno-psabi -Wno-misleading-indentation`n"
+        Add-Content make\local "STAN_THREADS=true`n"
         make -f make/standalone math-libs -j2
 
     - name: Add TBB to PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Download and install Rtools45
       if: runner.os == 'Windows'
       run: |
-        $ARCH = if ('${{ matrix.os }}' == 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
-        $RTOOLS = if ('${{ matrix.os }}' == 'windows-11-arm') { 'rtools45-$ARCH' } else { 'rtools45' }
+        $ARCH = if ('${{ matrix.os }}' -eq 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
+        $RTOOLS = if ('${{ matrix.os }}' -eq 'windows-11-arm') { 'rtools45-$ARCH' } else { 'rtools45' }
         Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile $RTOOLS.exe
         Start-Process -FilePath $RTOOLS.exe -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
         echo "C:/$RTOOLS/usr/bin;C:/$RTOOLS/$ARCH-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
@@ -92,8 +92,8 @@ jobs:
     - name: Download and install Rtools45
       if: runner.os == 'Windows'
       run: |
-        $ARCH = if ('${{ matrix.os }}' == 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
-        $RTOOLS = if ('${{ matrix.os }}' == 'windows-11-arm') { 'rtools45-$ARCH' } else { 'rtools45' }
+        $ARCH = if ('${{ matrix.os }}' -eq 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
+        $RTOOLS = if ('${{ matrix.os }}' -eq 'windows-11-arm') { 'rtools45-$ARCH' } else { 'rtools45' }
         Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile $RTOOLS.exe
         Start-Process -FilePath $RTOOLS.exe -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
         echo "C:/$RTOOLS/usr/bin;C:/$RTOOLS/$ARCH-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ develop, master ]
   push:
-    branches: [ develop, winarm64-ci ]
+    branches: [ develop ]
     paths-ignore:
       - 'doygen/**'
       - 'hooks/**'
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-11-arm]
+        os: [windows-11-arm, ubuntu-24.04-arm]
         config: [
           { label: misc, tests: 'test/unit/*_test.cpp test/unit/math/*_test.cpp test/unit/math/memory' },
           { label: prim, tests: 'test/unit/math/prim' },
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-11-arm]
+        os: [windows-11-arm, ubuntu-24.04-arm]
         group: [1, 2, 3, 4, 5]
 
     steps:


### PR DESCRIPTION
## Summary

Windows ARM runners are now available for public repos, so we can add them to the CI. I've just replaced the existing windows runners, but can also add them separately if we want both x86-64 & arm64 rtools.

The `setup-r` action doesn't support arm64, so I've just added a step to manually install RTools

## Tests
N/A - existing tests should still pass

## Side Effects

N/A

## Release notes

Added Windows ARM64 to the Github CI

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
