### PR TITLE
Fix blocking issues for exposing poisson-binomial in Stan

### DIFF
--- a/stan/math/prim/fun/poisson_binomial_log_probs.hpp
+++ b/stan/math/prim/fun/poisson_binomial_log_probs.hpp
@@ -24,24 +24,24 @@ namespace math {
  */
 template <typename T_theta, typename T_scalar = scalar_type_t<T_theta>,
           require_vector_t<T_theta>* = nullptr>
-Eigen::Matrix<T_scalar, 1, -1>
+Eigen::Matrix<T_scalar, -1, 1>
   poisson_binomial_log_probs(int y, const T_theta& theta) {
   int size_theta = theta.size();
   plain_type_t<T_theta> log_theta = log(theta);
   plain_type_t<T_theta> log1m_theta = log1m(theta);
 
-  Eigen::Matrix<T_scalar, Eigen::Dynamic, Eigen::Dynamic> alpha(size_theta + 1,
-                                                                y + 1);
+  Eigen::Matrix<T_scalar, Eigen::Dynamic, Eigen::Dynamic> alpha(y + 1,
+                                                                size_theta + 1);
 
   // alpha[i, j] = log prob of j successes in first i trials
   alpha(0, 0) = 0.0;
   for (int i = 0; i < size_theta; ++i) {
     // no success in i trials
-    alpha(i + 1, 0) = alpha(i, 0) + log1m_theta[i];
+    alpha(0, i + 1) = alpha(0, i) + log1m_theta[i];
 
     // 0 < j < i successes in i trials
     for (int j = 0; j < std::min(y, i); ++j) {
-      alpha(i + 1, j + 1) = log_mix(theta[i], alpha(i, j), alpha(i, j + 1));
+      alpha(j + 1, i + 1) = log_mix(theta[i], alpha(j, i), alpha(j + 1, i));
     }
 
     // i successes in i trials
@@ -50,7 +50,22 @@ Eigen::Matrix<T_scalar, 1, -1>
     }
   }
 
-  return alpha.row(size_theta);
+  return alpha.col(size_theta);
+}
+
+template <typename T_y, typename T_theta, require_vt_integral<T_y>* = nullptr>
+auto poisson_binomial_log_probs(const T_y& y, const T_theta& theta) {
+  using T_scalar = scalar_type_t<T_theta>;
+  size_t max_sizes = std::max(stan::math::size(y), size_mvt(theta));
+  std::vector<Eigen::Matrix<T_scalar, Eigen::Dynamic, 1>> result(max_sizes);
+  scalar_seq_view<T_y> y_vec(y);
+  vector_seq_view<T_theta> theta_vec(theta);
+
+  for (size_t i = 0; i < max_sizes; ++i) {
+    result[i] = poisson_binomial_log_probs(y_vec[i], theta_vec[i]);
+  }
+
+  return result;
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/poisson_binomial_log_probs.hpp
+++ b/stan/math/prim/fun/poisson_binomial_log_probs.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/log1m.hpp>
 #include <stan/math/prim/fun/log_sum_exp.hpp>
+#include <stan/math/prim/fun/log_mix.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/vector_seq_view.hpp>
 

--- a/stan/math/prim/fun/poisson_binomial_log_probs.hpp
+++ b/stan/math/prim/fun/poisson_binomial_log_probs.hpp
@@ -22,8 +22,9 @@ namespace math {
  * @return the last row of the computed log probability matrix
  */
 template <typename T_theta, typename T_scalar = scalar_type_t<T_theta>,
-          require_eigen_vector_t<T_theta>* = nullptr>
-plain_type_t<T_theta> poisson_binomial_log_probs(int y, const T_theta& theta) {
+          require_vector_t<T_theta>* = nullptr>
+Eigen::Matrix<T_scalar, 1, -1>
+  poisson_binomial_log_probs(int y, const T_theta& theta) {
   int size_theta = theta.size();
   plain_type_t<T_theta> log_theta = log(theta);
   plain_type_t<T_theta> log1m_theta = log1m(theta);
@@ -39,32 +40,16 @@ plain_type_t<T_theta> poisson_binomial_log_probs(int y, const T_theta& theta) {
 
     // 0 < j < i successes in i trials
     for (int j = 0; j < std::min(y, i); ++j) {
-      alpha(i + 1, j + 1) = log_sum_exp(alpha(i, j) + log_theta[i],
-                                        alpha(i, j + 1) + log1m_theta[i]);
+      alpha(i + 1, j + 1) = log_mix(theta[i], alpha(i, j), alpha(i, j + 1));
     }
 
     // i successes in i trials
     if (i < y) {
-      alpha(i + 1, i + 1) = alpha(i, i) + log_theta(i);
+      alpha(i + 1, i + 1) = alpha(i, i) + log_theta[i];
     }
   }
 
   return alpha.row(size_theta);
-}
-
-template <typename T_y, typename T_theta, require_vt_integral<T_y>* = nullptr>
-auto poisson_binomial_log_probs(const T_y& y, const T_theta& theta) {
-  using T_scalar = scalar_type_t<T_theta>;
-  size_t max_sizes = std::max(stan::math::size(y), size_mvt(theta));
-  std::vector<Eigen::Matrix<T_scalar, Eigen::Dynamic, 1>> result(max_sizes);
-  scalar_seq_view<T_y> y_vec(y);
-  vector_seq_view<T_theta> theta_vec(theta);
-
-  for (size_t i = 0; i < max_sizes; ++i) {
-    result[i] = poisson_binomial_log_probs(y_vec[i], theta_vec[i]);
-  }
-
-  return result;
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/poisson_binomial_log_probs.hpp
+++ b/stan/math/prim/fun/poisson_binomial_log_probs.hpp
@@ -24,8 +24,8 @@ namespace math {
  */
 template <typename T_theta, typename T_scalar = scalar_type_t<T_theta>,
           require_vector_t<T_theta>* = nullptr>
-Eigen::Matrix<T_scalar, -1, 1>
-  poisson_binomial_log_probs(int y, const T_theta& theta) {
+Eigen::Matrix<T_scalar, -1, 1> poisson_binomial_log_probs(
+    int y, const T_theta& theta) {
   int size_theta = theta.size();
   plain_type_t<T_theta> log_theta = log(theta);
   plain_type_t<T_theta> log1m_theta = log1m(theta);

--- a/stan/math/prim/fun/size_mvt.hpp
+++ b/stan/math/prim/fun/size_mvt.hpp
@@ -26,6 +26,11 @@ int64_t size_mvt(const ScalarT& /* unused */) {
   throw std::invalid_argument("size_mvt passed to an unrecognized type.");
 }
 
+template <typename ScalarT, require_stan_scalar_t<ScalarT>* = nullptr>
+int64_t size_mvt(const std::vector<ScalarT>& /* unused */) {
+  return 1;
+}
+
 template <typename MatrixT, require_matrix_t<MatrixT>* = nullptr>
 int64_t size_mvt(const MatrixT& /* unused */) {
   return 1;
@@ -33,6 +38,11 @@ int64_t size_mvt(const MatrixT& /* unused */) {
 
 template <typename MatrixT, require_matrix_t<MatrixT>* = nullptr>
 int64_t size_mvt(const std::vector<MatrixT>& x) {
+  return x.size();
+}
+
+template <typename StdVectorT, require_std_vector_t<StdVectorT>* = nullptr>
+int64_t size_mvt(const std::vector<StdVectorT>& x) {
   return x.size();
 }
 

--- a/stan/math/prim/fun/vector_seq_view.hpp
+++ b/stan/math/prim/fun/vector_seq_view.hpp
@@ -6,6 +6,15 @@
 #include <vector>
 
 namespace stan {
+namespace internal {
+template <typename T>
+using is_matrix_or_std_vector
+  = math::disjunction<is_matrix<T>, is_std_vector<T>>;
+
+template <typename T>
+using is_scalar_container = math::conjunction<is_matrix_or_std_vector<T>,
+                                              is_stan_scalar<value_type_t<T>>>;
+}
 
 /**
  * This class provides a low-cost wrapper for situations where you either need
@@ -33,7 +42,7 @@ class vector_seq_view;
  * @tparam T the type of the underlying Vector
  */
 template <typename T>
-class vector_seq_view<T, require_matrix_t<T>> {
+class vector_seq_view<T, require_t<internal::is_scalar_container<T>>> {
  public:
   explicit vector_seq_view(const T& m) : m_(m) {}
   static constexpr auto size() { return 1; }
@@ -46,18 +55,12 @@ class vector_seq_view<T, require_matrix_t<T>> {
 
   template <typename C = T, require_st_autodiff<C>* = nullptr>
   inline auto val(size_t /* i */) const noexcept {
-    return m_.val();
+    return value_of(m_);
   }
 
  private:
   const ref_type_t<T> m_;
 };
-
-namespace internal {
-template <typename T>
-using is_matrix_or_std_vector
-    = math::disjunction<is_matrix<T>, is_std_vector<T>>;
-}
 
 /**
  * This class provides a low-cost wrapper for situations where you either need

--- a/stan/math/prim/fun/vector_seq_view.hpp
+++ b/stan/math/prim/fun/vector_seq_view.hpp
@@ -9,13 +9,13 @@ namespace stan {
 namespace internal {
 template <typename T>
 using is_matrix_or_std_vector
-  = math::disjunction<is_matrix<T>, is_std_vector<T>>;
+    = math::disjunction<is_matrix<T>, is_std_vector<T>>;
 
 template <typename T>
 using is_scalar_container = math::disjunction<
-  is_matrix<T>,
-  math::conjunction<is_std_vector<T>, is_stan_scalar<value_type_t<T>>>>;
-}
+    is_matrix<T>,
+    math::conjunction<is_std_vector<T>, is_stan_scalar<value_type_t<T>>>>;
+}  // namespace internal
 
 /**
  * This class provides a low-cost wrapper for situations where you either need

--- a/stan/math/prim/fun/vector_seq_view.hpp
+++ b/stan/math/prim/fun/vector_seq_view.hpp
@@ -12,8 +12,9 @@ using is_matrix_or_std_vector
   = math::disjunction<is_matrix<T>, is_std_vector<T>>;
 
 template <typename T>
-using is_scalar_container = math::conjunction<is_matrix_or_std_vector<T>,
-                                              is_stan_scalar<value_type_t<T>>>;
+using is_scalar_container = math::disjunction<
+  is_matrix<T>,
+  math::conjunction<is_std_vector<T>, is_stan_scalar<value_type_t<T>>>>;
 }
 
 /**

--- a/stan/math/prim/prob/poisson_binomial_rng.hpp
+++ b/stan/math/prim/prob/poisson_binomial_rng.hpp
@@ -24,14 +24,14 @@ namespace math {
 template <typename T_theta, typename RNG>
 inline int poisson_binomial_rng(const T_theta& theta, RNG& rng) {
   static constexpr const char* function = "poisson_binomial_rng";
-  check_finite(function, "Probability parameters", theta);
-  check_bounded(function, "Probability parameters", value_of(theta), 0.0, 1.0);
   ref_type_t<T_theta> theta_ref = theta;
+  check_finite(function, "Probability parameters", theta_ref);
+  check_bounded(function, "Probability parameters", theta_ref, 0.0, 1.0);
 
   int y = 0;
   for (size_t i = 0; i < theta.size(); ++i) {
     boost::variate_generator<RNG&, boost::bernoulli_distribution<> >
-        bernoulli_rng(rng, boost::bernoulli_distribution<>(theta[i]));
+        bernoulli_rng(rng, boost::bernoulli_distribution<>(theta_ref[i]));
     y += bernoulli_rng();
   }
 

--- a/stan/math/prim/prob/poisson_binomial_rng.hpp
+++ b/stan/math/prim/prob/poisson_binomial_rng.hpp
@@ -21,17 +21,17 @@ namespace math {
  * @return a Poisson binomial distribution random variable
  * @throw std::domain_error if theta is not a valid probability
  */
-template <typename T_theta, typename RNG,
-          require_eigen_vt<std::is_arithmetic, T_theta>* = nullptr>
+template <typename T_theta, typename RNG>
 inline int poisson_binomial_rng(const T_theta& theta, RNG& rng) {
   static constexpr const char* function = "poisson_binomial_rng";
   check_finite(function, "Probability parameters", theta);
   check_bounded(function, "Probability parameters", value_of(theta), 0.0, 1.0);
+  ref_type_t<T_theta> theta_ref = theta;
 
   int y = 0;
   for (size_t i = 0; i < theta.size(); ++i) {
     boost::variate_generator<RNG&, boost::bernoulli_distribution<> >
-        bernoulli_rng(rng, boost::bernoulli_distribution<>(theta(i)));
+        bernoulli_rng(rng, boost::bernoulli_distribution<>(theta[i]));
     y += bernoulli_rng();
   }
 

--- a/test/unit/math/prim/prob/poisson_binomial_test.cpp
+++ b/test/unit/math/prim/prob/poisson_binomial_test.cpp
@@ -6,15 +6,26 @@
 #include <vector>
 
 TEST(ProbDistributionsPoissonBinomial, lpmf_length_0_length_1) {
+  using stan::math::poisson_binomial_lpmf;
+  using stan::math::to_row_vector;
+  using stan::math::to_array_1d;
+
   Eigen::VectorXd v0(0);
   Eigen::VectorXd v1(1);
   v1 << 0.4;
 
-  EXPECT_FLOAT_EQ(stan::math::poisson_binomial_lpmf(0, v0), 0.0);
-  EXPECT_FLOAT_EQ(stan::math::poisson_binomial_lpmf(1, v1), std::log(0.4));
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(0, v0), 0.0);
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(0, to_row_vector(v0)), 0.0);
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(0, to_array_1d(v0)), 0.0);
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(1, v1), std::log(0.4));
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(1, to_row_vector(v1)), std::log(0.4));
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(1, to_array_1d(v1)), std::log(0.4));
 }
-
 TEST(ProbDistributionsPoissonBinomial, lpmf_length_0_length_1_vectorial_y) {
+  using stan::math::poisson_binomial_lpmf;
+  using stan::math::to_row_vector;
+  using stan::math::to_array_1d;
+
   Eigen::VectorXd v0(0);
   Eigen::VectorXd v1(1);
   v1 << 0.4;
@@ -22,8 +33,12 @@ TEST(ProbDistributionsPoissonBinomial, lpmf_length_0_length_1_vectorial_y) {
   std::vector<int> y0{0, 0};
   std::vector<int> y1{1, 1};
 
-  EXPECT_FLOAT_EQ(stan::math::poisson_binomial_lpmf(y0, v0), 0.0);
-  EXPECT_FLOAT_EQ(stan::math::poisson_binomial_lpmf(y1, v1), std::log(0.4) * 2);
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y0, v0), 0.0);
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y0, to_row_vector(v0)), 0.0);
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y0, to_array_1d(v0)), 0.0);
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y1, v1), std::log(0.4) * 2);
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y1, to_row_vector(v1)), std::log(0.4) * 2);
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y1, to_array_1d(v1)), std::log(0.4) * 2);
 }
 
 TEST(ProbDistributionsPoissonBinomial, lpmf_works_on_scalar_arguments) {
@@ -41,6 +56,8 @@ TEST(ProbDistributionsPoissonBinomial, lpmf_works_on_scalar_arguments) {
 
 TEST(ProbDistributionsPoissonBinomial, lpmf_works_on_vectorial_y) {
   using stan::math::poisson_binomial_lpmf;
+  using stan::math::to_row_vector;
+  using stan::math::to_array_1d;
   using vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
 
   vec p(3, 1);
@@ -48,18 +65,26 @@ TEST(ProbDistributionsPoissonBinomial, lpmf_works_on_vectorial_y) {
   std::vector<int> y{2, 2};
 
   EXPECT_NEAR(-0.967584 * 2, poisson_binomial_lpmf(y, p), 1e-6);
+  EXPECT_NEAR(-0.967584 * 2, poisson_binomial_lpmf(y, to_row_vector(p)), 1e-6);
+  EXPECT_NEAR(-0.967584 * 2, poisson_binomial_lpmf(y, to_array_1d(p)), 1e-6);
 }
 
 TEST(ProbDistributionsPoissonBinomial, lpmf_works_on_vectorial_y_and_theta) {
   using stan::math::poisson_binomial_lpmf;
+  using stan::math::to_row_vector;
+  using stan::math::to_array_1d;
   using vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
 
   vec p(3, 1);
   p << 0.5, 0.2, 0.7;
   std::vector<int> y{2, 0};
   std::vector<vec> ps{p, p};
+  std::vector<Eigen::RowVectorXd> ps_rv{to_row_vector(p), to_row_vector(p)};
+  std::vector<std::vector<double>> ps_std{to_array_1d(p), to_array_1d(p)};
 
   EXPECT_NEAR(-0.967584 - 2.12026, poisson_binomial_lpmf(y, ps), 1e-5);
+  EXPECT_NEAR(-0.967584 - 2.12026, poisson_binomial_lpmf(y, ps_rv), 1e-5);
+  EXPECT_NEAR(-0.967584 - 2.12026, poisson_binomial_lpmf(y, ps_std), 1e-5);
 }
 
 TEST(ProbDistributionsPoissonBinomial,

--- a/test/unit/math/prim/prob/poisson_binomial_test.cpp
+++ b/test/unit/math/prim/prob/poisson_binomial_test.cpp
@@ -37,8 +37,10 @@ TEST(ProbDistributionsPoissonBinomial, lpmf_length_0_length_1_vectorial_y) {
   EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y0, to_row_vector(v0)), 0.0);
   EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y0, to_array_1d(v0)), 0.0);
   EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y1, v1), std::log(0.4) * 2);
-  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y1, to_row_vector(v1)), std::log(0.4) * 2);
-  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y1, to_array_1d(v1)), std::log(0.4) * 2);
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y1, to_row_vector(v1)),
+                  std::log(0.4) * 2);
+  EXPECT_FLOAT_EQ(poisson_binomial_lpmf(y1, to_array_1d(v1)),
+                  std::log(0.4) * 2);
 }
 
 TEST(ProbDistributionsPoissonBinomial, lpmf_works_on_scalar_arguments) {

--- a/test/unit/math/prim/prob/poisson_binomial_test.cpp
+++ b/test/unit/math/prim/prob/poisson_binomial_test.cpp
@@ -7,8 +7,8 @@
 
 TEST(ProbDistributionsPoissonBinomial, lpmf_length_0_length_1) {
   using stan::math::poisson_binomial_lpmf;
-  using stan::math::to_row_vector;
   using stan::math::to_array_1d;
+  using stan::math::to_row_vector;
 
   Eigen::VectorXd v0(0);
   Eigen::VectorXd v1(1);
@@ -23,8 +23,8 @@ TEST(ProbDistributionsPoissonBinomial, lpmf_length_0_length_1) {
 }
 TEST(ProbDistributionsPoissonBinomial, lpmf_length_0_length_1_vectorial_y) {
   using stan::math::poisson_binomial_lpmf;
-  using stan::math::to_row_vector;
   using stan::math::to_array_1d;
+  using stan::math::to_row_vector;
 
   Eigen::VectorXd v0(0);
   Eigen::VectorXd v1(1);
@@ -58,8 +58,8 @@ TEST(ProbDistributionsPoissonBinomial, lpmf_works_on_scalar_arguments) {
 
 TEST(ProbDistributionsPoissonBinomial, lpmf_works_on_vectorial_y) {
   using stan::math::poisson_binomial_lpmf;
-  using stan::math::to_row_vector;
   using stan::math::to_array_1d;
+  using stan::math::to_row_vector;
   using vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
 
   vec p(3, 1);
@@ -73,8 +73,8 @@ TEST(ProbDistributionsPoissonBinomial, lpmf_works_on_vectorial_y) {
 
 TEST(ProbDistributionsPoissonBinomial, lpmf_works_on_vectorial_y_and_theta) {
   using stan::math::poisson_binomial_lpmf;
-  using stan::math::to_row_vector;
   using stan::math::to_array_1d;
+  using stan::math::to_row_vector;
   using vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
 
   vec p(3, 1);


### PR DESCRIPTION
## Summary

This PR addresses the issues from #2490 required for exposing `poisson_binomial`  in the language (#618):

  - Supporting `row_vector` and `array[] real` arguments for `theta`
  - `poisson_binomial_rng` fails expression tests

I haven't added support for passing scalar arguments to `theta` (i.e., `int`, `real`) since `theta` is supposed to be a vector of probabilities (similar to `categorical_rng`).

I had to make some minor changes to `size_mvt` and `vector_seq_view` to support `std::vector<double>` arguments, but the other changes are fairly minor

## Tests

Expanded `poisson_binomial` tests to use `row_vector` and `array[] real` types

## Side Effects

N/A

## Release notes

Fixed expression test errors with `poisson_binomial_rng`, added support for row-vector and `std::vector<double>` `theta` arguments for `poisson_binomial`

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
