### PR TITLE
Fix RTools CI hang: Skip installation if Toolchain already present

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,13 +41,20 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Download and install Rtools45
+    - name: Download and Install Rtools45
       if: runner.os == 'Windows'
       run: |
         $ARCH = if ('${{ matrix.os }}' -eq 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
         $RTOOLS = if ('${{ matrix.os }}' -eq 'windows-11-arm') { "rtools45-$ARCH" } else { 'rtools45' }
-        Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile "$RTOOLS.exe"
-        Start-Process -FilePath "$RTOOLS.exe" -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
+
+        # Installation will hang if the toolchain is already installed
+        if (-Not $(Test-Path -Path "C:/$RTOOLS")) {
+          Invoke-WebRequest `
+              -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe `
+              -OutFile "$RTOOLS.exe"
+          Start-Process -FilePath "$RTOOLS.exe" -ArgumentList "/INSTALL /VERYSILENT /SUPPRESSMSGBOXES" -Wait
+        }
+
         echo "C:/$RTOOLS/usr/bin;C:/$RTOOLS/$ARCH-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
         echo "$(pwd)/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
@@ -85,13 +92,20 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Download and install Rtools45
+    - name: Download and Install Rtools45
       if: runner.os == 'Windows'
       run: |
         $ARCH = if ('${{ matrix.os }}' -eq 'windows-11-arm') { 'aarch64' } else { 'x86_64' }
         $RTOOLS = if ('${{ matrix.os }}' -eq 'windows-11-arm') { "rtools45-$ARCH" } else { 'rtools45' }
-        Invoke-WebRequest -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe -OutFile "$RTOOLS.exe"
-        Start-Process -FilePath "$RTOOLS.exe" -ArgumentList "/install /norestart /verysilent /SUPPRESSMSGBOXES" -NoNewWindow -Wait
+
+        # Installation will hang if the toolchain is already installed
+        if (-Not $(Test-Path -Path "C:/$RTOOLS")) {
+          Invoke-WebRequest `
+              -Uri https://github.com/r-hub/rtools45/releases/download/latest/$RTOOLS.exe `
+              -OutFile "$RTOOLS.exe"
+          Start-Process -FilePath "$RTOOLS.exe" -ArgumentList "/INSTALL /VERYSILENT /SUPPRESSMSGBOXES" -Wait
+        }
+
         echo "C:/$RTOOLS/usr/bin;C:/$RTOOLS/$ARCH-w64-mingw32.static.posix/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
         echo "$(pwd)/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 


### PR DESCRIPTION
## Summary
Sorry for breaking the CI for a bit! It looks like the silent installation of rtools hangs if the toolchain is already installed - which is why it was only hanging on the x64 runners

## Tests

N/A - Tests should finish now!

## Side Effects

N/A

## Release notes

Fix rtools installation hanging in CI

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
