### PR TITLE
Add compile_flags.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ lib/boost_*/user-config.jam
 
 # Clang compilation database
 compile_commands.json
+compile_flags.txt
 
 # Visual Studio Project Setup
 .vscode/*


### PR DESCRIPTION
This is a legacy version of the already-ignored `compile_commands.json` that is a bit easier to edit by hand