### PR TITLE
Makefile: Disable Make's implict suffix rules

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -75,8 +75,7 @@ CXX_MINOR := $(word 2,$(subst ., ,$(CXX_VERSION)))
 # this should make Make slightly faster, as well as avoiding some unexpected
 # behavior when there are other files lying around with the same name as
 # Stan models
-# We do need to leave some rules in place for things like googletest to function
-.SUFFIXES: .cc 
+.SUFFIXES:
 
 ################################################################################
 # Set optional compiler flags for performance

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -75,7 +75,7 @@ CXX_MINOR := $(word 2,$(subst ., ,$(CXX_VERSION)))
 # this should make Make slightly faster, as well as avoiding some unexpected
 # behavior when there are other files lying around with the same name as
 # Stan models
-.SUFFIXES:
+.SUFFIXES: .cpp
 
 ################################################################################
 # Set optional compiler flags for performance

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -70,6 +70,13 @@ CXX_VERSION :=  $(shell $(CXX) -dumpfullversion -dumpversion 2>&1)
 CXX_MAJOR := $(word 1,$(subst ., ,$(CXX_VERSION)))
 CXX_MINOR := $(word 2,$(subst ., ,$(CXX_VERSION)))
 
+# disable Make's implicit suffix rules
+# see: https://www.gnu.org/software/make/manual/html_node/Implicit-Rules.html
+# this should make Make slightly faster, as well as avoiding some unexpected
+# behavior when there are other files lying around with the same name as
+# Stan models
+.SUFFIXES:
+
 ################################################################################
 # Set optional compiler flags for performance
 #

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -75,7 +75,8 @@ CXX_MINOR := $(word 2,$(subst ., ,$(CXX_VERSION)))
 # this should make Make slightly faster, as well as avoiding some unexpected
 # behavior when there are other files lying around with the same name as
 # Stan models
-.SUFFIXES:
+# We do need to leave some rules in place for things like googletest to function
+.SUFFIXES: .cc 
 
 ################################################################################
 # Set optional compiler flags for performance

--- a/make/libraries
+++ b/make/libraries
@@ -252,11 +252,8 @@ endif
 ############################################################
 # Google Test:
 #   Build the google test library.
-$(GTEST)/src/gtest-all.o: CXXFLAGS += $(CXXFLAGS_GTEST)
-$(GTEST)/src/gtest-all.o: CPPFLAGS += $(CPPFLAGS_GTEST)
-$(GTEST)/src/gtest-all.o: INC += $(INC_GTEST)
-
-
+$(GTEST)/src/gtest-all.o: $(GTEST)/src/gtest-all.cc
+	$(COMPILE.cpp) -x c++ $(CXXFLAGS_GTEST) $(CPPFLAGS_GTEST) $(INC_GTEST) -o $@ -c $<
 
 ############################################################
 # Clean all libraries


### PR DESCRIPTION
## Summary
These rules can cause some very unintuitive behavior, see: https://www.gnu.org/software/make/manual/html_node/Implicit-Rules.html

Hopefully we aren't relying on them anywhere, I'm counting on Jenkins to tell me if so...

## Tests

None

## Side Effects

None 🤞🏻 

## Release notes

Disabled Make's implicit rules in our Makefiles.

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
