### PR TITLE
update to_ref test to use Eigen::all instead of Eigen::placeholders::all

### DIFF
--- a/test/unit/math/prim/fun/to_ref_test.cpp
+++ b/test/unit/math/prim/fun/to_ref_test.cpp
@@ -25,8 +25,7 @@ TEST(MathMatrix, to_ref_matrix_exprs_tuple) {
 TEST(MathMatrix, to_ref_matrix_views_tuple) {
   Eigen::MatrixXd a = Eigen::MatrixXd::Random(3, 3);
   auto x = std::make_tuple(a.block(0, 0, 1, 1),
-                           a(Eigen::all, std::vector{2, 1, 1}),
-                           a.array());
+                           a(Eigen::all, std::vector{2, 1, 1}), a.array());
   auto x_ref = stan::math::to_ref(x);
   using x_ref_t = decltype(x_ref);
   using stan::test::is_same_tuple_element_v;
@@ -46,8 +45,7 @@ TEST(MathMatrix, to_ref_matrix_views_exprs_tuple) {
   Eigen::MatrixXd a = Eigen::MatrixXd::Random(3, 3);
   auto x = std::make_tuple(
       a.block(0, 0, 1, 1),
-      std::make_tuple(a.block(0, 0, 1, 1),
-                      a(Eigen::all, std::vector{2, 1, 1}),
+      std::make_tuple(a.block(0, 0, 1, 1), a(Eigen::all, std::vector{2, 1, 1}),
                       a.array()),
       std::make_tuple(a * a, a, a.array() * 3),
       a(Eigen::all, std::vector{2, 1, 1}), a.array() * a.array());

--- a/test/unit/math/prim/fun/to_ref_test.cpp
+++ b/test/unit/math/prim/fun/to_ref_test.cpp
@@ -25,7 +25,7 @@ TEST(MathMatrix, to_ref_matrix_exprs_tuple) {
 TEST(MathMatrix, to_ref_matrix_views_tuple) {
   Eigen::MatrixXd a = Eigen::MatrixXd::Random(3, 3);
   auto x = std::make_tuple(a.block(0, 0, 1, 1),
-                           a(Eigen::placeholders::all, std::vector{2, 1, 1}),
+                           a(Eigen::all, std::vector{2, 1, 1}),
                            a.array());
   auto x_ref = stan::math::to_ref(x);
   using x_ref_t = decltype(x_ref);
@@ -47,10 +47,10 @@ TEST(MathMatrix, to_ref_matrix_views_exprs_tuple) {
   auto x = std::make_tuple(
       a.block(0, 0, 1, 1),
       std::make_tuple(a.block(0, 0, 1, 1),
-                      a(Eigen::placeholders::all, std::vector{2, 1, 1}),
+                      a(Eigen::all, std::vector{2, 1, 1}),
                       a.array()),
       std::make_tuple(a * a, a, a.array() * 3),
-      a(Eigen::placeholders::all, std::vector{2, 1, 1}), a.array() * a.array());
+      a(Eigen::all, std::vector{2, 1, 1}), a.array() * a.array());
   auto x_ref = stan::math::to_ref(x);
   using x_ref_t = decltype(x_ref);
   using stan::test::is_same_tuple_element_v;
@@ -99,11 +99,11 @@ TEST(MathMatrix, to_ref_matrix_views_exprs_moves_tuple) {
       a.block(0, 0, 1, 1),
       std::forward_as_tuple(
           a.block(0, 0, 1, 1),
-          a(Eigen::placeholders::all,
+          a(Eigen::all,
             std::vector{Eigen::Index{2}, Eigen::Index{1}, Eigen::Index{1}}),
           a.array()),
       std::forward_as_tuple(a * a, a, a.array() * 3),
-      a(Eigen::placeholders::all,
+      a(Eigen::all,
         std::vector{Eigen::Index{2}, Eigen::Index{1}, Eigen::Index{1}}),
       a.array() * a.array()));
   using x_ref_t = decltype(x_ref);


### PR DESCRIPTION
## Summary
 
Develop uses `-Werror` and eigen deprecated `Eigen::placeholders:all` for `Eigen::all`. So this just changes those.

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
