### PR TITLE
Add line numbers to a few errors that we ask users to report

### DIFF
--- a/stan/math/prim/meta/forward_as.hpp
+++ b/stan/math/prim/meta/forward_as.hpp
@@ -59,7 +59,10 @@ template <typename T_desired, typename T_actual,
               !std::is_same<std::decay<T_actual>, std::decay<T_desired>>::value
               && (!is_eigen<T_desired>::value || !is_eigen<T_actual>::value)>>
 inline T_desired forward_as(const T_actual& a) {
-  throw std::runtime_error("Wrong type assumed! Please file a bug report.");
+  throw std::runtime_error(
+      "Wrong type assumed! Please file a bug report. prim/meta/forward_as.hpp "
+      "line "
+      + std::to_string(__LINE__));
 }
 
 /** \ingroup type_trait
@@ -120,7 +123,10 @@ template <
             T_desired::ColsAtCompileTime,
             std::decay_t<T_actual>::ColsAtCompileTime)>* = nullptr>
 inline T_desired forward_as(const T_actual& a) {
-  throw std::runtime_error("Wrong type assumed! Please file a bug report.");
+  throw std::runtime_error(
+      "Wrong type assumed! Please file a bug report. prim/meta/forward_as.hpp "
+      "line "
+      + std::to_string(__LINE__));
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/adjoint_of.hpp
+++ b/stan/math/rev/fun/adjoint_of.hpp
@@ -16,13 +16,15 @@ struct nonexisting_adjoint {
   nonexisting_adjoint operator+=(T) const {
     throw std::runtime_error(
         "internal::nonexisting_adjoint::operator+= should never be called! "
-        "Please file a bug report.");
+        "Please file a bug report. rev/fun/adjoint_of.hpp line "
+        + std::to_string(__LINE__));
   }
   template <typename T>
   nonexisting_adjoint operator-=(T) const {
     throw std::runtime_error(
         "internal::nonexisting_adjoint::operator-= should never be called! "
-        "Please file a bug report.");
+        "Please file a bug report. rev/fun/adjoint_of.hpp line "
+        + std::to_string(__LINE__));
   }
 };
 }  // namespace internal


### PR DESCRIPTION
## Summary

@avehtari reported on slack that he had one of these errors raise on a model. I've not yet been able to re-create locally, but it would be nice to have a bit more information in the error if a user does run into it.

## Tests

## Side Effects


## Release notes

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
