### PR TITLE
Allow forward_as to convert integers to doubles

### DIFF
--- a/stan/math/prim/meta/forward_as.hpp
+++ b/stan/math/prim/meta/forward_as.hpp
@@ -54,12 +54,13 @@ inline T_actual&& forward_as(T_actual&& a) {  // NOLINT
  * @return nothing, this always throws
  * @throw always throws std::runtime_error
  */
-template <typename T_desired, typename T_actual,
-          require_any_not_eigen_t<T_desired, T_actual>* = nullptr,
-          typename = std::enable_if_t<
-              !std::is_same<std::decay<T_actual>, std::decay<T_desired>>::value
-              && !(std::is_arithmetic_v<std::decay_t<T_desired>>
-                   && std::is_arithmetic_v<std::decay_t<T_actual>>)>>
+template <
+    typename T_desired, typename T_actual,
+    require_any_not_eigen_t<T_desired, T_actual>* = nullptr,
+    typename = std::enable_if_t<
+        !std::is_same<std::decay<T_actual>, std::decay<T_desired>>::value
+        && !(std::is_arithmetic_v<std::decay_t<
+                 T_desired>> && std::is_arithmetic_v<std::decay_t<T_actual>>)>>
 inline T_desired forward_as(const T_actual& a) {
   throw std::runtime_error("Wrong type assumed! Please file a bug report.");
 }
@@ -79,11 +80,13 @@ inline T_desired forward_as(const T_actual& a) {
  * @param a input value
  * @return a
  */
-template <typename T_desired, typename T_actual,
-          typename = std::enable_if_t<
-              !std::is_same_v<std::decay_t<T_actual>, std::decay_t<T_desired>>
-              && std::is_arithmetic_v<std::decay_t<T_desired>>
-              && std::is_arithmetic_v<std::decay_t<T_actual>>>>
+template <
+    typename T_desired, typename T_actual,
+    typename = std::enable_if_t<
+        !std::is_same_v<
+            std::decay_t<T_actual>,
+            std::decay_t<
+                T_desired>> && std::is_arithmetic_v<std::decay_t<T_desired>> && std::is_arithmetic_v<std::decay_t<T_actual>>>>
 inline T_desired forward_as(const T_actual& a) {
   return static_cast<T_desired>(a);
 }

--- a/stan/math/prim/meta/forward_as.hpp
+++ b/stan/math/prim/meta/forward_as.hpp
@@ -54,12 +54,13 @@ inline T_actual&& forward_as(T_actual&& a) {  // NOLINT
  * @return nothing, this always throws
  * @throw always throws std::runtime_error
  */
-template <typename T_desired, typename T_actual,
-          require_any_not_eigen_t<T_desired, T_actual>* = nullptr,
-          typename = std::enable_if_t<
-              !std::is_same<std::decay<T_actual>, std::decay<T_desired>>::value
-              && !(std::is_floating_point_v<std::decay_t<T_desired>>
-                   && std::is_integral_v<std::decay_t<T_actual>>)>>
+template <
+    typename T_desired, typename T_actual,
+    require_any_not_eigen_t<T_desired, T_actual>* = nullptr,
+    typename = std::enable_if_t<
+        !std::is_same<std::decay<T_actual>, std::decay<T_desired>>::value
+        && !(std::is_floating_point_v<std::decay_t<
+                 T_desired>> && std::is_integral_v<std::decay_t<T_actual>>)>>
 inline T_desired forward_as(const T_actual& a) {
   throw std::runtime_error("Wrong type assumed! Please file a bug report.");
 }
@@ -80,9 +81,9 @@ inline T_desired forward_as(const T_actual& a) {
  * @return a
  */
 template <typename T_desired, typename T_actual,
-          typename
-          = std::enable_if_t<std::is_floating_point_v<std::decay_t<T_desired>>
-                             && std::is_integral_v<std::decay_t<T_actual>>>>
+          typename = std::enable_if_t<
+              std::is_floating_point_v<std::decay_t<
+                  T_desired>> && std::is_integral_v<std::decay_t<T_actual>>>>
 inline T_desired forward_as(const T_actual& a) {
   return static_cast<T_desired>(a);
 }

--- a/stan/math/prim/meta/forward_as.hpp
+++ b/stan/math/prim/meta/forward_as.hpp
@@ -55,11 +55,37 @@ inline T_actual&& forward_as(T_actual&& a) {  // NOLINT
  * @throw always throws std::runtime_error
  */
 template <typename T_desired, typename T_actual,
+          require_any_not_eigen_t<T_desired, T_actual>* = nullptr,
           typename = std::enable_if_t<
               !std::is_same<std::decay<T_actual>, std::decay<T_desired>>::value
-              && (!is_eigen<T_desired>::value || !is_eigen<T_actual>::value)>>
+              && !(std::is_arithmetic_v<std::decay_t<T_desired>>
+                   && std::is_arithmetic_v<std::decay_t<T_actual>>)>>
 inline T_desired forward_as(const T_actual& a) {
   throw std::runtime_error("Wrong type assumed! Please file a bug report.");
+}
+
+/** \ingroup type_trait
+ * Assume which type we get. If actual type is not convertible to assumed type
+ * or in case of eigen types compile time rows and columns are not the same and
+ * desired sizes are not dynamic this has return type of \c T_desired, but it
+ * only throws. This version should only be used where it is optimized away so
+ * the throw should never happen.
+ *
+ * This handles the edge case where both types are simple arithmetic types
+ * and we would like to just convert one to another.
+ *
+ * @tparam T_desired type of output we need to avoid compile time errors
+ * @tparam T_actual actual type of the argument
+ * @param a input value
+ * @return a
+ */
+template <typename T_desired, typename T_actual,
+          typename = std::enable_if_t<
+              !std::is_same_v<std::decay_t<T_actual>, std::decay_t<T_desired>>
+              && std::is_arithmetic_v<std::decay_t<T_desired>>
+              && std::is_arithmetic_v<std::decay_t<T_actual>>>>
+inline T_desired forward_as(const T_actual& a) {
+  return static_cast<T_desired>(a);
 }
 
 /** \ingroup type_trait

--- a/stan/math/prim/meta/forward_as.hpp
+++ b/stan/math/prim/meta/forward_as.hpp
@@ -54,13 +54,12 @@ inline T_actual&& forward_as(T_actual&& a) {  // NOLINT
  * @return nothing, this always throws
  * @throw always throws std::runtime_error
  */
-template <
-    typename T_desired, typename T_actual,
-    require_any_not_eigen_t<T_desired, T_actual>* = nullptr,
-    typename = std::enable_if_t<
-        !std::is_same<std::decay<T_actual>, std::decay<T_desired>>::value
-        && !(std::is_arithmetic_v<std::decay_t<
-                 T_desired>> && std::is_arithmetic_v<std::decay_t<T_actual>>)>>
+template <typename T_desired, typename T_actual,
+          require_any_not_eigen_t<T_desired, T_actual>* = nullptr,
+          typename = std::enable_if_t<
+              !std::is_same<std::decay<T_actual>, std::decay<T_desired>>::value
+              && !(std::is_floating_point_v<std::decay_t<T_desired>>
+                   && std::is_integral_v<std::decay_t<T_actual>>)>>
 inline T_desired forward_as(const T_actual& a) {
   throw std::runtime_error("Wrong type assumed! Please file a bug report.");
 }
@@ -80,13 +79,10 @@ inline T_desired forward_as(const T_actual& a) {
  * @param a input value
  * @return a
  */
-template <
-    typename T_desired, typename T_actual,
-    typename = std::enable_if_t<
-        !std::is_same_v<
-            std::decay_t<T_actual>,
-            std::decay_t<
-                T_desired>> && std::is_arithmetic_v<std::decay_t<T_desired>> && std::is_arithmetic_v<std::decay_t<T_actual>>>>
+template <typename T_desired, typename T_actual,
+          typename
+          = std::enable_if_t<std::is_floating_point_v<std::decay_t<T_desired>>
+                             && std::is_integral_v<std::decay_t<T_actual>>>>
 inline T_desired forward_as(const T_actual& a) {
   return static_cast<T_desired>(a);
 }

--- a/test/unit/math/prim/meta/forward_as_test.cpp
+++ b/test/unit/math/prim/meta/forward_as_test.cpp
@@ -9,5 +9,5 @@ TEST(MathMetaPrim, ForwardAsScalar) {
 
   EXPECT_NO_THROW(forward_as<int>(a) = 2);
   EXPECT_EQ(a, 2);
-  EXPECT_THROW(forward_as<double>(a), std::runtime_error);
+  EXPECT_FLOAT_EQ(forward_as<double>(a), 2.0);
 }

--- a/test/unit/math/rev/prob/normal_id_glm_lpdf_test.cpp
+++ b/test/unit/math/rev/prob/normal_id_glm_lpdf_test.cpp
@@ -745,3 +745,23 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_error_checking) {
   EXPECT_THROW(stan::math::normal_id_glm_lpdf(y, x, alpha, beta, sigmaw3),
                std::domain_error);
 }
+
+TEST(ProbDistributionsNormalIdGLM, glm_type_issue_3189) {
+  // regression test for https://github.com/stan-dev/math/issues/3189
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::var;
+  int J = 3;
+  int K = 2;
+
+  Eigen::Matrix<double, -1, -1> x(J, K);
+  x << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+  Eigen::Matrix<stan::math::var, -1, 1> y(J);
+  y << 0.1, 0.2, 0.3;
+  Eigen::Matrix<stan::math::var, -1, 1> beta(K);
+  beta << 0.5, 0.6;
+
+  EXPECT_FLOAT_EQ(stan::math::normal_id_glm_lpdf<false>(y, x, 0, beta, 1).val(),
+                  -27.701815);
+}


### PR DESCRIPTION
## Summary
Closes #3189. 

Note that we will probably want to eventually remove this function (#3190), but for now this fixes the bug with `normal_id_glm_lpdf`.

## Tests

Added the reproducer from #3189 as a test

## Side Effects
None?
## Release notes

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
