### PR TITLE
Remove some usages of uninitialized memory in constraint tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ import org.stan.Utils
 
 def runTests(String testPath, boolean jumbo = false) {
     try {
+        sh "echo CXXFLAGS += -DEIGEN_INITIALIZE_MATRICES_BY_NAN >> make/local"
         sh "cat make/local"
         sh "make print-compiler-flags"
         if (jumbo && !params.disableJumbo) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ import org.stan.Utils
 
 def runTests(String testPath, boolean jumbo = false) {
     try {
-        sh "echo CXXFLAGS += -DEIGEN_INITIALIZE_MATRICES_BY_NAN >> make/local"
         sh "cat make/local"
         sh "make print-compiler-flags"
         if (jumbo && !params.disableJumbo) {

--- a/test/unit/math/prim/constraint/lb_transform_test.cpp
+++ b/test/unit/math/prim/constraint/lb_transform_test.cpp
@@ -37,6 +37,7 @@ TEST(prob_transform, lb_constrain_matrix) {
   double lbd = 2.0;
 
   Eigen::VectorXd lb_bad(3);
+  lb_bad << 1.0, 2.0, 3.0;
 
   // matrix, real
   {
@@ -93,6 +94,7 @@ TEST(prob_transform, lb_constrain_std_vector) {
   double lbd = 2.0;
 
   Eigen::VectorXd lb_bad(3);
+  lb_bad << 1.0, 2.0, 3.0;
 
   std::vector<Eigen::VectorXd> x_vec = {x, x};
   std::vector<Eigen::VectorXd> lb_vec = {lb, lb2};

--- a/test/unit/math/prim/constraint/lb_transform_test.cpp
+++ b/test/unit/math/prim/constraint/lb_transform_test.cpp
@@ -90,7 +90,7 @@ TEST(prob_transform, lb_constrain_std_vector) {
   Eigen::VectorXd lb(2);
   lb << 2.0, stan::math::NEGATIVE_INFTY;
   Eigen::VectorXd lb2(2);
-  lb << stan::math::NEGATIVE_INFTY, 1.0;
+  lb2 << stan::math::NEGATIVE_INFTY, 1.0;
   double lbd = 2.0;
 
   Eigen::VectorXd lb_bad(3);

--- a/test/unit/math/prim/constraint/lub_transform_test.cpp
+++ b/test/unit/math/prim/constraint/lub_transform_test.cpp
@@ -134,7 +134,10 @@ TEST(prob_transform, lub_constrain_matrix) {
   double lbd = -2.0;
 
   Eigen::VectorXd ub_bad(3);
+  ub_bad << 1.0, 2.0, 3.0;
+
   Eigen::VectorXd lb_bad(3);
+  lb_bad << -1.0, -2.0, -3.0;
 
   // matrix, real, real
   {
@@ -330,7 +333,9 @@ TEST(prob_transform, lub_constrain_stdvec_matrix) {
   double lbd = -2.0;
 
   Eigen::VectorXd ub_bad(3);
+  ub_bad << 1.0, 2.0, 3.0;
   Eigen::VectorXd lb_bad(3);
+  lb_bad << -1.0, -2.0, -3.0;
 
   std::vector<Eigen::VectorXd> x_vec{x, x};
   std::vector<Eigen::VectorXd> ub_vec{ub, ub};

--- a/test/unit/math/prim/constraint/ub_transform_test.cpp
+++ b/test/unit/math/prim/constraint/ub_transform_test.cpp
@@ -37,6 +37,7 @@ TEST(prob_transform, ub_constrain_matrix) {
   double ubd = 2.0;
 
   Eigen::VectorXd ub_bad(3);
+  ub_bad << 1.0, 2.0, 3.0;
 
   // matrix, real
   {
@@ -94,6 +95,7 @@ TEST(prob_transform, ub_constrain_std_vector) {
   double ubd = 2.0;
 
   Eigen::VectorXd ub_bad(3);
+  ub_bad << 1.0, 2.0, 3.0;
 
   std::vector<Eigen::VectorXd> x_vec = {x, 2 * x};
   std::vector<Eigen::VectorXd> ub_vec = {ub, ub2};

--- a/test/unit/math/prim/fun/fma_test.cpp
+++ b/test/unit/math/prim/fun/fma_test.cpp
@@ -54,7 +54,7 @@ TEST(MathFunctions, fma_matrix) {
   Eigen::RowVectorXd y_rowvec(2);
   y_rowvec << 2.0, -3.0;
   Eigen::MatrixXd y_mat(2, 2);
-  x_mat << 1.0, 2.0, -1.0, 1.1;
+  y_mat << 1.0, 2.0, -1.0, 1.1;
 
   double z_scalar = 3.0;
   Eigen::VectorXd z_vec(2);
@@ -62,7 +62,7 @@ TEST(MathFunctions, fma_matrix) {
   Eigen::RowVectorXd z_rowvec(2);
   z_rowvec << -3.0, 4.0;
   Eigen::MatrixXd zm(2, 2);
-  x_mat << 3.0, 4.0, -1.0, 1.1;
+  zm << 3.0, 4.0, -1.0, 1.1;
 
   EXPECT_MATRIX_EQ(add(elt_multiply(x_scalar, y_scalar), z_vec),
                    fma(x_scalar, y_scalar, z_vec));

--- a/test/unit/math/prim/fun/get_base1_lhs_test.cpp
+++ b/test/unit/math/prim/fun/get_base1_lhs_test.cpp
@@ -7,6 +7,8 @@ TEST(MathMatrixPrimMat, get_base1_lhs_failing_in_26) {
   using Eigen::Matrix;
   using stan::math::get_base1_lhs;
   Matrix<double, Dynamic, Dynamic> y(2, 3);
+  y << 1, 2, 3, 4, 5, 6;
+
   EXPECT_THROW(get_base1_lhs(y, 3, 1, "y", 2), std::exception);
   EXPECT_THROW(get_base1_lhs(y, 1, 4, "y", 2), std::exception);
   for (int i = 1; i <= 2; ++i)

--- a/test/unit/math/prim/prob/multi_normal_prec_rng_test.cpp
+++ b/test/unit/math/prim/prob/multi_normal_prec_rng_test.cpp
@@ -14,6 +14,7 @@ TEST(ProbDistributionsMultiNormalPrec, vectorized) {
   Eigen::RowVectorXd mu_t(3);
   std::vector<Eigen::VectorXd> vec_mu(2);
   std::vector<Eigen::RowVectorXd> vec_mu_t(2);
+  mu << -1.0, 2.0, 4.0;
   vec_mu[0] = mu;
   vec_mu_t[0] = mu;
   mu << 2.0, -1.0, 4.0;

--- a/test/unit/math/rev/fun/scalar_seq_view_test.cpp
+++ b/test/unit/math/rev/fun/scalar_seq_view_test.cpp
@@ -82,28 +82,28 @@ void expect_scalar_seq_view_adjoints(const C& v) {
 
 TEST(MathMetaRev, ScalarSeqViewVectorVar) {
   using stan::math::var;
-  Eigen::Matrix<var, -1, 1> A = Eigen::VectorXd(4);
+  Eigen::Matrix<var, -1, 1> A = Eigen::VectorXd::Ones(4);
   expect_scalar_seq_view_value(A);
   expect_scalar_seq_view_adjoints(A);
 }
 
 TEST(MathMetaRev, ScalarSeqViewRowVectorVar) {
   using stan::math::var;
-  Eigen::Matrix<var, 1, -1> A = Eigen::RowVectorXd(4);
+  Eigen::Matrix<var, 1, -1> A = Eigen::RowVectorXd::Ones(4);
   expect_scalar_seq_view_value(A);
   expect_scalar_seq_view_adjoints(A);
 }
 
 TEST(MathMetaRev, VarScalarSeqViewVector) {
   using stan::math::var_value;
-  var_value<Eigen::Matrix<double, -1, 1>> A = Eigen::VectorXd(4);
+  var_value<Eigen::Matrix<double, -1, 1>> A = Eigen::VectorXd::Ones(4);
   expect_scalar_seq_view_value(A);
   expect_scalar_seq_view_adjoints(A);
 }
 
 TEST(MathMetaRev, VarScalarSeqViewRowVector) {
   using stan::math::var_value;
-  var_value<Eigen::Matrix<double, 1, -1>> A = Eigen::RowVectorXd(4);
+  var_value<Eigen::Matrix<double, 1, -1>> A = Eigen::RowVectorXd::Ones(4);
   expect_scalar_seq_view_value(A);
   expect_scalar_seq_view_adjoints(A);
 }


### PR DESCRIPTION
## Summary

We've been getting sporadic failures on our Windows tests and I believe it is because these variables are uninitialized. The specific thing being tested is that objects of the wrong size lead to errors, so initializing them doesn't nullify the test. 


## Tests


## Side Effects


## Release notes


## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
