### PR TITLE
bugfix: removing includes to files in the test directory

### DIFF
--- a/stan/math/mix/functor/laplace_marginal_density.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_MIX_FUNCTOR_LAPLACE_MARGINAL_DENSITY_HPP
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/mix/functor/laplace_likelihood.hpp>
-#include <test/unit/pretty_print_types.hpp>
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/fun.hpp>

--- a/stan/math/prim/fun/promote_scalar.hpp
+++ b/stan/math/prim/fun/promote_scalar.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/functor/apply.hpp>
-#include <test/unit/pretty_print_types.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <vector>
 #include <tuple>


### PR DESCRIPTION
## Summary

Two source files include files from the `test/` directory. This causes compilation failures in StanHeaders because the test directory is not included.

From inspection, it looks like the includes can be removed safely.

## Tests

No new tests.


## Side Effects

None.

## Release notes

Fixes an include problem for StanHeaders

## Checklist

- [x] Copyright holder: Daniel Lee

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
