### PR TITLE
Replace exception with static_assert in promote_scalar else branch

### DIFF
--- a/stan/math/mix/functor/laplace_marginal_density.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density.hpp
@@ -314,7 +314,9 @@ inline void set_zero_adjoint(Output&& output) {
             static_assert(
                 sizeof(std::decay_t<output_i_t>*) == 0,
                 "INTERNAL ERROR:(laplace_marginal_lpdf) set_zero_adjoints was "
-                "not able to deduce the actions needed for the given type.");
+                "not able to deduce the actions needed for the given type. "
+                "This is an internal error, please report it: "
+                "https://github.com/stan-dev/math/issues");
           }
         },
         std::forward<Output>(output));
@@ -359,7 +361,9 @@ inline void collect_adjoints(Output& output, Input&& input) {
           static_assert(
               sizeof(std::decay_t<output_i_t>*) == 0,
               "INTERNAL ERROR:(laplace_marginal_lpdf) set_zero_adjoints was "
-              "not able to deduce the actions needed for the given type.");
+              "not able to deduce the actions needed for the given type. "
+              "This is an internal error, please report it: "
+              "https://github.com/stan-dev/math/issues");
         }
       },
       std::forward<Output>(output), std::forward<Input>(input));
@@ -813,7 +817,9 @@ inline void collect_adjoints(Output&& output, Input&& input) {
           static_assert(
               sizeof(std::decay_t<output_i_t>*) == 0,
               "INTERNAL ERROR:(laplace_marginal_lpdf) set_zero_adjoints was "
-              "not able to deduce the actions needed for the given type.");
+              "not able to deduce the actions needed for the given type. "
+              "This is an internal error, please report it: "
+              "https://github.com/stan-dev/math/issues");
         }
       },
       std::forward<Output>(output), std::forward<Input>(input));
@@ -863,7 +869,9 @@ inline void copy_compute_s2(Output&& output, Input&& input) {
           static_assert(
               sizeof(std::decay_t<output_i_t>*) == 0,
               "INTERNAL ERROR:(laplace_marginal_lpdf) set_zero_adjoints was "
-              "not able to deduce the actions needed for the given type.");
+              "not able to deduce the actions needed for the given type. "
+              "This is an internal error, please report it: "
+              "https://github.com/stan-dev/math/issues");
         }
       },
       std::forward<Output>(output), std::forward<Input>(input));
@@ -920,11 +928,11 @@ template <typename Output, typename Input>
 inline void collect_adjoints(Output&& output, const vari* ret, Input&& input) {
   if constexpr (is_tuple_v<Output>) {
     static_assert(sizeof(std::decay_t<Output>*) == 0,
-                  "INTERNAL ERROR:(laplace_marginal_lpdf)"
+                  "INTERNAL ERROR:(laplace_marginal_lpdf) "
                   "Accumulate Adjoints called on a tuple, but tuples cannot be "
-                  "on the reverse mode stack!"
-                  "This is an internal error, please report it to the stan "
-                  "github as an issue.");
+                  "on the reverse mode stack! "
+                  "This is an internal error, please report it: "
+                  "https://github.com/stan-dev/math/issues");
   } else if constexpr (is_std_vector_v<Output>) {
     if constexpr (!is_var_v<value_type_t<Output>>) {
       const auto output_size = output.size();

--- a/stan/math/prim/fun/promote_scalar.hpp
+++ b/stan/math/prim/fun/promote_scalar.hpp
@@ -45,9 +45,10 @@ inline constexpr auto promote_scalar(UnPromotedTypes&& x) {
     return PromotionScalars(std::forward<UnPromotedTypes>(x));
   } else {
     static_assert(sizeof(std::decay_t<UnPromotedTypes>*) == 0,
-                  "promote_scalar: Unrecognized type for promotion. "
-                  "This is an internal error, please report it to the stan "
-                  "github as an issue.");
+                  "INTERNAL ERROR:(promote_scalar) "
+                  "Unrecognized type for promotion. "
+                  "This is an internal error, please report it: "
+                  "https://github.com/stan-dev/math/issues");
   }
 }
 

--- a/stan/math/prim/fun/promote_scalar.hpp
+++ b/stan/math/prim/fun/promote_scalar.hpp
@@ -44,9 +44,10 @@ inline constexpr auto promote_scalar(UnPromotedTypes&& x) {
   } else if constexpr (is_stan_scalar_v<UnPromotedTypes>) {
     return PromotionScalars(std::forward<UnPromotedTypes>(x));
   } else {
-    throw std::domain_error(
-        "promote_scalar: "
-        "Unrecognized type for promotion");
+    static_assert(sizeof(std::decay_t<UnPromotedTypes>*) == 0,
+                  "promote_scalar: Unrecognized type for promotion. "
+                  "This is an internal error, please report it to the stan "
+                  "github as an issue.");
   }
 }
 

--- a/test/unit/math/laplace/laplace_utility.hpp
+++ b/test/unit/math/laplace/laplace_utility.hpp
@@ -252,7 +252,9 @@ inline void print_adjoint(Output&& output) {
   } else {
     static_assert(sizeof(Output*) == 0,
                   "INTERNAL ERROR:(laplace_marginal_lpdf) print_adjoint was "
-                  "not able to deduce the actiopns needed for the given type.");
+                  "not able to deduce the actiopns needed for the given type. "
+                  "This is an internal error, please report it: "
+                  "https://github.com/stan-dev/math/issues");
   }
 }
 


### PR DESCRIPTION
## Summary

This was changed in the laplace PR but it is certainly a bug we should catch at compile time if this function gets called with types that aren't supported. 

## Tests


## Side Effects


## Release notes


## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
