### PR TITLE
 Update templating inside cholesky_decompose 

### DIFF
--- a/stan/math/prim/fun/cholesky_decompose.hpp
+++ b/stan/math/prim/fun/cholesky_decompose.hpp
@@ -1,11 +1,9 @@
 #ifndef STAN_MATH_PRIM_FUN_CHOLESKY_DECOMPOSE_HPP
 #define STAN_MATH_PRIM_FUN_CHOLESKY_DECOMPOSE_HPP
 
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
-#include <stan/math/prim/fun/Eigen.hpp>
-
-#include <cmath>
 
 namespace stan {
 namespace math {
@@ -31,12 +29,11 @@ template <typename EigMat, require_eigen_t<EigMat>* = nullptr,
 inline Eigen::Matrix<value_type_t<EigMat>, EigMat::RowsAtCompileTime,
                      EigMat::ColsAtCompileTime>
 cholesky_decompose(const EigMat& m) {
-  const eval_return_type_t<EigMat>& m_eval = m.eval();
+  using PlainMat = plain_type_t<EigMat>;
+  PlainMat m_eval = m;
   check_symmetric("cholesky_decompose", "m", m_eval);
   check_not_nan("cholesky_decompose", "m", m_eval);
-  Eigen::LLT<Eigen::Matrix<value_type_t<EigMat>, EigMat::RowsAtCompileTime,
-                           EigMat::ColsAtCompileTime>>
-      llt = m_eval.llt();
+  Eigen::LLT<PlainMat> llt = m_eval.llt();
   check_pos_definite("cholesky_decompose", "m", llt);
   return llt.matrixL();
 }

--- a/stan/math/prim/fun/cholesky_decompose.hpp
+++ b/stan/math/prim/fun/cholesky_decompose.hpp
@@ -1,9 +1,11 @@
 #ifndef STAN_MATH_PRIM_FUN_CHOLESKY_DECOMPOSE_HPP
 #define STAN_MATH_PRIM_FUN_CHOLESKY_DECOMPOSE_HPP
 
-#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+
+#include <cmath>
 
 namespace stan {
 namespace math {
@@ -26,14 +28,11 @@ namespace math {
  */
 template <typename EigMat, require_eigen_t<EigMat>* = nullptr,
           require_not_eigen_vt<is_var, EigMat>* = nullptr>
-inline Eigen::Matrix<value_type_t<EigMat>, EigMat::RowsAtCompileTime,
-                     EigMat::ColsAtCompileTime>
-cholesky_decompose(const EigMat& m) {
-  using PlainMat = plain_type_t<EigMat>;
-  PlainMat m_eval = m;
+inline plain_type_t<EigMat> cholesky_decompose(const EigMat& m) {
+  auto&& m_eval = to_ref(m);
   check_symmetric("cholesky_decompose", "m", m_eval);
   check_not_nan("cholesky_decompose", "m", m_eval);
-  Eigen::LLT<PlainMat> llt = m_eval.llt();
+  Eigen::LLT<plain_type_t<EigMat>> llt = m_eval.llt();
   check_pos_definite("cholesky_decompose", "m", llt);
   return llt.matrixL();
 }

--- a/test/unit/math/prim/fun/cholesky_decompose_test.cpp
+++ b/test/unit/math/prim/fun/cholesky_decompose_test.cpp
@@ -35,3 +35,18 @@ TEST(MathMatrixPrimMat, cholesky_decompose_exception) {
   EXPECT_THROW_MSG(stan::math::cholesky_decompose(m), std::domain_error,
                    "is not symmetric");
 }
+
+TEST(MathMatrixPrimMat, cholesky_decompose_expressions) {
+  // Test for https://github.com/stan-dev/math/issues/3198
+  stan::math::matrix_d A(2, 3);
+  A << 1, 2, 3, 4, 5, 6;
+
+  stan::math::vector_d L_u(3);
+  L_u << 1, 0, 0.5;
+
+  auto L = stan::math::cholesky_corr_constrain(L_u, 3);
+
+  EXPECT_NO_THROW(stan::math::cholesky_decompose(stan::math::multiply(
+      stan::math::multiply(A, stan::math::multiply_lower_tri_self_transpose(L)),
+      stan::math::transpose(A))));
+}


### PR DESCRIPTION
## Summary

Closes #3198 

Aside: this was the last place `eval_return_type_t` was used in the codebase, we might want to consider its removal.

## Tests

Added a minimal version of the reported model that fails to compile under `develop`.

## Side Effects



## Release notes

Fixed an issue where `cholesky_decompose` could fail to compile during template instantiation. 

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
