### PR TITLE
Use Jenkins executor-local PARALLEL value

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -272,7 +272,7 @@ pipeline {
                     agent {
                         docker {
                             image 'stanorg/ci:gpu-cpp17'
-                            label 'linux'
+                            label 'linux && 8core'
                             args '--cap-add SYS_PTRACE'
                         }
                     }
@@ -506,7 +506,7 @@ pipeline {
                     }
                 }
             }
-            agent { label 'linux && docker' }
+            agent { label 'linux && docker && 8core' }
             steps {
                 script {
                     def tests = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -506,13 +506,13 @@ pipeline {
                     }
                 }
             }
-            agent { label 'linux && docker && 8core' }
+            agent { label 'linux && docker' }
             steps {
                 script {
                     def tests = [:]
                     for (f in changedDistributionTests.collate(24)) {
                         def names = f.join(" ")
-                        tests["Distribution Tests: ${names}"] = { node ("linux && docker") {
+                        tests["Distribution Tests: ${names}"] = { node ("linux && docker && 8core") {
                             deleteDir()
                             docker.image('stanorg/ci:gpu-cpp17').inside {
                                 catchError {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,9 +7,9 @@ def runTests(String testPath, boolean jumbo = false) {
         sh "cat make/local"
         sh "make print-compiler-flags"
         if (jumbo && !params.disableJumbo) {
-            sh "python3 runTests.py -j${env.PARALLEL} ${testPath} --jumbo --debug"
+            sh "python3 runTests.py -j${PARALLEL} ${testPath} --jumbo --debug"
         } else {
-            sh "python3 runTests.py -j${env.PARALLEL} ${testPath}"
+            sh "python3 runTests.py -j${PARALLEL} ${testPath}"
         }
     }
         finally { junit 'test/**/*.xml' }
@@ -61,7 +61,6 @@ pipeline {
         OPENCL_PLATFORM_ID = 1
         OPENCL_PLATFORM_ID_CPU = 0
         OPENCL_PLATFORM_ID_GPU = 0
-        PARALLEL = 4
         GIT_AUTHOR_NAME = 'Stan Jenkins'
         GIT_AUTHOR_EMAIL = 'mc.stanislaw@gmail.com'
         GIT_COMMITTER_NAME = 'Stan Jenkins'


### PR DESCRIPTION
## Summary

Flatiron's Jenkins recently added some 8-core executors that we pick up on occasion, but we are currently hardcoding that we should only ever use 4 jobs for compilation. Each executor also sets `$PARALLEL`, so this should be 4 on most machines but occasionally it will be 8 and we will use all of them. 

## Tests


## Side Effects

CI should be faster on average

## Release notes


## Checklist

- [ ] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
