### PR TITLE
bugfix for temporary falling out of scope in poisson_ccdf_log

### DIFF
--- a/stan/math/prim/fun/gamma_p.hpp
+++ b/stan/math/prim/fun/gamma_p.hpp
@@ -88,8 +88,8 @@ inline double gamma_p(double z, double a) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto gamma_p(T1&& a, T2&& b) {
-  return apply_scalar_binary(
-      [](auto&& c, auto&& d) { return gamma_p(c, d); }, std::forward<T1>(a), std::forward<T2>(b));
+  return apply_scalar_binary([](auto&& c, auto&& d) { return gamma_p(c, d); },
+                             std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/gamma_p.hpp
+++ b/stan/math/prim/fun/gamma_p.hpp
@@ -87,9 +87,9 @@ inline double gamma_p(double z, double a) {
  * @return gamma_p function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto gamma_p(const T1& a, const T2& b) {
+inline auto gamma_p(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return gamma_p(c, d); }, a, b);
+      [](auto&& c, auto&& d) { return gamma_p(c, d); }, std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -81,9 +81,9 @@ inline auto log(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto log(const Container& x) {
+inline auto log(Container&& x) {
   return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().log(); });
+      std::forward<Container>(x), [](const auto& v) { return v.array().log(); });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -83,7 +83,8 @@ template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
 inline auto log(Container&& x) {
   return apply_vector_unary<Container>::apply(
-      std::forward<Container>(x), [](const auto& v) { return v.array().log(); });
+      std::forward<Container>(x),
+      [](const auto& v) { return v.array().log(); });
 }
 
 namespace internal {

--- a/stan/math/prim/functor/apply_vector_unary.hpp
+++ b/stan/math/prim/functor/apply_vector_unary.hpp
@@ -43,14 +43,17 @@ struct apply_vector_unary<T, require_eigen_t<T>> {
   template <typename F, typename T2 = T,
             require_t<is_eigen_matrix_base<plain_type_t<T2>>>* = nullptr>
   static inline auto apply(T2&& x, F&& f) {
-    return make_holder([](const auto& a, auto&& f) { return f(a).matrix().derived(); },
-                       std::forward<T2>(x), std::forward<F>(f));
+    return make_holder(
+        [](const auto& a, auto&& f) { return f(a).matrix().derived(); },
+        std::forward<T2>(x), std::forward<F>(f));
   }
 
   template <typename F, typename T2 = T,
             require_t<is_eigen_array<plain_type_t<T2>>>* = nullptr>
   static inline auto apply(T2&& x, F&& f) {
-    return make_holder([](const auto& a, auto&& f) { return f(a).array().derived(); }, std::forward<T2>(x), std::forward<F>(f));
+    return make_holder(
+        [](const auto& a, auto&& f) { return f(a).array().derived(); },
+        std::forward<T2>(x), std::forward<F>(f));
   }
 
   /**

--- a/stan/math/prim/functor/apply_vector_unary.hpp
+++ b/stan/math/prim/functor/apply_vector_unary.hpp
@@ -42,15 +42,15 @@ struct apply_vector_unary<T, require_eigen_t<T>> {
    */
   template <typename F, typename T2 = T,
             require_t<is_eigen_matrix_base<plain_type_t<T2>>>* = nullptr>
-  static inline auto apply(const T& x, const F& f) {
-    return make_holder([](const auto& a) { return a.matrix().derived(); },
-                       f(x));
+  static inline auto apply(T2&& x, F&& f) {
+    return make_holder([](const auto& a, auto&& f) { return f(a).matrix().derived(); },
+                       std::forward<T2>(x), std::forward<F>(f));
   }
 
   template <typename F, typename T2 = T,
             require_t<is_eigen_array<plain_type_t<T2>>>* = nullptr>
-  static inline auto apply(const T& x, const F& f) {
-    return make_holder([](const auto& a) { return a.array().derived(); }, f(x));
+  static inline auto apply(T2&& x, F&& f) {
+    return make_holder([](const auto& a, auto&& f) { return f(a).array().derived(); }, std::forward<T2>(x), std::forward<F>(f));
   }
 
   /**

--- a/stan/math/prim/meta/holder.hpp
+++ b/stan/math/prim/meta/holder.hpp
@@ -1,9 +1,10 @@
 #ifndef STAN_MATH_PRIM_FUN_HOLDER_HPP
 #define STAN_MATH_PRIM_FUN_HOLDER_HPP
 
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta/is_eigen.hpp>
 #include <stan/math/prim/meta/is_plain_type.hpp>
-#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/meta/ref_type.hpp>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -255,10 +256,10 @@ inline Holder<T, Ptrs...> holder(T&& arg, Ptrs*... pointers) {
 // trivial case with no pointers constructs no holder object
 template <typename T>
 inline decltype(auto) holder(T&& arg) {
-  if constexpr (std::is_rvalue_reference<T&&>::value) {
+  if constexpr (std::is_rvalue_reference_v<T&&>) {
     return std::decay_t<T>(std::forward<T>(arg));
   } else {
-    return std::forward<T>(arg);
+    return arg;
   }
 }
 


### PR DESCRIPTION
## Summary

I'm still investigating this as it only happens on my work desktop and not my mac.

An error shows up on my linux desktop for several tests

```
./runTests.py -j4 ./test/prob/poisson/poisson_ccdf_log_00000_generated_v_test
[----------] Global test environment tear-down
[==========] 180 tests from 18 test suites ran. (17 ms total)
[  PASSED  ] 177 tests.
[  FAILED  ] 3 tests, listed below:
[  FAILED  ] AgradCcdfLogPoisson_v_2/AgradCcdfLogTestFixture/0.RepeatAsVector, where TypeParam = std::tuple<AgradCcdfLogPoisson, std::tuple<int, Eigen::Matrix<double, -1, 1, 0, -1, 1>, empty, empty, empty, empty> >
[  FAILED  ] AgradCcdfLogPoisson_v_2/AgradCcdfLogTestFixture/0.UpperBound, where TypeParam = std::tuple<AgradCcdfLogPoisson, std::tuple<int, Eigen::Matrix<double, -1, 1, 0, -1, 1>, empty, empty, empty, empty> >
[  FAILED  ] AgradCcdfLogPoisson_v_2/AgradCcdfLogTestFixture/0.AsScalarsVsAsVector, where TypeParam = std::tuple<AgradCcdfLogPoisson, std::tuple<int, Eigen::Matrix<double, -1, 1, 0, -1, 1>, empty, empty, empty, empty> >

```

I tracked it down to this line in [poisson_ccdf](https://github.com/stan-dev/math/blob/develop/stan/math/prim/prob/poisson_lccdf.hpp#L55)


```cpp
  const auto& log_Pi = to_ref_if<!is_constant_all<T_rate>::value>(
      log(gamma_p(n_val + 1.0, lambda_val)));
  T_partials_return P = sum(log_Pi);
```

Removing the `to_ref_if` there causes the tests to pass. I need to make an MIR showing the effect here, but I'm pretty sure that `n_val + 1.0` is falling out of scope after we build up all of our expressions. the `to_ref_if`'s template parameter evaluates to `false` here so it is returning back an expression on the right hand side. But once the expression is made `n_val + 1.0` falls out of scope and so we get a wrong answer.

@t4c1 if you are around to have a look at this it would be great.

## Tests


## Side Effects

Are there any side effects that we should be aware of?

## Release notes

Replace this text with a short note on what will change if this pull request is merged in which case this will be included in the release notes.

## Checklist

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
