### PR TITLE
[DRAFT/RFC] Gaussian Copula Cholesky LPDF

### DIFF
--- a/stan/math/prim/fun/size.hpp
+++ b/stan/math/prim/fun/size.hpp
@@ -34,7 +34,6 @@ inline int64_t size(const T& m) {
   return m.size();
 }
 
-
 template <typename T, require_tuple_t<T>* = nullptr>
 inline int64_t size(const T& /*t*/) {
   return std::tuple_size<std::remove_reference_t<T>>{};

--- a/stan/math/prim/fun/size.hpp
+++ b/stan/math/prim/fun/size.hpp
@@ -34,6 +34,12 @@ inline int64_t size(const T& m) {
   return m.size();
 }
 
+
+template <typename T, require_tuple_t<T>* = nullptr>
+inline int64_t size(const T& /*t*/) {
+  return std::tuple_size<std::remove_reference_t<T>>{};
+}
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/fun/size_mvt.hpp
+++ b/stan/math/prim/fun/size_mvt.hpp
@@ -36,8 +36,18 @@ int64_t size_mvt(const MatrixT& /* unused */) {
   return 1;
 }
 
+template <typename TupleT, require_tuple_t<TupleT>* = nullptr>
+int64_t size_mvt(const TupleT& /* unused */) {
+  return 1;
+}
+
 template <typename MatrixT, require_matrix_t<MatrixT>* = nullptr>
 int64_t size_mvt(const std::vector<MatrixT>& x) {
+  return x.size();
+}
+
+template <typename TupleT, require_tuple_t<TupleT>* = nullptr>
+int64_t size_mvt(const std::vector<TupleT>& x) {
   return x.size();
 }
 

--- a/stan/math/prim/fun/vector_seq_view.hpp
+++ b/stan/math/prim/fun/vector_seq_view.hpp
@@ -8,12 +8,13 @@
 namespace stan {
 namespace internal {
 template <typename T>
-using is_matrix_or_std_vector
-    = math::disjunction<is_matrix<T>, is_std_vector<T>>;
+using is_matrix_or_std_vector_or_tuple
+    = math::disjunction<is_matrix<T>, is_std_vector<T>, math::is_tuple<T>>;
 
 template <typename T>
 using is_scalar_container = math::disjunction<
     is_matrix<T>,
+    math::is_tuple<T>,
     math::conjunction<is_std_vector<T>, is_stan_scalar<value_type_t<T>>>>;
 }  // namespace internal
 
@@ -76,7 +77,7 @@ class vector_seq_view<T, require_t<internal::is_scalar_container<T>>> {
  */
 template <typename T>
 class vector_seq_view<
-    T, require_std_vector_vt<internal::is_matrix_or_std_vector, T>> {
+    T, require_std_vector_vt<internal::is_matrix_or_std_vector_or_tuple, T>> {
  public:
   explicit vector_seq_view(const T& v) noexcept : v_(v) {}
   inline auto size() const noexcept { return v_.size(); }

--- a/stan/math/prim/fun/vector_seq_view.hpp
+++ b/stan/math/prim/fun/vector_seq_view.hpp
@@ -13,8 +13,7 @@ using is_matrix_or_std_vector_or_tuple
 
 template <typename T>
 using is_scalar_container = math::disjunction<
-    is_matrix<T>,
-    math::is_tuple<T>,
+    is_matrix<T>, math::is_tuple<T>,
     math::conjunction<is_std_vector<T>, is_stan_scalar<value_type_t<T>>>>;
 }  // namespace internal
 

--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -111,6 +111,7 @@
 #include <stan/math/prim/prob/gamma_lcdf.hpp>
 #include <stan/math/prim/prob/gamma_lpdf.hpp>
 #include <stan/math/prim/prob/gamma_rng.hpp>
+#include <stan/math/prim/prob/gaussian_copula_cholesky_lpdf.hpp>
 #include <stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp>
 #include <stan/math/prim/prob/gaussian_dlm_obs_rng.hpp>
 #include <stan/math/prim/prob/gumbel_ccdf_log.hpp>

--- a/stan/math/prim/prob/gaussian_copula_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_copula_cholesky_lpdf.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
-#include <stan/math/prim/fun/inv_Phi.hpp>
 #include <stan/math/prim/fun/to_vector.hpp>
 #include <stan/math/prim/fun/rep_vector.hpp>
 #include <stan/math/prim/fun/vector_seq_view.hpp>
@@ -11,84 +10,106 @@
 #include <stan/math/prim/fun/size_mvt.hpp>
 #include <stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp>
 #include <stan/math/prim/prob/std_normal_lpdf.hpp>
+#include <stan/math/prim/prob/std_normal_log_qf.hpp>
 
 namespace stan {
 namespace math {
 namespace internal {
 
 template <typename Ty_elem, typename Ttuple, std::size_t... I>
-auto apply_cdfs_elem_impl(Ty_elem&& y_elem, Ttuple&& cdf_tuple, std::index_sequence<I...>){
-  auto&& cdf_func = std::get<0>(cdf_tuple);
-  return cdf_func(
+auto apply_lcdfs_elem_impl(
+  Ty_elem&& y_elem, Ttuple&& lcdf_tuple, std::index_sequence<I...>) {
+  auto&& lcdf_func = std::get<0>(lcdf_tuple);
+  return lcdf_func(
     std::forward<Ty_elem>(y_elem),
-    std::get<I + 1>(std::forward<Ttuple>(cdf_tuple))...
+    std::get<I + 1>(std::forward<Ttuple>(lcdf_tuple))...
   );
 }
 
 
 template <typename Ty, typename Ttuple, std::size_t... I>
-auto apply_cdfs_impl(Ty&& y, Ttuple&& cdf_tuple, std::index_sequence<I...>){
-  plain_type_t<Ty> res(y.size());
-
-  // Use initializer-list expansion to assign the result of each CDF
-  // to the respective element in the result vector, as we need a constant
-  // expression for indexing the tuple of CDF functors
-  static_cast<void>(std::initializer_list<int>{(
-    res[I] = apply_cdfs_elem_impl(
+std::vector<return_type_t<Ty, Ttuple>> apply_lcdfs_impl(
+  Ty&& y, Ttuple&& lcdf_tuple, std::index_sequence<I...>) {
+  // Use initializer-list expansion to return a vector with the result of
+  // applying each LCDF functor to the respective input.
+  // We cannot use apply_scalar_unary here as we need a constant
+  // expression for indexing the tuple of LCDF functors
+ return {
+    apply_lcdfs_elem_impl(
       std::forward<decltype(y[I])>(y[I]),
-      std::get<I>(cdf_tuple),
-        std::make_index_sequence<
-          // Using size - 1 as the first element is the functor to apply
-          std::tuple_size<
-            std::remove_reference_t<
-              decltype(std::get<I>(cdf_tuple))>>{} - 1>{}),
-    0)...});
-
-  return res;
+      std::get<I>(lcdf_tuple),
+      std::make_index_sequence<
+        // Using size - 1 as the first element is the functor to apply
+        std::tuple_size<
+          std::remove_reference_t<
+            decltype(std::get<I>(lcdf_tuple))>>{} - 1>{}
+    )...
+  };
 }
 
 template <typename Ty, typename Ttuple>
-auto apply_cdfs(Ty&& y, Ttuple&& cdf_tuple){
-  return apply_cdfs_impl(
+auto apply_lcdfs(Ty&& y, Ttuple&& lcdf_tuple){
+  return apply_lcdfs_impl(
     std::forward<Ty>(y),
-    std::forward<Ttuple>(cdf_tuple),
-      std::make_index_sequence<
-          std::tuple_size<std::remove_reference_t<Ttuple>>{}>{}
+    std::forward<Ttuple>(lcdf_tuple),
+    std::make_index_sequence<
+       std::tuple_size<std::remove_reference_t<Ttuple>>{}>{}
   );
 }
 }
 
-/*
-  vectors ~ gaussian_copula_cholesky(cdf_funs_tuple, chol)
-  (cdf_fun, ...)
-*/
 
-template <typename T_y, typename T_cdf_fun_tuple, typename T_chol,
-          typename T_return = return_type_t<T_y, T_cdf_fun_tuple, T_chol>>
+/** \ingroup multivar_dists
+ * The log of the Gaussian copula density for the given y and
+ * a Cholesky factor L of the variance matrix.
+ *
+ * As the Gaussian copula requires inputs to be in the unit interval,
+ * users are required to provide a tuple (of the same size as y) where each
+ * element is a tuple containing a functor for calculating the LCDF and any
+ * additional parameters required by the LCDF functor.
+ *
+ * This version of the function is vectorized on y and the tuple of LCDF
+ * functor tuples.
+ *
+ * @param y A scalar vector
+ * @param lcdf_fun_tuple A tuple of tuples, where each inner tuple follows the
+ *   structure {functor, param1, param2, ...}, where the functor has signature
+ *   (y[i], param1, param2, ...) and returns the log CDF for the given y[i].
+ * @param chol The Cholesky decomposition of a variance matrix
+ * of the multivariate normal distribution
+ * @return The log of the gaussian copula density.
+ * @throw std::domain_error if LL' is not square, not symmetric,
+ * or not semi-positive definite.
+ * @tparam T_y Type of scalar.
+ * @tparam T_lcdf_fun_tuple Type of tuple of LCDF functor tuples.
+ * @tparam T_chol Type of cholesky factor.
+ */
+template <bool propto, typename T_y, typename T_lcdf_fun_tuple, typename T_chol,
+          typename T_return = return_type_t<T_y, T_lcdf_fun_tuple, T_chol>>
 T_return gaussian_copula_cholesky_lpdf(
-  const T_y& y, const T_cdf_fun_tuple& cdf_fun_tuple, const T_chol chol) {
+  const T_y& y, const T_lcdf_fun_tuple& lcdf_fun_tuple, const T_chol chol) {
   static constexpr const char* function = "gaussian_copula_cholesky_lpdf";
 
   using T_y_ref = ref_type_t<T_y>;
-  using T_chochol_ref = ref_type_t<T_chol>;
-  using T_cdf_ref = ref_type_t<T_cdf_fun_tuple>;
+  using T_chol_ref = ref_type_t<T_chol>;
+  using T_lcdf_ref = ref_type_t<T_lcdf_fun_tuple>;
 
-  check_consistent_sizes_mvt(function, "y", y, "cdf_fun_tuple", cdf_fun_tuple);
+  check_consistent_sizes_mvt(function, "y", y, "lcdf_fun_tuple", lcdf_fun_tuple);
   const size_t size_mvt_y = size_mvt(y);
-  const size_t size_mvt_cdf_tuple = size_mvt(cdf_fun_tuple);
+  const size_t size_mvt_lcdf_tuple = size_mvt(lcdf_fun_tuple);
   if (size_mvt_y == 0) {
     return 0;
   }
   T_y_ref y_ref = y;
-  T_chochol_ref chol_ref = chol;
-  T_cdf_ref cdf_tuple_ref = cdf_fun_tuple;
+  T_chol_ref chol_ref = chol;
+  T_lcdf_ref lcdf_tuple_ref = lcdf_fun_tuple;
 
   vector_seq_view<T_y_ref> y_vec(y_ref);
-  vector_seq_view<T_cdf_ref> cdf_tuple_vec(cdf_tuple_ref);
-  const size_t size_vec = max_size_mvt(y, cdf_fun_tuple);
+  vector_seq_view<T_lcdf_ref> lcdf_tuple_vec(lcdf_tuple_ref);
+  const size_t size_vec = max_size_mvt(y, lcdf_fun_tuple);
 
   const int size_y = math::size(y_vec[0]);
-  const int size_cdf_tuple = math::size(cdf_tuple_vec[0]);
+  const int size_lcdf_tuple = math::size(lcdf_tuple_vec[0]);
 
   // check size consistency of all random variables y
   for (size_t i = 1; i < size_mvt_y; i++) {
@@ -101,18 +122,18 @@ T_return gaussian_copula_cholesky_lpdf(
                      size_y);
   }
   // check size consistency of all CDF tuples
-  for (size_t i = 1; i < size_mvt_cdf_tuple; i++) {
+  for (size_t i = 1; i < size_mvt_lcdf_tuple; i++) {
     check_size_match(function,
                      "Size of one of the vectors of "
                      "the CDF functor tuple",
-                     math::size(cdf_tuple_vec[i]),
+                     math::size(lcdf_tuple_vec[i]),
                      "Size of the first vector of the "
                      "location variable",
-                     size_cdf_tuple);
+                     size_lcdf_tuple);
   }
 
   check_size_match(function, "Size of random variable", size_y,
-                   "size of CDF functor tuple", size_cdf_tuple);
+                   "size of CDF functor tuple", size_lcdf_tuple);
   check_size_match(function, "Size of random variable", size_y,
                    "rows of covariance parameter", chol.rows());
   check_size_match(function, "Size of random variable", size_y,
@@ -127,14 +148,22 @@ T_return gaussian_copula_cholesky_lpdf(
   promote_scalar_t<T_return, std::vector<Eigen::VectorXd>> q(size_vec);
   T_return lp(0);
   for (size_t i = 0; i < size_vec; i++) {
-    q[i] = to_vector(inv_Phi(internal::apply_cdfs(y_vec[i], cdf_tuple_vec[i])));
-    lp -= std_normal_lpdf(q[i]);
+    const auto& u = internal::apply_lcdfs(y_vec[i], lcdf_tuple_vec[i]);
+    check_bounded(function, "CDF-transformed inputs", u, NEGATIVE_INFTY, 0);
+    q[i] = to_vector(std_normal_log_qf(u));
+    lp -= std_normal_lpdf<propto>(q[i]);
   }
   const std::vector<Eigen::VectorXd> zero_vec(size_vec, rep_vector(0, size_y));
-  lp += multi_normal_cholesky_lpdf(q, zero_vec, chol_ref);
+  lp += multi_normal_cholesky_lpdf<propto>(q, zero_vec, chol_ref);
   return lp;
 }
 
+template <typename T_y, typename T_lcdf_fun_tuple, typename T_chol,
+          typename T_return = return_type_t<T_y, T_lcdf_fun_tuple, T_chol>>
+T_return gaussian_copula_cholesky_lpdf(
+  const T_y& y, const T_lcdf_fun_tuple& lcdf_fun_tuple, const T_chol chol) {
+  return gaussian_copula_cholesky_lpdf<false>(y, lcdf_fun_tuple, chol);
+}
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/prob/gaussian_copula_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_copula_cholesky_lpdf.hpp
@@ -125,7 +125,7 @@ T_return gaussian_copula_cholesky_lpdf(
   for (size_t i = 1; i < size_mvt_lcdf_tuple; i++) {
     check_size_match(function,
                      "Size of one of the vectors of "
-                     "the CDF functor tuple",
+                     "the LCDF functor tuple",
                      math::size(lcdf_tuple_vec[i]),
                      "Size of the first vector of the "
                      "location variable",
@@ -133,7 +133,7 @@ T_return gaussian_copula_cholesky_lpdf(
   }
 
   check_size_match(function, "Size of random variable", size_y,
-                   "size of CDF functor tuple", size_lcdf_tuple);
+                   "size of LCDF functor tuple", size_lcdf_tuple);
   check_size_match(function, "Size of random variable", size_y,
                    "rows of covariance parameter", chol.rows());
   check_size_match(function, "Size of random variable", size_y,
@@ -149,7 +149,7 @@ T_return gaussian_copula_cholesky_lpdf(
   T_return lp(0);
   for (size_t i = 0; i < size_vec; i++) {
     const auto& u = internal::apply_lcdfs(y_vec[i], lcdf_tuple_vec[i]);
-    check_bounded(function, "CDF-transformed inputs", u, NEGATIVE_INFTY, 0);
+    check_bounded(function, "LCDF-transformed inputs", u, NEGATIVE_INFTY, 0);
     q[i] = to_vector(std_normal_log_qf(u));
     lp -= std_normal_lpdf<propto>(q[i]);
   }

--- a/stan/math/prim/prob/gaussian_copula_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_copula_cholesky_lpdf.hpp
@@ -17,29 +17,25 @@ namespace math {
 namespace internal {
 
 template <typename Ty_elem, typename Ttuple, std::size_t... I>
-auto apply_lcdfs_elem_impl(
-  Ty_elem&& y_elem, Ttuple&& lcdf_tuple, std::index_sequence<I...>) {
+auto apply_lcdfs_elem_impl(Ty_elem&& y_elem, Ttuple&& lcdf_tuple,
+                           std::index_sequence<I...>) {
   auto&& lcdf_func = std::get<0>(lcdf_tuple);
-  return lcdf_func(
-    std::forward<Ty_elem>(y_elem),
-    std::get<I + 1>(std::forward<Ttuple>(lcdf_tuple))...
-  );
+  return lcdf_func(std::forward<Ty_elem>(y_elem),
+                   std::get<I + 1>(std::forward<Ttuple>(lcdf_tuple))...);
 }
 
 template <typename Ty, typename Ttuple>
 auto apply_lcdfs(Ty&& y, Ttuple&& lcdf_tuple) {
   return index_apply<std::tuple_size<std::remove_reference_t<Ttuple>>{}>(
-    [&y, &lcdf_tuple](auto... Is) {
-      return std::make_tuple(
-        apply_lcdfs_elem_impl(
-          y[Is], std::get<Is>(lcdf_tuple), std::make_index_sequence<
-            std::tuple_size<std::remove_reference_t<decltype(std::get<Is>(lcdf_tuple))>>{} - 1>{}
-        )...
-      );
-    });
+      [&y, &lcdf_tuple](auto... Is) {
+        return std::make_tuple(apply_lcdfs_elem_impl(
+            y[Is], std::get<Is>(lcdf_tuple),
+            std::make_index_sequence<std::tuple_size<std::remove_reference_t<
+                                         decltype(std::get<Is>(lcdf_tuple))>>{}
+                                     - 1>{})...);
+      });
 }
-}
-
+}  // namespace internal
 
 /** \ingroup multivar_dists
  * The log of the Gaussian copula density for the given y and
@@ -67,15 +63,17 @@ auto apply_lcdfs(Ty&& y, Ttuple&& lcdf_tuple) {
  * @tparam T_chol Type of cholesky factor.
  */
 template <bool propto, typename T_y, typename T_lcdf_fun_tuple, typename T_chol>
-auto gaussian_copula_cholesky_lpdf(
-  const T_y& y, const T_lcdf_fun_tuple& lcdf_fun_tuple, const T_chol chol) {
+auto gaussian_copula_cholesky_lpdf(const T_y& y,
+                                   const T_lcdf_fun_tuple& lcdf_fun_tuple,
+                                   const T_chol chol) {
   static constexpr const char* function = "gaussian_copula_cholesky_lpdf";
 
   using T_y_ref = ref_type_t<T_y>;
   using T_chol_ref = ref_type_t<T_chol>;
   using T_lcdf_ref = ref_type_t<T_lcdf_fun_tuple>;
 
-  check_consistent_sizes_mvt(function, "y", y, "lcdf_fun_tuple", lcdf_fun_tuple);
+  check_consistent_sizes_mvt(function, "y", y, "lcdf_fun_tuple",
+                             lcdf_fun_tuple);
   const size_t size_mvt_y = size_mvt(y);
   const size_t size_mvt_lcdf_tuple = size_mvt(lcdf_fun_tuple);
   T_y_ref y_ref = y;
@@ -84,7 +82,9 @@ auto gaussian_copula_cholesky_lpdf(
 
   vector_seq_view<T_y_ref> y_vec(y_ref);
   vector_seq_view<T_lcdf_ref> lcdf_tuple_vec(lcdf_tuple_ref);
-  using T_return = return_type_t<T_y, decltype(internal::apply_lcdfs(y_vec[0], lcdf_tuple_vec[0])), T_chol>;
+  using T_return = return_type_t<
+      T_y, decltype(internal::apply_lcdfs(y_vec[0], lcdf_tuple_vec[0])),
+      T_chol>;
 
   if (size_mvt_y == 0) {
     return T_return(0);
@@ -135,14 +135,14 @@ auto gaussian_copula_cholesky_lpdf(
     const auto& func_i = lcdf_tuple_vec[i];
 
     const auto& res = internal::apply_lcdfs(y_i, func_i);
-    const auto& u = index_apply<std::tuple_size<std::remove_reference_t<decltype(res)>>{}>(
-      [&res, size_y](auto... Is) {
-        Eigen::Matrix<T_return, Eigen::Dynamic, 1> u_inner(size_y);
-        static_cast<void>(std::initializer_list<int>{
-          (u_inner[Is] = std::get<Is>(res), 0)...
+    const auto& u = index_apply<
+        std::tuple_size<std::remove_reference_t<decltype(res)>>{}>(
+        [&res, size_y](auto... Is) {
+          Eigen::Matrix<T_return, Eigen::Dynamic, 1> u_inner(size_y);
+          static_cast<void>(std::initializer_list<int>{
+              (u_inner[Is] = std::get<Is>(res), 0)...});
+          return u_inner;
         });
-        return u_inner;
-      });
     check_bounded(function, "LCDF-transformed inputs", u, NEGATIVE_INFTY, 0);
     q[i] = std_normal_log_qf(u);
     lp -= std_normal_lpdf<propto>(q[i]);
@@ -153,8 +153,9 @@ auto gaussian_copula_cholesky_lpdf(
 }
 
 template <typename T_y, typename T_lcdf_fun_tuple, typename T_chol>
-auto gaussian_copula_cholesky_lpdf(
-  const T_y& y, const T_lcdf_fun_tuple& lcdf_fun_tuple, const T_chol chol) {
+auto gaussian_copula_cholesky_lpdf(const T_y& y,
+                                   const T_lcdf_fun_tuple& lcdf_fun_tuple,
+                                   const T_chol chol) {
   return gaussian_copula_cholesky_lpdf<false>(y, lcdf_fun_tuple, chol);
 }
 }  // namespace math

--- a/stan/math/prim/prob/gaussian_copula_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_copula_cholesky_lpdf.hpp
@@ -26,35 +26,17 @@ auto apply_lcdfs_elem_impl(
   );
 }
 
-
-template <typename Ty, typename Ttuple, std::size_t... I>
-std::vector<return_type_t<Ty, Ttuple>> apply_lcdfs_impl(
-  Ty&& y, Ttuple&& lcdf_tuple, std::index_sequence<I...>) {
-  // Use initializer-list expansion to return a vector with the result of
-  // applying each LCDF functor to the respective input.
-  // We cannot use apply_scalar_unary here as we need a constant
-  // expression for indexing the tuple of LCDF functors
- return {
-    apply_lcdfs_elem_impl(
-      std::forward<decltype(y[I])>(y[I]),
-      std::get<I>(lcdf_tuple),
-      std::make_index_sequence<
-        // Using size - 1 as the first element is the functor to apply
-        std::tuple_size<
-          std::remove_reference_t<
-            decltype(std::get<I>(lcdf_tuple))>>{} - 1>{}
-    )...
-  };
-}
-
 template <typename Ty, typename Ttuple>
-auto apply_lcdfs(Ty&& y, Ttuple&& lcdf_tuple){
-  return apply_lcdfs_impl(
-    std::forward<Ty>(y),
-    std::forward<Ttuple>(lcdf_tuple),
-    std::make_index_sequence<
-       std::tuple_size<std::remove_reference_t<Ttuple>>{}>{}
-  );
+auto apply_lcdfs(Ty&& y, Ttuple&& lcdf_tuple) {
+  return index_apply<std::tuple_size<std::remove_reference_t<Ttuple>>{}>(
+    [&y, &lcdf_tuple](auto... Is) {
+      return std::make_tuple(
+        apply_lcdfs_elem_impl(
+          y[Is], std::get<Is>(lcdf_tuple), std::make_index_sequence<
+            std::tuple_size<std::remove_reference_t<decltype(std::get<Is>(lcdf_tuple))>>{} - 1>{}
+        )...
+      );
+    });
 }
 }
 
@@ -84,9 +66,8 @@ auto apply_lcdfs(Ty&& y, Ttuple&& lcdf_tuple){
  * @tparam T_lcdf_fun_tuple Type of tuple of LCDF functor tuples.
  * @tparam T_chol Type of cholesky factor.
  */
-template <bool propto, typename T_y, typename T_lcdf_fun_tuple, typename T_chol,
-          typename T_return = return_type_t<T_y, T_lcdf_fun_tuple, T_chol>>
-T_return gaussian_copula_cholesky_lpdf(
+template <bool propto, typename T_y, typename T_lcdf_fun_tuple, typename T_chol>
+auto gaussian_copula_cholesky_lpdf(
   const T_y& y, const T_lcdf_fun_tuple& lcdf_fun_tuple, const T_chol chol) {
   static constexpr const char* function = "gaussian_copula_cholesky_lpdf";
 
@@ -97,15 +78,17 @@ T_return gaussian_copula_cholesky_lpdf(
   check_consistent_sizes_mvt(function, "y", y, "lcdf_fun_tuple", lcdf_fun_tuple);
   const size_t size_mvt_y = size_mvt(y);
   const size_t size_mvt_lcdf_tuple = size_mvt(lcdf_fun_tuple);
-  if (size_mvt_y == 0) {
-    return 0;
-  }
   T_y_ref y_ref = y;
   T_chol_ref chol_ref = chol;
   T_lcdf_ref lcdf_tuple_ref = lcdf_fun_tuple;
 
   vector_seq_view<T_y_ref> y_vec(y_ref);
   vector_seq_view<T_lcdf_ref> lcdf_tuple_vec(lcdf_tuple_ref);
+  using T_return = return_type_t<T_y, decltype(internal::apply_lcdfs(y_vec[0], lcdf_tuple_vec[0])), T_chol>;
+
+  if (size_mvt_y == 0) {
+    return T_return(0);
+  }
   const size_t size_vec = max_size_mvt(y, lcdf_fun_tuple);
 
   const int size_y = math::size(y_vec[0]);
@@ -148,9 +131,20 @@ T_return gaussian_copula_cholesky_lpdf(
   promote_scalar_t<T_return, std::vector<Eigen::VectorXd>> q(size_vec);
   T_return lp(0);
   for (size_t i = 0; i < size_vec; i++) {
-    const auto& u = internal::apply_lcdfs(y_vec[i], lcdf_tuple_vec[i]);
+    const auto& y_i = y_vec[i];
+    const auto& func_i = lcdf_tuple_vec[i];
+
+    const auto& res = internal::apply_lcdfs(y_i, func_i);
+    const auto& u = index_apply<std::tuple_size<std::remove_reference_t<decltype(res)>>{}>(
+      [&res, size_y](auto... Is) {
+        Eigen::Matrix<T_return, Eigen::Dynamic, 1> u_inner(size_y);
+        static_cast<void>(std::initializer_list<int>{
+          (u_inner[Is] = std::get<Is>(res), 0)...
+        });
+        return u_inner;
+      });
     check_bounded(function, "LCDF-transformed inputs", u, NEGATIVE_INFTY, 0);
-    q[i] = to_vector(std_normal_log_qf(u));
+    q[i] = std_normal_log_qf(u);
     lp -= std_normal_lpdf<propto>(q[i]);
   }
   const std::vector<Eigen::VectorXd> zero_vec(size_vec, rep_vector(0, size_y));
@@ -158,9 +152,8 @@ T_return gaussian_copula_cholesky_lpdf(
   return lp;
 }
 
-template <typename T_y, typename T_lcdf_fun_tuple, typename T_chol,
-          typename T_return = return_type_t<T_y, T_lcdf_fun_tuple, T_chol>>
-T_return gaussian_copula_cholesky_lpdf(
+template <typename T_y, typename T_lcdf_fun_tuple, typename T_chol>
+auto gaussian_copula_cholesky_lpdf(
   const T_y& y, const T_lcdf_fun_tuple& lcdf_fun_tuple, const T_chol chol) {
   return gaussian_copula_cholesky_lpdf<false>(y, lcdf_fun_tuple, chol);
 }

--- a/stan/math/prim/prob/gaussian_copula_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_copula_cholesky_lpdf.hpp
@@ -1,0 +1,140 @@
+#ifndef STAN_MATH_PRIM_PROB_GAUSSIAN_COPULA_CHOLESKY_LPDF_HPP
+#define STAN_MATH_PRIM_PROB_GAUSSIAN_COPULA_CHOLESKY_LPDF_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/inv_Phi.hpp>
+#include <stan/math/prim/fun/to_vector.hpp>
+#include <stan/math/prim/fun/rep_vector.hpp>
+#include <stan/math/prim/fun/vector_seq_view.hpp>
+#include <stan/math/prim/fun/size.hpp>
+#include <stan/math/prim/fun/size_mvt.hpp>
+#include <stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp>
+#include <stan/math/prim/prob/std_normal_lpdf.hpp>
+
+namespace stan {
+namespace math {
+namespace internal {
+
+template <typename Ty_elem, typename Ttuple, std::size_t... I>
+auto apply_cdfs_elem_impl(Ty_elem&& y_elem, Ttuple&& cdf_tuple, std::index_sequence<I...>){
+  auto&& cdf_func = std::get<0>(cdf_tuple);
+  return cdf_func(
+    std::forward<Ty_elem>(y_elem),
+    std::get<I + 1>(std::forward<Ttuple>(cdf_tuple))...
+  );
+}
+
+
+template <typename Ty, typename Ttuple, std::size_t... I>
+auto apply_cdfs_impl(Ty&& y, Ttuple&& cdf_tuple, std::index_sequence<I...>){
+  plain_type_t<Ty> res(y.size());
+
+  // Use initializer-list expansion to assign the result of each CDF
+  // to the respective element in the result vector, as we need a constant
+  // expression for indexing the tuple of CDF functors
+  static_cast<void>(std::initializer_list<int>{(
+    res[I] = apply_cdfs_elem_impl(
+      std::forward<decltype(y[I])>(y[I]),
+      std::get<I>(cdf_tuple),
+        std::make_index_sequence<
+          // Using size - 1 as the first element is the functor to apply
+          std::tuple_size<
+            std::remove_reference_t<
+              decltype(std::get<I>(cdf_tuple))>>{} - 1>{}),
+    0)...});
+
+  return res;
+}
+
+template <typename Ty, typename Ttuple>
+auto apply_cdfs(Ty&& y, Ttuple&& cdf_tuple){
+  return apply_cdfs_impl(
+    std::forward<Ty>(y),
+    std::forward<Ttuple>(cdf_tuple),
+      std::make_index_sequence<
+          std::tuple_size<std::remove_reference_t<Ttuple>>{}>{}
+  );
+}
+}
+
+/*
+  vectors ~ gaussian_copula_cholesky(cdf_funs_tuple, chol)
+  (cdf_fun, ...)
+*/
+
+template <typename T_y, typename T_cdf_fun_tuple, typename T_chol,
+          typename T_return = return_type_t<T_y, T_cdf_fun_tuple, T_chol>>
+T_return gaussian_copula_cholesky_lpdf(
+  const T_y& y, const T_cdf_fun_tuple& cdf_fun_tuple, const T_chol chol) {
+  static constexpr const char* function = "gaussian_copula_cholesky_lpdf";
+
+  using T_y_ref = ref_type_t<T_y>;
+  using T_chochol_ref = ref_type_t<T_chol>;
+  using T_cdf_ref = ref_type_t<T_cdf_fun_tuple>;
+
+  check_consistent_sizes_mvt(function, "y", y, "cdf_fun_tuple", cdf_fun_tuple);
+  const size_t size_mvt_y = size_mvt(y);
+  const size_t size_mvt_cdf_tuple = size_mvt(cdf_fun_tuple);
+  if (size_mvt_y == 0) {
+    return 0;
+  }
+  T_y_ref y_ref = y;
+  T_chochol_ref chol_ref = chol;
+  T_cdf_ref cdf_tuple_ref = cdf_fun_tuple;
+
+  vector_seq_view<T_y_ref> y_vec(y_ref);
+  vector_seq_view<T_cdf_ref> cdf_tuple_vec(cdf_tuple_ref);
+  const size_t size_vec = max_size_mvt(y, cdf_fun_tuple);
+
+  const int size_y = math::size(y_vec[0]);
+  const int size_cdf_tuple = math::size(cdf_tuple_vec[0]);
+
+  // check size consistency of all random variables y
+  for (size_t i = 1; i < size_mvt_y; i++) {
+    check_size_match(function,
+                     "Size of one of the vectors of "
+                     "the random variable",
+                     math::size(y_vec[i]),
+                     "Size of the first vector of the "
+                     "random variable",
+                     size_y);
+  }
+  // check size consistency of all CDF tuples
+  for (size_t i = 1; i < size_mvt_cdf_tuple; i++) {
+    check_size_match(function,
+                     "Size of one of the vectors of "
+                     "the CDF functor tuple",
+                     math::size(cdf_tuple_vec[i]),
+                     "Size of the first vector of the "
+                     "location variable",
+                     size_cdf_tuple);
+  }
+
+  check_size_match(function, "Size of random variable", size_y,
+                   "size of CDF functor tuple", size_cdf_tuple);
+  check_size_match(function, "Size of random variable", size_y,
+                   "rows of covariance parameter", chol.rows());
+  check_size_match(function, "Size of random variable", size_y,
+                   "columns of covariance parameter", chol.cols());
+
+  for (size_t i = 0; i < size_vec; i++) {
+    check_not_nan(function, "Random variable", y_vec[i]);
+  }
+  check_cholesky_factor(function, "Cholesky decomposition of a variance matrix",
+                        chol_ref);
+
+  promote_scalar_t<T_return, std::vector<Eigen::VectorXd>> q(size_vec);
+  T_return lp(0);
+  for (size_t i = 0; i < size_vec; i++) {
+    q[i] = to_vector(inv_Phi(internal::apply_cdfs(y_vec[i], cdf_tuple_vec[i])));
+    lp -= std_normal_lpdf(q[i]);
+  }
+  const std::vector<Eigen::VectorXd> zero_vec(size_vec, rep_vector(0, size_y));
+  lp += multi_normal_cholesky_lpdf(q, zero_vec, chol_ref);
+  return lp;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/test/unit/math/mix/prob/gaussian_copula_cholesky_test.cpp
+++ b/test/unit/math/mix/prob/gaussian_copula_cholesky_test.cpp
@@ -4,10 +4,8 @@ TEST_F(AgradRev, ProbDistributionsGaussCopulaCholesky) {
   // Bind functors for compatibility with AD framework
   auto f = [](const auto func1, const auto func2) {
     return [=](const auto& y, const auto& args, const auto& sigma) {
-      auto lcdf_functors = std::make_tuple(
-        std::make_tuple(func1, args[0]),
-        std::make_tuple(func2, args[1])
-      );
+      auto lcdf_functors = std::make_tuple(std::make_tuple(func1, args[0]),
+                                           std::make_tuple(func2, args[1]));
       auto sigma_sym = stan::math::multiply(0.5, sigma + sigma.transpose());
       auto L = stan::math::cholesky_decompose(sigma_sym);
       return stan::math::gaussian_copula_cholesky_lpdf(y, lcdf_functors, L);
@@ -24,9 +22,7 @@ TEST_F(AgradRev, ProbDistributionsGaussCopulaCholesky) {
   auto func1 = [](const auto& y, const auto& mu) {
     return stan::math::normal_lcdf(y, mu, 1.0);
   };
-  auto func2 = [](const auto& y) {
-    return stan::math::std_normal_lcdf(y);
-  };
+  auto func2 = [](const auto& y) { return stan::math::std_normal_lcdf(y); };
 
   Eigen::MatrixXd Sigma22(2, 2);
   Sigma22 << 2.0, 0.5, 0.5, 1.1;

--- a/test/unit/math/mix/prob/gaussian_copula_cholesky_test.cpp
+++ b/test/unit/math/mix/prob/gaussian_copula_cholesky_test.cpp
@@ -1,0 +1,35 @@
+#include <test/unit/math/test_ad.hpp>
+
+TEST_F(AgradRev, ProbDistributionsGaussCopulaCholesky) {
+  // Bind functors for compatibility with AD framework
+  auto f = [](const auto func1, const auto func2) {
+    return [=](const auto& y, const auto& args, const auto& sigma) {
+      auto lcdf_functors = std::make_tuple(
+        std::make_tuple(func1, args[0]),
+        std::make_tuple(func2, args[1])
+      );
+      auto sigma_sym = stan::math::multiply(0.5, sigma + sigma.transpose());
+      auto L = stan::math::cholesky_decompose(sigma_sym);
+      return stan::math::gaussian_copula_cholesky_lpdf(y, lcdf_functors, L);
+    };
+  };
+
+  // y[0] ~ gamma(2, 1)
+  // y[1] ~ std_normal()
+  Eigen::VectorXd y1(2);
+  y1 << 1.0, 0.1;
+  Eigen::VectorXd args(2);
+  args << 0, 2.0;
+
+  auto func1 = [](const auto& y, const auto& mu) {
+    return stan::math::normal_lcdf(y, mu, 1.0);
+  };
+  auto func2 = [](const auto& y) {
+    return stan::math::std_normal_lcdf(y);
+  };
+
+  Eigen::MatrixXd Sigma22(2, 2);
+  Sigma22 << 2.0, 0.5, 0.5, 1.1;
+
+  stan::test::expect_ad(f(func2, func2), y1, args, Sigma22);
+}

--- a/test/unit/math/mix/prob/gaussian_copula_cholesky_test.cpp
+++ b/test/unit/math/mix/prob/gaussian_copula_cholesky_test.cpp
@@ -4,8 +4,8 @@ TEST_F(AgradRev, ProbDistributionsGaussCopulaCholesky) {
   // Bind functors for compatibility with AD framework
   auto f = [](const auto func1, const auto func2) {
     return [=](const auto& y, const auto& args, const auto& sigma) {
-      auto lcdf_functors = std::make_tuple(std::make_tuple(func1, args[0]),
-                                           std::make_tuple(func2, args[1]));
+      auto lcdf_functors = std::make_tuple(std::make_tuple(func1, args[0], args[1]),
+                                           std::make_tuple(func2));
       auto sigma_sym = stan::math::multiply(0.5, sigma + sigma.transpose());
       auto L = stan::math::cholesky_decompose(sigma_sym);
       return stan::math::gaussian_copula_cholesky_lpdf(y, lcdf_functors, L);
@@ -17,15 +17,15 @@ TEST_F(AgradRev, ProbDistributionsGaussCopulaCholesky) {
   Eigen::VectorXd y1(2);
   y1 << 1.0, 0.1;
   Eigen::VectorXd args(2);
-  args << 0, 2.0;
+  args << 2, 1;
 
-  auto func1 = [](const auto& y, const auto& mu) {
-    return stan::math::normal_lcdf(y, mu, 1.0);
+  auto func1 = [](const auto& y, const auto& shape, const auto& scale) {
+    return stan::math::gamma_lcdf(y, shape, scale);
   };
   auto func2 = [](const auto& y) { return stan::math::std_normal_lcdf(y); };
 
   Eigen::MatrixXd Sigma22(2, 2);
   Sigma22 << 2.0, 0.5, 0.5, 1.1;
 
-  stan::test::expect_ad(f(func2, func2), y1, args, Sigma22);
+  stan::test::expect_ad(f(func1, func2), y1, args, Sigma22);
 }

--- a/test/unit/math/mix/prob/gaussian_copula_cholesky_test.cpp
+++ b/test/unit/math/mix/prob/gaussian_copula_cholesky_test.cpp
@@ -4,8 +4,8 @@ TEST_F(AgradRev, ProbDistributionsGaussCopulaCholesky) {
   // Bind functors for compatibility with AD framework
   auto f = [](const auto func1, const auto func2) {
     return [=](const auto& y, const auto& args, const auto& sigma) {
-      auto lcdf_functors = std::make_tuple(std::make_tuple(func1, args[0], args[1]),
-                                           std::make_tuple(func2));
+      auto lcdf_functors = std::make_tuple(
+          std::make_tuple(func1, args[0], args[1]), std::make_tuple(func2));
       auto sigma_sym = stan::math::multiply(0.5, sigma + sigma.transpose());
       auto L = stan::math::cholesky_decompose(sigma_sym);
       return stan::math::gaussian_copula_cholesky_lpdf(y, lcdf_functors, L);

--- a/test/unit/math/prim/prob/gaussian_copula_cholesky_lpdf_test.cpp
+++ b/test/unit/math/prim/prob/gaussian_copula_cholesky_lpdf_test.cpp
@@ -1,0 +1,123 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbDistributionsGaussianCopulaCholesky, EqualsMultiNormalCholesky) {
+  using stan::math::gaussian_copula_cholesky_lpdf;
+  using stan::math::multi_normal_cholesky_lpdf;
+  using stan::math::diag_pre_multiply;
+
+  Eigen::VectorXd y(2);
+  y << 1, 3;
+
+  Eigen::VectorXd mu(2);
+  mu << 0.1, 0;
+
+  Eigen::VectorXd sd(2);
+  sd << 2, 1;
+
+  Eigen::MatrixXd chol(2, 2);
+  chol << 1, 0, 0.5, 0.8660254037844386;
+
+  auto norm_lcdf = [](auto&& y, auto&& mu, auto&& sigma) {
+    return stan::math::normal_lcdf(y, mu, sigma);
+  };
+
+  auto std_norm_lcdf = [](auto&& y) {
+    return stan::math::std_normal_lcdf(y);
+  };
+
+  // y[0] ~ normal(0.1, 2)
+  // y[1] ~ normal(0, 1)
+  auto lcdf_functors = std::make_tuple(
+    std::make_tuple(norm_lcdf, mu[0], sd[0]),
+    std::make_tuple(std_norm_lcdf)
+  );
+
+  double log_prob =
+    stan::math::normal_lpdf(y[0], 0.1, 2) +
+    stan::math::std_normal_lpdf(y[1]) +
+    gaussian_copula_cholesky_lpdf(y, lcdf_functors, chol);
+
+
+  double expected_log_prob = multi_normal_cholesky_lpdf(
+    y, mu, diag_pre_multiply(sd, chol));
+
+  EXPECT_FLOAT_EQ(log_prob, expected_log_prob);
+}
+
+TEST(ProbDistributionsGaussianCopulaCholesky, NonNormalMarginals) {
+  Eigen::VectorXd y(2);
+  y << 10, 6;
+
+  Eigen::MatrixXd chol(2, 2);
+  chol << 1, 0, 0.2, 0.9797958971;
+
+  auto gamma_lcdf = [](auto&& y, auto&& shape, auto&& scale) {
+    return stan::math::gamma_lcdf(y, shape, scale);
+  };
+
+  auto exp_lcdf = [](auto&& y, auto&& scale) {
+    return stan::math::exponential_lcdf(y, scale);
+  };
+
+  // y[0] ~ gamma(2, 1)
+  // y[1] ~ exponential(2)
+  auto lcdf_functors = std::make_tuple(
+    std::make_tuple(gamma_lcdf, 2.0, 1.0),
+    std::make_tuple(exp_lcdf, 2.0)
+  );
+
+  double log_prob =
+    stan::math::gamma_lpdf(y[0], 2.0, 1.0) +
+    stan::math::exponential_lpdf(y[1], 2.0) +
+    stan::math::gaussian_copula_cholesky_lpdf(y, lcdf_functors, chol);
+
+  EXPECT_FLOAT_EQ(log_prob, -16.61005941);
+}
+
+TEST(ProbDistributionsGaussianCopulaCholesky, Errors) {
+  Eigen::VectorXd y(2);
+  y << 10, 6;
+
+  Eigen::VectorXd small_y(1);
+  small_y << 10;
+
+  Eigen::MatrixXd chol(2, 2);
+  chol << 1, 0, 0.2, 0.9797958971;
+
+  auto gamma_lcdf = [](auto&& y, auto&& shape, auto&& scale) {
+    return stan::math::gamma_lcdf(y, shape, scale);
+  };
+  auto exp_lcdf = [](auto&& y, auto&& scale) {
+    return stan::math::exponential_lcdf(y, scale);
+  };
+
+  auto lcdf_functors = std::make_tuple(
+    std::make_tuple(gamma_lcdf, 2.0, 1.0),
+    std::make_tuple(exp_lcdf, 2.0)
+  );
+
+  auto small_lcdf_functors = std::make_tuple(
+    std::make_tuple(gamma_lcdf, 2.0, 1.0)
+  );
+
+  auto invalid_lcdf_functors = std::make_tuple(
+    std::make_tuple(gamma_lcdf, 2.0, 1.0),
+    std::make_tuple([](auto&& y){ return y * 10; })
+  );
+
+  EXPECT_THROW(
+    stan::math::gaussian_copula_cholesky_lpdf(y, small_lcdf_functors, chol),
+    std::invalid_argument
+  );
+
+  EXPECT_THROW(
+    stan::math::gaussian_copula_cholesky_lpdf(small_y, lcdf_functors, chol),
+    std::invalid_argument
+  );
+
+  EXPECT_THROW(
+    stan::math::gaussian_copula_cholesky_lpdf(y, invalid_lcdf_functors, chol),
+    std::domain_error
+  );
+}

--- a/test/unit/math/prim/prob/gaussian_copula_cholesky_lpdf_test.cpp
+++ b/test/unit/math/prim/prob/gaussian_copula_cholesky_lpdf_test.cpp
@@ -2,9 +2,9 @@
 #include <gtest/gtest.h>
 
 TEST(ProbDistributionsGaussianCopulaCholesky, EqualsMultiNormalCholesky) {
+  using stan::math::diag_pre_multiply;
   using stan::math::gaussian_copula_cholesky_lpdf;
   using stan::math::multi_normal_cholesky_lpdf;
-  using stan::math::diag_pre_multiply;
 
   Eigen::VectorXd y(2);
   y << 1, 3;
@@ -22,25 +22,19 @@ TEST(ProbDistributionsGaussianCopulaCholesky, EqualsMultiNormalCholesky) {
     return stan::math::normal_lcdf(y, mu, sigma);
   };
 
-  auto std_norm_lcdf = [](auto&& y) {
-    return stan::math::std_normal_lcdf(y);
-  };
+  auto std_norm_lcdf = [](auto&& y) { return stan::math::std_normal_lcdf(y); };
 
   // y[0] ~ normal(0.1, 2)
   // y[1] ~ normal(0, 1)
-  auto lcdf_functors = std::make_tuple(
-    std::make_tuple(norm_lcdf, mu[0], sd[0]),
-    std::make_tuple(std_norm_lcdf)
-  );
+  auto lcdf_functors = std::make_tuple(std::make_tuple(norm_lcdf, mu[0], sd[0]),
+                                       std::make_tuple(std_norm_lcdf));
 
-  double log_prob =
-    stan::math::normal_lpdf(y[0], 0.1, 2) +
-    stan::math::std_normal_lpdf(y[1]) +
-    gaussian_copula_cholesky_lpdf(y, lcdf_functors, chol);
+  double log_prob = stan::math::normal_lpdf(y[0], 0.1, 2)
+                    + stan::math::std_normal_lpdf(y[1])
+                    + gaussian_copula_cholesky_lpdf(y, lcdf_functors, chol);
 
-
-  double expected_log_prob = multi_normal_cholesky_lpdf(
-    y, mu, diag_pre_multiply(sd, chol));
+  double expected_log_prob
+      = multi_normal_cholesky_lpdf(y, mu, diag_pre_multiply(sd, chol));
 
   EXPECT_FLOAT_EQ(log_prob, expected_log_prob);
 }
@@ -62,15 +56,13 @@ TEST(ProbDistributionsGaussianCopulaCholesky, NonNormalMarginals) {
 
   // y[0] ~ gamma(2, 1)
   // y[1] ~ exponential(2)
-  auto lcdf_functors = std::make_tuple(
-    std::make_tuple(gamma_lcdf, 2.0, 1.0),
-    std::make_tuple(exp_lcdf, 2.0)
-  );
+  auto lcdf_functors = std::make_tuple(std::make_tuple(gamma_lcdf, 2.0, 1.0),
+                                       std::make_tuple(exp_lcdf, 2.0));
 
-  double log_prob =
-    stan::math::gamma_lpdf(y[0], 2.0, 1.0) +
-    stan::math::exponential_lpdf(y[1], 2.0) +
-    stan::math::gaussian_copula_cholesky_lpdf(y, lcdf_functors, chol);
+  double log_prob
+      = stan::math::gamma_lpdf(y[0], 2.0, 1.0)
+        + stan::math::exponential_lpdf(y[1], 2.0)
+        + stan::math::gaussian_copula_cholesky_lpdf(y, lcdf_functors, chol);
 
   EXPECT_FLOAT_EQ(log_prob, -16.61005941);
 }
@@ -92,32 +84,25 @@ TEST(ProbDistributionsGaussianCopulaCholesky, Errors) {
     return stan::math::exponential_lcdf(y, scale);
   };
 
-  auto lcdf_functors = std::make_tuple(
-    std::make_tuple(gamma_lcdf, 2.0, 1.0),
-    std::make_tuple(exp_lcdf, 2.0)
-  );
+  auto lcdf_functors = std::make_tuple(std::make_tuple(gamma_lcdf, 2.0, 1.0),
+                                       std::make_tuple(exp_lcdf, 2.0));
 
-  auto small_lcdf_functors = std::make_tuple(
-    std::make_tuple(gamma_lcdf, 2.0, 1.0)
-  );
+  auto small_lcdf_functors
+      = std::make_tuple(std::make_tuple(gamma_lcdf, 2.0, 1.0));
 
-  auto invalid_lcdf_functors = std::make_tuple(
-    std::make_tuple(gamma_lcdf, 2.0, 1.0),
-    std::make_tuple([](auto&& y){ return y * 10; })
-  );
+  auto invalid_lcdf_functors
+      = std::make_tuple(std::make_tuple(gamma_lcdf, 2.0, 1.0),
+                        std::make_tuple([](auto&& y) { return y * 10; }));
 
   EXPECT_THROW(
-    stan::math::gaussian_copula_cholesky_lpdf(y, small_lcdf_functors, chol),
-    std::invalid_argument
-  );
+      stan::math::gaussian_copula_cholesky_lpdf(y, small_lcdf_functors, chol),
+      std::invalid_argument);
 
   EXPECT_THROW(
-    stan::math::gaussian_copula_cholesky_lpdf(small_y, lcdf_functors, chol),
-    std::invalid_argument
-  );
+      stan::math::gaussian_copula_cholesky_lpdf(small_y, lcdf_functors, chol),
+      std::invalid_argument);
 
   EXPECT_THROW(
-    stan::math::gaussian_copula_cholesky_lpdf(y, invalid_lcdf_functors, chol),
-    std::domain_error
-  );
+      stan::math::gaussian_copula_cholesky_lpdf(y, invalid_lcdf_functors, chol),
+      std::domain_error);
 }


### PR DESCRIPTION
## Summary

Opening this as a draft PR for feedback on the signature/approach.

For the Gaussian copula (and other copula families), the user needs to provide both the `y` variable and a means of transforming that variable to the unit-scale.

The method I've gone with is to require a tuple of the same length as `y`, where each element is itself a tuple - with a functor for computing the LCDF as the first element, and any additional args as the remaining.

For example, if the user wanted to model the correlation between a `Gamma(2, 1)` variable and a `Exp(2)` variable, they would pass the tuple-of-tuples:

```cpp
std::make_tuple(
    std::make_tuple(gamma_lcdf, 2, 1),
    std::make_tuple(exp_lcdf, 2)
)
```

So the final signature would be:

```
real gaussian_copula_cholesky_lpdf(vector | tuple-of-tuples, cholesky_factor_corr)
```

The current framework only supports continuous outcomes, but once we settle on a good approach I can expand to discrete outcomes by requiring that a uniform parameter for data-augmentation is also included in the tuple for that outcome.

## Tests

Basic `prim` and `mix` are added, but the `fwd` components of the `mix` tests are currently failing

## Side Effects

Extended a few of the utilities (`size`, `vector_seq_view`) for tuples

## Release notes

Replace this text with a short note on what will change if this pull request is merged in which case this will be included in the release notes.

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
