### PR TITLE
Improve numerical stability of fwd gradients for std_normal_log_qf

### DIFF
--- a/stan/math/fwd/prob/std_normal_log_qf.hpp
+++ b/stan/math/fwd/prob/std_normal_log_qf.hpp
@@ -16,9 +16,7 @@ namespace math {
 template <typename T>
 inline fvar<T> std_normal_log_qf(const fvar<T>& p) {
   const T xv = std_normal_log_qf(p.val_);
-  return fvar<T>(
-      xv,
-      p.d_ * exp(p.val_ - std_normal_lpdf(xv)));
+  return fvar<T>(xv, p.d_ * exp(p.val_ - std_normal_lpdf(xv)));
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/fwd/prob/std_normal_log_qf.hpp
+++ b/stan/math/fwd/prob/std_normal_log_qf.hpp
@@ -16,15 +16,9 @@ namespace math {
 template <typename T>
 inline fvar<T> std_normal_log_qf(const fvar<T>& p) {
   const T xv = std_normal_log_qf(p.val_);
-  int p_sign = 1;
-  auto p_d = p.d_;
-  if (p.d_ < 0) {
-    p_sign = -1;
-    p_d *= -1;
-  }
   return fvar<T>(
       xv,
-      p_sign * exp(p.val_ + log(p_d) - NEG_LOG_SQRT_TWO_PI + 0.5 * square(xv)));
+      p.d_ * exp(p.val_ - std_normal_lpdf(xv)));
 }
 }  // namespace math
 }  // namespace stan

--- a/test/unit/math/mix/prob/std_normal_log_qf_test.cpp
+++ b/test/unit/math/mix/prob/std_normal_log_qf_test.cpp
@@ -4,7 +4,6 @@
 #include <test/unit/math/test_ad.hpp>
 #include <stan/math/fwd/prob/std_normal_log_qf.hpp>
 
-
 TEST_F(AgradRev, mathMixLogFun_stdNormalLogQf) {
   auto f = [](const auto& x1) { return stan::math::std_normal_log_qf(x1); };
   stan::test::expect_ad(f, -100.25);

--- a/test/unit/math/mix/prob/std_normal_log_qf_test.cpp
+++ b/test/unit/math/mix/prob/std_normal_log_qf_test.cpp
@@ -4,6 +4,7 @@
 #include <test/unit/math/test_ad.hpp>
 #include <stan/math/fwd/prob/std_normal_log_qf.hpp>
 
+
 TEST_F(AgradRev, mathMixLogFun_stdNormalLogQf) {
   auto f = [](const auto& x1) { return stan::math::std_normal_log_qf(x1); };
   stan::test::expect_ad(f, -100.25);
@@ -45,4 +46,15 @@ TEST_F(AgradRev, mathMixMatFunLog_stdNormalLogQfVarmat) {
     A(i) = all_args[i];
   }
   expect_ad_vector_matvar(f, A);
+}
+
+TEST_F(AgradRev, GradientStabilityStdNormalLogQf) {
+  auto f = [](const auto& y) {
+    return stan::math::sum(stan::math::std_normal_log_qf(y));
+  };
+
+  Eigen::VectorXd y1(2);
+  y1 << -10, -2;
+
+  stan::test::expect_ad(f, y1);
 }


### PR DESCRIPTION
## Summary

The source of the test failures in #3206 turned out to be the fwd gradients for the `std_normal_log_qf` function. I'd previously updated the `rev` gradients in #3139, but forgot about `fwd`!

## Tests

Test case added which failed under previous implementation

## Side Effects

N/A

## Release notes

Improved numerical stability of forward-mode gradients for `std_normal_log_qf`

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
