### PR TITLE
Compile Time Theta Default

### DIFF
--- a/stan/math/mix/functor/laplace_base_rng.hpp
+++ b/stan/math/mix/functor/laplace_base_rng.hpp
@@ -32,12 +32,12 @@ namespace math {
  * \msg_arg
  */
 template <typename LLFunc, typename LLArgs, typename CovarFun,
-          typename CovarArgs, typename RNG,
+          typename CovarArgs, typename ThetaVec, typename RNG,
           require_t<is_all_arithmetic_scalar<CovarArgs, LLArgs>>* = nullptr>
 inline Eigen::VectorXd laplace_base_rng(LLFunc&& ll_fun, LLArgs&& ll_args,
                                         CovarFun&& covariance_function,
                                         CovarArgs&& covar_args,
-                                        const laplace_options& options,
+                                        const laplace_options_base<ThetaVec>& options,
                                         RNG& rng, std::ostream* msgs) {
   auto md_est = internal::laplace_marginal_density_est(
       ll_fun, std::forward<LLArgs>(ll_args),

--- a/stan/math/mix/functor/laplace_base_rng.hpp
+++ b/stan/math/mix/functor/laplace_base_rng.hpp
@@ -32,12 +32,12 @@ namespace math {
  * \msg_arg
  */
 template <typename LLFunc, typename LLArgs, typename CovarFun,
-          typename CovarArgs, typename ThetaVec, typename RNG,
+          typename CovarArgs, bool InitTheta, typename RNG,
           require_t<is_all_arithmetic_scalar<CovarArgs, LLArgs>>* = nullptr>
 inline Eigen::VectorXd laplace_base_rng(LLFunc&& ll_fun, LLArgs&& ll_args,
                                         CovarFun&& covariance_function,
                                         CovarArgs&& covar_args,
-                                        const laplace_options<ThetaVec>& options,
+                                        const laplace_options<InitTheta>& options,
                                         RNG& rng, std::ostream* msgs) {
   auto md_est = internal::laplace_marginal_density_est(
       ll_fun, std::forward<LLArgs>(ll_args),

--- a/stan/math/mix/functor/laplace_base_rng.hpp
+++ b/stan/math/mix/functor/laplace_base_rng.hpp
@@ -37,7 +37,7 @@ template <typename LLFunc, typename LLArgs, typename CovarFun,
 inline Eigen::VectorXd laplace_base_rng(LLFunc&& ll_fun, LLArgs&& ll_args,
                                         CovarFun&& covariance_function,
                                         CovarArgs&& covar_args,
-                                        const laplace_options_base<ThetaVec>& options,
+                                        const laplace_options<ThetaVec>& options,
                                         RNG& rng, std::ostream* msgs) {
   auto md_est = internal::laplace_marginal_density_est(
       ll_fun, std::forward<LLArgs>(ll_args),

--- a/stan/math/mix/functor/laplace_marginal_density.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density.hpp
@@ -27,7 +27,6 @@ namespace math {
 /**
  * Options for the laplace sampler
  */
-template <typename Theta>
 struct laplace_options_base {
   /* Size of the blocks in block diagonal hessian*/
   int hessian_block_size{1};
@@ -46,14 +45,22 @@ struct laplace_options_base {
   double tolerance{1e-6};
   /* Maximum number of steps*/
   int max_num_steps{100};
+};
+
+template <typename Theta, typename = void>
+struct laplace_options;
+
+template <typename Theta>
+struct laplace_options<Theta, require_eigen_t<Theta>> : public laplace_options_base {
 
   /* Initial value for theta. Defaults to 0s of the correct size if nullopt */
   Theta theta_0{0};
 };
 
-using laplace_options = laplace_options_base<Eigen::VectorXd>;
-using laplace_options_default = laplace_options_base<double>;
+template <typename Theta>
+struct laplace_options<Theta, require_not_eigen_t<Theta>> : public laplace_options_base {};
 
+using laplace_options_default = laplace_options<void>;
 namespace internal {
 
 template <typename Covar, typename ThetaVec, typename WR, typename L_t,
@@ -461,7 +468,7 @@ template <typename LLFun, typename LLTupleArgs, typename CovarFun,
 inline auto laplace_marginal_density_est(LLFun&& ll_fun, LLTupleArgs&& ll_args,
                                          CovarFun&& covariance_function,
                                          CovarArgs&& covar_args,
-                                         const laplace_options_base<ThetaVec>& options,
+                                         const laplace_options<ThetaVec>& options,
                                          std::ostream* msgs) {
   using Eigen::MatrixXd;
   using Eigen::SparseMatrix;
@@ -793,7 +800,7 @@ template <
 inline double laplace_marginal_density(LLFun&& ll_fun, LLTupleArgs&& ll_args,
                                        CovarFun&& covariance_function,
                                        CovarArgs&& covar_args,
-                                       const laplace_options_base<ThetaVec>& options,
+                                       const laplace_options<ThetaVec>& options,
                                        std::ostream* msgs) {
   return internal::laplace_marginal_density_est(
              std::forward<LLFun>(ll_fun), std::forward<LLTupleArgs>(ll_args),
@@ -1035,7 +1042,7 @@ template <typename LLFun, typename LLTupleArgs, typename CovarFun,
 inline auto laplace_marginal_density(const LLFun& ll_fun, LLTupleArgs&& ll_args,
                                      CovarFun&& covariance_function,
                                      CovarArgs&& covar_args,
-                                     const laplace_options_base<ThetaVec>& options,
+                                     const laplace_options<ThetaVec>& options,
                                      std::ostream* msgs) {
   auto covar_args_refs = to_ref(std::forward<CovarArgs>(covar_args));
   auto ll_args_refs = to_ref(std::forward<LLTupleArgs>(ll_args));

--- a/stan/math/mix/functor/laplace_marginal_density.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density.hpp
@@ -53,7 +53,7 @@ struct laplace_options;
 template <typename Theta>
 struct laplace_options<Theta, require_eigen_t<Theta>> : public laplace_options_base {
 
-  /* Initial value for theta. Defaults to 0s of the correct size if nullopt */
+  /* Value for user supplied initial theta  */
   Theta theta_0{0};
 };
 

--- a/stan/math/mix/functor/laplace_marginal_density.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density.hpp
@@ -27,7 +27,8 @@ namespace math {
 /**
  * Options for the laplace sampler
  */
-struct laplace_options {
+template <typename Theta>
+struct laplace_options_base {
   /* Size of the blocks in block diagonal hessian*/
   int hessian_block_size{1};
   /**
@@ -47,8 +48,11 @@ struct laplace_options {
   int max_num_steps{100};
 
   /* Initial value for theta. Defaults to 0s of the correct size if nullopt */
-  std::optional<Eigen::VectorXd> theta_0{std::nullopt};
+  Theta theta_0{0};
 };
+
+using laplace_options = laplace_options_base<Eigen::VectorXd>;
+using laplace_options_default = laplace_options_base<double>;
 
 namespace internal {
 
@@ -452,21 +456,20 @@ inline STAN_COLD_PATH void throw_nan(NameStr&& name_str, ParamStr&& param_str,
  *
  */
 template <typename LLFun, typename LLTupleArgs, typename CovarFun,
-          typename CovarArgs,
+          typename CovarArgs, typename ThetaVec,
           require_t<is_all_arithmetic_scalar<CovarArgs>>* = nullptr>
 inline auto laplace_marginal_density_est(LLFun&& ll_fun, LLTupleArgs&& ll_args,
                                          CovarFun&& covariance_function,
                                          CovarArgs&& covar_args,
-                                         const laplace_options& options,
+                                         const laplace_options_base<ThetaVec>& options,
                                          std::ostream* msgs) {
   using Eigen::MatrixXd;
   using Eigen::SparseMatrix;
   using Eigen::VectorXd;
-  if (options.theta_0.has_value()) {
-    check_nonzero_size("laplace_marginal", "initial guess", *options.theta_0);
-    check_finite("laplace_marginal", "initial guess", *options.theta_0);
+  if constexpr (is_eigen_v<ThetaVec>) {
+    check_nonzero_size("laplace_marginal", "initial guess", options.theta_0);
+    check_finite("laplace_marginal", "initial guess", options.theta_0);
   }
-
   check_nonnegative("laplace_marginal", "tolerance", options.tolerance);
   check_positive("laplace_marginal", "max_num_steps", options.max_num_steps);
   check_positive("laplace_marginal", "hessian_block_size",
@@ -510,9 +513,13 @@ inline auto laplace_marginal_density_est(LLFun&& ll_fun, LLTupleArgs&& ll_args,
         + std::to_string(max_num_steps) + " exceeded.");
   };
   auto ll_args_vals = value_of(ll_args);
-  Eigen::VectorXd theta = options.theta_0.has_value()
-                              ? *options.theta_0
-                              : Eigen::VectorXd::Zero(theta_size);
+  Eigen::VectorXd theta = [theta_size, &options]() {
+    if constexpr (is_eigen_v<ThetaVec>) {
+      return options.theta_0;
+    } else {
+      return Eigen::VectorXd::Zero(theta_size);
+    }
+  }(); 
   double objective_old = std::numeric_limits<double>::lowest();
   double objective_new = std::numeric_limits<double>::lowest() + 1;
   Eigen::VectorXd a_prev = Eigen::VectorXd::Zero(theta_size);
@@ -584,7 +591,7 @@ inline auto laplace_marginal_density_est(LLFun&& ll_fun, LLTupleArgs&& ll_args,
         }
       }
     } else {
-      Eigen::SparseMatrix<double> W_r(theta.rows(), theta.rows());
+      Eigen::SparseMatrix<double> W_r(theta_size, theta_size);
       Eigen::Index block_size = options.hessian_block_size;
       W_r.reserve(Eigen::VectorXi::Constant(W_r.cols(), block_size));
       const Eigen::Index n_block = W_r.cols() / block_size;
@@ -781,12 +788,12 @@ inline auto laplace_marginal_density_est(LLFun&& ll_fun, LLTupleArgs&& ll_args,
  * @return the log maginal density, p(y | phi)
  */
 template <
-    typename LLFun, typename LLTupleArgs, typename CovarFun, typename CovarArgs,
+    typename LLFun, typename LLTupleArgs, typename CovarFun, typename CovarArgs, typename ThetaVec,
     require_t<is_all_arithmetic_scalar<CovarArgs, LLTupleArgs>>* = nullptr>
 inline double laplace_marginal_density(LLFun&& ll_fun, LLTupleArgs&& ll_args,
                                        CovarFun&& covariance_function,
                                        CovarArgs&& covar_args,
-                                       const laplace_options& options,
+                                       const laplace_options_base<ThetaVec>& options,
                                        std::ostream* msgs) {
   return internal::laplace_marginal_density_est(
              std::forward<LLFun>(ll_fun), std::forward<LLTupleArgs>(ll_args),
@@ -1023,12 +1030,12 @@ inline void reverse_pass_collect_adjoints(var ret, Output&& output,
  * @return the log maginal density, p(y | phi)
  */
 template <typename LLFun, typename LLTupleArgs, typename CovarFun,
-          typename CovarArgs,
+          typename CovarArgs, typename ThetaVec,
           require_t<is_any_var_scalar<LLTupleArgs, CovarArgs>>* = nullptr>
 inline auto laplace_marginal_density(const LLFun& ll_fun, LLTupleArgs&& ll_args,
                                      CovarFun&& covariance_function,
                                      CovarArgs&& covar_args,
-                                     const laplace_options& options,
+                                     const laplace_options_base<ThetaVec>& options,
                                      std::ostream* msgs) {
   auto covar_args_refs = to_ref(std::forward<CovarArgs>(covar_args));
   auto ll_args_refs = to_ref(std::forward<LLTupleArgs>(ll_args));

--- a/stan/math/mix/functor/laplace_marginal_density.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density.hpp
@@ -47,19 +47,21 @@ struct laplace_options_base {
   int max_num_steps{100};
 };
 
-template <typename Theta, typename = void>
+template <bool HasInitTheta>
 struct laplace_options;
 
-template <typename Theta>
-struct laplace_options<Theta, require_eigen_t<Theta>> : public laplace_options_base {
+template <>
+struct laplace_options<false> : public laplace_options_base {};
+
+template <>
+struct laplace_options<true> : public laplace_options_base {
   /* Value for user supplied initial theta  */
-  Theta theta_0{0};
+  Eigen::VectorXd theta_0{0};
 };
 
-template <typename Theta>
-struct laplace_options<Theta, require_not_eigen_t<Theta>> : public laplace_options_base {};
 
-using laplace_options_default = laplace_options<void>;
+using laplace_options_default = laplace_options<false>;
+using laplace_options_user_supplied = laplace_options<true>;  
 namespace internal {
 
 template <typename Covar, typename ThetaVec, typename WR, typename L_t,
@@ -462,17 +464,17 @@ inline STAN_COLD_PATH void throw_nan(NameStr&& name_str, ParamStr&& param_str,
  *
  */
 template <typename LLFun, typename LLTupleArgs, typename CovarFun,
-          typename CovarArgs, typename ThetaVec,
+          typename CovarArgs, bool InitTheta,
           require_t<is_all_arithmetic_scalar<CovarArgs>>* = nullptr>
 inline auto laplace_marginal_density_est(LLFun&& ll_fun, LLTupleArgs&& ll_args,
                                          CovarFun&& covariance_function,
                                          CovarArgs&& covar_args,
-                                         const laplace_options<ThetaVec>& options,
+                                         const laplace_options<InitTheta>& options,
                                          std::ostream* msgs) {
   using Eigen::MatrixXd;
   using Eigen::SparseMatrix;
   using Eigen::VectorXd;
-  if constexpr (is_eigen_v<ThetaVec>) {
+  if constexpr (InitTheta) {
     check_nonzero_size("laplace_marginal", "initial guess", options.theta_0);
     check_finite("laplace_marginal", "initial guess", options.theta_0);
   }
@@ -520,7 +522,7 @@ inline auto laplace_marginal_density_est(LLFun&& ll_fun, LLTupleArgs&& ll_args,
   };
   auto ll_args_vals = value_of(ll_args);
   Eigen::VectorXd theta = [theta_size, &options]() {
-    if constexpr (is_eigen_v<ThetaVec>) {
+    if constexpr (InitTheta) {
       return options.theta_0;
     } else {
       return Eigen::VectorXd::Zero(theta_size);
@@ -794,12 +796,12 @@ inline auto laplace_marginal_density_est(LLFun&& ll_fun, LLTupleArgs&& ll_args,
  * @return the log maginal density, p(y | phi)
  */
 template <
-    typename LLFun, typename LLTupleArgs, typename CovarFun, typename CovarArgs, typename ThetaVec,
+    typename LLFun, typename LLTupleArgs, typename CovarFun, typename CovarArgs, bool InitTheta,
     require_t<is_all_arithmetic_scalar<CovarArgs, LLTupleArgs>>* = nullptr>
 inline double laplace_marginal_density(LLFun&& ll_fun, LLTupleArgs&& ll_args,
                                        CovarFun&& covariance_function,
                                        CovarArgs&& covar_args,
-                                       const laplace_options<ThetaVec>& options,
+                                       const laplace_options<InitTheta>& options,
                                        std::ostream* msgs) {
   return internal::laplace_marginal_density_est(
              std::forward<LLFun>(ll_fun), std::forward<LLTupleArgs>(ll_args),
@@ -1036,12 +1038,12 @@ inline void reverse_pass_collect_adjoints(var ret, Output&& output,
  * @return the log maginal density, p(y | phi)
  */
 template <typename LLFun, typename LLTupleArgs, typename CovarFun,
-          typename CovarArgs, typename ThetaVec,
+          typename CovarArgs, bool InitTheta,
           require_t<is_any_var_scalar<LLTupleArgs, CovarArgs>>* = nullptr>
 inline auto laplace_marginal_density(const LLFun& ll_fun, LLTupleArgs&& ll_args,
                                      CovarFun&& covariance_function,
                                      CovarArgs&& covar_args,
-                                     const laplace_options<ThetaVec>& options,
+                                     const laplace_options<InitTheta>& options,
                                      std::ostream* msgs) {
   auto covar_args_refs = to_ref(std::forward<CovarArgs>(covar_args));
   auto ll_args_refs = to_ref(std::forward<LLTupleArgs>(ll_args));

--- a/stan/math/mix/functor/laplace_marginal_density.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density.hpp
@@ -52,7 +52,6 @@ struct laplace_options;
 
 template <typename Theta>
 struct laplace_options<Theta, require_eigen_t<Theta>> : public laplace_options_base {
-
   /* Value for user supplied initial theta  */
   Theta theta_0{0};
 };

--- a/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
@@ -36,7 +36,7 @@ inline Eigen::VectorXd laplace_latent_tol_bernoulli_logit_rng(
     const double tolerance, const int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, RNG& rng, std::ostream* msgs) {
-  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options_user_supplied ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_base_rng(bernoulli_logit_likelihood{},
                           std::forward_as_tuple(to_vector(y), n_samples),

--- a/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
@@ -66,11 +66,10 @@ inline Eigen::VectorXd laplace_latent_bernoulli_logit_rng(
     const std::vector<int>& y, const std::vector<int>& n_samples,
     CovarFun&& covariance_function, CovarArgs&& covar_args, RNG& rng,
     std::ostream* msgs) {
-  const laplace_options ops{1, 1, 0, 1e-6, 100, std::nullopt};
   return laplace_base_rng(bernoulli_logit_likelihood{},
                           std::forward_as_tuple(to_vector(y), n_samples),
                           std::forward<CovarFun>(covariance_function),
-                          std::forward<CovarArgs>(covar_args), ops, rng, msgs);
+                          std::forward<CovarArgs>(covar_args), laplace_options_default{}, rng, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
@@ -36,7 +36,7 @@ inline Eigen::VectorXd laplace_latent_tol_bernoulli_logit_rng(
     const double tolerance, const int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, RNG& rng, std::ostream* msgs) {
-  laplace_options ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_base_rng(bernoulli_logit_likelihood{},
                           std::forward_as_tuple(to_vector(y), n_samples),

--- a/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
@@ -42,7 +42,7 @@ inline Eigen::VectorXd laplace_latent_tol_neg_binomial_2_log_rng(
     const double tolerance, const int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, RNG& rng, std::ostream* msgs) {
-  laplace_options ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_base_rng(
       neg_binomial_2_log_likelihood{},

--- a/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
@@ -78,12 +78,11 @@ inline Eigen::VectorXd laplace_latent_neg_binomial_2_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Eta&& eta,
     CovarFun&& covariance_function, CovarArgs&& covar_args, RNG& rng,
     std::ostream* msgs) {
-  const laplace_options ops{1, 1, 0, 1e-6, 100, std::nullopt};
   return laplace_base_rng(
       neg_binomial_2_log_likelihood{},
       std::forward_as_tuple(std::forward<Eta>(eta), y, y_index),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), ops, rng, msgs);
+      std::forward<CovarArgs>(covar_args), laplace_options_default{}, rng, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
@@ -42,7 +42,7 @@ inline Eigen::VectorXd laplace_latent_tol_neg_binomial_2_log_rng(
     const double tolerance, const int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, RNG& rng, std::ostream* msgs) {
-  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options_user_supplied ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_base_rng(
       neg_binomial_2_log_likelihood{},

--- a/stan/math/mix/prob/laplace_latent_poisson_log_2_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_poisson_log_2_rng.hpp
@@ -71,11 +71,10 @@ inline auto laplace_latent_poisson_2_log_rng(const std::vector<int>& y,
                                              CovarFun&& covariance_function,
                                              CovarArgs&& covar_args, RNG& rng,
                                              std::ostream* msgs) {
-  const laplace_options ops{1, 1, 0, 1e-6, 100, std::nullopt};
   return laplace_base_rng(poisson_log_2_likelihood{},
                           std::forward_as_tuple(y, y_index, ye),
                           std::forward<CovarFun>(covariance_function),
-                          std::forward<CovarArgs>(covar_args), ops, rng, msgs);
+                          std::forward<CovarArgs>(covar_args), laplace_options_default{}, rng, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_latent_poisson_log_2_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_poisson_log_2_rng.hpp
@@ -38,7 +38,7 @@ inline auto laplace_latent_tol_poisson_2_log_rng(
     const double tolerance, const int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, RNG& rng, std::ostream* msgs) {
-  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options_user_supplied ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_base_rng(poisson_log_2_likelihood{},
                           std::forward_as_tuple(y, y_index, ye),

--- a/stan/math/mix/prob/laplace_latent_poisson_log_2_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_poisson_log_2_rng.hpp
@@ -38,7 +38,7 @@ inline auto laplace_latent_tol_poisson_2_log_rng(
     const double tolerance, const int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, RNG& rng, std::ostream* msgs) {
-  laplace_options ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_base_rng(poisson_log_2_likelihood{},
                           std::forward_as_tuple(y, y_index, ye),

--- a/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
@@ -67,11 +67,10 @@ inline Eigen::VectorXd laplace_latent_poisson_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index,
     CovarFun&& covariance_function, CovarArgs&& covar_args, RNG& rng,
     std::ostream* msgs) {
-  const laplace_options ops{1, 1, 0, 1e-6, 100, std::nullopt};
   return laplace_base_rng(poisson_log_likelihood{},
                           std::forward_as_tuple(y, y_index),
                           std::forward<CovarFun>(covariance_function),
-                          std::forward<CovarArgs>(covar_args), ops, rng, msgs);
+                          std::forward<CovarArgs>(covar_args), laplace_options_default{}, rng, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
@@ -36,7 +36,7 @@ inline Eigen::VectorXd laplace_latent_tol_poisson_log_rng(
     const double tolerance, const int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, RNG& rng, std::ostream* msgs) {
-  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options_user_supplied ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_base_rng(poisson_log_likelihood{},
                           std::forward_as_tuple(y, y_index),

--- a/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
@@ -36,7 +36,7 @@ inline Eigen::VectorXd laplace_latent_tol_poisson_log_rng(
     const double tolerance, const int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, RNG& rng, std::ostream* msgs) {
-  laplace_options ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_base_rng(poisson_log_likelihood{},
                           std::forward_as_tuple(y, y_index),

--- a/stan/math/mix/prob/laplace_latent_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_rng.hpp
@@ -36,7 +36,7 @@ inline auto laplace_latent_tol_rng(
     CovarArgs&& covar_args, ThetaVec&& theta_0, const double tolerance,
     const int max_num_steps, const int hessian_block_size, const int solver,
     const int max_steps_line_search, RNG& rng, std::ostream* msgs) {
-  const laplace_options ops{hessian_block_size,    solver,
+  const laplace_options<Eigen::VectorXd> ops{hessian_block_size,    solver,
                             max_steps_line_search, tolerance,
                             max_num_steps,         value_of(theta_0)};
   return laplace_base_rng(std::forward<LLFunc>(L_f),

--- a/stan/math/mix/prob/laplace_latent_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_rng.hpp
@@ -36,7 +36,7 @@ inline auto laplace_latent_tol_rng(
     CovarArgs&& covar_args, ThetaVec&& theta_0, const double tolerance,
     const int max_num_steps, const int hessian_block_size, const int solver,
     const int max_steps_line_search, RNG& rng, std::ostream* msgs) {
-  const laplace_options<Eigen::VectorXd> ops{hessian_block_size,    solver,
+  const laplace_options_user_supplied ops{hessian_block_size,    solver,
                             max_steps_line_search, tolerance,
                             max_num_steps,         value_of(theta_0)};
   return laplace_base_rng(std::forward<LLFunc>(L_f),

--- a/stan/math/mix/prob/laplace_latent_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_rng.hpp
@@ -69,11 +69,10 @@ inline auto laplace_latent_rng(LLFunc&& L_f, LLArgs&& ll_args,
                                CovarFun&& covariance_function,
                                CovarArgs&& covar_args, RNG& rng,
                                std::ostream* msgs) {
-  const laplace_options ops{1, 1, 0, 1e-6, 100, std::nullopt};
   return laplace_base_rng(std::forward<LLFunc>(L_f),
                           std::forward<LLArgs>(ll_args),
                           std::forward<CovarFun>(covariance_function),
-                          std::forward<CovarArgs>(covar_args), ops, rng, msgs);
+                          std::forward<CovarArgs>(covar_args), laplace_options_default{}, rng, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_marginal.hpp
+++ b/stan/math/mix/prob/laplace_marginal.hpp
@@ -33,7 +33,7 @@ inline auto laplace_marginal_tol(
     CovarArgs&& covar_args, const ThetaVec& theta_0, double tolerance,
     int max_num_steps, const int hessian_block_size, const int solver,
     const int max_steps_line_search, std::ostream* msgs) {
-  laplace_options ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_marginal_density(
       std::forward<LFun>(L_f), std::forward<LArgs>(l_args),

--- a/stan/math/mix/prob/laplace_marginal.hpp
+++ b/stan/math/mix/prob/laplace_marginal.hpp
@@ -33,7 +33,7 @@ inline auto laplace_marginal_tol(
     CovarArgs&& covar_args, const ThetaVec& theta_0, double tolerance,
     int max_num_steps, const int hessian_block_size, const int solver,
     const int max_steps_line_search, std::ostream* msgs) {
-  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options_user_supplied ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_marginal_density(
       std::forward<LFun>(L_f), std::forward<LArgs>(l_args),

--- a/stan/math/mix/prob/laplace_marginal.hpp
+++ b/stan/math/mix/prob/laplace_marginal.hpp
@@ -63,11 +63,10 @@ template <bool propto = false, typename LFun, typename LArgs, typename CovarFun,
 inline auto laplace_marginal(LFun&& L_f, LArgs&& l_args,
                              CovarFun&& covariance_function,
                              CovarArgs&& covar_args, std::ostream* msgs) {
-  const laplace_options ops{1, 1, 0, 1e-6, 100, std::nullopt};
   return laplace_marginal_density(
       std::forward<LFun>(L_f), std::forward<LArgs>(l_args),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), ops, msgs);
+      std::forward<CovarArgs>(covar_args), laplace_options_default{}, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
@@ -55,7 +55,7 @@ inline auto laplace_marginal_tol_bernoulli_logit_lpmf(
     const ThetaVec& theta_0, double tolerance, int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, std::ostream* msgs) {
-  laplace_options ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_marginal_density(
       bernoulli_logit_likelihood{},

--- a/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
@@ -55,7 +55,7 @@ inline auto laplace_marginal_tol_bernoulli_logit_lpmf(
     const ThetaVec& theta_0, double tolerance, int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, std::ostream* msgs) {
-  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options_user_supplied ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_marginal_density(
       bernoulli_logit_likelihood{},

--- a/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
@@ -84,12 +84,11 @@ inline auto laplace_marginal_bernoulli_logit_lpmf(
     const std::vector<int>& y, const std::vector<int>& n_samples,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
     std::ostream* msgs) {
-  const laplace_options ops{1, 1, 0, 1e-6, 100, std::nullopt};
   return laplace_marginal_density(
       bernoulli_logit_likelihood{},
       std::forward_as_tuple(to_vector(y), n_samples),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), ops, msgs);
+      std::forward<CovarArgs>(covar_args), laplace_options_default{}, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
@@ -73,7 +73,7 @@ inline auto laplace_marginal_tol_neg_binomial_2_log_lpmf(
     const ThetaVec& theta_0, double tolerance, int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, std::ostream* msgs) {
-  laplace_options ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood{}, std::forward_as_tuple(eta, y, y_index),
@@ -158,7 +158,7 @@ inline auto laplace_marginal_tol_neg_binomial_2_log_summary_lpmf(
     const ThetaVec& theta_0, double tolerance, int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, std::ostream* msgs) {
-  laplace_options ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood_summary{},

--- a/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
@@ -103,11 +103,10 @@ inline auto laplace_marginal_neg_binomial_2_log_lpmf(
     const std::vector<int>& y, const std::vector<int>& y_index, const Eta& eta,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
     std::ostream* msgs) {
-  const laplace_options ops{1, 1, 0, 1e-6, 100, std::nullopt};
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood{}, std::forward_as_tuple(eta, y, y_index),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), ops, msgs);
+      std::forward<CovarArgs>(covar_args), laplace_options_default{}, msgs);
 }
 
 struct neg_binomial_2_log_likelihood_summary {
@@ -191,12 +190,11 @@ inline auto laplace_marginal_neg_binomial_2_log_summary_lpmf(
     const std::vector<int>& counts_per_group, const Eta& eta,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
     std::ostream* msgs) {
-  const laplace_options ops{1, 1, 0, 1e-6, 100, std::nullopt};
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood_summary{},
       std::forward_as_tuple(eta, y, n_per_group, counts_per_group),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), ops, msgs);
+      std::forward<CovarArgs>(covar_args), laplace_options_default{}, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
@@ -73,7 +73,7 @@ inline auto laplace_marginal_tol_neg_binomial_2_log_lpmf(
     const ThetaVec& theta_0, double tolerance, int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, std::ostream* msgs) {
-  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options_user_supplied ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood{}, std::forward_as_tuple(eta, y, y_index),
@@ -158,7 +158,7 @@ inline auto laplace_marginal_tol_neg_binomial_2_log_summary_lpmf(
     const ThetaVec& theta_0, double tolerance, int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, std::ostream* msgs) {
-  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options_user_supplied ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood_summary{},

--- a/stan/math/mix/prob/laplace_marginal_poisson_log_2_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_poisson_log_2_lpmf.hpp
@@ -80,7 +80,7 @@ inline auto laplace_marginal_tol_poisson_2_log_lpmf(
     const ThetaVec& theta_0, double tolerance, int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, std::ostream* msgs) {
-  laplace_options ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_marginal_density(
       poisson_log_2_likelihood{}, std::forward_as_tuple(y, y_index, ye),

--- a/stan/math/mix/prob/laplace_marginal_poisson_log_2_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_poisson_log_2_lpmf.hpp
@@ -112,11 +112,10 @@ inline auto laplace_marginal_poisson_2_log_lpmf(const std::vector<int>& y,
                                                 CovarFun&& covariance_function,
                                                 CovarArgs&& covar_args,
                                                 std::ostream* msgs) {
-  const laplace_options ops{1, 1, 0, 1e-6, 100, std::nullopt};
   return laplace_marginal_density(
       poisson_log_2_likelihood{}, std::forward_as_tuple(y, y_index, ye),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), ops, msgs);
+      std::forward<CovarArgs>(covar_args), laplace_options_default{}, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_marginal_poisson_log_2_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_poisson_log_2_lpmf.hpp
@@ -80,7 +80,7 @@ inline auto laplace_marginal_tol_poisson_2_log_lpmf(
     const ThetaVec& theta_0, double tolerance, int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, std::ostream* msgs) {
-  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options_user_supplied ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_marginal_density(
       poisson_log_2_likelihood{}, std::forward_as_tuple(y, y_index, ye),

--- a/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
@@ -69,7 +69,7 @@ inline auto laplace_marginal_tol_poisson_log_lpmf(
     const ThetaVec& theta_0, double tolerance, int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, std::ostream* msgs) {
-  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options_user_supplied ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_marginal_density(
       poisson_log_likelihood{}, std::forward_as_tuple(y, y_index),

--- a/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
@@ -96,10 +96,9 @@ inline auto laplace_marginal_poisson_log_lpmf(const std::vector<int>& y,
                                               CovarFun&& covariance_function,
                                               CovarArgs&& covar_args,
                                               std::ostream* msgs) {
-  const laplace_options ops{1, 1, 0, 1e-6, 100, std::nullopt};
   return laplace_marginal_density(
       poisson_log_likelihood{}, std::forward_as_tuple(y, y_index),
-      covariance_function, std::forward<CovarArgs>(covar_args), ops, msgs);
+      covariance_function, std::forward<CovarArgs>(covar_args), laplace_options_default{}, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
@@ -69,7 +69,7 @@ inline auto laplace_marginal_tol_poisson_log_lpmf(
     const ThetaVec& theta_0, double tolerance, int max_num_steps,
     const int hessian_block_size, const int solver,
     const int max_steps_line_search, std::ostream* msgs) {
-  laplace_options ops{hessian_block_size, solver,        max_steps_line_search,
+  laplace_options<Eigen::VectorXd> ops{hessian_block_size, solver,        max_steps_line_search,
                       tolerance,          max_num_steps, value_of(theta_0)};
   return laplace_marginal_density(
       poisson_log_likelihood{}, std::forward_as_tuple(y, y_index),


### PR DESCRIPTION
## Summary

@WardBrian how do you feel about this alternative to #3209 ? Instead of an `std::optional` for `theta_0` I added a template to `laplace_options` for the type of `theta_0`. Since we know at compile time whether we are using the default `theta_0` we can save having to make an optional here.

## Tests

No new tests 


## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
