### PR TITLE
Include assertion that failed in STAN_OVERRIDE_EIGEN_ASSERT

### DIFF
--- a/stan/math/prim/fun/Eigen.hpp
+++ b/stan/math/prim/fun/Eigen.hpp
@@ -5,9 +5,10 @@
 #ifdef eigen_assert
 #undef eigen_assert
 #endif
-#define eigen_assert(x)                               \
-  if (!(x)) {                                         \
-    throw(std::domain_error("Internal Eigen Error: Assertion '" #x "' failed in " __FILE__ )); \
+#define eigen_assert(x)                                            \
+  if (!(x)) {                                                      \
+    throw(std::domain_error("Internal Eigen Error: Assertion '" #x \
+                            "' failed in " __FILE__));             \
   }
 #endif
 #ifdef EIGEN_MATRIXBASE_PLUGIN

--- a/stan/math/prim/fun/Eigen.hpp
+++ b/stan/math/prim/fun/Eigen.hpp
@@ -7,7 +7,7 @@
 #endif
 #define eigen_assert(x)                               \
   if (!(x)) {                                         \
-    throw(std::domain_error("Internal Eigen Error")); \
+    throw(std::domain_error("Internal Eigen Error: Assertion '" #x "' failed in " __FILE__ )); \
   }
 #endif
 #ifdef EIGEN_MATRIXBASE_PLUGIN


### PR DESCRIPTION


## Summary

Small improvement to what was added in #3097. 
If the user passes `-DSTAN_OVERRIDE_EIGEN_ASSERT`, the resulting exception would now include what the assertion actually was

## Tests



## Side Effects



## Release notes


## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
