### PR TITLE
Fix rows/columns_dot_product not properly checking inputs

### DIFF
--- a/stan/math/opencl/prim/columns_dot_product.hpp
+++ b/stan/math/opencl/prim/columns_dot_product.hpp
@@ -5,7 +5,7 @@
 #include <stan/math/opencl/prim/sum.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err/check_vector.hpp>
-#include <stan/math/prim/err/check_matching_sizes.hpp>
+#include <stan/math/prim/err/check_matching_dims.hpp>
 
 namespace stan {
 namespace math {
@@ -26,7 +26,7 @@ template <typename T_a, typename T_b,
           require_all_kernel_expressions_and_none_scalar_t<T_a, T_b>* = nullptr>
 inline auto columns_dot_product(const T_a& a, const T_b& b) {
   using res_scal = std::common_type_t<value_type_t<T_a>, value_type_t<T_b>>;
-  check_matching_sizes("columns_dot_product", "a", a, "b", b);
+  check_matching_dims("columns_dot_product", "a", a, "b", b);
   matrix_cl<res_scal> res;
 
   if (size_zero(a, b)) {

--- a/stan/math/opencl/prim/rows_dot_product.hpp
+++ b/stan/math/opencl/prim/rows_dot_product.hpp
@@ -5,7 +5,7 @@
 #include <stan/math/opencl/prim/sum.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err/check_vector.hpp>
-#include <stan/math/prim/err/check_matching_sizes.hpp>
+#include <stan/math/prim/err/check_matching_dims.hpp>
 
 namespace stan {
 namespace math {
@@ -25,7 +25,7 @@ namespace math {
 template <typename T_a, typename T_b,
           require_all_kernel_expressions_and_none_scalar_t<T_a, T_b>* = nullptr>
 inline auto rows_dot_product(T_a&& a, T_b&& b) {
-  check_matching_sizes("rows_dot_product", "a", a, "b", b);
+  check_matching_dims("rows_dot_product", "a", a, "b", b);
   return rowwise_sum(elt_multiply(std::forward<T_a>(a), std::forward<T_b>(b)));
 }
 

--- a/stan/math/opencl/rev/columns_dot_product.hpp
+++ b/stan/math/opencl/rev/columns_dot_product.hpp
@@ -28,7 +28,7 @@ template <
     typename T1, typename T2, require_any_var_t<T1, T2>* = nullptr,
     require_all_nonscalar_prim_or_rev_kernel_expression_t<T1, T2>* = nullptr>
 inline var_value<matrix_cl<double>> columns_dot_product(T1&& v1, T2&& v2) {
-  check_matching_sizes("columns_dot_product(OpenCL)", "v1", v1, "v2", v2);
+  check_matching_dims("columns_dot_product(OpenCL)", "v1", v1, "v2", v2);
 
   if (size_zero(v1, v2)) {
     return var_value<matrix_cl<double>>(constant(0.0, 1, v1.cols()));

--- a/stan/math/opencl/rev/rows_dot_product.hpp
+++ b/stan/math/opencl/rev/rows_dot_product.hpp
@@ -28,7 +28,7 @@ template <
     typename T1, typename T2, require_any_var_t<T1, T2>* = nullptr,
     require_all_nonscalar_prim_or_rev_kernel_expression_t<T1, T2>* = nullptr>
 inline var_value<matrix_cl<double>> rows_dot_product(T1&& v1, T2&& v2) {
-  check_matching_sizes("rows_dot_product(OpenCL)", "v1", v1, "v2", v2);
+  check_matching_dims("rows_dot_product(OpenCL)", "v1", v1, "v2", v2);
 
   arena_t<T1> v1_arena = std::forward<T1>(v1);
   arena_t<T2> v2_arena = std::forward<T2>(v2);

--- a/stan/math/prim/fun/columns_dot_product.hpp
+++ b/stan/math/prim/fun/columns_dot_product.hpp
@@ -26,7 +26,7 @@ template <typename Mat1, typename Mat2,
           require_all_not_eigen_vt<is_var, Mat1, Mat2>* = nullptr>
 inline Eigen::Matrix<return_type_t<Mat1, Mat2>, 1, Mat1::ColsAtCompileTime>
 columns_dot_product(const Mat1& v1, const Mat2& v2) {
-  check_matching_sizes("columns_dot_product", "v1", v1, "v2", v2);
+  check_matching_dims("columns_dot_product", "v1", v1, "v2", v2);
   return v1.cwiseProduct(v2).colwise().sum();
 }
 

--- a/stan/math/prim/fun/rows_dot_product.hpp
+++ b/stan/math/prim/fun/rows_dot_product.hpp
@@ -26,7 +26,7 @@ template <typename Mat1, typename Mat2,
           require_all_not_eigen_vt<is_var, Mat1, Mat2>* = nullptr>
 inline Eigen::Matrix<return_type_t<Mat1, Mat2>, Mat1::RowsAtCompileTime, 1>
 rows_dot_product(const Mat1& v1, const Mat2& v2) {
-  check_matching_sizes("rows_dot_product", "v1", v1, "v2", v2);
+  check_matching_dims("rows_dot_product", "v1", v1, "v2", v2);
   return (v1.cwiseProduct(v2)).rowwise().sum();
 }
 

--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -33,7 +33,7 @@ template <typename Mat1, typename Mat2,
           require_any_eigen_vt<is_var, Mat1, Mat2>* = nullptr>
 inline Eigen::Matrix<return_type_t<Mat1, Mat2>, 1, Mat1::ColsAtCompileTime>
 columns_dot_product(const Mat1& v1, const Mat2& v2) {
-  check_matching_sizes("dot_product", "v1", v1, "v2", v2);
+  check_matching_dims("check_matching_dims", "v1", v1, "v2", v2);
   Eigen::Matrix<var, 1, Mat1::ColsAtCompileTime> ret(1, v1.cols());
   for (size_type j = 0; j < v1.cols(); ++j) {
     ret.coeffRef(j) = dot_product(v1.col(j), v2.col(j));
@@ -62,7 +62,7 @@ template <typename Mat1, typename Mat2,
           require_all_matrix_t<Mat1, Mat2>* = nullptr,
           require_any_var_matrix_t<Mat1, Mat2>* = nullptr>
 inline auto columns_dot_product(const Mat1& v1, const Mat2& v2) {
-  check_matching_sizes("columns_dot_product", "v1", v1, "v2", v2);
+  check_matching_dims("columns_dot_product", "v1", v1, "v2", v2);
   using inner_return_t = decltype(
       (value_of(v1).array() * value_of(v2).array()).colwise().sum().matrix());
   using return_t = return_var_matrix_t<inner_return_t, Mat1, Mat2>;

--- a/stan/math/rev/fun/rows_dot_product.hpp
+++ b/stan/math/rev/fun/rows_dot_product.hpp
@@ -32,7 +32,7 @@ template <typename Mat1, typename Mat2,
           require_any_eigen_vt<is_var, Mat1, Mat2>* = nullptr>
 inline Eigen::Matrix<var, Mat1::RowsAtCompileTime, 1> rows_dot_product(
     const Mat1& v1, const Mat2& v2) {
-  check_matching_sizes("dot_product", "v1", v1, "v2", v2);
+  check_matching_dims("rows_dot_product", "v1", v1, "v2", v2);
   Eigen::Matrix<var, Mat1::RowsAtCompileTime, 1> ret(v1.rows(), 1);
   for (size_type j = 0; j < v1.rows(); ++j) {
     ret.coeffRef(j) = dot_product(v1.row(j), v2.row(j));
@@ -61,7 +61,7 @@ template <typename Mat1, typename Mat2,
           require_all_matrix_t<Mat1, Mat2>* = nullptr,
           require_any_var_matrix_t<Mat1, Mat2>* = nullptr>
 inline auto rows_dot_product(const Mat1& v1, const Mat2& v2) {
-  check_matching_sizes("rows_dot_product", "v1", v1, "v2", v2);
+  check_matching_dims("rows_dot_product", "v1", v1, "v2", v2);
 
   using return_t = return_var_matrix_t<
       decltype((v1.val().array() * v2.val().array()).rowwise().sum().matrix()),

--- a/test/unit/math/mix/fun/columns_dot_product_test.cpp
+++ b/test/unit/math/mix/fun/columns_dot_product_test.cpp
@@ -61,6 +61,7 @@ TEST(MathMixMatFun, columnsDotProduct) {
   stan::test::expect_ad(f, erv2, erv3);
   stan::test::expect_ad(f, em33, em23);
   stan::test::expect_ad(f, em23, em33);
+  stan::test::expect_ad(f, em23, em32);
   stan::test::expect_ad_matvar(f, ev2, ev3);
   stan::test::expect_ad_matvar(f, erv2, erv3);
   stan::test::expect_ad_matvar(f, em33, em23);

--- a/test/unit/math/mix/fun/rows_dot_product_test.cpp
+++ b/test/unit/math/mix/fun/rows_dot_product_test.cpp
@@ -61,6 +61,7 @@ TEST(MathMixMatFun, rowsDotProduct) {
   stan::test::expect_ad(f, erv2, erv3);
   stan::test::expect_ad(f, em33, em23);
   stan::test::expect_ad(f, em23, em33);
+  stan::test::expect_ad(f, em23, em32);
   stan::test::expect_ad_matvar(f, ev2, ev3);
   stan::test::expect_ad_matvar(f, erv2, erv3);
   stan::test::expect_ad_matvar(f, em33, em23);


### PR DESCRIPTION
## Summary

Closes #3216 

## Tests

First commit adds tests that crash under `develop`

## Side Effects

None

## Release notes
Fixed an issue where columns_dot_product and rows_dot_product were not properly checking the dimensions of their inputs, which could lead to crashes. 

## Checklist

- [x] Copyright holder: Simons foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
