### PR TITLE
add yule_simon_lpmf

### DIFF
--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -316,5 +316,5 @@
 #include <stan/math/prim/prob/wishart_cholesky_rng.hpp>
 #include <stan/math/prim/prob/wishart_lpdf.hpp>
 #include <stan/math/prim/prob/wishart_rng.hpp>
-
+#include <stan/math/prim/prob/yule_simon_lpmf.hpp>
 #endif

--- a/stan/math/prim/prob/yule_simon_lpmf.hpp
+++ b/stan/math/prim/prob/yule_simon_lpmf.hpp
@@ -1,0 +1,88 @@
+#ifndef STAN_MATH_PRIM_PROB_YULE_SIMON_LPMF_HPP
+#define STAN_MATH_PRIM_PROB_YULE_SIMON_LPMF_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/digamma.hpp>
+#include <stan/math/prim/fun/lbeta.hpp>
+#include <stan/math/prim/fun/lgamma.hpp>
+#include <stan/math/prim/fun/max_size.hpp>
+#include <stan/math/prim/fun/scalar_seq_view.hpp>
+#include <stan/math/prim/fun/size.hpp>
+#include <stan/math/prim/fun/size_zero.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/functor/partials_propagator.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup prob_dists
+ * Returns the log PMF of the Yule-Simon distribution with shape parameter.
+ * Given containers of matching sizes, returns the log sum of probabilities.
+ *
+ * @tparam T_n type of outcome variable
+ * @tparam T_alpha type of shape parameter
+ *
+ * @param n outcome variable
+ * @param alpha shape parameter
+ * @return log probability or log sum of probabilities
+ * @throw std::domain_error if alpha fails to be positive
+ * @throw std::invalid_argument if container sizes mismatch
+ */
+template <bool propto, typename T_n, typename T_alpha,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_n, T_alpha> * = nullptr>
+inline return_type_t<T_alpha> yule_simon_lpmf(const T_n &n,
+                                              const T_alpha &alpha) {
+  using std::log;
+  using T_partials_return = partials_return_t<T_n, T_alpha>;
+  using T_n_ref = ref_type_t<T_n>;
+  using T_alpha_ref = ref_type_t<T_alpha>;
+  static constexpr const char *function = "yule_simon_lpmf";
+  check_consistent_sizes(function, "Failures variable", n, "Shape parameter",
+                         alpha);
+  if (size_zero(n, alpha)) {
+    return 0.0;
+  }
+
+  T_n_ref n_ref = n;
+  T_alpha_ref alpha_ref = alpha;
+  check_greater_or_equal(function, "Outcome variable", n_ref, 1);
+  check_positive_finite(function, "Shape parameter", alpha_ref);
+
+  if constexpr (!include_summand<propto, T_alpha>::value) {
+    return 0.0;
+  }
+
+  auto ops_partials = make_partials_propagator(alpha_ref);
+
+  scalar_seq_view<T_n> n_vec(n);
+  scalar_seq_view<T_alpha_ref> alpha_vec(alpha_ref);
+  const size_t max_size_seq_view = max_size(n, alpha);
+  T_partials_return logp(0.0);
+  for (size_t i = 0; i < max_size_seq_view; i++) {
+    if constexpr (include_summand<propto>::value) {
+      logp += lgamma(n_vec.val(i));
+    }
+    T_partials_return alpha_plus_one = alpha_vec.val(i) + 1.0;
+    logp += log(alpha_vec.val(i)) + lgamma(alpha_plus_one)
+            - lgamma(n_vec.val(i) + alpha_plus_one);
+    if constexpr (!is_constant<T_alpha>::value) {
+      partials<0>(ops_partials)[i] += 1.0 / alpha_vec.val(i)
+                                      + digamma(alpha_plus_one)
+                                      - digamma(n_vec.val(i) + alpha_plus_one);
+    }
+  }
+  return ops_partials.build(logp);
+}
+
+template <typename T_n, typename T_alpha>
+inline return_type_t<T_alpha> yule_simon_lpmf(const T_n &n,
+                                              const T_alpha &alpha) {
+  return yule_simon_lpmf<false>(n, alpha);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/prob/yule_simon_lpmf.hpp
+++ b/stan/math/prim/prob/yule_simon_lpmf.hpp
@@ -57,13 +57,20 @@ inline return_type_t<T_alpha> yule_simon_lpmf(const T_n &n,
 
   auto ops_partials = make_partials_propagator(alpha_ref);
 
-  scalar_seq_view<T_n> n_vec(n);
+  scalar_seq_view<T_n_ref> n_vec(n_ref);
   scalar_seq_view<T_alpha_ref> alpha_vec(alpha_ref);
-  const size_t max_size_seq_view = max_size(n, alpha);
+  const size_t max_size_seq_view = max_size(n_ref, alpha_ref);
   T_partials_return logp(0.0);
+  if constexpr (include_summand<propto>::value) {
+    if constexpr (is_stan_scalar_v<T_n>) {
+      logp += lgamma(n_ref) * max_size_seq_view;
+    }
+  }
   for (size_t i = 0; i < max_size_seq_view; i++) {
     if constexpr (include_summand<propto>::value) {
-      logp += lgamma(n_vec.val(i));
+      if constexpr (!is_stan_scalar_v<T_n>) {
+        logp += lgamma(n_vec.val(i));
+      }
     }
     T_partials_return alpha_plus_one = alpha_vec.val(i) + 1.0;
     logp += log(alpha_vec.val(i)) + lgamma(alpha_plus_one)

--- a/test/prob/yule_simon/yule_simon_test.hpp
+++ b/test/prob/yule_simon/yule_simon_test.hpp
@@ -1,0 +1,71 @@
+// Arguments: Ints, Doubles
+#include <stan/math/prim/prob/yule_simon_lpmf.hpp>
+#include <stan/math/prim/fun/lbeta.hpp>
+#include <stan/math/prim/fun/lgamma.hpp>
+
+using std::numeric_limits;
+using std::vector;
+
+class AgradDistributionsYuleSimon : public AgradDistributionTest {
+ public:
+  void valid_values(vector<vector<double> >& parameters,
+                    vector<double>& log_prob) {
+    vector<double> param(2);
+
+    param[0] = 5;     // n
+    param[1] = 20.0;  // alpha
+    parameters.push_back(param);
+    log_prob.push_back(-9.494202658325099);  // expected log_prob
+
+    param[0] = 10;   // n
+    param[1] = 5.5;  // alpha
+    parameters.push_back(param);
+    log_prob.push_back(-9.108616882863778);  // expected log_prob
+  }
+
+  void invalid_values(vector<size_t>& index, vector<double>& value) {
+    // n
+    index.push_back(0U);
+    value.push_back(-1);
+
+    index.push_back(0U);
+    value.push_back(0);
+
+    // alpha
+    index.push_back(1U);
+    value.push_back(0.0);
+
+    index.push_back(1U);
+    value.push_back(-1.0);
+
+    index.push_back(1U);
+    value.push_back(std::numeric_limits<double>::infinity());
+  }
+
+  template <class T_n, class T_alpha, typename T2, typename T3, typename T4,
+            typename T5>
+  stan::return_type_t<T_alpha> log_prob(const T_n& n, const T_alpha& alpha,
+                                        const T2&, const T3&, const T4&,
+                                        const T5&) {
+    return stan::math::yule_simon_lpmf(n, alpha);
+  }
+
+  template <bool propto, class T_n, class T_alpha, typename T2, typename T3,
+            typename T4, typename T5>
+  stan::return_type_t<T_alpha> log_prob(const T_n& n, const T_alpha& alpha,
+                                        const T2&, const T3&, const T4&,
+                                        const T5&) {
+    return stan::math::yule_simon_lpmf<propto>(n, alpha);
+  }
+
+  template <class T_n, class T_alpha, typename T2, typename T3, typename T4,
+            typename T5>
+  stan::return_type_t<T_alpha> log_prob_function(const T_n& n,
+                                                 const T_alpha& alpha,
+                                                 const T2&, const T3&,
+                                                 const T4&, const T5&) {
+    using stan::math::lbeta;
+    using std::log;
+    return log(alpha) + lbeta(n, alpha + 1.0);
+  }
+};


### PR DESCRIPTION
## Summary

With this PR the lpmf of Yule Simon distribution are added.
See issue https://github.com/stan-dev/math/issues/3219
Other functions of this distribution will be added in following PRs.

Expressions involved:

PMF

$$
\log f(n) = \log \alpha + \log\text{Beta}(n,\alpha+1), \quad n=1,2,... \quad \alpha>0
$$

Derivatives w.r.t the parameter

$$
\begin{align}
\frac{\partial \log f(\alpha)}{\partial \alpha} &= \frac{1}{\alpha} + \text{digamma}(\alpha+1) - \text{digamma}(n + \alpha +1)
\end{align}
$$


## Tests

Test is written follow the [guide](https://mc-stan.org/math/md_doxygen_2contributor__help__pages_2adding__new__distributions.html).

## Side Effects

No

## Release notes
`yule_simon_lpmf` is available if merged. Allows modeling power-law count data.

## Checklist

- [x] Copyright holder: Zhi Ling

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested