### PR TITLE
Patch TBB's out-of-range enum usage for clang 21.1

### DIFF
--- a/lib/tbb_2020.3/STAN_CHANGES
+++ b/lib/tbb_2020.3/STAN_CHANGES
@@ -14,4 +14,4 @@ This file documents changes done for the stan-math project
     - L84 Wrapped the use of `-flifetime-dse` flag in conditional on non-WINARM64
     - L101 Wrapped the use of `-msse` in conditional on non-WINARM64
 
-- Add `constexpr` to lines 589-593 of `task.h` to fix a build failure in Clang 21.1
+- Added variants to the `kind_type` enum to prevent creation of out-of-range values

--- a/lib/tbb_2020.3/STAN_CHANGES
+++ b/lib/tbb_2020.3/STAN_CHANGES
@@ -13,4 +13,5 @@ This file documents changes done for the stan-math project
   - build/windows.gcc.inc
     - L84 Wrapped the use of `-flifetime-dse` flag in conditional on non-WINARM64
     - L101 Wrapped the use of `-msse` in conditional on non-WINARM64
-    
+
+- Add `constexpr` to lines 589-593 of `task.h` to fix a build failure in Clang 21.1

--- a/lib/tbb_2020.3/include/tbb/task.h
+++ b/lib/tbb_2020.3/include/tbb/task.h
@@ -376,7 +376,10 @@ private:
 public:
     enum kind_type {
         isolated,
-        bound
+        bound,
+        kind_complete,
+        kind_detached,
+        kind_dying
     };
 
     enum traits_type {
@@ -586,10 +589,10 @@ private:
     friend class task;
     friend class internal::allocate_root_with_context_proxy;
 
-    static constexpr kind_type binding_required = bound;
-    static constexpr kind_type binding_completed = kind_type(bound+1);
-    static constexpr kind_type detached = kind_type(binding_completed+1);
-    static constexpr kind_type dying = kind_type(detached+1);
+    static const kind_type binding_required = bound;
+    static const kind_type binding_completed = kind_type(bound+1);
+    static const kind_type detached = kind_type(binding_completed+1);
+    static const kind_type dying = kind_type(detached+1);
 
     //! Propagates any state change detected to *this, and as an optimisation possibly also upward along the heritage line.
     template <typename T>

--- a/lib/tbb_2020.3/include/tbb/task.h
+++ b/lib/tbb_2020.3/include/tbb/task.h
@@ -586,10 +586,10 @@ private:
     friend class task;
     friend class internal::allocate_root_with_context_proxy;
 
-    static const kind_type binding_required = bound;
-    static const kind_type binding_completed = kind_type(bound+1);
-    static const kind_type detached = kind_type(binding_completed+1);
-    static const kind_type dying = kind_type(detached+1);
+    static constexpr kind_type binding_required = bound;
+    static constexpr kind_type binding_completed = kind_type(bound+1);
+    static constexpr kind_type detached = kind_type(binding_completed+1);
+    static constexpr kind_type dying = kind_type(detached+1);
 
     //! Propagates any state change detected to *this, and as an optimisation possibly also upward along the heritage line.
     template <typename T>


### PR DESCRIPTION
Closes #3222.

Clang is getting stricter on what it allows in constant evaluated contexts, including disallowing out-of-range enum values. TBB was using a couple of these. The easiest thing to do seems to be just add values to the enum.

This branch is running against clang 21.1.0-rc1 [here](https://jenkins.flatironinstitute.org/blue/organizations/jenkins/Stan%2FBleedingEdgeCompilersMonthly/detail/BleedingEdgeCompilersMonthly/274/pipeline/) (already past where it was failing prior to this patch)

## Summary



## Tests


## Side Effects



## Release notes

Patched an issue preventing TBB from building with clang 21.1

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
