### PR TITLE
update bessel so that reverse mode is chosen over the perfect forward…

### DIFF
--- a/stan/math/prim/fun/bessel_second_kind.hpp
+++ b/stan/math/prim/fun/bessel_second_kind.hpp
@@ -53,7 +53,7 @@ inline T2 bessel_second_kind(int v, const T2 z) {
  * @return Bessel second kind function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
-          require_not_var_matrix_t<T2>* = nullptr>
+          require_not_var_t<T2>* = nullptr>
 inline auto bessel_second_kind(T1&& a, T2&& b) {
   return apply_scalar_binary(
       [](auto&& c, auto&& d) {

--- a/stan/math/prim/fun/bessel_second_kind.hpp
+++ b/stan/math/prim/fun/bessel_second_kind.hpp
@@ -53,7 +53,7 @@ inline T2 bessel_second_kind(int v, const T2 z) {
  * @return Bessel second kind function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
-          require_not_var_t<T2>* = nullptr>
+  require_not_var_matrix_t<T2>* = nullptr>
 inline auto bessel_second_kind(T1&& a, T2&& b) {
   return apply_scalar_binary(
       [](auto&& c, auto&& d) {

--- a/stan/math/prim/fun/bessel_second_kind.hpp
+++ b/stan/math/prim/fun/bessel_second_kind.hpp
@@ -53,7 +53,7 @@ inline T2 bessel_second_kind(int v, const T2 z) {
  * @return Bessel second kind function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
- require_not_var_matrix_t<T2>* = nullptr>
+          require_not_var_matrix_t<T2>* = nullptr>
 inline auto bessel_second_kind(T1&& a, T2&& b) {
   return apply_scalar_binary(
       [](auto&& c, auto&& d) {

--- a/stan/math/prim/fun/bessel_second_kind.hpp
+++ b/stan/math/prim/fun/bessel_second_kind.hpp
@@ -53,7 +53,7 @@ inline T2 bessel_second_kind(int v, const T2 z) {
  * @return Bessel second kind function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
-  require_not_var_matrix_t<T2>* = nullptr>
+          require_not_var_matrix_t<T2>* = nullptr>
 inline auto bessel_second_kind(T1&& a, T2&& b) {
   return apply_scalar_binary(
       [](auto&& c, auto&& d) {

--- a/stan/math/prim/fun/bessel_second_kind.hpp
+++ b/stan/math/prim/fun/bessel_second_kind.hpp
@@ -52,7 +52,8 @@ inline T2 bessel_second_kind(int v, const T2 z) {
  * @param b Second input
  * @return Bessel second kind function applied to the two inputs.
  */
-template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
+ require_not_var_matrix_t<T2>* = nullptr>
 inline auto bessel_second_kind(T1&& a, T2&& b) {
   return apply_scalar_binary(
       [](auto&& c, auto&& d) {

--- a/stan/math/prim/functor/apply_scalar_unary.hpp
+++ b/stan/math/prim/functor/apply_scalar_unary.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta/is_eigen.hpp>
 #include <stan/math/prim/meta/is_complex.hpp>
+#include <stan/math/prim/meta/holder.hpp>
 #include <stan/math/prim/meta/require_generics.hpp>
 #include <stan/math/prim/meta/is_vector.hpp>
 #include <stan/math/prim/meta/is_vector_like.hpp>

--- a/stan/math/rev/fun/bessel_second_kind.hpp
+++ b/stan/math/rev/fun/bessel_second_kind.hpp
@@ -9,8 +9,7 @@ namespace stan {
 namespace math {
 
 template <typename T1, typename T2, require_integral_t<T1>* = nullptr,
-          require_var_t<T2>* = nullptr, 
-          require_stan_scalar_t<T2>* = nullptr>
+          require_var_t<T2>* = nullptr, require_stan_scalar_t<T2>* = nullptr>
 inline var bessel_second_kind(T1&& v, T2&& a) {
   double ret_val = bessel_second_kind(v, a.val());
   auto precomp_bessel

--- a/stan/math/rev/fun/bessel_second_kind.hpp
+++ b/stan/math/rev/fun/bessel_second_kind.hpp
@@ -8,31 +8,26 @@
 namespace stan {
 namespace math {
 
-inline var bessel_second_kind(int v, const var& a) {
-  double ret_val = bessel_second_kind(v, a.val());
-  auto precomp_bessel
-      = v * ret_val / a.val() - bessel_second_kind(v + 1, a.val());
-  return make_callback_var(ret_val, [precomp_bessel, a](auto& vi) mutable {
-    a.adj() += vi.adj() * precomp_bessel;
-  });
-}
-
-/**
- * Overload with `var_value<Matrix>` for `int`, `std::vector<int>`, and
- * `std::vector<std::vector<int>>`
- */
-template <typename T1, typename T2, require_st_integral<T1>* = nullptr,
-          require_eigen_t<T2>* = nullptr>
-inline auto bessel_second_kind(const T1& v, const var_value<T2>& a) {
-  auto ret_val = bessel_second_kind(v, a.val()).array().eval();
-  auto v_map = as_array_or_scalar(v);
-  auto precomp_bessel
-      = to_arena(v_map * ret_val / a.val().array()
-                 - bessel_second_kind(v_map + 1, a.val().array()));
-  return make_callback_var(
-      ret_val.matrix(), [precomp_bessel, a](const auto& vi) mutable {
-        a.adj().array() += vi.adj().array() * precomp_bessel;
-      });
+template <typename T1, typename T2, require_st_integral<T1>* = nullptr, require_var_t<T2>* = nullptr>
+inline auto bessel_second_kind(T1&& v, T2&& a) {
+  if constexpr (is_stan_scalar_v<T2>) {
+    double ret_val = bessel_second_kind(v, a.val());
+    auto precomp_bessel
+        = v * ret_val / a.val() - bessel_second_kind(v + 1, a.val());
+    return make_callback_var(ret_val, [precomp_bessel, a](auto& vi) mutable {
+      a.adj() += vi.adj() * precomp_bessel;
+    });
+  } else {
+    auto ret_val = bessel_second_kind(v, a.val()).array().eval();
+    auto v_map = as_array_or_scalar(v);
+    auto precomp_bessel
+        = to_arena(v_map * ret_val / a.val().array()
+                  - bessel_second_kind(v_map + 1, a.val().array()));
+    return make_callback_var(
+        ret_val.matrix(), [precomp_bessel, a](const auto& vi) mutable {
+          a.adj().array() += vi.adj().array() * precomp_bessel;
+        });
+  }
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/bessel_second_kind.hpp
+++ b/stan/math/rev/fun/bessel_second_kind.hpp
@@ -8,7 +8,8 @@
 namespace stan {
 namespace math {
 
-template <typename T1, typename T2, require_st_integral<T1>* = nullptr, require_var_t<T2>* = nullptr>
+template <typename T1, typename T2, require_st_integral<T1>* = nullptr,
+          require_var_t<T2>* = nullptr>
 inline auto bessel_second_kind(T1&& v, T2&& a) {
   if constexpr (is_stan_scalar_v<T2>) {
     double ret_val = bessel_second_kind(v, a.val());
@@ -22,7 +23,7 @@ inline auto bessel_second_kind(T1&& v, T2&& a) {
     auto v_map = as_array_or_scalar(v);
     auto precomp_bessel
         = to_arena(v_map * ret_val / a.val().array()
-                  - bessel_second_kind(v_map + 1, a.val().array()));
+                   - bessel_second_kind(v_map + 1, a.val().array()));
     return make_callback_var(
         ret_val.matrix(), [precomp_bessel, a](const auto& vi) mutable {
           a.adj().array() += vi.adj().array() * precomp_bessel;

--- a/stan/math/rev/fun/bessel_second_kind.hpp
+++ b/stan/math/rev/fun/bessel_second_kind.hpp
@@ -8,27 +8,34 @@
 namespace stan {
 namespace math {
 
+template <typename T1, typename T2, require_integral_t<T1>* = nullptr,
+          require_var_t<T2>* = nullptr, 
+          require_stan_scalar_t<T2>* = nullptr>
+inline var bessel_second_kind(T1&& v, T2&& a) {
+  double ret_val = bessel_second_kind(v, a.val());
+  auto precomp_bessel
+      = v * ret_val / a.val() - bessel_second_kind(v + 1, a.val());
+  return make_callback_var(ret_val, [precomp_bessel, a](auto& vi) mutable {
+    a.adj() += vi.adj() * precomp_bessel;
+  });
+}
+
+/**
+ * Overload with `var_value<Matrix>` for `int`, `std::vector<int>`, and
+ * `std::vector<std::vector<int>>`
+ */
 template <typename T1, typename T2, require_st_integral<T1>* = nullptr,
-          require_var_t<T2>* = nullptr>
+          require_var_matrix_t<T2>* = nullptr>
 inline auto bessel_second_kind(T1&& v, T2&& a) {
-  if constexpr (is_stan_scalar_v<T2>) {
-    double ret_val = bessel_second_kind(v, a.val());
-    auto precomp_bessel
-        = v * ret_val / a.val() - bessel_second_kind(v + 1, a.val());
-    return make_callback_var(ret_val, [precomp_bessel, a](auto& vi) mutable {
-      a.adj() += vi.adj() * precomp_bessel;
-    });
-  } else {
-    auto ret_val = bessel_second_kind(v, a.val()).array().eval();
-    auto v_map = as_array_or_scalar(v);
-    auto precomp_bessel
-        = to_arena(v_map * ret_val / a.val().array()
-                   - bessel_second_kind(v_map + 1, a.val().array()));
-    return make_callback_var(
-        ret_val.matrix(), [precomp_bessel, a](const auto& vi) mutable {
-          a.adj().array() += vi.adj().array() * precomp_bessel;
-        });
-  }
+  auto ret_val = bessel_second_kind(v, a.val()).array().eval();
+  auto v_map = as_array_or_scalar(v);
+  auto precomp_bessel
+      = to_arena(v_map * ret_val / a.val().array()
+                 - bessel_second_kind(v_map + 1, a.val().array()));
+  return make_callback_var(
+      ret_val.matrix(), [precomp_bessel, a](const auto& vi) mutable {
+        a.adj().array() += vi.adj().array() * precomp_bessel;
+      });
 }
 
 }  // namespace math

--- a/test/unit/math/mix/fun/bessel_second_kind_test.cpp
+++ b/test/unit/math/mix/fun/bessel_second_kind_test.cpp
@@ -25,10 +25,12 @@ TEST(mathMixScalFun, besselSecondKind_vec) {
   Eigen::VectorXd in2(2);
   in2 << 0.5, 3.4;
   stan::test::expect_ad_vectorized_binary(f, std_in1, in2);
+  stan::test::expect_ad_matvar(f, std_in1, in2);
 
   std::vector<std::vector<int>> std_std_in1{std_in1, std_in1};
   Eigen::MatrixXd mat_in2 = in2.replicate(1, 2);
   stan::test::expect_ad_vectorized_binary(f, std_std_in1, mat_in2);
+  stan::test::expect_ad_matvar(f, std_std_in1, mat_in2);
 }
 
 TEST(mathMixScalFun, besselSecondKind_matvec) {

--- a/test/unit/math/mix/fun/bessel_second_kind_test.cpp
+++ b/test/unit/math/mix/fun/bessel_second_kind_test.cpp
@@ -3,7 +3,7 @@
 
 TEST(mathMixScalFun, besselSecondKind) {
   // bind integer arg because can't autodiff through
-  auto f = [](const int x1) {
+  auto f = [](const auto& x1) {
     return
         [=](const auto& x2) { return stan::math::bessel_second_kind(x1, x2); };
   };
@@ -13,6 +13,13 @@ TEST(mathMixScalFun, besselSecondKind) {
   stan::test::expect_ad(f(1), 3.0);
   stan::test::expect_ad(f(1), std::numeric_limits<double>::quiet_NaN());
   stan::test::expect_ad(f(2), 2.79);
+  std::vector<int> std_in1{3, 1};
+  stan::test::expect_ad(f(std_in1), 4.0);
+  stan::test::expect_ad(f(std_in1), std::numeric_limits<double>::quiet_NaN());
+  stan::test::expect_ad(f(std_in1), -3.0);
+  stan::test::expect_ad(f(std_in1), 3.0);
+  stan::test::expect_ad(f(std_in1), std::numeric_limits<double>::quiet_NaN());
+  stan::test::expect_ad(f(std_in1), 2.79);
 }
 
 TEST(mathMixScalFun, besselSecondKind_vec) {
@@ -31,6 +38,7 @@ TEST(mathMixScalFun, besselSecondKind_vec) {
   Eigen::MatrixXd mat_in2 = in2.replicate(1, 2);
   stan::test::expect_ad_vectorized_binary(f, std_std_in1, mat_in2);
   stan::test::expect_ad_matvar(f, std_std_in1, mat_in2);
+
 }
 
 TEST(mathMixScalFun, besselSecondKind_matvec) {

--- a/test/unit/math/mix/fun/bessel_second_kind_test.cpp
+++ b/test/unit/math/mix/fun/bessel_second_kind_test.cpp
@@ -38,7 +38,6 @@ TEST(mathMixScalFun, besselSecondKind_vec) {
   Eigen::MatrixXd mat_in2 = in2.replicate(1, 2);
   stan::test::expect_ad_vectorized_binary(f, std_std_in1, mat_in2);
   stan::test::expect_ad_matvar(f, std_std_in1, mat_in2);
-
 }
 
 TEST(mathMixScalFun, besselSecondKind_matvec) {


### PR DESCRIPTION
## Summary

This fixes `bessel_second_kind` so that the reverse mode specialization is chosen over the perfect forwarding version of the function we use for the vectorized prim function.

## Tests

Added tests for `bessel_second_kind` that uses reverse mode autodiff for `std::vector<int>` and `std::vector<std::vector<int>>` as the lhs.

## Side Effects

@WardBrian can we run the stanc3 tests on this to make sure this fixes the issue?

## Release notes


## Checklist

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
