### PR TITLE
apply_scalar_binary: avoid using moved-from variable for result size.

### DIFF
--- a/stan/math/prim/functor/apply_scalar_binary.hpp
+++ b/stan/math/prim/functor/apply_scalar_binary.hpp
@@ -335,8 +335,8 @@ template <typename F, typename T1, typename T2,
           require_stan_scalar_t<T1>* = nullptr,
           require_std_vector_vt<is_stan_scalar, T2>* = nullptr>
 inline auto apply_scalar_binary(F&& f, T1&& x, T2&& y) {
-  decltype(auto) y_vec = as_column_vector_or_scalar(y);
   using T_return = std::decay_t<decltype(f(x, y[0]))>;
+  decltype(auto) y_vec = as_column_vector_or_scalar(std::forward<T2>(y));
   std::vector<T_return> result(y_vec.size());
   Eigen::Map<Eigen::Matrix<T_return, -1, 1>>(result.data(), result.size())
       = y_vec.unaryExpr(

--- a/stan/math/prim/functor/apply_scalar_binary.hpp
+++ b/stan/math/prim/functor/apply_scalar_binary.hpp
@@ -306,7 +306,7 @@ template <typename F, typename T1, typename T2,
 inline auto apply_scalar_binary(F&& f, T1&& x, T2&& y) {
   decltype(auto) x_vec = as_column_vector_or_scalar(std::forward<T1>(x));
   using T_return = std::decay_t<decltype(f(x[0], y))>;
-  std::vector<T_return> result(x.size());
+  std::vector<T_return> result(x_vec.size());
   Eigen::Map<Eigen::Matrix<T_return, -1, 1>>(result.data(), result.size())
       = x_vec.unaryExpr(
           [f_ = std::forward<F>(f), y](auto&& v) { return f_(v, y); });
@@ -337,7 +337,7 @@ template <typename F, typename T1, typename T2,
 inline auto apply_scalar_binary(F&& f, T1&& x, T2&& y) {
   decltype(auto) y_vec = as_column_vector_or_scalar(y);
   using T_return = std::decay_t<decltype(f(x, y[0]))>;
-  std::vector<T_return> result(y.size());
+  std::vector<T_return> result(y_vec.size());
   Eigen::Map<Eigen::Matrix<T_return, -1, 1>>(result.data(), result.size())
       = y_vec.unaryExpr(
           [f_ = std::forward<F>(f), x](auto&& v) { return f_(x, v); });

--- a/test/unit/math/prim/fun/log_modified_bessel_first_kind_test.cpp
+++ b/test/unit/math/prim/fun/log_modified_bessel_first_kind_test.cpp
@@ -91,3 +91,22 @@ TEST(MathFunctions, log_modified_bessel_first_kind_vec) {
   in2 << 7.3, 0.7, 2.8;
   stan::test::binary_scalar_tester(f, in1, in2);
 }
+
+TEST(MathFunctions, log_modified_bessel_first_kind_aki_regression) {
+  // https://github.com/stan-dev/cmdstan/issues/1324#issuecomment-3206462728
+
+  using stan::math::log_modified_bessel_first_kind;
+  double rho = 0.5;
+  double alpha = 2.0;
+  int M = 20;
+
+  double a = (1 / stan::math::pow(rho, 2));
+  Eigen::Matrix<double, -1, 1> q = stan::math::exp(stan::math::add(
+      stan::math::log(alpha),
+      stan::math::multiply(
+          0.5,
+          stan::math::add(
+              (stan::math::log(2) - a),
+              stan::math::to_vector(stan::math::log_modified_bessel_first_kind(
+                  stan::math::linspaced_int_array(M, 1, M), a))))));
+}


### PR DESCRIPTION
 

## Summary

Fixes a crash found by @avehtari [here](https://github.com/stan-dev/cmdstan/issues/1324#issuecomment-3206462728)

## Tests

I added a test that crashes if run on `develop`

## Side Effects

None

## Release notes


## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
