### PR TITLE
Remove uses of `forward_as`

### DIFF
--- a/stan/math/fwd/fun/hypergeometric_1F0.hpp
+++ b/stan/math/fwd/fun/hypergeometric_1F0.hpp
@@ -36,10 +36,10 @@ FvarT hypergeometric_1F0(const Ta& a, const Tz& z) {
   partials_type_t<Tz> z_val = value_of(z);
   FvarT rtn = FvarT(hypergeometric_1F0(a_val, z_val), 0.0);
   if constexpr (is_autodiff_v<Ta>) {
-    rtn.d_ += forward_as<FvarT>(a).d() * -rtn.val() * log1m(z_val);
+    rtn.d_ += a.d() * -rtn.val() * log1m(z_val);
   }
   if constexpr (is_autodiff_v<Tz>) {
-    rtn.d_ += forward_as<FvarT>(z).d() * rtn.val() * a_val * inv(1 - z_val);
+    rtn.d_ += z.d() * rtn.val() * a_val * inv(1 - z_val);
   }
   return rtn;
 }

--- a/stan/math/fwd/fun/hypergeometric_2F1.hpp
+++ b/stan/math/fwd/fun/hypergeometric_2F1.hpp
@@ -46,16 +46,16 @@ inline return_type_t<Ta1, Ta2, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   typename fvar_t::Scalar grad = 0;
 
   if constexpr (is_autodiff_v<Ta1>) {
-    grad += forward_as<fvar_t>(a1).d() * std::get<0>(grad_tuple);
+    grad += a1.d() * std::get<0>(grad_tuple);
   }
   if constexpr (is_autodiff_v<Ta2>) {
-    grad += forward_as<fvar_t>(a2).d() * std::get<1>(grad_tuple);
+    grad += a2.d() * std::get<1>(grad_tuple);
   }
   if constexpr (is_autodiff_v<Tb>) {
-    grad += forward_as<fvar_t>(b).d() * std::get<2>(grad_tuple);
+    grad += b.d() * std::get<2>(grad_tuple);
   }
   if constexpr (is_autodiff_v<Tz>) {
-    grad += forward_as<fvar_t>(z).d() * std::get<3>(grad_tuple);
+    grad += z.d() * std::get<3>(grad_tuple);
   }
 
   return fvar_t(hypergeometric_2F1(a1_val, a2_val, b_val, z_val), grad);

--- a/stan/math/fwd/fun/inv_inc_beta.hpp
+++ b/stan/math/fwd/fun/inv_inc_beta.hpp
@@ -80,8 +80,7 @@ inline fvar<partials_return_t<T1, T2, T3>> inv_inc_beta(const T1& a,
   }
 
   if constexpr (is_fvar<T3>::value) {
-    inv_d_ += p.d_
-              * exp(one_m_b * log1m_w + one_m_a * log_w + lbeta_ab);
+    inv_d_ += p.d_ * exp(one_m_b * log1m_w + one_m_a * log_w + lbeta_ab);
   }
 
   return fvar<T_return>(w, inv_d_);

--- a/stan/math/fwd/fun/inv_inc_beta.hpp
+++ b/stan/math/fwd/fun/inv_inc_beta.hpp
@@ -63,7 +63,7 @@ inline fvar<partials_return_t<T1, T2, T3>> inv_inc_beta(const T1& a,
                    + log(hypergeometric_3F2(da_a, da_b, w)) - 2 * lgamma(ap1));
     auto da3 = inc_beta(a_val, b_val, w) * exp(lbeta_ab)
                * (log_w - digamma(a_val) + digamma_apb);
-    inv_d_ += forward_as<fvar<T_return>>(a).d_ * da1 * (da2 - da3);
+    inv_d_ += a.d_ * da1 * (da2 - da3);
   }
 
   if constexpr (is_fvar<T2>::value) {
@@ -76,11 +76,11 @@ inline fvar<partials_return_t<T1, T2, T3>> inv_inc_beta(const T1& a,
     auto db3 = inc_beta(b_val, a_val, one_m_w) * exp(lbeta_ab)
                * (log1m_w - digamma(b_val) + digamma_apb);
 
-    inv_d_ += forward_as<fvar<T_return>>(b).d_ * db1 * (exp(db2) - db3);
+    inv_d_ += b.d_ * db1 * (exp(db2) - db3);
   }
 
   if constexpr (is_fvar<T3>::value) {
-    inv_d_ += forward_as<fvar<T_return>>(p).d_
+    inv_d_ += p.d_
               * exp(one_m_b * log1m_w + one_m_a * log_w + lbeta_ab);
   }
 

--- a/stan/math/fwd/functor/integrate_1d.hpp
+++ b/stan/math/fwd/functor/integrate_1d.hpp
@@ -48,7 +48,7 @@ inline return_type_t<T_a, T_b, Args...> integrate_1d_impl(
   if constexpr (is_fvar<T_a>::value || is_fvar<T_b>::value) {
     auto val_args = std::make_tuple(value_of(args)...);
     if constexpr (is_fvar<T_a>::value) {
-      ret.d_ += math::forward_as<FvarT>(a).d_
+      ret.d_ += a.d_
                 * math::apply(
                     [&](auto &&... tuple_args) {
                       return -f(a_val, 0.0, msgs, tuple_args...);
@@ -56,7 +56,7 @@ inline return_type_t<T_a, T_b, Args...> integrate_1d_impl(
                     val_args);
     }
     if constexpr (is_fvar<T_b>::value) {
-      ret.d_ += math::forward_as<FvarT>(b).d_
+      ret.d_ += b.d_
                 * math::apply(
                     [&](auto &&... tuple_args) {
                       return f(b_val, 0.0, msgs, tuple_args...);

--- a/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
@@ -144,7 +144,8 @@ return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> bernoulli_logit_glm_lpmf(
     if constexpr (is_alpha_vector) {
       partials<1>(ops_partials) = theta_derivative_cl;
     } else {
-      partials<1>(ops_partials)[0] = sum(from_matrix_cl(theta_derivative_sum_cl));
+      partials<1>(ops_partials)[0]
+          = sum(from_matrix_cl(theta_derivative_sum_cl));
     }
   }
   if constexpr (is_autodiff_v<T_beta_cl>) {

--- a/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
@@ -144,9 +144,7 @@ return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> bernoulli_logit_glm_lpmf(
     if constexpr (is_alpha_vector) {
       partials<1>(ops_partials) = theta_derivative_cl;
     } else {
-      forward_as<internal::broadcast_array<double>>(
-          partials<1>(ops_partials))[0]
-          = sum(from_matrix_cl(theta_derivative_sum_cl));
+      partials<1>(ops_partials)[0] = sum(from_matrix_cl(theta_derivative_sum_cl));
     }
   }
   if constexpr (is_autodiff_v<T_beta_cl>) {

--- a/stan/math/opencl/prim/bernoulli_lpmf.hpp
+++ b/stan/math/opencl/prim/bernoulli_lpmf.hpp
@@ -77,7 +77,7 @@ return_type_t<T_prob_cl> bernoulli_lpmf(const T_n_cl& n,
       partials<0>(ops_partials) = deriv_cl;
     }
   } else {
-    auto n_sum_expr = rowwise_sum(forward_as<matrix_cl<int>>(n));
+    auto n_sum_expr = rowwise_sum(n);
 
     matrix_cl<int> n_sum_cl;
 
@@ -85,7 +85,7 @@ return_type_t<T_prob_cl> bernoulli_lpmf(const T_n_cl& n,
         = expressions(n_sum_expr, n_bounded_expr);
 
     size_t n_sum = sum(from_matrix_cl(n_sum_cl));
-    double theta_val_scal = forward_as<double>(theta_val);
+    double theta_val_scal = theta_val;
     if (n_sum == N) {
       logp = N * log(theta_val_scal);
     } else if (n_sum == 0) {
@@ -94,8 +94,7 @@ return_type_t<T_prob_cl> bernoulli_lpmf(const T_n_cl& n,
       logp = n_sum * log(theta_val_scal) + (N - n_sum) * log1m(theta_val_scal);
     }
     if constexpr (is_autodiff_v<T_prob_cl>) {
-      double& edge1_partial = forward_as<internal::broadcast_array<double>>(
-          partials<0>(ops_partials))[0];
+      double& edge1_partial = partials<0>(ops_partials)[0];
       if (n_sum == N) {
         edge1_partial += N / theta_val_scal;
       } else if (n_sum == 0) {

--- a/stan/math/opencl/prim/binomial_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/binomial_logit_glm_lpmf.hpp
@@ -111,9 +111,7 @@ return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> binomial_logit_glm_lpmf(
     if constexpr (is_alpha_vector) {
       partials<1>(ops_partials) = theta_deriv_cl;
     } else {
-      forward_as<internal::broadcast_array<double>>(
-          partials<1>(ops_partials))[0]
-          = sum(from_matrix_cl(theta_deriv_sum_cl));
+      partials<1>(ops_partials)[0] = sum(from_matrix_cl(theta_deriv_sum_cl));
     }
   }
   if constexpr (is_autodiff_v<T_beta_cl>) {

--- a/stan/math/opencl/prim/binomial_lpmf.hpp
+++ b/stan/math/opencl/prim/binomial_lpmf.hpp
@@ -113,9 +113,8 @@ return_type_t<T_prob_cl> binomial_lpmf(const T_n_cl& n, const T_N_cl N,
     if constexpr (need_sums) {
       int sum_n = sum(from_matrix_cl(sum_n_cl));
       int sum_N = sum(from_matrix_cl(sum_N_cl));
-      double theta_dbl = forward_as<double>(theta_val);
-      double& partial = forward_as<internal::broadcast_array<double>>(
-          partials<0>(ops_partials))[0];
+      double theta_dbl = theta_val;
+      double& partial = partials<0>(ops_partials)[0];
       if (sum_N != 0) {
         if (sum_n == 0) {
           partial = -sum_N / (1.0 - theta_dbl);

--- a/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
@@ -88,8 +88,8 @@ return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_lpmf(
       = opencl_kernels::categorical_logit_glm.get_option("LOCAL_SIZE_");
   const int wgs = (N_instances + local_size - 1) / local_size;
 
-  bool need_alpha_derivative = is_autodiff_v<T_alpha>;
-  bool need_beta_derivative = is_autodiff_v<T_beta>;
+  constexpr bool need_alpha_derivative = is_autodiff_v<T_alpha>;
+  constexpr bool need_beta_derivative = is_autodiff_v<T_beta>;
 
   matrix_cl<double> logp_cl(wgs, 1);
   matrix_cl<double> exp_lin_cl(N_instances, N_classes);
@@ -127,13 +127,13 @@ return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_lpmf(
     if constexpr (is_y_vector) {
       partials<0>(ops_partials)
           = indexing(beta_val, col_index(x.rows(), x.cols()),
-                     rowwise_broadcast(forward_as<matrix_cl<int>>(y_val) - 1))
+                     rowwise_broadcast(y_val - 1))
             - elt_multiply(exp_lin_cl * transpose(beta_val),
                            rowwise_broadcast(inv_sum_exp_lin_cl));
     } else {
       partials<0>(ops_partials)
           = indexing(beta_val, col_index(x.rows(), x.cols()),
-                     forward_as<int>(y_val) - 1)
+                     y_val - 1)
             - elt_multiply(exp_lin_cl * transpose(beta_val),
                            rowwise_broadcast(inv_sum_exp_lin_cl));
     }
@@ -152,7 +152,7 @@ return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_lpmf(
       try {
         opencl_kernels::categorical_logit_glm_beta_derivative(
             cl::NDRange(local_size * N_attributes), cl::NDRange(local_size),
-            forward_as<arena_matrix_cl<double>>(partials<2>(ops_partials)),
+            partials<2>(ops_partials),
             temp, y_val_cl, x_val, N_instances, N_attributes, N_classes,
             is_y_vector);
       } catch (const cl::Error& e) {

--- a/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
@@ -132,8 +132,7 @@ return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_lpmf(
                            rowwise_broadcast(inv_sum_exp_lin_cl));
     } else {
       partials<0>(ops_partials)
-          = indexing(beta_val, col_index(x.rows(), x.cols()),
-                     y_val - 1)
+          = indexing(beta_val, col_index(x.rows(), x.cols()), y_val - 1)
             - elt_multiply(exp_lin_cl * transpose(beta_val),
                            rowwise_broadcast(inv_sum_exp_lin_cl));
     }
@@ -152,9 +151,8 @@ return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_lpmf(
       try {
         opencl_kernels::categorical_logit_glm_beta_derivative(
             cl::NDRange(local_size * N_attributes), cl::NDRange(local_size),
-            partials<2>(ops_partials),
-            temp, y_val_cl, x_val, N_instances, N_attributes, N_classes,
-            is_y_vector);
+            partials<2>(ops_partials), temp, y_val_cl, x_val, N_instances,
+            N_attributes, N_classes, is_y_vector);
       } catch (const cl::Error& e) {
         check_opencl_error(function, e);
       }

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -169,13 +169,13 @@ neg_binomial_2_log_glm_lpmf(const T_y_cl& y, const T_x_cl& x,
 
   if constexpr (include_summand<propto, T_phi_cl>::value && !is_phi_vector) {
     logp += N
-            * (multiply_log(forward_as<double>(phi_val),
-                            forward_as<double>(phi_val))
-               - lgamma(forward_as<double>(phi_val)));
+            * (multiply_log(phi_val,
+                            phi_val)
+               - lgamma(phi_val));
   }
   if constexpr (include_summand<propto, T_phi_cl>::value && !is_y_vector
                 && !is_phi_vector) {
-    logp += forward_as<double>(lgamma(y_val + phi_val)) * N;
+    logp += lgamma(y_val + phi_val) * N;
   }
 
   auto ops_partials = make_partials_propagator(x, alpha, beta, phi);
@@ -203,18 +203,14 @@ neg_binomial_2_log_glm_lpmf(const T_y_cl& y, const T_x_cl& x,
     if constexpr (is_alpha_vector) {
       partials<1>(ops_partials) = std::move(theta_derivative_cl);
     } else {
-      forward_as<internal::broadcast_array<double>>(
-          partials<1>(ops_partials))[0]
-          = sum(from_matrix_cl(theta_derivative_sum_cl));
+      partials<1>(ops_partials)[0] = sum(from_matrix_cl(theta_derivative_sum_cl));
     }
   }
   if constexpr (is_autodiff_v<T_phi_cl>) {
     if constexpr (is_phi_vector) {
       partials<3>(ops_partials) = std::move(phi_derivative_cl);
     } else {
-      forward_as<internal::broadcast_array<double>>(
-          partials<3>(ops_partials))[0]
-          = sum(from_matrix_cl(phi_derivative_cl));
+      partials<3>(ops_partials)[0] = sum(from_matrix_cl(phi_derivative_cl));
     }
   }
   return ops_partials.build(logp);

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -168,10 +168,7 @@ neg_binomial_2_log_glm_lpmf(const T_y_cl& y, const T_x_cl& x,
   }
 
   if constexpr (include_summand<propto, T_phi_cl>::value && !is_phi_vector) {
-    logp += N
-            * (multiply_log(phi_val,
-                            phi_val)
-               - lgamma(phi_val));
+    logp += N * (multiply_log(phi_val, phi_val) - lgamma(phi_val));
   }
   if constexpr (include_summand<propto, T_phi_cl>::value && !is_y_vector
                 && !is_phi_vector) {
@@ -203,7 +200,8 @@ neg_binomial_2_log_glm_lpmf(const T_y_cl& y, const T_x_cl& x,
     if constexpr (is_alpha_vector) {
       partials<1>(ops_partials) = std::move(theta_derivative_cl);
     } else {
-      partials<1>(ops_partials)[0] = sum(from_matrix_cl(theta_derivative_sum_cl));
+      partials<1>(ops_partials)[0]
+          = sum(from_matrix_cl(theta_derivative_sum_cl));
     }
   }
   if constexpr (is_autodiff_v<T_phi_cl>) {

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -149,9 +149,7 @@ normal_id_glm_lpdf(const T_y_cl& y, const T_x_cl& x, const T_alpha_cl& alpha,
     if constexpr (is_y_vector) {
       partials<0>(ops_partials) = -mu_derivative_cl;
     } else {
-      forward_as<internal::broadcast_array<double>>(
-          partials<0>(ops_partials))[0]
-          = -mu_derivative_sum;
+      partials<0>(ops_partials)[0] = -mu_derivative_sum;
     }
   }
   if constexpr (is_autodiff_v<T_x_cl>) {
@@ -162,9 +160,7 @@ normal_id_glm_lpdf(const T_y_cl& y, const T_x_cl& x, const T_alpha_cl& alpha,
     if constexpr (is_alpha_vector) {
       partials<2>(ops_partials) = mu_derivative_cl;
     } else {
-      forward_as<internal::broadcast_array<double>>(
-          partials<2>(ops_partials))[0]
-          = mu_derivative_sum;
+      partials<2>(ops_partials)[0] = mu_derivative_sum;
     }
   }
   if constexpr (is_autodiff_v<T_beta_cl>) {
@@ -207,7 +203,7 @@ normal_id_glm_lpdf(const T_y_cl& y, const T_x_cl& x, const T_alpha_cl& alpha,
     if constexpr (is_sigma_vector) {
       logp -= sum(from_matrix_cl(log_sigma_sum_cl));
     } else {
-      logp -= N * log(forward_as<double>(sigma_val));
+      logp -= N * log(sigma_val);
     }
   }
   logp -= 0.5 * y_scaled_sq_sum;

--- a/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
@@ -133,9 +133,7 @@ return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> poisson_log_glm_lpmf(
     if constexpr (is_alpha_vector) {
       partials<1>(ops_partials) = theta_derivative_cl;
     } else {
-      forward_as<internal::broadcast_array<double>>(
-          partials<1>(ops_partials))[0]
-          = theta_derivative_sum;
+      partials<1>(ops_partials)[0] = theta_derivative_sum;
     }
   }
   if constexpr (is_autodiff_v<T_beta_cl>) {

--- a/stan/math/opencl/rev/add_diag.hpp
+++ b/stan/math/opencl/rev/add_diag.hpp
@@ -40,8 +40,7 @@ inline auto add_diag(const T_m& mat, const T_a& to_add) {
     }
     if constexpr (is_autodiff_v<T_a>) {
       if constexpr (!is_stan_scalar<T_a>::value) {
-        auto& to_add_adj
-            = to_add_arena.adj();
+        auto& to_add_adj = to_add_arena.adj();
         to_add_adj += diagonal(res.adj());
       } else {
         auto& to_add_adj = to_add_arena.adj();

--- a/stan/math/opencl/rev/add_diag.hpp
+++ b/stan/math/opencl/rev/add_diag.hpp
@@ -41,10 +41,10 @@ inline auto add_diag(const T_m& mat, const T_a& to_add) {
     if constexpr (is_autodiff_v<T_a>) {
       if constexpr (!is_stan_scalar<T_a>::value) {
         auto& to_add_adj
-            = forward_as<var_value<matrix_cl<double>>>(to_add_arena).adj();
+            = to_add_arena.adj();
         to_add_adj += diagonal(res.adj());
       } else {
-        auto& to_add_adj = forward_as<var_value<double>>(to_add_arena).adj();
+        auto& to_add_adj = to_add_arena.adj();
         to_add_adj += to_add_adj + sum(diagonal(res.adj()));
       }
     }

--- a/stan/math/prim/meta/compiler_attributes.hpp
+++ b/stan/math/prim/meta/compiler_attributes.hpp
@@ -39,7 +39,9 @@
 #ifndef unlikely
 #define unlikely(x) x
 #endif
-
+#ifndef STAN_DEPRECATED
+#define STAN_DEPRECATED
+#endif
 /**
  * Turns all range and size checks into no-ops
  */

--- a/stan/math/prim/meta/compiler_attributes.hpp
+++ b/stan/math/prim/meta/compiler_attributes.hpp
@@ -30,7 +30,6 @@
 
 #endif
 
-
 #ifndef STAN_COLD_PATH
 #define STAN_COLD_PATH
 #endif

--- a/stan/math/prim/meta/compiler_attributes.hpp
+++ b/stan/math/prim/meta/compiler_attributes.hpp
@@ -20,7 +20,17 @@
 #endif
 #endif
 #endif
+#ifndef STAN_DEPRECATED
+#if __has_attribute(deprecated)
+#define STAN_DEPRECATED __attribute__((deprecated))
+#else
+#define STAN_DEPRECATED
 #endif
+#endif
+
+#endif
+
+
 #ifndef STAN_COLD_PATH
 #define STAN_COLD_PATH
 #endif

--- a/stan/math/prim/meta/forward_as.hpp
+++ b/stan/math/prim/meta/forward_as.hpp
@@ -34,7 +34,7 @@ template <typename T_desired, typename T_actual,
           = std::enable_if_t<std::is_same<std::decay_t<T_actual>,
                                           std::decay_t<T_desired>>::value
                              && !is_eigen<T_desired>::value>>
-inline T_actual&& forward_as(T_actual&& a) {  // NOLINT
+STAN_DEPRECATED inline T_actual&& forward_as(T_actual&& a) {  // NOLINT
   return std::forward<T_actual>(a);
 }
 
@@ -61,7 +61,7 @@ template <
         !std::is_same<std::decay<T_actual>, std::decay<T_desired>>::value
         && !(std::is_floating_point_v<std::decay_t<
                  T_desired>> && std::is_integral_v<std::decay_t<T_actual>>)>>
-inline T_desired forward_as(const T_actual& a) {
+STAN_DEPRECATED inline T_desired forward_as(const T_actual& a) {
   throw std::runtime_error(
       "Wrong type assumed! Please file a bug report. prim/meta/forward_as.hpp "
       "line "
@@ -87,7 +87,7 @@ template <typename T_desired, typename T_actual,
           typename = std::enable_if_t<
               std::is_floating_point_v<std::decay_t<
                   T_desired>> && std::is_integral_v<std::decay_t<T_actual>>>>
-inline T_desired forward_as(const T_actual& a) {
+STAN_DEPRECATED inline T_desired forward_as(const T_actual& a) {
   return static_cast<T_desired>(a);
 }
 
@@ -117,7 +117,7 @@ template <
         && internal::eigen_static_size_match(
             T_desired::ColsAtCompileTime,
             std::decay_t<T_actual>::ColsAtCompileTime)>* = nullptr>
-inline T_actual&& forward_as(T_actual&& a) {  // NOLINT
+STAN_DEPRECATED inline T_actual&& forward_as(T_actual&& a) {  // NOLINT
   return std::forward<T_actual>(a);
 }
 
@@ -148,7 +148,7 @@ template <
         || !internal::eigen_static_size_match(
             T_desired::ColsAtCompileTime,
             std::decay_t<T_actual>::ColsAtCompileTime)>* = nullptr>
-inline T_desired forward_as(const T_actual& a) {
+STAN_DEPRECATED inline T_desired forward_as(const T_actual& a) {
   throw std::runtime_error(
       "Wrong type assumed! Please file a bug report. prim/meta/forward_as.hpp "
       "line "

--- a/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
@@ -108,7 +108,7 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   Array<T_partials_return, Dynamic, 1> ytheta(N_instances);
   if constexpr (T_x_rows == 1) {
     T_ytheta_tmp ytheta_tmp
-        = forward_as<T_xbeta_tmp>((x_val * beta_val_vec)(0, 0));
+        = (x_val * beta_val_vec)(0, 0);
     ytheta = signs * (ytheta_tmp + as_array_or_scalar(alpha_val_vec));
   } else {
     ytheta = (x_val * beta_val_vec).array();
@@ -143,8 +143,7 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
     if constexpr (is_autodiff_v<T_beta>) {
       if constexpr (T_x_rows == 1) {
         edge<2>(ops_partials).partials_
-            = forward_as<Matrix<T_partials_return, 1, Dynamic>>(
-                theta_derivative.sum() * x_val);
+            = theta_derivative.sum() * x_val;
       } else {
         partials<2>(ops_partials) = x_val.transpose() * theta_derivative;
       }
@@ -152,8 +151,7 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
     if constexpr (is_autodiff_v<T_x>) {
       if constexpr (T_x_rows == 1) {
         edge<0>(ops_partials).partials_
-            = forward_as<Array<T_partials_return, Dynamic, T_x_rows>>(
-                beta_val_vec * theta_derivative.sum());
+            = beta_val_vec * theta_derivative.sum();
       } else {
         edge<0>(ops_partials).partials_
             = (beta_val_vec * theta_derivative.transpose()).transpose();

--- a/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
@@ -57,14 +57,10 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   using std::exp;
   using std::isfinite;
   constexpr int T_x_rows = T_x::RowsAtCompileTime;
-  using T_xbeta_partials = partials_return_t<T_x, T_beta>;
   using T_partials_return = partials_return_t<T_y, T_x, T_alpha, T_beta>;
   using T_ytheta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_partials_return,
                                   Array<T_partials_return, Dynamic, 1>>;
-  using T_xbeta_tmp =
-      typename std::conditional_t<T_x_rows == 1, T_xbeta_partials,
-                                  Array<T_xbeta_partials, Dynamic, 1>>;
   using T_x_ref = ref_type_if_not_constant_t<T_x>;
   using T_alpha_ref = ref_type_if_not_constant_t<T_alpha>;
   using T_beta_ref = ref_type_if_not_constant_t<T_beta>;

--- a/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
@@ -107,8 +107,7 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
 
   Array<T_partials_return, Dynamic, 1> ytheta(N_instances);
   if constexpr (T_x_rows == 1) {
-    T_ytheta_tmp ytheta_tmp
-        = (x_val * beta_val_vec)(0, 0);
+    T_ytheta_tmp ytheta_tmp = (x_val * beta_val_vec)(0, 0);
     ytheta = signs * (ytheta_tmp + as_array_or_scalar(alpha_val_vec));
   } else {
     ytheta = (x_val * beta_val_vec).array();
@@ -142,16 +141,14 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
                                   signs * exp_m_ytheta / (exp_m_ytheta + 1)));
     if constexpr (is_autodiff_v<T_beta>) {
       if constexpr (T_x_rows == 1) {
-        edge<2>(ops_partials).partials_
-            = theta_derivative.sum() * x_val;
+        edge<2>(ops_partials).partials_ = theta_derivative.sum() * x_val;
       } else {
         partials<2>(ops_partials) = x_val.transpose() * theta_derivative;
       }
     }
     if constexpr (is_autodiff_v<T_x>) {
       if constexpr (T_x_rows == 1) {
-        edge<0>(ops_partials).partials_
-            = beta_val_vec * theta_derivative.sum();
+        edge<0>(ops_partials).partials_ = beta_val_vec * theta_derivative.sum();
       } else {
         edge<0>(ops_partials).partials_
             = (beta_val_vec * theta_derivative.transpose()).transpose();

--- a/stan/math/prim/prob/bernoulli_logit_glm_rng.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_rng.hpp
@@ -67,7 +67,7 @@ inline typename VectorBuilder<true, int, T_alpha>::type bernoulli_logit_glm_rng(
   if constexpr (is_vector<T_beta>::value) {
     x_beta = x_ref * beta_vector;
   } else {
-    x_beta = (x_ref.array() * forward_as<double>(beta_vector)).rowwise().sum();
+    x_beta = (x_ref.array() * beta_vector).rowwise().sum();
   }
 
   scalar_seq_view<T_alpha> alpha_vec(alpha_ref);

--- a/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
@@ -65,8 +65,7 @@ return_type_t<T_prob> bernoulli_logit_lpmf(const T_n& n, const T_prob& theta) {
   if constexpr (is_vector<T_n>::value || is_vector<T_prob>::value) {
     ntheta = signs * theta_val;
   } else {
-    T_partials_return ntheta_s
-        = signs * theta_val;
+    T_partials_return ntheta_s = signs * theta_val;
     ntheta = T_partials_array::Constant(1, 1, ntheta_s);
   }
   T_partials_array exp_m_ntheta = exp(-ntheta);

--- a/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
@@ -63,10 +63,10 @@ return_type_t<T_prob> bernoulli_logit_lpmf(const T_n& n, const T_prob& theta) {
       (2 * as_array_or_scalar(n_double) - 1));
   T_partials_array ntheta;
   if constexpr (is_vector<T_n>::value || is_vector<T_prob>::value) {
-    ntheta = forward_as<T_partials_array>(signs * theta_val);
+    ntheta = signs * theta_val;
   } else {
     T_partials_return ntheta_s
-        = forward_as<T_partials_return>(signs * theta_val);
+        = signs * theta_val;
     ntheta = T_partials_array::Constant(1, 1, ntheta_s);
   }
   T_partials_array exp_m_ntheta = exp(-ntheta);

--- a/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
@@ -104,7 +104,7 @@ return_type_t<T_x, T_alpha, T_beta> binomial_logit_glm_lpmf(
   auto&& x_val = value_of(x_ref);
   Eigen::Array<T_partials_return, -1, 1> theta(N_instances);
   if constexpr (T_x_rows == 1) {
-    theta = forward_as<T_xbeta_tmp>((x_val * beta_val)(0, 0)) + alpha_val;
+    theta = (x_val * beta_val)(0, 0) + alpha_val;
   } else {
     theta = (x_val * beta_val).array() + alpha_val;
   }
@@ -135,8 +135,7 @@ return_type_t<T_x, T_alpha, T_beta> binomial_logit_glm_lpmf(
     if constexpr (is_autodiff_v<T_beta>) {
       if constexpr (T_x_rows == 1) {
         edge<2>(ops_partials).partials_
-            = forward_as<Eigen::Matrix<T_partials_return, 1, -1>>(
-                theta_derivative.sum() * x_val);
+            = theta_derivative.sum() * x_val;
       } else {
         partials<2>(ops_partials) = x_val.transpose() * theta_derivative;
       }
@@ -145,8 +144,7 @@ return_type_t<T_x, T_alpha, T_beta> binomial_logit_glm_lpmf(
     if constexpr (is_autodiff_v<T_x>) {
       if constexpr (T_x_rows == 1) {
         edge<0>(ops_partials).partials_
-            = forward_as<Eigen::Array<T_partials_return, -1, T_x_rows>>(
-                beta_val * theta_derivative.sum());
+            = beta_val * theta_derivative.sum();
       } else {
         edge<0>(ops_partials).partials_
             = (beta_val * theta_derivative.transpose()).transpose();

--- a/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
@@ -134,8 +134,7 @@ return_type_t<T_x, T_alpha, T_beta> binomial_logit_glm_lpmf(
 
     if constexpr (is_autodiff_v<T_beta>) {
       if constexpr (T_x_rows == 1) {
-        edge<2>(ops_partials).partials_
-            = theta_derivative.sum() * x_val;
+        edge<2>(ops_partials).partials_ = theta_derivative.sum() * x_val;
       } else {
         partials<2>(ops_partials) = x_val.transpose() * theta_derivative;
       }
@@ -143,8 +142,7 @@ return_type_t<T_x, T_alpha, T_beta> binomial_logit_glm_lpmf(
 
     if constexpr (is_autodiff_v<T_x>) {
       if constexpr (T_x_rows == 1) {
-        edge<0>(ops_partials).partials_
-            = beta_val * theta_derivative.sum();
+        edge<0>(ops_partials).partials_ = beta_val * theta_derivative.sum();
       } else {
         edge<0>(ops_partials).partials_
             = (beta_val * theta_derivative.transpose()).transpose();

--- a/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_glm_lpmf.hpp
@@ -57,11 +57,7 @@ return_type_t<T_x, T_alpha, T_beta> binomial_logit_glm_lpmf(
     const T_n& n, const T_N& N, const T_x& x, const T_alpha& alpha,
     const T_beta& beta) {
   constexpr int T_x_rows = T_x::RowsAtCompileTime;
-  using T_xbeta_partials = partials_return_t<T_x, T_beta>;
   using T_partials_return = partials_return_t<T_x, T_alpha, T_beta>;
-  using T_xbeta_tmp =
-      typename std::conditional_t<T_x_rows == 1, T_xbeta_partials,
-                                  Eigen::Array<T_xbeta_partials, -1, 1>>;
   using T_n_ref = ref_type_if_t<is_autodiff_v<T_n>, T_n>;
   using T_N_ref = ref_type_if_t<is_autodiff_v<T_N>, T_N>;
   using T_x_ref = ref_type_if_t<is_autodiff_v<T_x>, T_x>;

--- a/stan/math/prim/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/chi_square_lpdf.hpp
@@ -45,7 +45,6 @@ template <bool propto, typename T_y, typename T_dof,
               T_y, T_dof>* = nullptr>
 return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
-  using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using std::log;
   static constexpr const char* function = "chi_square_lpdf";
   using T_y_ref = ref_type_t<T_y>;

--- a/stan/math/prim/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/chi_square_lpdf.hpp
@@ -88,7 +88,8 @@ return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
   }
   if constexpr (is_autodiff_v<T_dof>) {
     if constexpr (is_vector<T_dof>::value) {
-      partials<1>(ops_partials) = (log_y - digamma(half_nu)) * 0.5 - HALF_LOG_TWO;
+      partials<1>(ops_partials)
+          = (log_y - digamma(half_nu)) * 0.5 - HALF_LOG_TWO;
     } else {
       partials<1>(ops_partials)[0]
           = sum(log_y - digamma(half_nu)) * 0.5 - HALF_LOG_TWO * N;

--- a/stan/math/prim/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/chi_square_lpdf.hpp
@@ -88,8 +88,7 @@ return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
   }
   if constexpr (is_autodiff_v<T_dof>) {
     if constexpr (is_vector<T_dof>::value) {
-      partials<1>(ops_partials) = forward_as<T_partials_array>(
-          (log_y - digamma(half_nu)) * 0.5 - HALF_LOG_TWO);
+      partials<1>(ops_partials) = (log_y - digamma(half_nu)) * 0.5 - HALF_LOG_TWO;
     } else {
       partials<1>(ops_partials)[0]
           = sum(log_y - digamma(half_nu)) * 0.5 - HALF_LOG_TWO * N;

--- a/stan/math/prim/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/prob/double_exponential_cdf.hpp
@@ -75,7 +75,6 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_cdf(
 
   T_rep_deriv rep_deriv;
   if constexpr (is_vector<T_y>::value || is_vector<T_loc>::value) {
-    using array_bool = Eigen::Array<bool, Eigen::Dynamic, 1>;
     cdf = (y_val < mu_val)
               .select(exp_scaled_diff * 0.5, 1.0 - 0.5 / exp_scaled_diff)
               .prod();

--- a/stan/math/prim/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/prob/double_exponential_cdf.hpp
@@ -77,23 +77,18 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_cdf(
   if constexpr (is_vector<T_y>::value || is_vector<T_loc>::value) {
     using array_bool = Eigen::Array<bool, Eigen::Dynamic, 1>;
     cdf = (y_val < mu_val)
-              .select(exp_scaled_diff * 0.5,
-                      1.0 - 0.5 / exp_scaled_diff)
+              .select(exp_scaled_diff * 0.5, 1.0 - 0.5 / exp_scaled_diff)
               .prod();
-    rep_deriv =
-        (y_val < mu_val)
-            .select((cdf * inv_sigma),
-                    cdf * inv_sigma
-                                                 / (2 * exp_scaled_diff - 1));
+    rep_deriv = (y_val < mu_val)
+                    .select((cdf * inv_sigma),
+                            cdf * inv_sigma / (2 * exp_scaled_diff - 1));
   } else {
     if constexpr (is_vector<T_scale>::value) {
-      cdf = (y_val < mu_val)
-                ? (exp_scaled_diff * 0.5).prod()
-                : (1.0 - 0.5 / exp_scaled_diff).prod();
+      cdf = (y_val < mu_val) ? (exp_scaled_diff * 0.5).prod()
+                             : (1.0 - 0.5 / exp_scaled_diff).prod();
     } else {
-      cdf = (y_val < mu_val)
-                ? exp_scaled_diff * 0.5
-                : 1.0 - 0.5 / exp_scaled_diff;
+      cdf = (y_val < mu_val) ? exp_scaled_diff * 0.5
+                             : 1.0 - 0.5 / exp_scaled_diff;
     }
     if (y_val < mu_val) {
       rep_deriv = cdf * inv_sigma;

--- a/stan/math/prim/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/prob/double_exponential_cdf.hpp
@@ -76,27 +76,26 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_cdf(
   T_rep_deriv rep_deriv;
   if constexpr (is_vector<T_y>::value || is_vector<T_loc>::value) {
     using array_bool = Eigen::Array<bool, Eigen::Dynamic, 1>;
-    cdf = forward_as<array_bool>(y_val < mu_val)
-              .select(forward_as<T_partials_array>(exp_scaled_diff * 0.5),
+    cdf = (y_val < mu_val)
+              .select(exp_scaled_diff * 0.5,
                       1.0 - 0.5 / exp_scaled_diff)
               .prod();
-    rep_deriv = forward_as<T_rep_deriv>(
-        forward_as<array_bool>(y_val < mu_val)
+    rep_deriv =
+        (y_val < mu_val)
             .select((cdf * inv_sigma),
-                    forward_as<T_partials_array>(cdf * inv_sigma
-                                                 / (2 * exp_scaled_diff - 1))));
+                    cdf * inv_sigma
+                                                 / (2 * exp_scaled_diff - 1));
   } else {
     if constexpr (is_vector<T_scale>::value) {
-      cdf = forward_as<bool>(y_val < mu_val)
-                ? forward_as<T_partials_array>(exp_scaled_diff * 0.5).prod()
-                : forward_as<T_partials_array>(1.0 - 0.5 / exp_scaled_diff)
-                      .prod();
+      cdf = (y_val < mu_val)
+                ? (exp_scaled_diff * 0.5).prod()
+                : (1.0 - 0.5 / exp_scaled_diff).prod();
     } else {
-      cdf = forward_as<bool>(y_val < mu_val)
-                ? forward_as<T_partials_return>(exp_scaled_diff * 0.5)
-                : forward_as<T_partials_return>(1.0 - 0.5 / exp_scaled_diff);
+      cdf = (y_val < mu_val)
+                ? exp_scaled_diff * 0.5
+                : 1.0 - 0.5 / exp_scaled_diff;
     }
-    if (forward_as<bool>(y_val < mu_val)) {
+    if (y_val < mu_val) {
       rep_deriv = cdf * inv_sigma;
     } else {
       rep_deriv = cdf * inv_sigma / (2 * exp_scaled_diff - 1);

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -30,7 +30,6 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
-  using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using T_y_ref = ref_type_if_not_constant_t<T_y>;
   using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
   using T_sigma_ref = ref_type_if_not_constant_t<T_scale>;
@@ -62,7 +61,6 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
   auto ops_partials
       = make_partials_propagator(y_ref, mu_ref, sigma_ref, lambda_ref);
 
-  using T_y_val_scalar = scalar_type_t<decltype(y_val)>;
   if constexpr (is_vector<T_y>::value) {
     if ((y_val == NEGATIVE_INFTY).any()) {
       return ops_partials.build(0.0);

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -64,13 +64,11 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
 
   using T_y_val_scalar = scalar_type_t<decltype(y_val)>;
   if constexpr (is_vector<T_y>::value) {
-    if ((forward_as<Eigen::Array<T_y_val_scalar, Eigen::Dynamic, 1>>(y_val)
-         == NEGATIVE_INFTY)
-            .any()) {
+    if ((y_val == NEGATIVE_INFTY).any()) {
       return ops_partials.build(0.0);
     }
   } else {
-    if (forward_as<T_y_val_scalar>(y_val) == NEGATIVE_INFTY) {
+    if (y_val == NEGATIVE_INFTY) {
       return ops_partials.build(0.0);
     }
   }
@@ -93,9 +91,9 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
 
   T_partials_return cdf(1.0);
   if constexpr (is_vector<decltype(cdf_n)>::value) {
-    cdf = forward_as<T_partials_array>(cdf_n).prod();
+    cdf = cdf_n.prod();
   } else {
-    cdf = forward_as<T_partials_return>(cdf_n);
+    cdf = cdf_n;
   }
 
   if constexpr (is_any_autodiff_v<T_y, T_loc, T_scale, T_inv_scale>) {

--- a/stan/math/prim/prob/exponential_cdf.hpp
+++ b/stan/math/prim/prob/exponential_cdf.hpp
@@ -60,9 +60,9 @@ return_type_t<T_y, T_inv_scale> exponential_cdf(const T_y& y,
 
   T_partials_return cdf(1.0);
   if constexpr (is_vector<T_y>::value || is_vector<T_inv_scale>::value) {
-    cdf = forward_as<T_partials_array>(one_m_exp).prod();
+    cdf = one_m_exp.prod();
   } else {
-    cdf = forward_as<T_partials_return>(one_m_exp);
+    cdf = one_m_exp;
   }
 
   if constexpr (any_derivatives) {

--- a/stan/math/prim/prob/exponential_cdf.hpp
+++ b/stan/math/prim/prob/exponential_cdf.hpp
@@ -35,7 +35,6 @@ template <typename T_y, typename T_inv_scale,
 return_type_t<T_y, T_inv_scale> exponential_cdf(const T_y& y,
                                                 const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
-  using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using T_y_ref = ref_type_if_not_constant_t<T_y>;
   using T_beta_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static constexpr const char* function = "exponential_cdf";

--- a/stan/math/prim/prob/exponential_lccdf.hpp
+++ b/stan/math/prim/prob/exponential_lccdf.hpp
@@ -46,9 +46,9 @@ return_type_t<T_y, T_inv_scale> exponential_lccdf(const T_y& y,
     using beta_val_array = Eigen::Array<beta_val_scalar, Eigen::Dynamic, 1>;
     if constexpr (is_vector<T_y>::value && !is_vector<T_inv_scale>::value) {
       partials<0>(ops_partials) = T_partials_array::Constant(
-          math::size(y), -forward_as<beta_val_scalar>(beta_val));
+          math::size(y), -beta_val);
     } else if constexpr (is_vector<T_inv_scale>::value) {
-      partials<0>(ops_partials) = -forward_as<beta_val_array>(beta_val);
+      partials<0>(ops_partials) = -beta_val;
     } else {
       partials<0>(ops_partials)[0] = -sum(beta_val);
     }
@@ -58,9 +58,9 @@ return_type_t<T_y, T_inv_scale> exponential_lccdf(const T_y& y,
     using y_val_array = Eigen::Array<y_val_scalar, Eigen::Dynamic, 1>;
     if constexpr (is_vector<T_inv_scale>::value && !is_vector<T_y>::value) {
       partials<1>(ops_partials) = T_partials_array::Constant(
-          math::size(beta), -forward_as<y_val_scalar>(y_val));
+          math::size(beta), -y_val);
     } else if constexpr (is_vector<T_y>::value) {
-      partials<1>(ops_partials) = -forward_as<y_val_array>(y_val);
+      partials<1>(ops_partials) = -y_val;
     } else {
       partials<1>(ops_partials)[0] = -sum(y_val);
     }

--- a/stan/math/prim/prob/exponential_lccdf.hpp
+++ b/stan/math/prim/prob/exponential_lccdf.hpp
@@ -42,8 +42,6 @@ return_type_t<T_y, T_inv_scale> exponential_lccdf(const T_y& y,
   T_partials_return ccdf_log = -sum(beta_val * y_val);
 
   if constexpr (is_autodiff_v<T_y>) {
-    using beta_val_scalar = scalar_type_t<decltype(beta_val)>;
-    using beta_val_array = Eigen::Array<beta_val_scalar, Eigen::Dynamic, 1>;
     if constexpr (is_vector<T_y>::value && !is_vector<T_inv_scale>::value) {
       partials<0>(ops_partials)
           = T_partials_array::Constant(math::size(y), -beta_val);
@@ -54,8 +52,6 @@ return_type_t<T_y, T_inv_scale> exponential_lccdf(const T_y& y,
     }
   }
   if constexpr (is_autodiff_v<T_inv_scale>) {
-    using y_val_scalar = scalar_type_t<decltype(y_val)>;
-    using y_val_array = Eigen::Array<y_val_scalar, Eigen::Dynamic, 1>;
     if constexpr (is_vector<T_inv_scale>::value && !is_vector<T_y>::value) {
       partials<1>(ops_partials)
           = T_partials_array::Constant(math::size(beta), -y_val);

--- a/stan/math/prim/prob/exponential_lccdf.hpp
+++ b/stan/math/prim/prob/exponential_lccdf.hpp
@@ -45,8 +45,8 @@ return_type_t<T_y, T_inv_scale> exponential_lccdf(const T_y& y,
     using beta_val_scalar = scalar_type_t<decltype(beta_val)>;
     using beta_val_array = Eigen::Array<beta_val_scalar, Eigen::Dynamic, 1>;
     if constexpr (is_vector<T_y>::value && !is_vector<T_inv_scale>::value) {
-      partials<0>(ops_partials) = T_partials_array::Constant(
-          math::size(y), -beta_val);
+      partials<0>(ops_partials)
+          = T_partials_array::Constant(math::size(y), -beta_val);
     } else if constexpr (is_vector<T_inv_scale>::value) {
       partials<0>(ops_partials) = -beta_val;
     } else {
@@ -57,8 +57,8 @@ return_type_t<T_y, T_inv_scale> exponential_lccdf(const T_y& y,
     using y_val_scalar = scalar_type_t<decltype(y_val)>;
     using y_val_array = Eigen::Array<y_val_scalar, Eigen::Dynamic, 1>;
     if constexpr (is_vector<T_inv_scale>::value && !is_vector<T_y>::value) {
-      partials<1>(ops_partials) = T_partials_array::Constant(
-          math::size(beta), -y_val);
+      partials<1>(ops_partials)
+          = T_partials_array::Constant(math::size(beta), -y_val);
     } else if constexpr (is_vector<T_y>::value) {
       partials<1>(ops_partials) = -y_val;
     } else {

--- a/stan/math/prim/prob/exponential_lpdf.hpp
+++ b/stan/math/prim/prob/exponential_lpdf.hpp
@@ -82,8 +82,6 @@ return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
   }
 
   if constexpr (is_autodiff_v<T_y>) {
-    using beta_val_scalar = scalar_type_t<decltype(beta_val)>;
-    using beta_val_array = Eigen::Array<beta_val_scalar, Eigen::Dynamic, 1>;
     if constexpr (is_vector<T_y>::value && !is_vector<T_inv_scale>::value) {
       partials<0>(ops_partials)
           = T_partials_array::Constant(math::size(y), -beta_val);

--- a/stan/math/prim/prob/exponential_lpdf.hpp
+++ b/stan/math/prim/prob/exponential_lpdf.hpp
@@ -85,13 +85,12 @@ return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
     using beta_val_scalar = scalar_type_t<decltype(beta_val)>;
     using beta_val_array = Eigen::Array<beta_val_scalar, Eigen::Dynamic, 1>;
     if constexpr (is_vector<T_y>::value && !is_vector<T_inv_scale>::value) {
-      partials<0>(ops_partials) = T_partials_array::Constant(
-          math::size(y), -beta_val);
+      partials<0>(ops_partials)
+          = T_partials_array::Constant(math::size(y), -beta_val);
     } else if constexpr (is_vector<T_inv_scale>::value) {
       partials<0>(ops_partials) = -beta_val;
     } else {
-      partials<0>(ops_partials)
-          = -beta_val;
+      partials<0>(ops_partials) = -beta_val;
     }
   }
   if constexpr (is_autodiff_v<T_inv_scale>) {

--- a/stan/math/prim/prob/exponential_lpdf.hpp
+++ b/stan/math/prim/prob/exponential_lpdf.hpp
@@ -86,13 +86,12 @@ return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
     using beta_val_array = Eigen::Array<beta_val_scalar, Eigen::Dynamic, 1>;
     if constexpr (is_vector<T_y>::value && !is_vector<T_inv_scale>::value) {
       partials<0>(ops_partials) = T_partials_array::Constant(
-          math::size(y), -forward_as<beta_val_scalar>(beta_val));
+          math::size(y), -beta_val);
     } else if constexpr (is_vector<T_inv_scale>::value) {
-      partials<0>(ops_partials) = -forward_as<beta_val_array>(beta_val);
+      partials<0>(ops_partials) = -beta_val;
     } else {
-      forward_as<internal::broadcast_array<T_partials_return>>(
-          partials<0>(ops_partials))
-          = -forward_as<beta_val_scalar>(beta_val);
+      partials<0>(ops_partials)
+          = -beta_val;
     }
   }
   if constexpr (is_autodiff_v<T_inv_scale>) {

--- a/stan/math/prim/prob/gumbel_cdf.hpp
+++ b/stan/math/prim/prob/gumbel_cdf.hpp
@@ -39,7 +39,6 @@ template <typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale> gumbel_cdf(const T_y& y, const T_loc& mu,
                                               const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-  using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using T_y_ref = ref_type_if_not_constant_t<T_y>;
   using T_mu_ref = ref_type_if_not_constant_t<T_loc>;
   using T_beta_ref = ref_type_if_not_constant_t<T_scale>;

--- a/stan/math/prim/prob/gumbel_cdf.hpp
+++ b/stan/math/prim/prob/gumbel_cdf.hpp
@@ -74,9 +74,9 @@ return_type_t<T_y, T_loc, T_scale> gumbel_cdf(const T_y& y, const T_loc& mu,
   T_partials_return cdf(1.0);
   if constexpr (is_vector<T_y>::value || is_vector<T_loc>::value
                 || is_vector<T_scale>::value) {
-    cdf = forward_as<T_partials_array>(cdf_n).prod();
+    cdf = cdf_n.prod();
   } else {
-    cdf = forward_as<T_partials_return>(cdf_n);
+    cdf = cdf_n;
   }
 
   if constexpr (is_any_autodiff_v<T_y, T_loc, T_scale>) {

--- a/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -143,8 +143,7 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
 
   Array<T_partials_return, Dynamic, 1> theta(N_instances);
   if constexpr (T_x_rows == 1) {
-    T_theta_tmp theta_tmp
-        = (x_val * beta_val_vec)(0, 0);
+    T_theta_tmp theta_tmp = (x_val * beta_val_vec)(0, 0);
     theta = theta_tmp + as_array_or_scalar(alpha_val_vec);
   } else {
     theta = (x_val * beta_val_vec).array();
@@ -176,10 +175,7 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
       }
     } else {
       using T_phi_scalar = scalar_type_t<decltype(phi_val_vec)>;
-      logp += N_instances
-              * (multiply_log(phi_val,
-                              phi_val)
-                 - lgamma(phi_val));
+      logp += N_instances * (multiply_log(phi_val, phi_val) - lgamma(phi_val));
     }
   }
   logp -= sum(y_plus_phi * logsumexp_theta_logphi);
@@ -205,8 +201,7 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
           = y_arr - theta_exp * y_plus_phi / (theta_exp + phi_arr);
       if constexpr (is_autodiff_v<T_beta>) {
         if constexpr (T_x_rows == 1) {
-          edge<2>(ops_partials).partials_
-              = theta_derivative.sum() * x_val;
+          edge<2>(ops_partials).partials_ = theta_derivative.sum() * x_val;
         } else {
           edge<2>(ops_partials).partials_
               = x_val.transpose() * theta_derivative;

--- a/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -144,7 +144,7 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   Array<T_partials_return, Dynamic, 1> theta(N_instances);
   if constexpr (T_x_rows == 1) {
     T_theta_tmp theta_tmp
-        = forward_as<T_xbeta_tmp>((x_val * beta_val_vec)(0, 0));
+        = (x_val * beta_val_vec)(0, 0);
     theta = theta_tmp + as_array_or_scalar(alpha_val_vec);
   } else {
     theta = (x_val * beta_val_vec).array();
@@ -177,9 +177,9 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
     } else {
       using T_phi_scalar = scalar_type_t<decltype(phi_val_vec)>;
       logp += N_instances
-              * (multiply_log(forward_as<T_phi_scalar>(phi_val),
-                              forward_as<T_phi_scalar>(phi_val))
-                 - lgamma(forward_as<T_phi_scalar>(phi_val)));
+              * (multiply_log(phi_val,
+                              phi_val)
+                 - lgamma(phi_val));
     }
   }
   logp -= sum(y_plus_phi * logsumexp_theta_logphi);
@@ -206,8 +206,7 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
       if constexpr (is_autodiff_v<T_beta>) {
         if constexpr (T_x_rows == 1) {
           edge<2>(ops_partials).partials_
-              = forward_as<Matrix<T_partials_return, 1, Dynamic>>(
-                  theta_derivative.sum() * x_val);
+              = theta_derivative.sum() * x_val;
         } else {
           edge<2>(ops_partials).partials_
               = x_val.transpose() * theta_derivative;
@@ -216,8 +215,7 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
       if constexpr (is_autodiff_v<T_x>) {
         if constexpr (T_x_rows == 1) {
           edge<0>(ops_partials).partials_
-              = forward_as<Array<T_partials_return, Dynamic, T_x_rows>>(
-                  beta_val_vec * theta_derivative.sum());
+              = beta_val_vec * theta_derivative.sum();
         } else {
           edge<0>(ops_partials).partials_
               = (beta_val_vec * theta_derivative.transpose()).transpose();

--- a/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -73,7 +73,6 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   using Eigen::log1p;
   using Eigen::Matrix;
   constexpr int T_x_rows = T_x::RowsAtCompileTime;
-  using T_xbeta_partials = partials_return_t<T_x, T_beta>;
   using T_partials_return
       = partials_return_t<T_y, T_x, T_alpha, T_beta, T_precision>;
   using T_precision_val = typename std::conditional_t<
@@ -87,9 +86,6 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   using T_theta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_partials_return,
                                   Array<T_partials_return, Dynamic, 1>>;
-  using T_xbeta_tmp =
-      typename std::conditional_t<T_x_rows == 1, T_xbeta_partials,
-                                  Array<T_xbeta_partials, Dynamic, 1>>;
   using T_x_ref = ref_type_if_not_constant_t<T_x>;
   using T_alpha_ref = ref_type_if_not_constant_t<T_alpha>;
   using T_beta_ref = ref_type_if_not_constant_t<T_beta>;
@@ -174,7 +170,6 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
         logp += multiply_log(phi_vec[n], phi_vec[n]) - lgamma(phi_vec[n]);
       }
     } else {
-      using T_phi_scalar = scalar_type_t<decltype(phi_val_vec)>;
       logp += N_instances * (multiply_log(phi_val, phi_val) - lgamma(phi_val));
     }
   }

--- a/stan/math/prim/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/prob/normal_id_glm_lpdf.hpp
@@ -122,8 +122,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
 
   Array<T_partials_return, Dynamic, 1> y_scaled(N_instances);
   if constexpr (T_x_rows == 1) {
-    T_y_scaled_tmp y_scaled_tmp
-        = (x_val * beta_val_vec).coeff(0, 0);
+    T_y_scaled_tmp y_scaled_tmp = (x_val * beta_val_vec).coeff(0, 0);
     y_scaled = (as_array_or_scalar(y_val_vec) - y_scaled_tmp
                 - as_array_or_scalar(alpha_val_vec))
                * inv_sigma;
@@ -148,8 +147,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
     }
     if constexpr (is_autodiff_v<T_x>) {
       if constexpr (T_x_rows == 1) {
-        edge<1>(ops_partials).partials_
-            = beta_val_vec * sum(mu_derivative);
+        edge<1>(ops_partials).partials_ = beta_val_vec * sum(mu_derivative);
       } else {
         edge<1>(ops_partials).partials_
             = (beta_val_vec * mu_derivative.transpose()).transpose();
@@ -157,8 +155,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
     }
     if constexpr (is_autodiff_v<T_beta>) {
       if constexpr (T_x_rows == 1) {
-        edge<3>(ops_partials).partials_
-            = mu_derivative.sum() * x_val;
+        edge<3>(ops_partials).partials_ = mu_derivative.sum() * x_val;
       } else {
         partials<3>(ops_partials) = mu_derivative.transpose() * x_val;
       }

--- a/stan/math/prim/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/prob/normal_id_glm_lpdf.hpp
@@ -123,7 +123,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   Array<T_partials_return, Dynamic, 1> y_scaled(N_instances);
   if constexpr (T_x_rows == 1) {
     T_y_scaled_tmp y_scaled_tmp
-        = forward_as<T_y_scaled_tmp>((x_val * beta_val_vec).coeff(0, 0));
+        = (x_val * beta_val_vec).coeff(0, 0);
     y_scaled = (as_array_or_scalar(y_val_vec) - y_scaled_tmp
                 - as_array_or_scalar(alpha_val_vec))
                * inv_sigma;
@@ -149,8 +149,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
     if constexpr (is_autodiff_v<T_x>) {
       if constexpr (T_x_rows == 1) {
         edge<1>(ops_partials).partials_
-            = forward_as<Array<T_partials_return, Dynamic, T_x_rows>>(
-                beta_val_vec * sum(mu_derivative));
+            = beta_val_vec * sum(mu_derivative);
       } else {
         edge<1>(ops_partials).partials_
             = (beta_val_vec * mu_derivative.transpose()).transpose();
@@ -159,8 +158,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
     if constexpr (is_autodiff_v<T_beta>) {
       if constexpr (T_x_rows == 1) {
         edge<3>(ops_partials).partials_
-            = forward_as<Matrix<T_partials_return, 1, Dynamic>>(
-                mu_derivative.sum() * x_val);
+            = mu_derivative.sum() * x_val;
       } else {
         partials<3>(ops_partials) = mu_derivative.transpose() * x_val;
       }
@@ -180,8 +178,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
       } else {
         y_scaled_sq_sum = sum(y_scaled * y_scaled);
         partials<4>(ops_partials)[0]
-            = (y_scaled_sq_sum - N_instances)
-              * forward_as<partials_return_t<T_sigma_ref>>(inv_sigma);
+            = (y_scaled_sq_sum - N_instances) * inv_sigma;
       }
     } else {
       y_scaled_sq_sum = sum(y_scaled * y_scaled);
@@ -207,8 +204,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
     if constexpr (is_vector<T_scale>::value) {
       logp -= sum(log(sigma_val_vec));
     } else {
-      logp -= N_instances
-              * log(forward_as<partials_return_t<T_sigma_ref>>(sigma_val_vec));
+      logp -= N_instances * log(sigma_val_vec);
     }
   }
   logp -= 0.5 * y_scaled_sq_sum;

--- a/stan/math/prim/prob/normal_sufficient_lpdf.hpp
+++ b/stan/math/prim/prob/normal_sufficient_lpdf.hpp
@@ -132,14 +132,14 @@ return_type_t<T_y, T_s, T_loc, T_scale> normal_sufficient_lpdf(
     using T_sigma_value_vector
         = Eigen::Array<T_sigma_value_scalar, Eigen::Dynamic, 1>;
     if constexpr (is_vector<T_scale>::value) {
-      edge<1>(ops_partials).partials_
-          = -0.5 / sigma_squared;
+      edge<1>(ops_partials).partials_ = -0.5 / sigma_squared;
     } else {
       if constexpr (is_vector<T_s>::value) {
-        partials<1>(ops_partials) = T_sigma_value_vector::Constant(
-            N, -0.5 / sigma_squared);
+        partials<1>(ops_partials)
+            = T_sigma_value_vector::Constant(N, -0.5 / sigma_squared);
       } else {
-        partials<1>(ops_partials) = -0.5 / sigma_squared * N / math::size(sigma);
+        partials<1>(ops_partials)
+            = -0.5 / sigma_squared * N / math::size(sigma);
       }
     }
   }

--- a/stan/math/prim/prob/normal_sufficient_lpdf.hpp
+++ b/stan/math/prim/prob/normal_sufficient_lpdf.hpp
@@ -133,15 +133,13 @@ return_type_t<T_y, T_s, T_loc, T_scale> normal_sufficient_lpdf(
         = Eigen::Array<T_sigma_value_scalar, Eigen::Dynamic, 1>;
     if constexpr (is_vector<T_scale>::value) {
       edge<1>(ops_partials).partials_
-          = -0.5 / forward_as<T_sigma_value_vector>(sigma_squared);
+          = -0.5 / sigma_squared;
     } else {
       if constexpr (is_vector<T_s>::value) {
         partials<1>(ops_partials) = T_sigma_value_vector::Constant(
-            N, -0.5 / forward_as<T_sigma_value_scalar>(sigma_squared));
+            N, -0.5 / sigma_squared);
       } else {
-        forward_as<internal::broadcast_array<T_partials_return>>(
-            partials<1>(ops_partials))
-            = -0.5 / sigma_squared * N / math::size(sigma);
+        partials<1>(ops_partials) = -0.5 / sigma_squared * N / math::size(sigma);
       }
     }
   }

--- a/stan/math/prim/prob/pareto_lccdf.hpp
+++ b/stan/math/prim/prob/pareto_lccdf.hpp
@@ -83,11 +83,9 @@ return_type_t<T_y, T_scale, T_shape> pareto_lccdf(const T_y& y,
       using Log_quot_scalar = partials_return_t<T_y, T_scale>;
       using Log_quot_array = Eigen::Array<Log_quot_scalar, Eigen::Dynamic, 1>;
       if constexpr (is_vector<T_y>::value || is_vector<T_scale>::value) {
-        edge<2>(ops_partials).partials_
-            = std::move(log_quot);
+        edge<2>(ops_partials).partials_ = std::move(log_quot);
       } else {
-        partials<2>(ops_partials) = Log_quot_array::Constant(
-            N, 1, log_quot);
+        partials<2>(ops_partials) = Log_quot_array::Constant(N, 1, log_quot);
       }
     } else {
       partials<2>(ops_partials) = log_quot * N / max_size(y, y_min);

--- a/stan/math/prim/prob/pareto_lccdf.hpp
+++ b/stan/math/prim/prob/pareto_lccdf.hpp
@@ -84,15 +84,13 @@ return_type_t<T_y, T_scale, T_shape> pareto_lccdf(const T_y& y,
       using Log_quot_array = Eigen::Array<Log_quot_scalar, Eigen::Dynamic, 1>;
       if constexpr (is_vector<T_y>::value || is_vector<T_scale>::value) {
         edge<2>(ops_partials).partials_
-            = forward_as<Log_quot_array>(std::move(log_quot));
+            = std::move(log_quot);
       } else {
         partials<2>(ops_partials) = Log_quot_array::Constant(
-            N, 1, forward_as<Log_quot_scalar>(log_quot));
+            N, 1, log_quot);
       }
     } else {
-      forward_as<internal::broadcast_array<T_partials_return>>(
-          partials<2>(ops_partials))
-          = log_quot * N / max_size(y, y_min);
+      partials<2>(ops_partials) = log_quot * N / max_size(y, y_min);
     }
   }
   return ops_partials.build(P);

--- a/stan/math/prim/prob/pareto_type_2_lccdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lccdf.hpp
@@ -83,14 +83,13 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lccdf(
       using Log_temp_array = Eigen::Array<Log_temp_scalar, Eigen::Dynamic, 1>;
       if constexpr (is_vector<T_y>::value || is_vector<T_loc>::value
                     || is_vector<T_scale>::value) {
-        partials<3>(ops_partials) = -forward_as<Log_temp_array>(log_temp);
+        partials<3>(ops_partials) = -log_temp;
       } else {
         partials<3>(ops_partials) = Log_temp_array::Constant(
-            N, 1, -forward_as<Log_temp_scalar>(log_temp));
+            N, 1, -log_temp);
       }
     } else {
-      forward_as<internal::broadcast_array<T_partials_return>>(
-          partials<3>(ops_partials))
+      partials<3>(ops_partials)
           = -log_temp * N / max_size(y, mu, lambda);
     }
   }

--- a/stan/math/prim/prob/pareto_type_2_lccdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lccdf.hpp
@@ -85,12 +85,10 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lccdf(
                     || is_vector<T_scale>::value) {
         partials<3>(ops_partials) = -log_temp;
       } else {
-        partials<3>(ops_partials) = Log_temp_array::Constant(
-            N, 1, -log_temp);
+        partials<3>(ops_partials) = Log_temp_array::Constant(N, 1, -log_temp);
       }
     } else {
-      partials<3>(ops_partials)
-          = -log_temp * N / max_size(y, mu, lambda);
+      partials<3>(ops_partials) = -log_temp * N / max_size(y, mu, lambda);
     }
   }
 

--- a/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
@@ -60,14 +60,10 @@ return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(const T_y& y,
   using std::exp;
   using std::isfinite;
   constexpr int T_x_rows = T_x::RowsAtCompileTime;
-  using T_xbeta_partials = partials_return_t<T_x, T_beta>;
   using T_partials_return = partials_return_t<T_y, T_x, T_alpha, T_beta>;
   using T_theta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_partials_return,
                                   Array<T_partials_return, Dynamic, 1>>;
-  using T_xbeta_tmp =
-      typename std::conditional_t<T_x_rows == 1, T_xbeta_partials,
-                                  Array<T_xbeta_partials, Dynamic, 1>>;
   using T_x_ref = ref_type_if_not_constant_t<T_x>;
   using T_alpha_ref = ref_type_if_not_constant_t<T_alpha>;
   using T_beta_ref = ref_type_if_not_constant_t<T_beta>;

--- a/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
@@ -106,8 +106,7 @@ return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(const T_y& y,
 
   Array<T_partials_return, Dynamic, 1> theta(N_instances);
   if constexpr (T_x_rows == 1) {
-    T_theta_tmp theta_tmp
-        = (x_val * beta_val_vec).coeff(0, 0);
+    T_theta_tmp theta_tmp = (x_val * beta_val_vec).coeff(0, 0);
     theta = theta_tmp + as_array_or_scalar(alpha_val_vec);
   } else {
     theta = x_val * beta_val_vec;

--- a/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
@@ -107,7 +107,7 @@ return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(const T_y& y,
   Array<T_partials_return, Dynamic, 1> theta(N_instances);
   if constexpr (T_x_rows == 1) {
     T_theta_tmp theta_tmp
-        = forward_as<T_xbeta_tmp>((x_val * beta_val_vec).coeff(0, 0));
+        = (x_val * beta_val_vec).coeff(0, 0);
     theta = theta_tmp + as_array_or_scalar(alpha_val_vec);
   } else {
     theta = x_val * beta_val_vec;
@@ -135,18 +135,14 @@ return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(const T_y& y,
   // Compute the necessary derivatives.
   if constexpr (is_autodiff_v<T_beta>) {
     if constexpr (T_x_rows == 1) {
-      edge<2>(ops_partials).partials_
-          = forward_as<Matrix<T_partials_return, 1, Dynamic>>(
-              theta_derivative.sum() * x_val);
+      edge<2>(ops_partials).partials_ = theta_derivative.sum() * x_val;
     } else {
       partials<2>(ops_partials) = x_val.transpose() * theta_derivative;
     }
   }
   if constexpr (is_autodiff_v<T_x>) {
     if constexpr (T_x_rows == 1) {
-      edge<0>(ops_partials).partials_
-          = forward_as<Array<T_partials_return, Dynamic, T_x_rows>>(
-              beta_val_vec * theta_derivative.sum());
+      edge<0>(ops_partials).partials_ = beta_val_vec * theta_derivative.sum();
     } else {
       edge<0>(ops_partials).partials_
           = (beta_val_vec * theta_derivative.transpose()).transpose();

--- a/stan/math/rev/constraint/lub_constrain.hpp
+++ b/stan/math/rev/constraint/lub_constrain.hpp
@@ -49,20 +49,19 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
     check_less("lub_constrain", "lb", lb_val, ub_val);
     auto diff = ub_val - lb_val;
     double inv_logit_x = inv_logit(value_of(x));
-    return make_callback_var(
-        diff * inv_logit_x + lb_val,
-        [x, ub, lb, diff, inv_logit_x](auto& vi) mutable {
-          if constexpr (is_autodiff_v<T>) {
-            x.adj()
-                += vi.adj() * diff * inv_logit_x * (1.0 - inv_logit_x);
-          }
-          if constexpr (is_autodiff_v<L>) {
-            lb.adj() += vi.adj() * (1.0 - inv_logit_x);
-          }
-          if constexpr (is_autodiff_v<U>) {
-            ub.adj() += vi.adj() * inv_logit_x;
-          }
-        });
+    return make_callback_var(diff * inv_logit_x + lb_val,
+                             [x, ub, lb, diff, inv_logit_x](auto& vi) mutable {
+                               if constexpr (is_autodiff_v<T>) {
+                                 x.adj() += vi.adj() * diff * inv_logit_x
+                                            * (1.0 - inv_logit_x);
+                               }
+                               if constexpr (is_autodiff_v<L>) {
+                                 lb.adj() += vi.adj() * (1.0 - inv_logit_x);
+                               }
+                               if constexpr (is_autodiff_v<U>) {
+                                 ub.adj() += vi.adj() * inv_logit_x;
+                               }
+                             });
   }
 }
 
@@ -125,22 +124,19 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
         diff * inv_logit_x + lb_val,
         [x, ub, lb, diff, lp, inv_logit_x](auto& vi) mutable {
           if constexpr (is_autodiff_v<T>) {
-            x.adj()
-                += vi.adj() * diff * inv_logit_x * (1.0 - inv_logit_x)
-                   + lp.adj() * (1.0 - 2.0 * inv_logit_x);
+            x.adj() += vi.adj() * diff * inv_logit_x * (1.0 - inv_logit_x)
+                       + lp.adj() * (1.0 - 2.0 * inv_logit_x);
           }
           if constexpr (is_autodiff_v<L> && is_autodiff_v<U>) {
             const auto one_over_diff = 1.0 / diff;
             lb.adj()
                 += vi.adj() * (1.0 - inv_logit_x) + -one_over_diff * lp.adj();
-            ub.adj()
-                += vi.adj() * inv_logit_x + one_over_diff * lp.adj();
+            ub.adj() += vi.adj() * inv_logit_x + one_over_diff * lp.adj();
           } else if constexpr (is_autodiff_v<L>) {
             lb.adj()
                 += vi.adj() * (1.0 - inv_logit_x) + (-1.0 / diff) * lp.adj();
           } else if constexpr (is_autodiff_v<U>) {
-            ub.adj()
-                += vi.adj() * inv_logit_x + (1.0 / diff) * lp.adj();
+            ub.adj() += vi.adj() * inv_logit_x + (1.0 / diff) * lp.adj();
           }
         });
   }
@@ -178,8 +174,7 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
             += ret.adj().array() * diff * inv_logit_x * (1.0 - inv_logit_x);
       }
       if constexpr (is_autodiff_v<L>) {
-        lb.adj()
-            += (ret.adj().array() * (1.0 - inv_logit_x)).sum();
+        lb.adj() += (ret.adj().array() * (1.0 - inv_logit_x)).sum();
       }
       if constexpr (is_autodiff_v<U>) {
         ub.adj() += (ret.adj().array() * inv_logit_x).sum();
@@ -227,18 +222,16 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
           if constexpr (is_autodiff_v<L> && is_autodiff_v<U>) {
             const auto lp_calc = lp.adj() * ret.size();
             const auto one_over_diff = 1.0 / diff;
-            lb.adj()
-                += (ret.adj().array() * (1.0 - inv_logit_x)).sum()
-                   + -one_over_diff * lp_calc;
+            lb.adj() += (ret.adj().array() * (1.0 - inv_logit_x)).sum()
+                        + -one_over_diff * lp_calc;
             ub.adj() += (ret.adj().array() * inv_logit_x).sum()
-                                         + one_over_diff * lp_calc;
+                        + one_over_diff * lp_calc;
           } else if constexpr (is_autodiff_v<L>) {
-            lb.adj()
-                += (ret.adj().array() * (1.0 - inv_logit_x)).sum()
-                   + -(1.0 / diff) * lp.adj() * ret.size();
+            lb.adj() += (ret.adj().array() * (1.0 - inv_logit_x)).sum()
+                        + -(1.0 / diff) * lp.adj() * ret.size();
           } else if constexpr (is_autodiff_v<U>) {
             ub.adj() += (ret.adj().array() * inv_logit_x).sum()
-                                         + (1.0 / diff) * lp.adj() * ret.size();
+                        + (1.0 / diff) * lp.adj() * ret.size();
           }
         });
     return ret_type(ret);
@@ -391,11 +384,10 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
             ret.adj().array() * diff * inv_logit_x * (1.0 - inv_logit_x));
       }
       if constexpr (is_autodiff_v<L>) {
-        lb.adj()
-            += (is_ub_inf)
-                   .select(ret.adj().array(),
-                           ret.adj().array() * (1.0 - inv_logit_x))
-                   .sum();
+        lb.adj() += (is_ub_inf)
+                        .select(ret.adj().array(),
+                                ret.adj().array() * (1.0 - inv_logit_x))
+                        .sum();
       }
       if constexpr (is_autodiff_v<U>) {
         arena_ub.adj().array()
@@ -450,12 +442,11 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
                 + lp.adj() * (1.0 - 2.0 * inv_logit_x));
       }
       if constexpr (is_autodiff_v<L>) {
-        lb.adj()
-            += (is_ub_inf)
-                   .select(ret.adj().array(),
-                           ret.adj().array() * (1.0 - inv_logit_x)
-                               + -(1.0 / diff) * lp_adj)
-                   .sum();
+        lb.adj() += (is_ub_inf)
+                        .select(ret.adj().array(),
+                                ret.adj().array() * (1.0 - inv_logit_x)
+                                    + -(1.0 / diff) * lp_adj)
+                        .sum();
       }
       if constexpr (is_autodiff_v<U>) {
         arena_ub.adj().array() += (is_ub_inf).select(
@@ -509,12 +500,10 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
             += ret.adj().array() * diff * inv_logit_x * (1.0 - inv_logit_x);
       }
       if constexpr (is_autodiff_v<L>) {
-        arena_lb.adj().array()
-            += ret.adj().array() * (1.0 - inv_logit_x);
+        arena_lb.adj().array() += ret.adj().array() * (1.0 - inv_logit_x);
       }
       if constexpr (is_autodiff_v<U>) {
-        arena_ub.adj().array()
-            += ret.adj().array() * inv_logit_x;
+        arena_ub.adj().array() += ret.adj().array() * inv_logit_x;
       }
     } else {
       if constexpr (is_autodiff_v<T>) {

--- a/stan/math/rev/constraint/lub_constrain.hpp
+++ b/stan/math/rev/constraint/lub_constrain.hpp
@@ -53,14 +53,14 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
         diff * inv_logit_x + lb_val,
         [x, ub, lb, diff, inv_logit_x](auto& vi) mutable {
           if constexpr (is_autodiff_v<T>) {
-            forward_as<var>(x).adj()
+            x.adj()
                 += vi.adj() * diff * inv_logit_x * (1.0 - inv_logit_x);
           }
           if constexpr (is_autodiff_v<L>) {
-            forward_as<var>(lb).adj() += vi.adj() * (1.0 - inv_logit_x);
+            lb.adj() += vi.adj() * (1.0 - inv_logit_x);
           }
           if constexpr (is_autodiff_v<U>) {
-            forward_as<var>(ub).adj() += vi.adj() * inv_logit_x;
+            ub.adj() += vi.adj() * inv_logit_x;
           }
         });
   }
@@ -125,21 +125,21 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
         diff * inv_logit_x + lb_val,
         [x, ub, lb, diff, lp, inv_logit_x](auto& vi) mutable {
           if constexpr (is_autodiff_v<T>) {
-            forward_as<var>(x).adj()
+            x.adj()
                 += vi.adj() * diff * inv_logit_x * (1.0 - inv_logit_x)
                    + lp.adj() * (1.0 - 2.0 * inv_logit_x);
           }
           if constexpr (is_autodiff_v<L> && is_autodiff_v<U>) {
             const auto one_over_diff = 1.0 / diff;
-            forward_as<var>(lb).adj()
+            lb.adj()
                 += vi.adj() * (1.0 - inv_logit_x) + -one_over_diff * lp.adj();
-            forward_as<var>(ub).adj()
+            ub.adj()
                 += vi.adj() * inv_logit_x + one_over_diff * lp.adj();
           } else if constexpr (is_autodiff_v<L>) {
-            forward_as<var>(lb).adj()
+            lb.adj()
                 += vi.adj() * (1.0 - inv_logit_x) + (-1.0 / diff) * lp.adj();
           } else if constexpr (is_autodiff_v<U>) {
-            forward_as<var>(ub).adj()
+            ub.adj()
                 += vi.adj() * inv_logit_x + (1.0 / diff) * lp.adj();
           }
         });
@@ -174,15 +174,15 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
     reverse_pass_callback([arena_x, ub, lb, ret, diff, inv_logit_x]() mutable {
       if constexpr (is_autodiff_v<T>) {
         using T_var = arena_t<promote_scalar_t<var, T>>;
-        forward_as<T_var>(arena_x).adj().array()
+        arena_x.adj().array()
             += ret.adj().array() * diff * inv_logit_x * (1.0 - inv_logit_x);
       }
       if constexpr (is_autodiff_v<L>) {
-        forward_as<var>(lb).adj()
+        lb.adj()
             += (ret.adj().array() * (1.0 - inv_logit_x)).sum();
       }
       if constexpr (is_autodiff_v<U>) {
-        forward_as<var>(ub).adj() += (ret.adj().array() * inv_logit_x).sum();
+        ub.adj() += (ret.adj().array() * inv_logit_x).sum();
       }
     });
     return ret_type(ret);
@@ -220,24 +220,24 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
     reverse_pass_callback(
         [arena_x, ub, lb, ret, lp, diff, inv_logit_x]() mutable {
           if constexpr (is_autodiff_v<T>) {
-            forward_as<arena_t<promote_scalar_t<var, T>>>(arena_x).adj().array()
+            arena_x.adj().array()
                 += ret.adj().array() * diff * inv_logit_x * (1.0 - inv_logit_x)
                    + lp.adj() * (1.0 - 2.0 * inv_logit_x);
           }
           if constexpr (is_autodiff_v<L> && is_autodiff_v<U>) {
             const auto lp_calc = lp.adj() * ret.size();
             const auto one_over_diff = 1.0 / diff;
-            forward_as<var>(lb).adj()
+            lb.adj()
                 += (ret.adj().array() * (1.0 - inv_logit_x)).sum()
                    + -one_over_diff * lp_calc;
-            forward_as<var>(ub).adj() += (ret.adj().array() * inv_logit_x).sum()
+            ub.adj() += (ret.adj().array() * inv_logit_x).sum()
                                          + one_over_diff * lp_calc;
           } else if constexpr (is_autodiff_v<L>) {
-            forward_as<var>(lb).adj()
+            lb.adj()
                 += (ret.adj().array() * (1.0 - inv_logit_x)).sum()
                    + -(1.0 / diff) * lp.adj() * ret.size();
           } else if constexpr (is_autodiff_v<U>) {
-            forward_as<var>(ub).adj() += (ret.adj().array() * inv_logit_x).sum()
+            ub.adj() += (ret.adj().array() * inv_logit_x).sum()
                                          + (1.0 / diff) * lp.adj() * ret.size();
           }
         });
@@ -275,18 +275,18 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
       using T_var = arena_t<promote_scalar_t<var, T>>;
       using L_var = arena_t<promote_scalar_t<var, L>>;
       if constexpr (is_autodiff_v<T>) {
-        forward_as<T_var>(arena_x).adj().array() += (is_lb_inf).select(
+        arena_x.adj().array() += (is_lb_inf).select(
             ret.adj().array() * -value_of(arena_x).array().exp(),
             ret.adj().array() * diff * inv_logit_x * (1.0 - inv_logit_x));
       }
       if constexpr (is_autodiff_v<U>) {
-        forward_as<var>(ub).adj()
+        ub.adj()
             += (is_lb_inf)
                    .select(ret.adj().array(), ret.adj().array() * inv_logit_x)
                    .sum();
       }
       if constexpr (is_autodiff_v<L>) {
-        forward_as<L_var>(arena_lb).adj().array()
+        arena_lb.adj().array()
             += (is_lb_inf).select(0, ret.adj().array() * (1.0 - inv_logit_x));
       }
     });
@@ -333,18 +333,18 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
       const auto lp_adj = lp.adj();
       if constexpr (is_autodiff_v<T>) {
         const auto x_sign = arena_x_val.sign().eval();
-        forward_as<T_var>(arena_x).adj().array() += (is_lb_inf).select(
+        arena_x.adj().array() += (is_lb_inf).select(
             ret.adj().array() * -arena_x_val.exp() + lp_adj,
             ret.adj().array() * diff * inv_logit_x * (1.0 - inv_logit_x)
                 + lp.adj() * (1.0 - 2.0 * inv_logit_x));
       }
       if constexpr (is_autodiff_v<L>) {
-        forward_as<L_var>(arena_lb).adj().array()
+        arena_lb.adj().array()
             += (is_lb_inf).select(0, ret.adj().array() * (1.0 - inv_logit_x)
                                          + -(1.0 / diff) * lp_adj);
       }
       if constexpr (is_autodiff_v<U>) {
-        forward_as<var>(ub).adj()
+        ub.adj()
             += (is_lb_inf)
                    .select(ret.adj().array(), ret.adj().array() * inv_logit_x
                                                   + (1.0 / diff) * lp_adj)
@@ -386,19 +386,19 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
       using T_var = arena_t<promote_scalar_t<var, T>>;
       using U_var = arena_t<promote_scalar_t<var, U>>;
       if constexpr (is_autodiff_v<T>) {
-        forward_as<T_var>(arena_x).adj().array() += (is_ub_inf).select(
+        arena_x.adj().array() += (is_ub_inf).select(
             ret.adj().array() * arena_x_val.array().exp(),
             ret.adj().array() * diff * inv_logit_x * (1.0 - inv_logit_x));
       }
       if constexpr (is_autodiff_v<L>) {
-        forward_as<var>(lb).adj()
+        lb.adj()
             += (is_ub_inf)
                    .select(ret.adj().array(),
                            ret.adj().array() * (1.0 - inv_logit_x))
                    .sum();
       }
       if constexpr (is_autodiff_v<U>) {
-        forward_as<U_var>(arena_ub).adj().array()
+        arena_ub.adj().array()
             += (is_ub_inf).select(0, ret.adj().array() * inv_logit_x);
       }
     });
@@ -444,13 +444,13 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
       using U_var = arena_t<promote_scalar_t<var, U>>;
       const auto lp_adj = lp.adj();
       if constexpr (is_autodiff_v<T>) {
-        forward_as<T_var>(arena_x).adj().array() += (is_ub_inf).select(
+        arena_x.adj().array() += (is_ub_inf).select(
             ret.adj().array() * arena_x_val.array().exp() + lp_adj,
             ret.adj().array() * diff * inv_logit_x * (1.0 - inv_logit_x)
                 + lp.adj() * (1.0 - 2.0 * inv_logit_x));
       }
       if constexpr (is_autodiff_v<L>) {
-        forward_as<var>(lb).adj()
+        lb.adj()
             += (is_ub_inf)
                    .select(ret.adj().array(),
                            ret.adj().array() * (1.0 - inv_logit_x)
@@ -458,7 +458,7 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
                    .sum();
       }
       if constexpr (is_autodiff_v<U>) {
-        forward_as<U_var>(arena_ub).adj().array() += (is_ub_inf).select(
+        arena_ub.adj().array() += (is_ub_inf).select(
             0, ret.adj().array() * inv_logit_x + (1.0 / diff) * lp_adj);
       }
     });
@@ -505,20 +505,20 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
     const bool is_none_inf = !(is_lb_inf.any() || is_ub_inf.any());
     if (is_none_inf) {
       if constexpr (is_autodiff_v<T>) {
-        forward_as<T_var>(arena_x).adj().array()
+        arena_x.adj().array()
             += ret.adj().array() * diff * inv_logit_x * (1.0 - inv_logit_x);
       }
       if constexpr (is_autodiff_v<L>) {
-        forward_as<L_var>(arena_lb).adj().array()
+        arena_lb.adj().array()
             += ret.adj().array() * (1.0 - inv_logit_x);
       }
       if constexpr (is_autodiff_v<U>) {
-        forward_as<U_var>(arena_ub).adj().array()
+        arena_ub.adj().array()
             += ret.adj().array() * inv_logit_x;
       }
     } else {
       if constexpr (is_autodiff_v<T>) {
-        forward_as<T_var>(arena_x).adj().array()
+        arena_x.adj().array()
             += (is_lb_ub_inf)
                    .select(
                        ret.adj().array(),
@@ -530,12 +530,12 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
                                    * (1.0 - inv_logit_x))));
       }
       if constexpr (is_autodiff_v<U>) {
-        forward_as<U_var>(arena_ub).adj().array() += (is_ub_inf).select(
+        arena_ub.adj().array() += (is_ub_inf).select(
             0, (is_lb_inf).select(ret.adj().array(),
                                   ret.adj().array() * inv_logit_x));
       }
       if constexpr (is_autodiff_v<L>) {
-        forward_as<L_var>(arena_lb).adj().array() += (is_lb_inf).select(
+        arena_lb.adj().array() += (is_lb_inf).select(
             0, (is_ub_inf).select(ret.adj().array(),
                                   ret.adj().array() * (1.0 - inv_logit_x)));
       }
@@ -594,21 +594,21 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
     const bool is_none_inf = !(is_lb_inf.any() || is_ub_inf.any());
     if (is_none_inf) {
       if constexpr (is_autodiff_v<T>) {
-        forward_as<T_var>(arena_x).adj().array()
+        arena_x.adj().array()
             += ret.adj().array() * diff * inv_logit_x * (1.0 - inv_logit_x)
                + lp.adj() * (1.0 - 2.0 * inv_logit_x);
       }
       if constexpr (is_autodiff_v<L>) {
-        forward_as<L_var>(arena_lb).adj().array()
+        arena_lb.adj().array()
             += ret.adj().array() * (1.0 - inv_logit_x) + -(1.0 / diff) * lp_adj;
       }
       if constexpr (is_autodiff_v<U>) {
-        forward_as<U_var>(arena_ub).adj().array()
+        arena_ub.adj().array()
             += ret.adj().array() * inv_logit_x + (1.0 / diff) * lp_adj;
       }
     } else {
       if constexpr (is_autodiff_v<T>) {
-        forward_as<T_var>(arena_x).adj().array()
+        arena_x.adj().array()
             += (is_lb_ub_inf)
                    .select(
                        ret.adj().array(),
@@ -623,13 +623,13 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
                                    + lp.adj() * (1.0 - 2.0 * inv_logit_x))));
       }
       if constexpr (is_autodiff_v<L>) {
-        forward_as<L_var>(arena_lb).adj().array() += (is_lb_inf).select(
+        arena_lb.adj().array() += (is_lb_inf).select(
             0, (is_ub_inf).select(ret.adj().array(),
                                   ret.adj().array() * (1.0 - inv_logit_x)
                                       + -(1.0 / diff) * lp_adj));
       }
       if constexpr (is_autodiff_v<U>) {
-        forward_as<U_var>(arena_ub).adj().array() += (is_ub_inf).select(
+        arena_ub.adj().array() += (is_ub_inf).select(
             0, (is_lb_inf).select(
                    ret.adj().array(),
                    ret.adj().array() * inv_logit_x + (1.0 / diff) * lp_adj));

--- a/stan/math/rev/constraint/lub_constrain.hpp
+++ b/stan/math/rev/constraint/lub_constrain.hpp
@@ -169,7 +169,6 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
     arena_t<ret_type> ret = diff * inv_logit_x + lb_val;
     reverse_pass_callback([arena_x, ub, lb, ret, diff, inv_logit_x]() mutable {
       if constexpr (is_autodiff_v<T>) {
-        using T_var = arena_t<promote_scalar_t<var, T>>;
         arena_x.adj().array()
             += ret.adj().array() * diff * inv_logit_x * (1.0 - inv_logit_x);
       }
@@ -265,8 +264,6 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
         ub_val - value_of(arena_x).array().exp(), diff * inv_logit_x + lb_val);
     reverse_pass_callback([arena_x, ub, arena_lb, ret, diff, inv_logit_x,
                            is_lb_inf]() mutable {
-      using T_var = arena_t<promote_scalar_t<var, T>>;
-      using L_var = arena_t<promote_scalar_t<var, L>>;
       if constexpr (is_autodiff_v<T>) {
         arena_x.adj().array() += (is_lb_inf).select(
             ret.adj().array() * -value_of(arena_x).array().exp(),
@@ -321,8 +318,6 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
               .sum();
     reverse_pass_callback([arena_x, arena_x_val, ub, arena_lb, ret, lp, diff,
                            inv_logit_x, is_lb_inf]() mutable {
-      using T_var = arena_t<promote_scalar_t<var, T>>;
-      using L_var = arena_t<promote_scalar_t<var, L>>;
       const auto lp_adj = lp.adj();
       if constexpr (is_autodiff_v<T>) {
         const auto x_sign = arena_x_val.sign().eval();
@@ -376,8 +371,6 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
         arena_x_val.array().exp() + lb_val, diff * inv_logit_x + lb_val);
     reverse_pass_callback([arena_x, arena_x_val, arena_ub, lb, ret, is_ub_inf,
                            inv_logit_x, diff]() mutable {
-      using T_var = arena_t<promote_scalar_t<var, T>>;
-      using U_var = arena_t<promote_scalar_t<var, U>>;
       if constexpr (is_autodiff_v<T>) {
         arena_x.adj().array() += (is_ub_inf).select(
             ret.adj().array() * arena_x_val.array().exp(),
@@ -432,8 +425,6 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
         arena_x_val.array().exp() + lb_val, diff * inv_logit_x + lb_val);
     reverse_pass_callback([arena_x, arena_x_val, diff, inv_logit_x, arena_ub,
                            lb, ret, lp, is_ub_inf]() mutable {
-      using T_var = arena_t<promote_scalar_t<var, T>>;
-      using U_var = arena_t<promote_scalar_t<var, U>>;
       const auto lp_adj = lp.adj();
       if constexpr (is_autodiff_v<T>) {
         arena_x.adj().array() += (is_ub_inf).select(
@@ -489,9 +480,6 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub) {
   reverse_pass_callback([arena_x, arena_x_val, inv_logit_x, arena_ub, arena_lb,
                          diff, ret, is_ub_inf, is_lb_inf,
                          is_lb_ub_inf]() mutable {
-    using T_var = arena_t<promote_scalar_t<var, T>>;
-    using L_var = arena_t<promote_scalar_t<var, L>>;
-    using U_var = arena_t<promote_scalar_t<var, U>>;
     // The most likely case is neither of them are infinity
     const bool is_none_inf = !(is_lb_inf.any() || is_ub_inf.any());
     if (is_none_inf) {
@@ -575,9 +563,6 @@ inline auto lub_constrain(const T& x, const L& lb, const U& ub,
   reverse_pass_callback([arena_x, arena_x_val, inv_logit_x, arena_ub, arena_lb,
                          diff, ret, is_ub_inf, is_lb_inf, is_lb_ub_inf,
                          lp]() mutable {
-    using T_var = arena_t<promote_scalar_t<var, T>>;
-    using L_var = arena_t<promote_scalar_t<var, L>>;
-    using U_var = arena_t<promote_scalar_t<var, U>>;
     const auto lp_adj = lp.adj();
     // The most likely case is neither of them are infinity
     const bool is_none_inf = !(is_lb_inf.any() || is_ub_inf.any());

--- a/stan/math/rev/fun/elt_divide.hpp
+++ b/stan/math/rev/fun/elt_divide.hpp
@@ -84,7 +84,7 @@ auto elt_divide(Scal s, const Mat& m) {
   reverse_pass_callback([m, s, res]() mutable {
     m.adj().array() -= res.val().array() * res.adj().array() / m.val().array();
     if constexpr (is_autodiff_v<Scal>)
-      forward_as<var>(s).adj() += (res.adj().array() / m.val().array()).sum();
+      s.adj() += (res.adj().array() / m.val().array()).sum();
   });
 
   return res;

--- a/stan/math/rev/fun/fma.hpp
+++ b/stan/math/rev/fun/fma.hpp
@@ -195,9 +195,6 @@ template <typename T1, typename T2, typename T3, typename T4,
           require_all_matrix_t<T1, T2, T3>* = nullptr>
 inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
   return [arena_x, arena_y, arena_z, ret]() mutable {
-    using T1_var = arena_t<plain_type_t<promote_scalar_t<var, T1>>>;
-    using T2_var = arena_t<plain_type_t<promote_scalar_t<var, T2>>>;
-    using T3_var = arena_t<plain_type_t<promote_scalar_t<var, T3>>>;
     if constexpr (is_autodiff_v<T1>) {
       arena_x.adj().array() += ret.adj().array() * value_of(arena_y).array();
     }
@@ -218,9 +215,6 @@ template <typename T1, typename T2, typename T3, typename T4,
           require_stan_scalar_t<T1>* = nullptr>
 inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
   return [arena_x, arena_y, arena_z, ret]() mutable {
-    using T1_var = arena_t<promote_scalar_t<var, T1>>;
-    using T2_var = arena_t<promote_scalar_t<var, T2>>;
-    using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
       arena_x.adj() += (ret.adj().array() * value_of(arena_y).array()).sum();
     }
@@ -241,9 +235,6 @@ template <typename T1, typename T2, typename T3, typename T4,
           require_stan_scalar_t<T2>* = nullptr>
 inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
   return [arena_x, arena_y, arena_z, ret]() mutable {
-    using T1_var = arena_t<promote_scalar_t<var, T1>>;
-    using T2_var = arena_t<promote_scalar_t<var, T2>>;
-    using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
       arena_x.adj().array() += ret.adj().array() * value_of(arena_y);
     }
@@ -264,9 +255,6 @@ template <typename T1, typename T2, typename T3, typename T4,
           require_all_stan_scalar_t<T1, T2>* = nullptr>
 inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
   return [arena_x, arena_y, arena_z, ret]() mutable {
-    using T1_var = arena_t<promote_scalar_t<var, T1>>;
-    using T2_var = arena_t<promote_scalar_t<var, T2>>;
-    using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
       arena_x.adj() += (ret.adj().array() * value_of(arena_y)).sum();
     }
@@ -287,9 +275,6 @@ template <typename T1, typename T2, typename T3, typename T4,
           require_stan_scalar_t<T3>* = nullptr>
 inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
   return [arena_x, arena_y, arena_z, ret]() mutable {
-    using T1_var = arena_t<promote_scalar_t<var, T1>>;
-    using T2_var = arena_t<promote_scalar_t<var, T2>>;
-    using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
       arena_x.adj().array() += ret.adj().array() * value_of(arena_y).array();
     }
@@ -310,9 +295,6 @@ template <typename T1, typename T2, typename T3, typename T4,
           require_all_stan_scalar_t<T1, T3>* = nullptr>
 inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
   return [arena_x, arena_y, arena_z, ret]() mutable {
-    using T1_var = arena_t<promote_scalar_t<var, T1>>;
-    using T2_var = arena_t<promote_scalar_t<var, T2>>;
-    using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
       arena_x.adj() += (ret.adj().array() * value_of(arena_y).array()).sum();
     }
@@ -333,9 +315,6 @@ template <typename T1, typename T2, typename T3, typename T4,
           require_all_stan_scalar_t<T2, T3>* = nullptr>
 inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
   return [arena_x, arena_y, arena_z, ret]() mutable {
-    using T1_var = arena_t<promote_scalar_t<var, T1>>;
-    using T2_var = arena_t<promote_scalar_t<var, T2>>;
-    using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
       arena_x.adj().array() += ret.adj().array() * value_of(arena_y);
     }

--- a/stan/math/rev/fun/fma.hpp
+++ b/stan/math/rev/fun/fma.hpp
@@ -199,15 +199,15 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<plain_type_t<promote_scalar_t<var, T2>>>;
     using T3_var = arena_t<plain_type_t<promote_scalar_t<var, T3>>>;
     if constexpr (is_autodiff_v<T1>) {
-      forward_as<T1_var>(arena_x).adj().array()
+      arena_x.adj().array()
           += ret.adj().array() * value_of(arena_y).array();
     }
     if constexpr (is_autodiff_v<T2>) {
-      forward_as<T2_var>(arena_y).adj().array()
+      arena_y.adj().array()
           += ret.adj().array() * value_of(arena_x).array();
     }
     if constexpr (is_autodiff_v<T3>) {
-      forward_as<T3_var>(arena_z).adj().array() += ret.adj().array();
+      arena_z.adj().array() += ret.adj().array();
     }
   };
 }
@@ -224,15 +224,15 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<promote_scalar_t<var, T2>>;
     using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
-      forward_as<T1_var>(arena_x).adj()
+      arena_x.adj()
           += (ret.adj().array() * value_of(arena_y).array()).sum();
     }
     if constexpr (is_autodiff_v<T2>) {
-      forward_as<T2_var>(arena_y).adj().array()
+      arena_y.adj().array()
           += ret.adj().array() * value_of(arena_x);
     }
     if constexpr (is_autodiff_v<T3>) {
-      forward_as<T3_var>(arena_z).adj().array() += ret.adj().array();
+      arena_z.adj().array() += ret.adj().array();
     }
   };
 }
@@ -249,15 +249,15 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<promote_scalar_t<var, T2>>;
     using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
-      forward_as<T1_var>(arena_x).adj().array()
+      arena_x.adj().array()
           += ret.adj().array() * value_of(arena_y);
     }
     if constexpr (is_autodiff_v<T2>) {
-      forward_as<T2_var>(arena_y).adj()
+      arena_y.adj()
           += (ret.adj().array() * value_of(arena_x).array()).sum();
     }
     if constexpr (is_autodiff_v<T3>) {
-      forward_as<T3_var>(arena_z).adj().array() += ret.adj().array();
+      arena_z.adj().array() += ret.adj().array();
     }
   };
 }
@@ -274,15 +274,15 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<promote_scalar_t<var, T2>>;
     using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
-      forward_as<T1_var>(arena_x).adj()
+      arena_x.adj()
           += (ret.adj().array() * value_of(arena_y)).sum();
     }
     if constexpr (is_autodiff_v<T2>) {
-      forward_as<T2_var>(arena_y).adj()
+      arena_y.adj()
           += (ret.adj().array() * value_of(arena_x)).sum();
     }
     if constexpr (is_autodiff_v<T3>) {
-      forward_as<T3_var>(arena_z).adj().array() += ret.adj().array();
+      arena_z.adj().array() += ret.adj().array();
     }
   };
 }
@@ -299,15 +299,15 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<promote_scalar_t<var, T2>>;
     using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
-      forward_as<T1_var>(arena_x).adj().array()
+      arena_x.adj().array()
           += ret.adj().array() * value_of(arena_y).array();
     }
     if constexpr (is_autodiff_v<T2>) {
-      forward_as<T2_var>(arena_y).adj().array()
+      arena_y.adj().array()
           += ret.adj().array() * value_of(arena_x).array();
     }
     if constexpr (is_autodiff_v<T3>) {
-      forward_as<T3_var>(arena_z).adj() += ret.adj().sum();
+      arena_z.adj() += ret.adj().sum();
     }
   };
 }
@@ -324,15 +324,15 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<promote_scalar_t<var, T2>>;
     using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
-      forward_as<T1_var>(arena_x).adj()
+      arena_x.adj()
           += (ret.adj().array() * value_of(arena_y).array()).sum();
     }
     if constexpr (is_autodiff_v<T2>) {
-      forward_as<T2_var>(arena_y).adj().array()
+      arena_y.adj().array()
           += ret.adj().array() * value_of(arena_x);
     }
     if constexpr (is_autodiff_v<T3>) {
-      forward_as<T3_var>(arena_z).adj() += ret.adj().sum();
+      arena_z.adj() += ret.adj().sum();
     }
   };
 }
@@ -349,15 +349,15 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<promote_scalar_t<var, T2>>;
     using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
-      forward_as<T1_var>(arena_x).adj().array()
+      arena_x.adj().array()
           += ret.adj().array() * value_of(arena_y);
     }
     if constexpr (is_autodiff_v<T2>) {
-      forward_as<T2_var>(arena_y).adj()
+      arena_y.adj()
           += (ret.adj().array() * value_of(arena_x).array()).sum();
     }
     if constexpr (is_autodiff_v<T3>) {
-      forward_as<T3_var>(arena_z).adj() += ret.adj().sum();
+      arena_z.adj() += ret.adj().sum();
     }
   };
 }

--- a/stan/math/rev/fun/fma.hpp
+++ b/stan/math/rev/fun/fma.hpp
@@ -199,12 +199,10 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<plain_type_t<promote_scalar_t<var, T2>>>;
     using T3_var = arena_t<plain_type_t<promote_scalar_t<var, T3>>>;
     if constexpr (is_autodiff_v<T1>) {
-      arena_x.adj().array()
-          += ret.adj().array() * value_of(arena_y).array();
+      arena_x.adj().array() += ret.adj().array() * value_of(arena_y).array();
     }
     if constexpr (is_autodiff_v<T2>) {
-      arena_y.adj().array()
-          += ret.adj().array() * value_of(arena_x).array();
+      arena_y.adj().array() += ret.adj().array() * value_of(arena_x).array();
     }
     if constexpr (is_autodiff_v<T3>) {
       arena_z.adj().array() += ret.adj().array();
@@ -224,12 +222,10 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<promote_scalar_t<var, T2>>;
     using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
-      arena_x.adj()
-          += (ret.adj().array() * value_of(arena_y).array()).sum();
+      arena_x.adj() += (ret.adj().array() * value_of(arena_y).array()).sum();
     }
     if constexpr (is_autodiff_v<T2>) {
-      arena_y.adj().array()
-          += ret.adj().array() * value_of(arena_x);
+      arena_y.adj().array() += ret.adj().array() * value_of(arena_x);
     }
     if constexpr (is_autodiff_v<T3>) {
       arena_z.adj().array() += ret.adj().array();
@@ -249,12 +245,10 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<promote_scalar_t<var, T2>>;
     using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
-      arena_x.adj().array()
-          += ret.adj().array() * value_of(arena_y);
+      arena_x.adj().array() += ret.adj().array() * value_of(arena_y);
     }
     if constexpr (is_autodiff_v<T2>) {
-      arena_y.adj()
-          += (ret.adj().array() * value_of(arena_x).array()).sum();
+      arena_y.adj() += (ret.adj().array() * value_of(arena_x).array()).sum();
     }
     if constexpr (is_autodiff_v<T3>) {
       arena_z.adj().array() += ret.adj().array();
@@ -274,12 +268,10 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<promote_scalar_t<var, T2>>;
     using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
-      arena_x.adj()
-          += (ret.adj().array() * value_of(arena_y)).sum();
+      arena_x.adj() += (ret.adj().array() * value_of(arena_y)).sum();
     }
     if constexpr (is_autodiff_v<T2>) {
-      arena_y.adj()
-          += (ret.adj().array() * value_of(arena_x)).sum();
+      arena_y.adj() += (ret.adj().array() * value_of(arena_x)).sum();
     }
     if constexpr (is_autodiff_v<T3>) {
       arena_z.adj().array() += ret.adj().array();
@@ -299,12 +291,10 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<promote_scalar_t<var, T2>>;
     using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
-      arena_x.adj().array()
-          += ret.adj().array() * value_of(arena_y).array();
+      arena_x.adj().array() += ret.adj().array() * value_of(arena_y).array();
     }
     if constexpr (is_autodiff_v<T2>) {
-      arena_y.adj().array()
-          += ret.adj().array() * value_of(arena_x).array();
+      arena_y.adj().array() += ret.adj().array() * value_of(arena_x).array();
     }
     if constexpr (is_autodiff_v<T3>) {
       arena_z.adj() += ret.adj().sum();
@@ -324,12 +314,10 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<promote_scalar_t<var, T2>>;
     using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
-      arena_x.adj()
-          += (ret.adj().array() * value_of(arena_y).array()).sum();
+      arena_x.adj() += (ret.adj().array() * value_of(arena_y).array()).sum();
     }
     if constexpr (is_autodiff_v<T2>) {
-      arena_y.adj().array()
-          += ret.adj().array() * value_of(arena_x);
+      arena_y.adj().array() += ret.adj().array() * value_of(arena_x);
     }
     if constexpr (is_autodiff_v<T3>) {
       arena_z.adj() += ret.adj().sum();
@@ -349,12 +337,10 @@ inline auto fma_reverse_pass(T1& arena_x, T2& arena_y, T3& arena_z, T4& ret) {
     using T2_var = arena_t<promote_scalar_t<var, T2>>;
     using T3_var = arena_t<promote_scalar_t<var, T3>>;
     if constexpr (is_autodiff_v<T1>) {
-      arena_x.adj().array()
-          += ret.adj().array() * value_of(arena_y);
+      arena_x.adj().array() += ret.adj().array() * value_of(arena_y);
     }
     if constexpr (is_autodiff_v<T2>) {
-      arena_y.adj()
-          += (ret.adj().array() * value_of(arena_x).array()).sum();
+      arena_y.adj() += (ret.adj().array() * value_of(arena_x).array()).sum();
     }
     if constexpr (is_autodiff_v<T3>) {
       arena_z.adj() += ret.adj().sum();

--- a/stan/math/rev/fun/hypergeometric_1F0.hpp
+++ b/stan/math/rev/fun/hypergeometric_1F0.hpp
@@ -37,10 +37,10 @@ var hypergeometric_1F0(const Ta& a, const Tz& z) {
   double rtn = hypergeometric_1F0(a_val, z_val);
   return make_callback_var(rtn, [rtn, a, z, a_val, z_val](auto& vi) mutable {
     if constexpr (is_autodiff_v<Ta>) {
-      forward_as<var>(a).adj() += vi.adj() * -rtn * log1m(z_val);
+      a.adj() += vi.adj() * -rtn * log1m(z_val);
     }
     if constexpr (is_autodiff_v<Tz>) {
-      forward_as<var>(z).adj() += vi.adj() * rtn * a_val * inv(1 - z_val);
+      z.adj() += vi.adj() * rtn * a_val * inv(1 - z_val);
     }
   });
 }

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -44,16 +44,16 @@ inline return_type_t<Ta1, Ta2, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
         auto grad_tuple = grad_2F1(a1, a2, b, z);
 
         if constexpr (is_autodiff_v<Ta1>) {
-          forward_as<var>(a1).adj() += vi.adj() * std::get<0>(grad_tuple);
+          a1.adj() += vi.adj() * std::get<0>(grad_tuple);
         }
         if constexpr (is_autodiff_v<Ta2>) {
-          forward_as<var>(a2).adj() += vi.adj() * std::get<1>(grad_tuple);
+          a2.adj() += vi.adj() * std::get<1>(grad_tuple);
         }
         if constexpr (is_autodiff_v<Tb>) {
-          forward_as<var>(b).adj() += vi.adj() * std::get<2>(grad_tuple);
+          b.adj() += vi.adj() * std::get<2>(grad_tuple);
         }
         if constexpr (is_autodiff_v<Tz>) {
-          forward_as<var>(z).adj() += vi.adj() * std::get<3>(grad_tuple);
+          z.adj() += vi.adj() * std::get<3>(grad_tuple);
         }
       });
 }

--- a/stan/math/rev/fun/hypergeometric_2F1.hpp
+++ b/stan/math/rev/fun/hypergeometric_2F1.hpp
@@ -38,24 +38,23 @@ inline return_type_t<Ta1, Ta2, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   double b_dbl = value_of(b);
   double z_dbl = value_of(z);
 
-  return make_callback_var(
-      hypergeometric_2F1(a1_dbl, a2_dbl, b_dbl, z_dbl),
-      [a1, a2, b, z](auto& vi) mutable {
-        auto grad_tuple = grad_2F1(a1, a2, b, z);
+  return make_callback_var(hypergeometric_2F1(a1_dbl, a2_dbl, b_dbl, z_dbl),
+                           [a1, a2, b, z](auto& vi) mutable {
+                             auto grad_tuple = grad_2F1(a1, a2, b, z);
 
-        if constexpr (is_autodiff_v<Ta1>) {
-          a1.adj() += vi.adj() * std::get<0>(grad_tuple);
-        }
-        if constexpr (is_autodiff_v<Ta2>) {
-          a2.adj() += vi.adj() * std::get<1>(grad_tuple);
-        }
-        if constexpr (is_autodiff_v<Tb>) {
-          b.adj() += vi.adj() * std::get<2>(grad_tuple);
-        }
-        if constexpr (is_autodiff_v<Tz>) {
-          z.adj() += vi.adj() * std::get<3>(grad_tuple);
-        }
-      });
+                             if constexpr (is_autodiff_v<Ta1>) {
+                               a1.adj() += vi.adj() * std::get<0>(grad_tuple);
+                             }
+                             if constexpr (is_autodiff_v<Ta2>) {
+                               a2.adj() += vi.adj() * std::get<1>(grad_tuple);
+                             }
+                             if constexpr (is_autodiff_v<Tb>) {
+                               b.adj() += vi.adj() * std::get<2>(grad_tuple);
+                             }
+                             if constexpr (is_autodiff_v<Tz>) {
+                               z.adj() += vi.adj() * std::get<3>(grad_tuple);
+                             }
+                           });
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/fun/inv_inc_beta.hpp
+++ b/stan/math/rev/fun/inv_inc_beta.hpp
@@ -82,7 +82,7 @@ inline var inv_inc_beta(const T1& a, const T2& b, const T3& p) {
       double da3 = inc_beta(a_val, b_val, w) * exp(lbeta_ab)
                    * (log_w - digamma(a_val) + digamma_apb);
 
-      forward_as<var>(a).adj() += vi.adj() * da1 * (exp(da2) - da3);
+      a.adj() += vi.adj() * da1 * (exp(da2) - da3);
     }
 
     if constexpr (is_autodiff_v<T2>) {
@@ -95,11 +95,11 @@ inline var inv_inc_beta(const T1& a, const T2& b, const T3& p) {
       double db3 = inc_beta(b_val, a_val, one_m_w) * exp(lbeta_ab)
                    * (log1m_w - digamma(b_val) + digamma_apb);
 
-      forward_as<var>(b).adj() += vi.adj() * db1 * (exp(db2) - db3);
+      b.adj() += vi.adj() * db1 * (exp(db2) - db3);
     }
 
     if constexpr (is_autodiff_v<T3>) {
-      forward_as<var>(p).adj()
+      p.adj()
           += vi.adj() * exp(one_m_b * log1m_w + one_m_a * log_w + lbeta_ab);
     }
   });

--- a/stan/math/rev/fun/inv_inc_beta.hpp
+++ b/stan/math/rev/fun/inv_inc_beta.hpp
@@ -99,8 +99,7 @@ inline var inv_inc_beta(const T1& a, const T2& b, const T3& p) {
     }
 
     if constexpr (is_autodiff_v<T3>) {
-      p.adj()
-          += vi.adj() * exp(one_m_b * log1m_w + one_m_a * log_w + lbeta_ab);
+      p.adj() += vi.adj() * exp(one_m_b * log1m_w + one_m_a * log_w + lbeta_ab);
     }
   });
 }

--- a/stan/math/rev/fun/pow.hpp
+++ b/stan/math/rev/fun/pow.hpp
@@ -101,12 +101,12 @@ inline auto pow(const Scal1& base, const Scal2& exponent) {
                                const double vi_mul = vi.adj() * vi.val();
 
                                if constexpr (is_autodiff_v<Scal1>) {
-                                 forward_as<var>(base).adj()
+                                 base.adj()
                                      += vi_mul * value_of(exponent)
                                         / value_of(base);
                                }
                                if constexpr (is_autodiff_v<Scal2>) {
-                                 forward_as<var>(exponent).adj()
+                                 exponent.adj()
                                      += vi_mul * std::log(value_of(base));
                                }
                              });
@@ -154,7 +154,7 @@ inline auto pow(const Mat1& base, const Mat2& exponent) {
     const auto& ret_mul = to_ref(ret.adj().array() * ret.val().array());
     if constexpr (is_autodiff_v<Mat1>) {
       using base_var_arena_t = arena_t<promote_scalar_t<var, base_arena_t>>;
-      forward_as<base_var_arena_t>(arena_base).adj()
+      arena_base.adj()
           += (are_vals_zero)
                  .select(
                      ret_mul * value_of(arena_exponent) / value_of(arena_base),
@@ -162,7 +162,7 @@ inline auto pow(const Mat1& base, const Mat2& exponent) {
     }
     if constexpr (is_autodiff_v<Mat2>) {
       using exp_var_arena_t = arena_t<promote_scalar_t<var, exp_arena_t>>;
-      forward_as<exp_var_arena_t>(arena_exponent).adj()
+      arena_exponent.adj()
           += (are_vals_zero).select(ret_mul * value_of(arena_base).log(), 0);
     }
   });
@@ -211,14 +211,14 @@ inline auto pow(const Mat1& base, const Scal1& exponent) {
     const auto& are_vals_zero = to_ref(value_of(arena_base).array() != 0.0);
     const auto& ret_mul = to_ref(ret.adj().array() * ret.val().array());
     if constexpr (is_autodiff_v<Mat1>) {
-      forward_as<ret_type>(arena_base).adj().array()
+      arena_base.adj().array()
           += (are_vals_zero)
                  .select(ret_mul * value_of(exponent)
                              / value_of(arena_base).array(),
                          0);
     }
     if constexpr (is_autodiff_v<Scal1>) {
-      forward_as<var>(exponent).adj()
+      exponent.adj()
           += (are_vals_zero)
                  .select(ret_mul * value_of(arena_base).array().log(), 0)
                  .sum();
@@ -261,12 +261,12 @@ inline auto pow(Scal1 base, const Mat1& exponent) {
     }
     const auto& ret_mul = to_ref(ret.adj().array() * ret.val().array());
     if constexpr (is_autodiff_v<Scal1>) {
-      forward_as<var>(base).adj()
+      base.adj()
           += (ret_mul * value_of(arena_exponent).array() / value_of(base))
                  .sum();
     }
     if constexpr (is_autodiff_v<Mat1>) {
-      forward_as<ret_type>(arena_exponent).adj().array()
+      arena_exponent.adj().array()
           += ret_mul * std::log(value_of(base));
     }
   });

--- a/stan/math/rev/fun/pow.hpp
+++ b/stan/math/rev/fun/pow.hpp
@@ -93,23 +93,21 @@ inline auto pow(const Scal1& base, const Scal2& exponent) {
         return inv_sqrt(base);
       }
     }
-    return make_callback_var(std::pow(value_of(base), value_of(exponent)),
-                             [base, exponent](auto&& vi) mutable {
-                               if (value_of(base) == 0.0) {
-                                 return;  // partials zero, avoids 0 & log(0)
-                               }
-                               const double vi_mul = vi.adj() * vi.val();
+    return make_callback_var(
+        std::pow(value_of(base), value_of(exponent)),
+        [base, exponent](auto&& vi) mutable {
+          if (value_of(base) == 0.0) {
+            return;  // partials zero, avoids 0 & log(0)
+          }
+          const double vi_mul = vi.adj() * vi.val();
 
-                               if constexpr (is_autodiff_v<Scal1>) {
-                                 base.adj()
-                                     += vi_mul * value_of(exponent)
-                                        / value_of(base);
-                               }
-                               if constexpr (is_autodiff_v<Scal2>) {
-                                 exponent.adj()
-                                     += vi_mul * std::log(value_of(base));
-                               }
-                             });
+          if constexpr (is_autodiff_v<Scal1>) {
+            base.adj() += vi_mul * value_of(exponent) / value_of(base);
+          }
+          if constexpr (is_autodiff_v<Scal2>) {
+            exponent.adj() += vi_mul * std::log(value_of(base));
+          }
+        });
   }
 }
 
@@ -154,11 +152,10 @@ inline auto pow(const Mat1& base, const Mat2& exponent) {
     const auto& ret_mul = to_ref(ret.adj().array() * ret.val().array());
     if constexpr (is_autodiff_v<Mat1>) {
       using base_var_arena_t = arena_t<promote_scalar_t<var, base_arena_t>>;
-      arena_base.adj()
-          += (are_vals_zero)
-                 .select(
-                     ret_mul * value_of(arena_exponent) / value_of(arena_base),
-                     0);
+      arena_base.adj() += (are_vals_zero)
+                              .select(ret_mul * value_of(arena_exponent)
+                                          / value_of(arena_base),
+                                      0);
     }
     if constexpr (is_autodiff_v<Mat2>) {
       using exp_var_arena_t = arena_t<promote_scalar_t<var, exp_arena_t>>;
@@ -266,8 +263,7 @@ inline auto pow(Scal1 base, const Mat1& exponent) {
                  .sum();
     }
     if constexpr (is_autodiff_v<Mat1>) {
-      arena_exponent.adj().array()
-          += ret_mul * std::log(value_of(base));
+      arena_exponent.adj().array() += ret_mul * std::log(value_of(base));
     }
   });
   return ret_type(ret);

--- a/stan/math/rev/fun/pow.hpp
+++ b/stan/math/rev/fun/pow.hpp
@@ -151,14 +151,12 @@ inline auto pow(const Mat1& base, const Mat2& exponent) {
     const auto& are_vals_zero = to_ref(value_of(arena_base) != 0.0);
     const auto& ret_mul = to_ref(ret.adj().array() * ret.val().array());
     if constexpr (is_autodiff_v<Mat1>) {
-      using base_var_arena_t = arena_t<promote_scalar_t<var, base_arena_t>>;
       arena_base.adj() += (are_vals_zero)
                               .select(ret_mul * value_of(arena_exponent)
                                           / value_of(arena_base),
                                       0);
     }
     if constexpr (is_autodiff_v<Mat2>) {
-      using exp_var_arena_t = arena_t<promote_scalar_t<var, exp_arena_t>>;
       arena_exponent.adj()
           += (are_vals_zero).select(ret_mul * value_of(arena_base).log(), 0);
     }

--- a/stan/math/rev/fun/rep_row_vector.hpp
+++ b/stan/math/rev/fun/rep_row_vector.hpp
@@ -21,7 +21,7 @@ template <typename T_ret, require_var_matrix_t<T_ret>* = nullptr,
           require_eigen_row_vector_t<value_type_t<T_ret>>* = nullptr>
 inline auto rep_row_vector(var x, int n) {
   return make_callback_var(rep_row_vector(x.val(), n), [x](auto& vi) mutable {
-    forward_as<var>(x).adj() += vi.adj().sum();
+    x.adj() += vi.adj().sum();
   });
 }
 

--- a/stan/math/rev/fun/rep_vector.hpp
+++ b/stan/math/rev/fun/rep_vector.hpp
@@ -21,7 +21,7 @@ template <typename T_ret, require_var_matrix_t<T_ret>* = nullptr,
           require_eigen_col_vector_t<value_type_t<T_ret>>* = nullptr>
 inline auto rep_vector(var x, int n) {
   return make_callback_var(rep_vector(x.val(), n), [x](auto& vi) mutable {
-    forward_as<var>(x).adj() += vi.adj().sum();
+    x.adj() += vi.adj().sum();
   });
 }
 

--- a/stan/math/rev/functor/cvodes_integrator_adjoint.hpp
+++ b/stan/math/rev/functor/cvodes_integrator_adjoint.hpp
@@ -526,8 +526,7 @@ class cvodes_integrator_adjoint_vari : public vari_base {
 
     // These are the dlog_density / d(initial_conditions[s]) adjoints
     if constexpr (is_var_y0_t0_) {
-      forward_as<Eigen::Matrix<var, Eigen::Dynamic, 1>>(solver_->y0_).adj()
-          += solver_->state_backward_;
+      solver_->y0_.adj() += solver_->state_backward_;
     }
 
     // These are the dlog_density / d(parameters[s]) adjoints

--- a/test/unit/math/expect_near_rel.hpp
+++ b/test/unit/math/expect_near_rel.hpp
@@ -132,7 +132,7 @@ void expect_near_rel(const std::string& msg, EigMat1&& x1, EigMat2&& x2,
   for (int j = 0; j < x1.cols(); ++j) {
     for (int i = 0; i < x1.rows(); ++i) {
       std::string msg2 = std::string("expect_near_rel; require items x1(");
-      if (stan::is_vector<EigMat1>::value) {
+      if constexpr (stan::is_vector<EigMat1>::value) {
         msg2 += std::to_string(sentinal_val) + ") = x2("
                 + std::to_string(sentinal_val) + "): " + msg;
       } else {

--- a/test/unit/math/mix/fun/rep_matrix_test.cpp
+++ b/test/unit/math/mix/fun/rep_matrix_test.cpp
@@ -4,14 +4,14 @@ TEST(MathMixMatFun, repMatrix) {
   // y is scalar
   auto f = [](int m, int n) {
     return [=](const auto& y) {
-      return stan::math::rep_matrix<decltype(y)>(y, m, n);
+      return stan::math::rep_matrix<std::decay_t<decltype(y)>>(y, m, n);
     };
   };
 
   // y is row vector or column vector
   auto g = [](int k) {
     return [=](const auto& y) {
-      return stan::math::rep_matrix<decltype(y)>(y, k);
+      return stan::math::rep_matrix<std::decay_t<decltype(y)>>(y, k);
     };
   };
 

--- a/test/unit/math/mix/fun/value_of_test.cpp
+++ b/test/unit/math/mix/fun/value_of_test.cpp
@@ -145,9 +145,6 @@ TEST(AgradMix, tuple_value_of) {
   // tuple(vector, array[tuple(vec, vec, vec, array[], tuple(mat, mat, mat,
   // array[]))])
   auto a_b_tuple_vec_tuple_ad = std::make_tuple(v_a, a_b_tuple_vec_ad, ffv_b);
-  using ffv = fvar<fvar<var>>;
-  using fv = fvar<var>;
-  using v = var;
   stan::math::test::recursive_for_each(
       [](auto&& x_ad, auto&& x_dbl) {
         EXPECT_FLOAT_EQ(stan::math::test::get_val(x_ad), x_dbl);

--- a/test/unit/math/opencl/rev/constraint/lb_constrain_test.cpp
+++ b/test/unit/math/opencl/rev/constraint/lb_constrain_test.cpp
@@ -10,7 +10,7 @@ auto lb_constrain_functor = [](const auto& a, const auto& b) {
 auto lb_constrain_functor2 = [](const auto& a, const auto& b) {
   using T_lp = stan::return_type_t<decltype(a), decltype(b)>;
   T_lp lp(4);
-  if (!stan::is_constant<T_lp>::value) {
+  if constexpr (!stan::is_constant<T_lp>::value) {
     stan::math::adjoint_of(lp) += 9;
   }
   return stan::math::lb_constrain(a, b, lp);

--- a/test/unit/math/opencl/rev/constraint/lub_constrain_test.cpp
+++ b/test/unit/math/opencl/rev/constraint/lub_constrain_test.cpp
@@ -10,7 +10,7 @@ auto lub_constrain_functor = [](const auto& a, const auto& b, const auto& c) {
 auto lub_constrain_functor2 = [](const auto& a, const auto& b, const auto& c) {
   using T_lp = stan::return_type_t<decltype(a), decltype(b), decltype(c)>;
   T_lp lp(4);
-  if (!stan::is_constant<T_lp>::value) {
+  if constexpr (!stan::is_constant<T_lp>::value) {
     stan::math::adjoint_of(lp) += 9;
   }
   return stan::math::lub_constrain(a, b, c, lp);

--- a/test/unit/math/opencl/rev/constraint/offset_multiplier_constrain_test.cpp
+++ b/test/unit/math/opencl/rev/constraint/offset_multiplier_constrain_test.cpp
@@ -12,7 +12,7 @@ auto offset_multiplier_constrain_functor2
     = [](const auto& a, const auto& b, const auto& c) {
         using T_lp = stan::return_type_t<decltype(a), decltype(b), decltype(c)>;
         T_lp lp(4);
-        if (!stan::is_constant<T_lp>::value) {
+        if constexpr (!stan::is_constant<T_lp>::value) {
           stan::math::adjoint_of(lp) += 9;
         }
         return stan::math::offset_multiplier_constrain(a, b, c, lp);

--- a/test/unit/math/opencl/rev/constraint/ub_constrain_test.cpp
+++ b/test/unit/math/opencl/rev/constraint/ub_constrain_test.cpp
@@ -10,7 +10,7 @@ auto ub_constrain_functor = [](const auto& a, const auto& b) {
 auto ub_constrain_functor2 = [](const auto& a, const auto& b) {
   using T_lp = stan::return_type_t<decltype(a), decltype(b)>;
   T_lp lp(4);
-  if (!stan::is_constant<T_lp>::value) {
+  if constexpr (!stan::is_constant<T_lp>::value) {
     stan::math::adjoint_of(lp) += 9;
   }
   return stan::math::ub_constrain(a, b, lp);

--- a/test/unit/math/opencl/rev/constraint/unit_vector_constrain_test.cpp
+++ b/test/unit/math/opencl/rev/constraint/unit_vector_constrain_test.cpp
@@ -9,7 +9,7 @@ auto unit_vector_constrain_functor
 auto unit_vector_constrain_functor2 = [](const auto& a) {
   using T_lp = stan::return_type_t<decltype(a)>;
   T_lp lp(4);
-  if (!stan::is_constant<T_lp>::value) {
+  if constexpr (!stan::is_constant<T_lp>::value) {
     stan::math::adjoint_of(lp) += 9;
   }
   return stan::math::unit_vector_constrain(a, lp);

--- a/test/unit/math/rev/functor/integrate_1d_impl_test.cpp
+++ b/test/unit/math/rev/functor/integrate_1d_impl_test.cpp
@@ -222,15 +222,15 @@ void test_derivatives(const F &f, double a, double b,
                                                  thetas_, x_r, x_i);
     integral.grad();
     EXPECT_LE(std::abs(val - integral.val()), tolerance);
-    if (stan::is_var<T_theta>::value) {
+    if constexpr (stan::is_var<T_theta>::value) {
       for (size_t i = 0; i < grad.size(); ++i)
         EXPECT_LE(std::abs(grad[i] - get_adjoint_if_var(thetas_[i])),
                   tolerance);
     }
-    if (stan::is_var<T_a>::value) {
+    if constexpr (stan::is_var<T_a>::value) {
       EXPECT_LE(std::abs(d_a - get_adjoint_if_var(a_)), tolerance);
     }
-    if (stan::is_var<T_b>::value) {
+    if constexpr (stan::is_var<T_b>::value) {
       EXPECT_LE(std::abs(d_b - get_adjoint_if_var(b_)), tolerance);
     }
   }

--- a/test/unit/math/rev/functor/integrate_1d_test.cpp
+++ b/test/unit/math/rev/functor/integrate_1d_test.cpp
@@ -222,15 +222,15 @@ void test_derivatives(const F &f, double a, double b,
                                             tolerance);
     integral.grad();
     EXPECT_LE(std::abs(val - integral.val()), tolerance);
-    if (stan::is_var<T_theta>::value) {
+    if constexpr (stan::is_var<T_theta>::value) {
       for (size_t i = 0; i < grad.size(); ++i)
         EXPECT_LE(std::abs(grad[i] - get_adjoint_if_var(thetas_[i])),
                   tolerance);
     }
-    if (stan::is_var<T_a>::value) {
+    if constexpr (stan::is_var<T_a>::value) {
       EXPECT_LE(std::abs(d_a - get_adjoint_if_var(a_)), tolerance);
     }
-    if (stan::is_var<T_b>::value) {
+    if constexpr (stan::is_var<T_b>::value) {
       EXPECT_LE(std::abs(d_b - get_adjoint_if_var(b_)), tolerance);
     }
   }

--- a/test/unit/math/rev/functor/lorenz_ode_typed_fd_test.cpp
+++ b/test/unit/math/rev/functor/lorenz_ode_typed_fd_test.cpp
@@ -22,11 +22,12 @@ using lorenz_test_types = boost::mp11::mp_product<
 
 TYPED_TEST_SUITE_P(lorenz_test);
 TYPED_TEST_P(lorenz_test, param_and_data_finite_diff) {
-  constexpr bool is_rk45 = std::is_same<TypeParam, std::tuple<ode_rk45_functor,
-                                                   ode_rk45_functor>>::value;
-  constexpr bool is_ckrk = std::is_same<TypeParam,
-                                    std::tuple<ode_ckrk_functor,
-                                               ode_ckrk_functor>>::value;
+  constexpr bool is_rk45
+      = std::is_same<TypeParam,
+                     std::tuple<ode_rk45_functor, ode_rk45_functor>>::value;
+  constexpr bool is_ckrk
+      = std::is_same<TypeParam,
+                     std::tuple<ode_ckrk_functor, ode_ckrk_functor>>::value;
   if constexpr (is_rk45) {
     this->test_fd_vd(1.e-6, 3e-2);
     this->test_fd_dv(1.e-6, 3e-2);

--- a/test/unit/math/rev/functor/lorenz_ode_typed_fd_test.cpp
+++ b/test/unit/math/rev/functor/lorenz_ode_typed_fd_test.cpp
@@ -22,12 +22,12 @@ using lorenz_test_types = boost::mp11::mp_product<
 
 TYPED_TEST_SUITE_P(lorenz_test);
 TYPED_TEST_P(lorenz_test, param_and_data_finite_diff) {
-  if (std::is_same<TypeParam,
+  if constexpr (std::is_same<TypeParam,
                    std::tuple<ode_rk45_functor, ode_rk45_functor>>::value) {
     this->test_fd_vd(1.e-6, 3e-2);
     this->test_fd_dv(1.e-6, 3e-2);
     this->test_fd_vv(1.e-6, 3e-2);
-  } else if (std::is_same<TypeParam, std::tuple<ode_ckrk_functor,
+  } else if constexpr (std::is_same<TypeParam, std::tuple<ode_ckrk_functor,
                                                 ode_ckrk_functor>>::value) {
     this->test_fd_vd(1.e-6, 5e-2);
     this->test_fd_dv(1.e-6, 5e-2);

--- a/test/unit/math/rev/functor/lorenz_ode_typed_fd_test.cpp
+++ b/test/unit/math/rev/functor/lorenz_ode_typed_fd_test.cpp
@@ -22,14 +22,16 @@ using lorenz_test_types = boost::mp11::mp_product<
 
 TYPED_TEST_SUITE_P(lorenz_test);
 TYPED_TEST_P(lorenz_test, param_and_data_finite_diff) {
-  if constexpr (std::is_same<TypeParam, std::tuple<ode_rk45_functor,
-                                                   ode_rk45_functor>>::value) {
+  constexpr bool is_rk45 = std::is_same<TypeParam, std::tuple<ode_rk45_functor,
+                                                   ode_rk45_functor>>::value;
+  constexpr bool is_ckrk = std::is_same<TypeParam,
+                                    std::tuple<ode_ckrk_functor,
+                                               ode_ckrk_functor>>::value;
+  if constexpr (is_rk45) {
     this->test_fd_vd(1.e-6, 3e-2);
     this->test_fd_dv(1.e-6, 3e-2);
     this->test_fd_vv(1.e-6, 3e-2);
-  } else if constexpr (std::is_same<TypeParam,
-                                    std::tuple<ode_ckrk_functor,
-                                               ode_ckrk_functor>>::value) {
+  } else if constexpr (is_ckrk) {
     this->test_fd_vd(1.e-6, 5e-2);
     this->test_fd_dv(1.e-6, 5e-2);
     this->test_fd_vv(1.e-6, 5e-2);

--- a/test/unit/math/rev/functor/lorenz_ode_typed_fd_test.cpp
+++ b/test/unit/math/rev/functor/lorenz_ode_typed_fd_test.cpp
@@ -22,13 +22,14 @@ using lorenz_test_types = boost::mp11::mp_product<
 
 TYPED_TEST_SUITE_P(lorenz_test);
 TYPED_TEST_P(lorenz_test, param_and_data_finite_diff) {
-  if constexpr (std::is_same<TypeParam,
-                   std::tuple<ode_rk45_functor, ode_rk45_functor>>::value) {
+  if constexpr (std::is_same<TypeParam, std::tuple<ode_rk45_functor,
+                                                   ode_rk45_functor>>::value) {
     this->test_fd_vd(1.e-6, 3e-2);
     this->test_fd_dv(1.e-6, 3e-2);
     this->test_fd_vv(1.e-6, 3e-2);
-  } else if constexpr (std::is_same<TypeParam, std::tuple<ode_ckrk_functor,
-                                                ode_ckrk_functor>>::value) {
+  } else if constexpr (std::is_same<TypeParam,
+                                    std::tuple<ode_ckrk_functor,
+                                               ode_ckrk_functor>>::value) {
     this->test_fd_vd(1.e-6, 5e-2);
     this->test_fd_dv(1.e-6, 5e-2);
     this->test_fd_vv(1.e-6, 5e-2);

--- a/test/unit/math/rev/functor/sho_ode_adjoint_typed_error_test.cpp
+++ b/test/unit/math/rev/functor/sho_ode_adjoint_typed_error_test.cpp
@@ -35,7 +35,7 @@ TYPED_TEST_P(harmonic_oscillator_ctl_test, value) {
   this->test_value(1.0);
   this->test_value(-1.0);
 
-  if (std::is_same<std::tuple_element_t<2, TypeParam>, double>::value
+  if constexpr (std::is_same<std::tuple_element_t<2, TypeParam>, double>::value
       && std::is_same<std::tuple_element_t<3, TypeParam>, double>::value
       && std::is_same<std::tuple_element_t<4, TypeParam>, double>::value) {
     EXPECT_EQ(stan::math::nested_size(), 0);

--- a/test/unit/math/rev/functor/sho_ode_adjoint_typed_error_test.cpp
+++ b/test/unit/math/rev/functor/sho_ode_adjoint_typed_error_test.cpp
@@ -36,8 +36,10 @@ TYPED_TEST_P(harmonic_oscillator_ctl_test, value) {
   this->test_value(-1.0);
 
   if constexpr (std::is_same<std::tuple_element_t<2, TypeParam>, double>::value
-      && std::is_same<std::tuple_element_t<3, TypeParam>, double>::value
-      && std::is_same<std::tuple_element_t<4, TypeParam>, double>::value) {
+                && std::is_same<std::tuple_element_t<3, TypeParam>,
+                                double>::value
+                && std::is_same<std::tuple_element_t<4, TypeParam>,
+                                double>::value) {
     EXPECT_EQ(stan::math::nested_size(), 0);
   } else {
     EXPECT_GT(stan::math::nested_size(), 0);

--- a/test/unit/math/rev/functor/sho_ode_typed_test.cpp
+++ b/test/unit/math/rev/functor/sho_ode_typed_test.cpp
@@ -101,23 +101,23 @@ using harmonic_oscillator_test_types = boost::mp11::mp_product<
 TYPED_TEST_SUITE_P(harmonic_oscillator_t0_ad_test);
 TYPED_TEST_P(harmonic_oscillator_t0_ad_test, t0_ad) {
   if constexpr (std::is_same<std::tuple_element_t<0, TypeParam>,
-                   ode_rk45_functor>::value) {
+                             ode_rk45_functor>::value) {
     this->test_t0_ad(5e-6);
   }
   if constexpr (std::is_same<std::tuple_element_t<0, TypeParam>,
-                   ode_ckrk_functor>::value) {
+                             ode_ckrk_functor>::value) {
     this->test_t0_ad(5e-6);
   }
   if constexpr (std::is_same<std::tuple_element_t<0, TypeParam>,
-                   ode_adams_functor>::value) {
+                             ode_adams_functor>::value) {
     this->test_t0_ad(1e-8);
   }
   if constexpr (std::is_same<std::tuple_element_t<0, TypeParam>,
-                   ode_bdf_functor>::value) {
+                             ode_bdf_functor>::value) {
     this->test_t0_ad(1e-7);
   }
   if constexpr (std::is_same<std::tuple_element_t<0, TypeParam>,
-                   ode_adjoint_functor>::value) {
+                             ode_adjoint_functor>::value) {
     this->test_t0_ad(1e-7);
   }
 }

--- a/test/unit/math/rev/functor/sho_ode_typed_test.cpp
+++ b/test/unit/math/rev/functor/sho_ode_typed_test.cpp
@@ -100,23 +100,23 @@ using harmonic_oscillator_test_types = boost::mp11::mp_product<
 
 TYPED_TEST_SUITE_P(harmonic_oscillator_t0_ad_test);
 TYPED_TEST_P(harmonic_oscillator_t0_ad_test, t0_ad) {
-  if (std::is_same<std::tuple_element_t<0, TypeParam>,
+  if constexpr (std::is_same<std::tuple_element_t<0, TypeParam>,
                    ode_rk45_functor>::value) {
     this->test_t0_ad(5e-6);
   }
-  if (std::is_same<std::tuple_element_t<0, TypeParam>,
+  if constexpr (std::is_same<std::tuple_element_t<0, TypeParam>,
                    ode_ckrk_functor>::value) {
     this->test_t0_ad(5e-6);
   }
-  if (std::is_same<std::tuple_element_t<0, TypeParam>,
+  if constexpr (std::is_same<std::tuple_element_t<0, TypeParam>,
                    ode_adams_functor>::value) {
     this->test_t0_ad(1e-8);
   }
-  if (std::is_same<std::tuple_element_t<0, TypeParam>,
+  if constexpr (std::is_same<std::tuple_element_t<0, TypeParam>,
                    ode_bdf_functor>::value) {
     this->test_t0_ad(1e-7);
   }
-  if (std::is_same<std::tuple_element_t<0, TypeParam>,
+  if constexpr (std::is_same<std::tuple_element_t<0, TypeParam>,
                    ode_adjoint_functor>::value) {
     this->test_t0_ad(1e-7);
   }

--- a/test/unit/math/rev/prob/test_gradients_multi_normal.hpp
+++ b/test/unit/math/rev/prob/test_gradients_multi_normal.hpp
@@ -21,7 +21,7 @@ std::vector<double> finite_diffs_multi_normal(
   std::vector<double> vec_sigma_plus = stan::math::value_of(vec_sigma);
   std::vector<double> vec_sigma_minus = vec_sigma_plus;
 
-  if (!stan::is_constant_all<T_y>::value) {
+  if constexpr (!stan::is_constant_all<T_y>::value) {
     for (size_t i = 0; i < vec_y.size(); ++i) {
       double recover_vec_y_plus = vec_y_plus[i];
       double recover_vec_y_minus = vec_y_minus[i];
@@ -34,7 +34,7 @@ std::vector<double> finite_diffs_multi_normal(
       vec_y_minus[i] = recover_vec_y_minus;
     }
   }
-  if (!stan::is_constant_all<T_mu>::value) {
+  if constexpr (!stan::is_constant_all<T_mu>::value) {
     for (size_t i = 0; i < vec_mu.size(); ++i) {
       double recover_vec_mu_plus = vec_mu_plus[i];
       double recover_vec_mu_minus = vec_mu_minus[i];
@@ -47,7 +47,7 @@ std::vector<double> finite_diffs_multi_normal(
       vec_mu_minus[i] = recover_vec_mu_minus;
     }
   }
-  if (!stan::is_constant_all<T_sigma>::value) {
+  if constexpr (!stan::is_constant_all<T_sigma>::value) {
     for (size_t i = 0; i < vec_sigma.size(); ++i) {
       double recover_vec_sigma_plus = vec_sigma_plus[i];
       double recover_vec_sigma_minus = vec_sigma_minus[i];
@@ -71,15 +71,15 @@ std::vector<double> grad_multi_normal(const F& fun,
   stan::math::var fx = fun(vec_y, vec_mu, vec_sigma);
   std::vector<double> grad;
   std::vector<stan::math::var> vec_vars;
-  if (!stan::is_constant_all<T_y>::value) {
+  if constexpr (!stan::is_constant_all<T_y>::value) {
     for (size_t i = 0; i < vec_y.size(); i++)
       vec_vars.push_back(vec_y[i]);
   }
-  if (!stan::is_constant_all<T_mu>::value) {
+  if constexpr (!stan::is_constant_all<T_mu>::value) {
     for (size_t i = 0; i < vec_mu.size(); i++)
       vec_vars.push_back(vec_mu[i]);
   }
-  if (!stan::is_constant_all<T_sigma>::value) {
+  if constexpr (!stan::is_constant_all<T_sigma>::value) {
     for (size_t i = 0; i < vec_sigma.size(); i++)
       vec_vars.push_back(vec_sigma[i]);
   }

--- a/test/unit/math/rev/prob/test_gradients_multi_student_t.hpp
+++ b/test/unit/math/rev/prob/test_gradients_multi_student_t.hpp
@@ -24,7 +24,7 @@ std::vector<double> finite_diffs_multi_normal3(
   double nu_plus = stan::math::value_of(nu);
   double nu_minus = nu_plus;
 
-  if (!stan::is_constant_all<T_y>::value) {
+  if constexpr (!stan::is_constant_all<T_y>::value) {
     for (size_t i = 0; i < vec_y.size(); ++i) {
       double recover_vec_y_plus = vec_y_plus[i];
       double recover_vec_y_minus = vec_y_minus[i];
@@ -38,7 +38,7 @@ std::vector<double> finite_diffs_multi_normal3(
       vec_y_minus[i] = recover_vec_y_minus;
     }
   }
-  if (!stan::is_constant_all<T_mu>::value) {
+  if constexpr (!stan::is_constant_all<T_mu>::value) {
     for (size_t i = 0; i < vec_mu.size(); ++i) {
       double recover_vec_mu_plus = vec_mu_plus[i];
       double recover_vec_mu_minus = vec_mu_minus[i];
@@ -52,7 +52,7 @@ std::vector<double> finite_diffs_multi_normal3(
       vec_mu_minus[i] = recover_vec_mu_minus;
     }
   }
-  if (!stan::is_constant_all<T_sigma>::value) {
+  if constexpr (!stan::is_constant_all<T_sigma>::value) {
     for (size_t i = 0; i < vec_sigma.size(); ++i) {
       double recover_vec_sigma_plus = vec_sigma_plus[i];
       double recover_vec_sigma_minus = vec_sigma_minus[i];
@@ -66,7 +66,7 @@ std::vector<double> finite_diffs_multi_normal3(
       vec_sigma_minus[i] = recover_vec_sigma_minus;
     }
   }
-  if (!stan::is_constant_all<T_nu>::value) {
+  if constexpr (!stan::is_constant_all<T_nu>::value) {
     nu_plus += epsilon;
     nu_minus -= epsilon;
     diffs.push_back(
@@ -87,19 +87,19 @@ std::vector<double> grad_multi_normal3(const F& fun,
   stan::math::var fx = fun(vec_y, vec_mu, vec_sigma, nu);
   std::vector<double> grad;
   std::vector<stan::math::var> vec_vars;
-  if (!stan::is_constant_all<T_y>::value) {
+  if constexpr (!stan::is_constant_all<T_y>::value) {
     for (size_t i = 0; i < vec_y.size(); i++)
       vec_vars.push_back(vec_y[i]);
   }
-  if (!stan::is_constant_all<T_mu>::value) {
+  if constexpr (!stan::is_constant_all<T_mu>::value) {
     for (size_t i = 0; i < vec_mu.size(); i++)
       vec_vars.push_back(vec_mu[i]);
   }
-  if (!stan::is_constant_all<T_sigma>::value) {
+  if constexpr (!stan::is_constant_all<T_sigma>::value) {
     for (size_t i = 0; i < vec_sigma.size(); i++)
       vec_vars.push_back(vec_sigma[i]);
   }
-  if (!stan::is_constant_all<T_nu>::value)
+  if constexpr (!stan::is_constant_all<T_nu>::value)
     vec_vars.push_back(nu);
 
   fx.grad(vec_vars, grad);

--- a/test/unit/math/rev/prob/test_gradients_multi_student_t_cholesky.hpp
+++ b/test/unit/math/rev/prob/test_gradients_multi_student_t_cholesky.hpp
@@ -24,7 +24,7 @@ std::vector<double> finite_diffs_multi_normal2(
   double nu_plus = stan::math::value_of(nu);
   double nu_minus = nu_plus;
 
-  if (!stan::is_constant_all<T_y>::value) {
+  if constexpr (!stan::is_constant_all<T_y>::value) {
     for (size_t i = 0; i < vec_y.size(); ++i) {
       double recover_vec_y_plus = vec_y_plus[i];
       double recover_vec_y_minus = vec_y_minus[i];
@@ -38,7 +38,7 @@ std::vector<double> finite_diffs_multi_normal2(
       vec_y_minus[i] = recover_vec_y_minus;
     }
   }
-  if (!stan::is_constant_all<T_mu>::value) {
+  if constexpr (!stan::is_constant_all<T_mu>::value) {
     for (size_t i = 0; i < vec_mu.size(); ++i) {
       double recover_vec_mu_plus = vec_mu_plus[i];
       double recover_vec_mu_minus = vec_mu_minus[i];
@@ -52,7 +52,7 @@ std::vector<double> finite_diffs_multi_normal2(
       vec_mu_minus[i] = recover_vec_mu_minus;
     }
   }
-  if (!stan::is_constant_all<T_sigma>::value) {
+  if constexpr (!stan::is_constant_all<T_sigma>::value) {
     for (size_t i = 0; i < vec_sigma.size(); ++i) {
       double recover_vec_sigma_plus = vec_sigma_plus[i];
       double recover_vec_sigma_minus = vec_sigma_minus[i];
@@ -66,7 +66,7 @@ std::vector<double> finite_diffs_multi_normal2(
       vec_sigma_minus[i] = recover_vec_sigma_minus;
     }
   }
-  if (!stan::is_constant_all<T_nu>::value) {
+  if constexpr (!stan::is_constant_all<T_nu>::value) {
     nu_plus += epsilon;
     nu_minus -= epsilon;
     diffs.push_back(
@@ -87,19 +87,19 @@ std::vector<double> grad_multi_normal2(const F& fun,
   stan::math::var fx = fun(vec_y, vec_mu, vec_sigma, nu);
   std::vector<double> grad;
   std::vector<stan::math::var> vec_vars;
-  if (!stan::is_constant_all<T_y>::value) {
+  if constexpr (!stan::is_constant_all<T_y>::value) {
     for (size_t i = 0; i < vec_y.size(); i++)
       vec_vars.push_back(vec_y[i]);
   }
-  if (!stan::is_constant_all<T_mu>::value) {
+  if constexpr (!stan::is_constant_all<T_mu>::value) {
     for (size_t i = 0; i < vec_mu.size(); i++)
       vec_vars.push_back(vec_mu[i]);
   }
-  if (!stan::is_constant_all<T_sigma>::value) {
+  if constexpr (!stan::is_constant_all<T_sigma>::value) {
     for (size_t i = 0; i < vec_sigma.size(); i++)
       vec_vars.push_back(vec_sigma[i]);
   }
-  if (!stan::is_constant_all<T_nu>::value)
+  if constexpr (!stan::is_constant_all<T_nu>::value)
     vec_vars.push_back(nu);
 
   fx.grad(vec_vars, grad);

--- a/test/unit/math/test_ad_matvar.hpp
+++ b/test/unit/math/test_ad_matvar.hpp
@@ -430,79 +430,77 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
   if (!stan::math::disjunction<is_var_matrix<Types>...>::value) {
     FAIL() << "expect_ad_matvar requires at least one varmat input!"
            << std::endl;
-  }
+  } else {
 
-  if (!stan::math::disjunction<is_var<scalar_type_t<Types>>...>::value) {
+  } if constexpr (!stan::math::disjunction<is_var<scalar_type_t<Types>>...>::value) {
     FAIL() << "expect_ad_matvar requires at least one autodiff input!"
            << std::endl;
-  }
+  } else {
+    auto A_mv_tuple = std::make_tuple(make_matvar_compatible<Types>(x)...);
+    auto A_vm_tuple = std::make_tuple(make_varmat_compatible<Types>(x)...);
 
-  auto A_mv_tuple = std::make_tuple(make_matvar_compatible<Types>(x)...);
-  auto A_vm_tuple = std::make_tuple(make_varmat_compatible<Types>(x)...);
+    constexpr bool any_varmat = stan::math::apply(
+        [](const auto&... args) {
+          return stan::math::disjunction<is_var_matrix<decltype(args)>...>::value
+                || stan::math::disjunction<stan::math::conjunction<
+                    is_std_vector<decltype(args)>,
+                    is_var_matrix<value_type_t<decltype(args)>>>...>::value;
+        },
+        A_vm_tuple);
 
-  bool any_varmat = stan::math::apply(
-      [](const auto&... args) {
-        return stan::math::disjunction<is_var_matrix<decltype(args)>...>::value
-               || stan::math::disjunction<stan::math::conjunction<
-                   is_std_vector<decltype(args)>,
-                   is_var_matrix<value_type_t<decltype(args)>>>...>::value;
-      },
-      A_vm_tuple);
-
-  if (!any_varmat) {
-    SUCCEED();  // If no varmats are created, skip this test
-    return;
-  }
-
-  using T_mv_ret = plain_type_t<decltype(stan::math::apply(f, A_mv_tuple))>;
-  using T_vm_ret = plain_type_t<decltype(stan::math::apply(f, A_vm_tuple))>;
-
-  T_mv_ret A_mv_ret;
-  T_vm_ret A_vm_ret;
-
-  if (is_var_matrix<T_mv_ret>::value
-      || (is_std_vector<T_mv_ret>::value
-          && is_var_matrix<value_type_t<T_mv_ret>>::value)) {
-    FAIL() << "A function with matvar inputs should not return "
-           << type_name<T_mv_ret>() << std::endl;
-  }
-
-  if (is_eigen<T_vm_ret>::value
-      || (is_std_vector<T_vm_ret>::value
-          && is_eigen<value_type_t<T_vm_ret>>::value)) {
-    FAIL() << "A function with varmat inputs should not return "
-           << type_name<T_vm_ret>() << std::endl;
-  }
-
-  // If one throws, the other should throw as well
-  try {
-    A_mv_ret = stan::math::apply(f, A_mv_tuple);
-  } catch (...) {
-    try {
-      stan::math::apply(f, A_vm_tuple);
-      FAIL() << "`Eigen::Matrix<var, R, C>` function throws and "
-                "`var_value<Eigen::Matrix<double, R, C>>` does not";
-    } catch (...) {
-      SUCCEED();
+    if constexpr (!any_varmat) {
+      SUCCEED();  // If no varmats are created, skip this test
       return;
+    } else {
+      using T_mv_ret = plain_type_t<decltype(stan::math::apply(f, A_mv_tuple))>;
+      using T_vm_ret = plain_type_t<decltype(stan::math::apply(f, A_vm_tuple))>;
+
+      T_mv_ret A_mv_ret;
+      T_vm_ret A_vm_ret;
+
+      if (is_var_matrix<T_mv_ret>::value
+          || (is_std_vector<T_mv_ret>::value
+              && is_var_matrix<value_type_t<T_mv_ret>>::value)) {
+        FAIL() << "A function with matvar inputs should not return "
+              << type_name<T_mv_ret>() << std::endl;
+      }
+
+      if (is_eigen<T_vm_ret>::value
+          || (is_std_vector<T_vm_ret>::value
+              && is_eigen<value_type_t<T_vm_ret>>::value)) {
+        FAIL() << "A function with varmat inputs should not return "
+              << type_name<T_vm_ret>() << std::endl;
+      }
+
+      // If one throws, the other should throw as well
+      try {
+        A_mv_ret = stan::math::apply(f, A_mv_tuple);
+      } catch (...) {
+        try {
+          stan::math::apply(f, A_vm_tuple);
+          FAIL() << "`Eigen::Matrix<var, R, C>` function throws and "
+                    "`var_value<Eigen::Matrix<double, R, C>>` does not";
+        } catch (...) {
+          SUCCEED();
+          return;
+        }
+      }
+      try {
+        A_vm_ret = stan::math::apply(f, A_vm_tuple);
+      } catch (...) {
+        try {
+          stan::math::apply(f, A_mv_tuple);
+          FAIL() << "`var_value<Eigen::Matrix<double, R, C>>` function throws and "
+                    "`Eigen::Matrix<var, R, C>` does not";
+        } catch (...) {
+          SUCCEED();
+          return;
+        }
+      }
+      test_matvar_gradient(tols, A_mv_ret, A_vm_ret, A_mv_tuple, A_vm_tuple);
+      stan::math::recover_memory();
     }
   }
-  try {
-    A_vm_ret = stan::math::apply(f, A_vm_tuple);
-  } catch (...) {
-    try {
-      stan::math::apply(f, A_mv_tuple);
-      FAIL() << "`var_value<Eigen::Matrix<double, R, C>>` function throws and "
-                "`Eigen::Matrix<var, R, C>` does not";
-    } catch (...) {
-      SUCCEED();
-      return;
-    }
-  }
-
-  test_matvar_gradient(tols, A_mv_ret, A_vm_ret, A_mv_tuple, A_vm_tuple);
-
-  stan::math::recover_memory();
 }
 
 /** @name expect_ad_matvar
@@ -550,7 +548,7 @@ void expect_ad_matvar(const ad_tolerances& tols, const F& f, const EigMat& x) {
  */
 template <typename F, typename EigMat>
 void expect_ad_matvar(const F& f, const EigMat& x) {
-  ad_tolerances tols;
+  constexpr ad_tolerances tols;
 
   expect_ad_matvar(tols, f, x);
 }

--- a/test/unit/math/test_ad_matvar.hpp
+++ b/test/unit/math/test_ad_matvar.hpp
@@ -431,8 +431,9 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
     FAIL() << "expect_ad_matvar requires at least one varmat input!"
            << std::endl;
   } else {
-
-  } if constexpr (!stan::math::disjunction<is_var<scalar_type_t<Types>>...>::value) {
+  }
+  if constexpr (!stan::math::disjunction<
+                    is_var<scalar_type_t<Types>>...>::value) {
     FAIL() << "expect_ad_matvar requires at least one autodiff input!"
            << std::endl;
   } else {
@@ -441,10 +442,11 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
 
     constexpr bool any_varmat = stan::math::apply(
         [](const auto&... args) {
-          return stan::math::disjunction<is_var_matrix<decltype(args)>...>::value
-                || stan::math::disjunction<stan::math::conjunction<
-                    is_std_vector<decltype(args)>,
-                    is_var_matrix<value_type_t<decltype(args)>>>...>::value;
+          return stan::math::disjunction<
+                     is_var_matrix<decltype(args)>...>::value
+                 || stan::math::disjunction<stan::math::conjunction<
+                     is_std_vector<decltype(args)>,
+                     is_var_matrix<value_type_t<decltype(args)>>>...>::value;
         },
         A_vm_tuple);
 
@@ -462,14 +464,14 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
           || (is_std_vector<T_mv_ret>::value
               && is_var_matrix<value_type_t<T_mv_ret>>::value)) {
         FAIL() << "A function with matvar inputs should not return "
-              << type_name<T_mv_ret>() << std::endl;
+               << type_name<T_mv_ret>() << std::endl;
       }
 
       if (is_eigen<T_vm_ret>::value
           || (is_std_vector<T_vm_ret>::value
               && is_eigen<value_type_t<T_vm_ret>>::value)) {
         FAIL() << "A function with varmat inputs should not return "
-              << type_name<T_vm_ret>() << std::endl;
+               << type_name<T_vm_ret>() << std::endl;
       }
 
       // If one throws, the other should throw as well
@@ -490,8 +492,9 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
       } catch (...) {
         try {
           stan::math::apply(f, A_mv_tuple);
-          FAIL() << "`var_value<Eigen::Matrix<double, R, C>>` function throws and "
-                    "`Eigen::Matrix<var, R, C>` does not";
+          FAIL()
+              << "`var_value<Eigen::Matrix<double, R, C>>` function throws and "
+                 "`Eigen::Matrix<var, R, C>` does not";
         } catch (...) {
           SUCCEED();
           return;

--- a/test/unit/math/test_ad_matvar.hpp
+++ b/test/unit/math/test_ad_matvar.hpp
@@ -431,7 +431,7 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
     FAIL() << "expect_ad_matvar requires at least one varmat input!"
            << std::endl;
   } else if constexpr (!stan::math::disjunction<
-                    is_var<scalar_type_t<Types>>...>::value) {
+                           is_var<scalar_type_t<Types>>...>::value) {
     FAIL() << "expect_ad_matvar requires at least one autodiff input!"
            << std::endl;
   } else {
@@ -459,15 +459,15 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
       T_vm_ret A_vm_ret;
 
       if constexpr (is_var_matrix<T_mv_ret>::value
-          || (is_std_vector<T_mv_ret>::value
-              && is_var_matrix<value_type_t<T_mv_ret>>::value)) {
+                    || (is_std_vector<T_mv_ret>::value
+                        && is_var_matrix<value_type_t<T_mv_ret>>::value)) {
         FAIL() << "A function with matvar inputs should not return "
                << type_name<T_mv_ret>() << std::endl;
       }
 
       if constexpr (is_eigen<T_vm_ret>::value
-          || (is_std_vector<T_vm_ret>::value
-              && is_eigen<value_type_t<T_vm_ret>>::value)) {
+                    || (is_std_vector<T_vm_ret>::value
+                        && is_eigen<value_type_t<T_vm_ret>>::value)) {
         FAIL() << "A function with varmat inputs should not return "
                << type_name<T_vm_ret>() << std::endl;
       }

--- a/test/unit/math/test_ad_matvar.hpp
+++ b/test/unit/math/test_ad_matvar.hpp
@@ -125,7 +125,7 @@ void expect_near_rel_matvar(const std::string& message,
                             const std::tuple<T1...>& x,
                             const std::tuple<T2...>& y,
                             const ad_tolerances& tols) {
-  if (!(sizeof...(T1) == sizeof...(T2))) {
+  if constexpr (!(sizeof...(T1) == sizeof...(T2))) {
     FAIL() << "The number of arguments in each tuple must match";
   }
   constexpr auto idxs = internal::make_tuple_seq(
@@ -427,12 +427,10 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
   using stan::math::var_value;
   using stan::math::test::type_name;
 
-  if (!stan::math::disjunction<is_var_matrix<Types>...>::value) {
+  if constexpr (!stan::math::disjunction<is_var_matrix<Types>...>::value) {
     FAIL() << "expect_ad_matvar requires at least one varmat input!"
            << std::endl;
-  } else {
-  }
-  if constexpr (!stan::math::disjunction<
+  } else if constexpr (!stan::math::disjunction<
                     is_var<scalar_type_t<Types>>...>::value) {
     FAIL() << "expect_ad_matvar requires at least one autodiff input!"
            << std::endl;
@@ -460,14 +458,14 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
       T_mv_ret A_mv_ret;
       T_vm_ret A_vm_ret;
 
-      if (is_var_matrix<T_mv_ret>::value
+      if constexpr (is_var_matrix<T_mv_ret>::value
           || (is_std_vector<T_mv_ret>::value
               && is_var_matrix<value_type_t<T_mv_ret>>::value)) {
         FAIL() << "A function with matvar inputs should not return "
                << type_name<T_mv_ret>() << std::endl;
       }
 
-      if (is_eigen<T_vm_ret>::value
+      if constexpr (is_eigen<T_vm_ret>::value
           || (is_std_vector<T_vm_ret>::value
               && is_eigen<value_type_t<T_vm_ret>>::value)) {
         FAIL() << "A function with varmat inputs should not return "

--- a/test/unit/math/test_ad_matvar.hpp
+++ b/test/unit/math/test_ad_matvar.hpp
@@ -426,8 +426,8 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
   using stan::math::var;
   using stan::math::var_value;
   using stan::math::test::type_name;
-  constexpr bool has_at_least_one_var = stan::math::disjunction<
-                           is_var<scalar_type_t<Types>>...>::value;
+  constexpr bool has_at_least_one_var
+      = stan::math::disjunction<is_var<scalar_type_t<Types>>...>::value;
   if constexpr (!stan::math::disjunction<is_var_matrix<Types>...>::value) {
     FAIL() << "expect_ad_matvar requires at least one varmat input!"
            << std::endl;

--- a/test/unit/math/test_ad_matvar.hpp
+++ b/test/unit/math/test_ad_matvar.hpp
@@ -426,12 +426,12 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
   using stan::math::var;
   using stan::math::var_value;
   using stan::math::test::type_name;
-
+  constexpr bool has_at_least_one_var = stan::math::disjunction<
+                           is_var<scalar_type_t<Types>>...>::value;
   if constexpr (!stan::math::disjunction<is_var_matrix<Types>...>::value) {
     FAIL() << "expect_ad_matvar requires at least one varmat input!"
            << std::endl;
-  } else if constexpr (!stan::math::disjunction<
-                           is_var<scalar_type_t<Types>>...>::value) {
+  } else if constexpr (!has_at_least_one_var) {
     FAIL() << "expect_ad_matvar requires at least one autodiff input!"
            << std::endl;
   } else {

--- a/test/unit/math/test_ad_matvar_test.cpp
+++ b/test/unit/math/test_ad_matvar_test.cpp
@@ -211,8 +211,7 @@ auto three_arg_bad_vals(const T1& x1, const stan::math::var_value<T3>& x3,
 
   stan::math::reverse_pass_callback([x3, ret]() mutable {
     if constexpr (stan::is_stan_scalar<T3>::value) {
-      x3.adj()
-          += stan::math::sum(ret.adj());
+      x3.adj() += stan::math::sum(ret.adj());
     } else {
       x3.adj() += ret.adj();
     }
@@ -232,8 +231,7 @@ auto three_arg_bad_vals(const stan::math::var_value<T3>& x3, const T1& x1,
 
   stan::math::reverse_pass_callback([x3, ret]() mutable {
     if constexpr (stan::is_stan_scalar<T3>::value) {
-      x3.adj()
-          += stan::math::sum(ret.adj());
+      x3.adj() += stan::math::sum(ret.adj());
     } else {
       x3.adj() += ret.adj();
     }
@@ -296,8 +294,7 @@ auto three_arg_bad_grads(const T1& x1, const T2& x2,
 
   stan::math::reverse_pass_callback([x3, ret]() mutable {
     if constexpr (stan::is_stan_scalar<T3>::value) {
-      x3.adj()
-          -= stan::math::sum(ret.adj());
+      x3.adj() -= stan::math::sum(ret.adj());
     } else {
       x3.adj() -= ret.adj();
     }
@@ -317,8 +314,7 @@ auto three_arg_bad_grads(const T1& x1, const stan::math::var_value<T3>& x3,
 
   stan::math::reverse_pass_callback([x3, ret]() mutable {
     if constexpr (stan::is_stan_scalar<T3>::value) {
-      x3.adj()
-          -= stan::math::sum(ret.adj());
+      x3.adj() -= stan::math::sum(ret.adj());
     } else {
       x3.adj() -= ret.adj();
     }
@@ -338,8 +334,7 @@ auto three_arg_bad_grads(const stan::math::var_value<T3>& x3, const T1& x1,
 
   stan::math::reverse_pass_callback([x3, ret]() mutable {
     if constexpr (stan::is_stan_scalar<T3>::value) {
-      x3.adj()
-          -= stan::math::sum(ret.adj());
+      x3.adj() -= stan::math::sum(ret.adj());
     } else {
       x3.adj() -= ret.adj();
     }

--- a/test/unit/math/test_ad_matvar_test.cpp
+++ b/test/unit/math/test_ad_matvar_test.cpp
@@ -66,11 +66,10 @@ auto two_arg_bad_vals(const T1& x1, const stan::math::var_value<T2>& x2) {
   stan::arena_t<ret_type> ret = ret_val;
 
   stan::math::reverse_pass_callback([x2, ret]() mutable {
-    if (stan::is_stan_scalar<T2>::value) {
-      stan::math::forward_as<stan::math::var>(x2).adj()
-          += stan::math::sum(ret.adj());
+    if constexpr (stan::is_stan_scalar<T2>::value) {
+      x2.adj() += stan::math::sum(ret.adj());
     } else {
-      stan::math::forward_as<Eigen::VectorXd>(x2.adj()) += ret.adj();
+      x2.adj() += ret.adj();
     }
   });
 
@@ -85,11 +84,10 @@ auto two_arg_bad_vals(const stan::math::var_value<T2>& x2, const T1& x1) {
   stan::arena_t<ret_type> ret = ret_val;
 
   stan::math::reverse_pass_callback([x2, ret]() mutable {
-    if (stan::is_stan_scalar<T2>::value) {
-      stan::math::forward_as<stan::math::var>(x2).adj()
-          += stan::math::sum(ret.adj());
+    if constexpr (stan::is_stan_scalar<T2>::value) {
+      x2.adj() += stan::math::sum(ret.adj());
     } else {
-      stan::math::forward_as<Eigen::VectorXd>(x2.adj()) += ret.adj();
+      x2.adj() += ret.adj();
     }
   });
 
@@ -127,11 +125,10 @@ auto two_arg_bad_grads(const T1& x1, const stan::math::var_value<T2>& x2) {
   stan::arena_t<ret_type> ret = stan::math::add(x1, x2.val());
 
   stan::math::reverse_pass_callback([x2, ret]() mutable {
-    if (stan::is_stan_scalar<T2>::value) {
-      stan::math::forward_as<stan::math::var>(x2).adj()
-          -= stan::math::sum(ret.adj());
+    if constexpr (stan::is_stan_scalar<T2>::value) {
+      x2.adj() -= stan::math::sum(ret.adj());
     } else {
-      stan::math::forward_as<Eigen::VectorXd>(x2.adj()) -= ret.adj();
+      x2.adj() -= ret.adj();
     }
   });
 
@@ -146,11 +143,10 @@ auto two_arg_bad_grads(const stan::math::var_value<T2>& x2, const T1& x1) {
   stan::arena_t<ret_type> ret = stan::math::add(x1, x2.val());
 
   stan::math::reverse_pass_callback([x2, ret]() mutable {
-    if (stan::is_stan_scalar<T2>::value) {
-      stan::math::forward_as<stan::math::var>(x2).adj()
-          -= stan::math::sum(ret.adj());
+    if constexpr (stan::is_stan_scalar<T2>::value) {
+      x2.adj() -= stan::math::sum(ret.adj());
     } else {
-      stan::math::forward_as<Eigen::VectorXd>(x2.adj()) -= ret.adj();
+      x2.adj() -= ret.adj();
     }
   });
 
@@ -194,11 +190,10 @@ auto three_arg_bad_vals(const T1& x1, const T2& x2,
   stan::arena_t<ret_type> ret = ret_val;
 
   stan::math::reverse_pass_callback([x3, ret]() mutable {
-    if (stan::is_stan_scalar<T3>::value) {
-      stan::math::forward_as<stan::math::var>(x3).adj()
-          += stan::math::sum(ret.adj());
+    if constexpr (stan::is_stan_scalar<T3>::value) {
+      x3.adj() += stan::math::sum(ret.adj());
     } else {
-      stan::math::forward_as<Eigen::VectorXd>(x3.adj()) += ret.adj();
+      x3.adj() += ret.adj();
     }
   });
 
@@ -215,11 +210,11 @@ auto three_arg_bad_vals(const T1& x1, const stan::math::var_value<T3>& x3,
   stan::arena_t<ret_type> ret = ret_val;
 
   stan::math::reverse_pass_callback([x3, ret]() mutable {
-    if (stan::is_stan_scalar<T3>::value) {
-      stan::math::forward_as<stan::math::var>(x3).adj()
+    if constexpr (stan::is_stan_scalar<T3>::value) {
+      x3.adj()
           += stan::math::sum(ret.adj());
     } else {
-      stan::math::forward_as<Eigen::VectorXd>(x3.adj()) += ret.adj();
+      x3.adj() += ret.adj();
     }
   });
 
@@ -236,11 +231,11 @@ auto three_arg_bad_vals(const stan::math::var_value<T3>& x3, const T1& x1,
   stan::arena_t<ret_type> ret = ret_val;
 
   stan::math::reverse_pass_callback([x3, ret]() mutable {
-    if (stan::is_stan_scalar<T3>::value) {
-      stan::math::forward_as<stan::math::var>(x3).adj()
+    if constexpr (stan::is_stan_scalar<T3>::value) {
+      x3.adj()
           += stan::math::sum(ret.adj());
     } else {
-      stan::math::forward_as<Eigen::VectorXd>(x3.adj()) += ret.adj();
+      x3.adj() += ret.adj();
     }
   });
 
@@ -300,11 +295,11 @@ auto three_arg_bad_grads(const T1& x1, const T2& x2,
   stan::arena_t<ret_type> ret = ret_val;
 
   stan::math::reverse_pass_callback([x3, ret]() mutable {
-    if (stan::is_stan_scalar<T3>::value) {
-      stan::math::forward_as<stan::math::var>(x3).adj()
+    if constexpr (stan::is_stan_scalar<T3>::value) {
+      x3.adj()
           -= stan::math::sum(ret.adj());
     } else {
-      stan::math::forward_as<Eigen::VectorXd>(x3.adj()) -= ret.adj();
+      x3.adj() -= ret.adj();
     }
   });
 
@@ -321,11 +316,11 @@ auto three_arg_bad_grads(const T1& x1, const stan::math::var_value<T3>& x3,
   stan::arena_t<ret_type> ret = ret_val;
 
   stan::math::reverse_pass_callback([x3, ret]() mutable {
-    if (stan::is_stan_scalar<T3>::value) {
-      stan::math::forward_as<stan::math::var>(x3).adj()
+    if constexpr (stan::is_stan_scalar<T3>::value) {
+      x3.adj()
           -= stan::math::sum(ret.adj());
     } else {
-      stan::math::forward_as<Eigen::VectorXd>(x3.adj()) -= ret.adj();
+      x3.adj() -= ret.adj();
     }
   });
 
@@ -342,11 +337,11 @@ auto three_arg_bad_grads(const stan::math::var_value<T3>& x3, const T1& x1,
   stan::arena_t<ret_type> ret = ret_val;
 
   stan::math::reverse_pass_callback([x3, ret]() mutable {
-    if (stan::is_stan_scalar<T3>::value) {
-      stan::math::forward_as<stan::math::var>(x3).adj()
+    if constexpr (stan::is_stan_scalar<T3>::value) {
+      x3.adj()
           -= stan::math::sum(ret.adj());
     } else {
-      stan::math::forward_as<Eigen::VectorXd>(x3.adj()) -= ret.adj();
+      x3.adj() -= ret.adj();
     }
   });
 
@@ -499,11 +494,8 @@ auto two_args_bad_vals_std_vector(
 
   stan::math::reverse_pass_callback([arena_x1, arena_x2, out]() mutable {
     for (size_t i = 0; i < arena_x1.size(); ++i) {
-      if (!stan::is_constant<T1>::value) {
-        stan::math::forward_as<
-            stan::return_var_matrix_t<T2, T1, stan::math::var>>(arena_x1[i])
-            .adj()
-            += out[i].adj();
+      if constexpr (!stan::is_constant<T1>::value) {
+        arena_x1[i].adj() += out[i].adj();
       }
       arena_x2[i].adj() += out[i].adj();
     }
@@ -558,11 +550,8 @@ auto two_args_bad_grads_std_vector(
 
   stan::math::reverse_pass_callback([arena_x1, arena_x2, out]() mutable {
     for (size_t i = 0; i < arena_x1.size(); ++i) {
-      if (!stan::is_constant<T1>::value) {
-        stan::math::forward_as<
-            stan::return_var_matrix_t<T2, T1, stan::math::var>>(arena_x1[i])
-            .adj()
-            += out[i].adj();
+      if constexpr (!stan::is_constant<T1>::value) {
+        arena_x1[i].adj() += out[i].adj();
       }
       arena_x2[i].adj() += out[i].adj() * 0;
     }


### PR DESCRIPTION
## Summary

Fixes #3190 . `forward_as` was a workaround for C++14 when we did not have `if constexpr` and needed both sides of expressions to be able to be evaluated. Now that we have C++17 we can remove all those and cleanup a good bit of the code

## Tests

No new tests

## Side Effects

Are there any side effects that we should be aware of?

## Release notes

Remove use of `forward_as` in the math library

## Checklist

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
