### PR TITLE
Add a few more type traits for use in stanc

### DIFF
--- a/stan/math/prim/meta.hpp
+++ b/stan/math/prim/meta.hpp
@@ -95,7 +95,9 @@
 #include <stan/math/prim/meta/is_eigen_matrix.hpp>
 #include <stan/math/prim/meta/is_eigen_matrix_base.hpp>
 #include <stan/math/prim/meta/is_eigen_sparse_base.hpp>
+#include <stan/math/prim/meta/is_floating_point.hpp>
 #include <stan/math/prim/meta/is_fvar.hpp>
+#include <stan/math/prim/meta/is_integral.hpp>
 #include <stan/math/prim/meta/is_kernel_expression.hpp>
 #include <stan/math/prim/meta/is_matrix_cl.hpp>
 #include <stan/math/prim/meta/is_matrix.hpp>
@@ -128,6 +130,7 @@
 #include <stan/math/prim/meta/scalar_type.hpp>
 #include <stan/math/prim/meta/seq_view.hpp>
 #include <stan/math/prim/meta/static_select.hpp>
+#include <stan/math/prim/meta/tuple_elt.hpp>
 #include <stan/math/prim/meta/value_type.hpp>
 #include <stan/math/prim/meta/void_t.hpp>
 #include <stan/math/prim/meta/StdVectorBuilder.hpp>

--- a/stan/math/prim/meta.hpp
+++ b/stan/math/prim/meta.hpp
@@ -130,7 +130,8 @@
 #include <stan/math/prim/meta/scalar_type.hpp>
 #include <stan/math/prim/meta/seq_view.hpp>
 #include <stan/math/prim/meta/static_select.hpp>
-#include <stan/math/prim/meta/tuple_elt.hpp>
+#include <stan/math/prim/meta/tuple_element.hpp>
+#include <stan/math/prim/meta/tuple_size.hpp>
 #include <stan/math/prim/meta/value_type.hpp>
 #include <stan/math/prim/meta/void_t.hpp>
 #include <stan/math/prim/meta/StdVectorBuilder.hpp>

--- a/stan/math/prim/meta/is_floating_point.hpp
+++ b/stan/math/prim/meta/is_floating_point.hpp
@@ -1,0 +1,29 @@
+#ifndef STAN_MATH_PRIM_META_IS_FLOATING_POINT_HPP
+#define STAN_MATH_PRIM_META_IS_FLOATING_POINT_HPP
+
+#include <type_traits>
+
+namespace stan {
+
+/**
+ * Checks if decayed type is a floating point type
+ * @tparam The type to check
+ * @ingroup type_trait
+ */
+template <typename T>
+using is_floating_point = std::is_floating_point<std::decay_t<T>>;
+
+template <typename T>
+inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
+
+template <typename... Types>
+inline constexpr bool is_all_floating_point_v
+    = (is_floating_point_v<Types> && ...);
+
+template <typename... Types>
+inline constexpr bool is_any_floating_point_v
+    = (is_floating_point_v<Types> || ...);
+
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/meta/is_floating_point.hpp
+++ b/stan/math/prim/meta/is_floating_point.hpp
@@ -14,15 +14,15 @@ template <typename T>
 using is_floating_point = std::is_floating_point<std::decay_t<T>>;
 
 template <typename T>
-inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
+inline constexpr bool is_floating_point_v = stan::is_floating_point<T>::value;
 
 template <typename... Types>
 inline constexpr bool is_all_floating_point_v
-    = (is_floating_point_v<Types> && ...);
+    = (stan::is_floating_point_v<Types> && ...);
 
 template <typename... Types>
 inline constexpr bool is_any_floating_point_v
-    = (is_floating_point_v<Types> || ...);
+    = (stan::is_floating_point_v<Types> || ...);
 
 }  // namespace stan
 

--- a/stan/math/prim/meta/is_integral.hpp
+++ b/stan/math/prim/meta/is_integral.hpp
@@ -1,0 +1,27 @@
+#ifndef STAN_MATH_PRIM_META_IS_INTEGRAL_HPP
+#define STAN_MATH_PRIM_META_IS_INTEGRAL_HPP
+
+#include <type_traits>
+
+namespace stan {
+
+/**
+ * Checks if decayed type is integral
+ * @tparam The type to check
+ * @ingroup type_trait
+ */
+template <typename T>
+using is_integral = std::is_integral<std::decay_t<T>>;
+
+template <typename T>
+inline constexpr bool is_integral_v = is_integral<T>::value;
+
+template <typename... Types>
+inline constexpr bool is_all_integral_v = (is_integral_v<Types> && ...);
+
+template <typename... Types>
+inline constexpr bool is_any_integral_v = (is_integral_v<Types> || ...);
+
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/meta/is_integral.hpp
+++ b/stan/math/prim/meta/is_integral.hpp
@@ -14,13 +14,13 @@ template <typename T>
 using is_integral = std::is_integral<std::decay_t<T>>;
 
 template <typename T>
-inline constexpr bool is_integral_v = is_integral<T>::value;
+inline constexpr bool is_integral_v = stan::is_integral<T>::value;
 
 template <typename... Types>
-inline constexpr bool is_all_integral_v = (is_integral_v<Types> && ...);
+inline constexpr bool is_all_integral_v = (stan::is_integral_v<Types> && ...);
 
 template <typename... Types>
-inline constexpr bool is_any_integral_v = (is_integral_v<Types> || ...);
+inline constexpr bool is_any_integral_v = (stan::is_integral_v<Types> || ...);
 
 }  // namespace stan
 

--- a/stan/math/prim/meta/is_tuple.hpp
+++ b/stan/math/prim/meta/is_tuple.hpp
@@ -62,10 +62,12 @@ inline constexpr bool is_tuple_v = math::is_tuple_v<T>;
  * @tparam N expected size
  * @ingroup type_trait
  */
+template <typename T, std::size_t N, typename = void>
+struct is_tuple_of_size : std::false_type {};
+
 template <typename T, std::size_t N>
-struct is_tuple_of_size
-    : std::bool_constant<
-          is_tuple_v<T> && std::tuple_size_v<std::decay_t<T>> == N> {};
+struct is_tuple_of_size<T, N, std::enable_if_t<is_tuple_v<T>>>
+    : std::bool_constant<std::tuple_size_v<std::decay_t<T>> == N> {};
 
 template <typename T, std::size_t N>
 inline constexpr bool is_tuple_of_size_v = is_tuple_of_size<T, N>::value;

--- a/stan/math/prim/meta/is_tuple.hpp
+++ b/stan/math/prim/meta/is_tuple.hpp
@@ -66,11 +66,11 @@ template <typename T, std::size_t N, typename = void>
 struct is_tuple_of_size : std::false_type {};
 
 template <typename T, std::size_t N>
-struct is_tuple_of_size<T, N, std::enable_if_t<is_tuple_v<T>>>
+struct is_tuple_of_size<T, N, std::enable_if_t<stan::is_tuple_v<T>>>
     : std::bool_constant<std::tuple_size_v<std::decay_t<T>> == N> {};
 
 template <typename T, std::size_t N>
-inline constexpr bool is_tuple_of_size_v = is_tuple_of_size<T, N>::value;
+inline constexpr bool is_tuple_of_size_v = stan::is_tuple_of_size<T, N>::value;
 
 }  // namespace stan
 

--- a/stan/math/prim/meta/is_tuple.hpp
+++ b/stan/math/prim/meta/is_tuple.hpp
@@ -64,8 +64,8 @@ inline constexpr bool is_tuple_v = math::is_tuple_v<T>;
  */
 template <typename T, std::size_t N>
 struct is_tuple_of_size
-    : std::bool_constant<is_tuple_v<T>
-                         && std::tuple_size_v<std::decay_t<T>> == N> {};
+    : std::bool_constant<
+          is_tuple_v<T> && std::tuple_size_v<std::decay_t<T>> == N> {};
 
 template <typename T, std::size_t N>
 inline constexpr bool is_tuple_of_size_v = is_tuple_of_size<T, N>::value;

--- a/stan/math/prim/meta/is_tuple.hpp
+++ b/stan/math/prim/meta/is_tuple.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_META_IS_TUPLE_HPP
 #define STAN_MATH_PRIM_META_IS_TUPLE_HPP
 
+#include <cstddef>
 #include <stan/math/prim/meta/require_helpers.hpp>
 #include <tuple>
 #include <type_traits>
@@ -48,6 +49,26 @@ using require_all_not_tuple_t
     = require_all_not_t<is_tuple<std::decay_t<Types>>...>;
 /*! @} */
 }  // namespace math
+
+template <typename T>
+using is_tuple = math::is_tuple<T>;
+
+template <typename T>
+inline constexpr bool is_tuple_v = math::is_tuple_v<T>;
+
+/**
+ * Checks both that T is a tuple and that its size is N
+ * @tparam T type to retrieve the element from
+ * @tparam N expected size
+ * @ingroup type_trait
+ */
+template <typename T, std::size_t N>
+struct is_tuple_of_size
+    : std::bool_constant<is_tuple_v<T>
+                         && std::tuple_size_v<std::decay_t<T>> == N> {};
+
+template <typename T, std::size_t N>
+inline constexpr bool is_tuple_of_size_v = is_tuple_of_size<T, N>::value;
 
 }  // namespace stan
 

--- a/stan/math/prim/meta/tuple_element.hpp
+++ b/stan/math/prim/meta/tuple_element.hpp
@@ -23,13 +23,14 @@ struct tuple_element {
 };
 
 template <std::size_t N, typename T>
-struct tuple_element<N, T,
-                     std::enable_if_t<is_tuple_v<T> && (N < tuple_size_v<T>)>> {
+struct tuple_element<
+    N, T,
+    std::enable_if_t<stan::is_tuple_v<T> && (N < stan::tuple_size_v<T>)>> {
   using type = std::tuple_element_t<N, std::decay_t<T>>;
 };
 
 template <std::size_t N, typename T>
-using tuple_element_t = typename tuple_element<N, T>::type;
+using tuple_element_t = typename stan::tuple_element<N, T>::type;
 }  // namespace stan
 
 #endif

--- a/stan/math/prim/meta/tuple_element.hpp
+++ b/stan/math/prim/meta/tuple_element.hpp
@@ -1,5 +1,8 @@
-#ifndef STAN_MATH_PRIM_META_IS_TUPLE_ELT_HPP
-#define STAN_MATH_PRIM_META_IS_TUPLE_ELT_HPP
+#ifndef STAN_MATH_PRIM_META_TUPLE_ELEMENT_HPP
+#define STAN_MATH_PRIM_META_TUPLE_ELEMENT_HPP
+
+#include <stan/math/prim/meta/is_tuple.hpp>
+#include <stan/math/prim/meta/tuple_size.hpp>
 
 #include <type_traits>
 #include <cstddef>
@@ -20,8 +23,8 @@ struct tuple_element {
 };
 
 template <std::size_t N, typename T>
-struct tuple_element<
-    N, T, std::enable_if_t<(N < std::tuple_size_v<std::decay_t<T>>)>> {
+struct tuple_element<N, T,
+                     std::enable_if_t<is_tuple_v<T> && (N < tuple_size_v<T>)>> {
   using type = std::tuple_element_t<N, std::decay_t<T>>;
 };
 

--- a/stan/math/prim/meta/tuple_elt.hpp
+++ b/stan/math/prim/meta/tuple_elt.hpp
@@ -1,0 +1,32 @@
+#ifndef STAN_MATH_PRIM_META_IS_TUPLE_ELT_HPP
+#define STAN_MATH_PRIM_META_IS_TUPLE_ELT_HPP
+
+#include <type_traits>
+#include <cstddef>
+#include <tuple>
+
+namespace stan {
+
+/**
+ * Equivalent to std::tuple_element but returns void if N is out of range
+ * to avoid a static assertion failure in libstdc++.
+ * @tparam N index of the element to retrieve
+ * @tparam T type to retrieve the element from
+ * @ingroup type_trait
+ */
+template <std::size_t N, typename T, typename = void>
+struct tuple_element {
+  using type = void;
+};
+
+template <std::size_t N, typename T>
+struct tuple_element<
+    N, T, std::enable_if_t<(N < std::tuple_size_v<std::decay_t<T>>)>> {
+  using type = std::tuple_element_t<N, std::decay_t<T>>;
+};
+
+template <std::size_t N, typename T>
+using tuple_element_t = typename tuple_element<N, T>::type;
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/meta/tuple_size.hpp
+++ b/stan/math/prim/meta/tuple_size.hpp
@@ -1,0 +1,28 @@
+#ifndef STAN_MATH_PRIM_META_TUPLE_SIZE_HPP
+#define STAN_MATH_PRIM_META_TUPLE_SIZE_HPP
+
+#include <stan/math/prim/meta/is_tuple.hpp>
+#include <type_traits>
+#include <cstddef>
+#include <tuple>
+
+namespace stan {
+
+/**
+ * Equivalent to std::tuple_size but returns 0 T is not a tuple
+ * @tparam T type to get tuple size of
+ * @ingroup type_trait
+ */
+template <typename T, typename = void>
+struct tuple_size : std::integral_constant<std::size_t, 0> {};
+
+template <typename T>
+struct tuple_size<T, std::enable_if_t<is_tuple_v<T>>>
+    : std::integral_constant<std::size_t, std::tuple_size_v<std::decay_t<T>>> {
+};
+
+template <typename T>
+constexpr std::size_t tuple_size_v = tuple_size<T>::value;
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/meta/tuple_size.hpp
+++ b/stan/math/prim/meta/tuple_size.hpp
@@ -17,12 +17,12 @@ template <typename T, typename = void>
 struct tuple_size : std::integral_constant<std::size_t, 0> {};
 
 template <typename T>
-struct tuple_size<T, std::enable_if_t<is_tuple_v<T>>>
+struct tuple_size<T, std::enable_if_t<stan::is_tuple_v<T>>>
     : std::integral_constant<std::size_t, std::tuple_size_v<std::decay_t<T>>> {
 };
 
 template <typename T>
-constexpr std::size_t tuple_size_v = tuple_size<T>::value;
+constexpr std::size_t tuple_size_v = stan::tuple_size<T>::value;
 }  // namespace stan
 
 #endif


### PR DESCRIPTION


## Summary

This adds a couple more type traits to the meta folder:

Two for resolving https://github.com/stan-dev/stan/issues/3356:
- `tuple_elt<N, T>` is a wrapper around `std::tuple_elt` but returns void if N is too big for the tuple size of T
- `is_tuple_of_size<T, N>` is `is_tuple` with an additional check that the size is what we expect.

Two for a general cleanup of the code gen:
- `is_integral<T>` is just `std::is_integral<std::decay<T>>`
- same for `is_floating_point`

## Tests


## Side Effects



## Release notes

Added some more type traits for dealing with tuples.

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
