### PR TITLE
Update wording of validate_positive_index

### DIFF
--- a/stan/math/prim/err/validate_positive_index.hpp
+++ b/stan/math/prim/err/validate_positive_index.hpp
@@ -10,19 +10,21 @@ namespace stan {
 namespace math {
 
 /**
- * Check that simplex is at least size 1
+ * Check that size is at least 1. Used for simplexes and
+ * other constraints that do a (size - 1) operation.
  *
- * @param var_name Name of simplex variable
+ * @param var_name Name of variable
  * @param expr Expression in which variable is declared
- * @param val Size of simplex
- * @throw std::invalid_argument if simplex size is less than 1
+ * @param val Size to check
+ * @throw std::invalid_argument if size is less than 1
  */
 inline void validate_positive_index(const char* var_name, const char* expr,
                                     int val) {
   if (val < 1) {
     [&]() STAN_COLD_PATH {
       std::stringstream msg;
-      msg << "Found dimension size less than one in simplex declaration"
+      msg << "Found dimension size less than one in constrained type "
+             "declaration (simplex, sum_to_zero_vector, etc.)"
           << "; variable=" << var_name << "; dimension size expression=" << expr
           << "; expression value=" << val;
       std::string msg_str(msg.str());


### PR DESCRIPTION


## Summary

Relevant for https://github.com/stan-dev/stanc3/pull/1563, the wording here is too specific

## Tests


## Side Effects



## Release notes



## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
