### PR TITLE
Fix expression tests for new Wiener functions

### DIFF
--- a/stan/math/prim/prob/wiener4_lccdf_defective.hpp
+++ b/stan/math/prim/prob/wiener4_lccdf_defective.hpp
@@ -75,7 +75,7 @@ inline auto wiener_prob_derivative_term(const T_a& a, const T_v& v,
   if (neg_v < 0) {
     ans = LOG_TWO + exponent_with_1mw - log1m_exp(exponent_with_1mw);
     diff_term = log1m_exp(exponent_with_w) - log1m_exp(exponent);
-  } else if (neg_v > 0) {
+  } else /* neg_v > 0 */ {
     ans = LOG_TWO - log1m_exp(exponent_with_1mw);
     diff_term = log_diff_exp(exponent_with_1mw, exponent) - log1m_exp(exponent);
   }

--- a/stan/math/prim/prob/wiener4_lccdf_defective.hpp
+++ b/stan/math/prim/prob/wiener4_lccdf_defective.hpp
@@ -226,7 +226,7 @@ template <bool propto = false, typename T_y, typename T_a, typename T_t0,
           typename T_w, typename T_v>
 inline auto wiener_lccdf_defective(const T_y& y, const T_a& a, const T_t0& t0,
                                    const T_w& w, const T_v& v,
-                                   const double& precision_derivatives) {
+                                   const double& precision_derivatives = 1e-4) {
   using T_partials_return = partials_return_t<T_y, T_a, T_t0, T_w, T_v>;
   using ret_t = return_type_t<T_y, T_a, T_t0, T_w, T_v>;
   using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;

--- a/stan/math/prim/prob/wiener4_lccdf_defective.hpp
+++ b/stan/math/prim/prob/wiener4_lccdf_defective.hpp
@@ -229,11 +229,11 @@ inline auto wiener_lccdf_defective(const T_y& y, const T_a& a, const T_t0& t0,
                                    const double& precision_derivatives = 1e-4) {
   using T_partials_return = partials_return_t<T_y, T_a, T_t0, T_w, T_v>;
   using ret_t = return_type_t<T_y, T_a, T_t0, T_w, T_v>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_a_ref = ref_type_if_t<!is_constant<T_a>::value, T_a>;
-  using T_t0_ref = ref_type_if_t<!is_constant<T_t0>::value, T_t0>;
-  using T_w_ref = ref_type_if_t<!is_constant<T_w>::value, T_w>;
-  using T_v_ref = ref_type_if_t<!is_constant<T_v>::value, T_v>;
+  using T_y_ref = ref_type_t<T_y>;
+  using T_a_ref = ref_type_t<T_a>;
+  using T_t0_ref = ref_type_t<T_t0>;
+  using T_w_ref = ref_type_t<T_w>;
+  using T_v_ref = ref_type_t<T_v>;
   using internal::GradientCalc;
 
   T_y_ref y_ref = y;

--- a/stan/math/prim/prob/wiener4_lcdf_defective.hpp
+++ b/stan/math/prim/prob/wiener4_lcdf_defective.hpp
@@ -590,11 +590,11 @@ inline auto wiener_lcdf_defective(const T_y& y, const T_a& a, const T_t0& t0,
                                   const T_w& w, const T_v& v,
                                   const double& precision_derivatives = 1e-4) {
   using T_partials_return = partials_return_t<T_y, T_a, T_t0, T_w, T_v>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_a_ref = ref_type_if_t<!is_constant<T_a>::value, T_a>;
-  using T_t0_ref = ref_type_if_t<!is_constant<T_t0>::value, T_t0>;
-  using T_w_ref = ref_type_if_t<!is_constant<T_w>::value, T_w>;
-  using T_v_ref = ref_type_if_t<!is_constant<T_v>::value, T_v>;
+  using T_y_ref = ref_type_t<T_y>;
+  using T_a_ref = ref_type_t<T_a>;
+  using T_t0_ref = ref_type_t<T_t0>;
+  using T_w_ref = ref_type_t<T_w>;
+  using T_v_ref = ref_type_t<T_v>;
   using internal::GradientCalc;
   using ret_t = return_type_t<T_y, T_a, T_t0, T_w, T_v>;
 

--- a/stan/math/prim/prob/wiener_full_lccdf_defective.hpp
+++ b/stan/math/prim/prob/wiener_full_lccdf_defective.hpp
@@ -89,14 +89,14 @@ inline auto wiener_lccdf_defective(const T_y& y, const T_a& a, const T_t0& t0,
                                    const T_sw& sw, const T_st0& st0,
                                    const double& precision_derivatives = 1e-8) {
   using ret_t = return_type_t<T_y, T_a, T_t0, T_w, T_v, T_sv, T_sw, T_st0>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_a_ref = ref_type_if_t<!is_constant<T_a>::value, T_a>;
-  using T_v_ref = ref_type_if_t<!is_constant<T_v>::value, T_v>;
-  using T_w_ref = ref_type_if_t<!is_constant<T_w>::value, T_w>;
-  using T_t0_ref = ref_type_if_t<!is_constant<T_t0>::value, T_t0>;
-  using T_sv_ref = ref_type_if_t<!is_constant<T_sv>::value, T_sv>;
-  using T_sw_ref = ref_type_if_t<!is_constant<T_sw>::value, T_sw>;
-  using T_st0_ref = ref_type_if_t<!is_constant<T_st0>::value, T_st0>;
+  using T_y_ref = ref_type_t<T_y>;
+  using T_a_ref = ref_type_t<T_a>;
+  using T_v_ref = ref_type_t<T_v>;
+  using T_w_ref = ref_type_t<T_w>;
+  using T_t0_ref = ref_type_t<T_t0>;
+  using T_sv_ref = ref_type_t<T_sv>;
+  using T_sw_ref = ref_type_t<T_sw>;
+  using T_st0_ref = ref_type_t<T_st0>;
   using internal::GradientCalc;
   using T_partials_return
       = partials_return_t<T_y, T_a, T_t0, T_w, T_v, T_sv, T_sw, T_st0>;

--- a/stan/math/prim/prob/wiener_full_lccdf_defective.hpp
+++ b/stan/math/prim/prob/wiener_full_lccdf_defective.hpp
@@ -267,9 +267,7 @@ inline auto wiener_lccdf_defective(const T_y& y, const T_a& a, const T_t0& t0,
 
     // computation of derivative for t and precision check in order to give
     // the value as deriv_t to edge1 and as -deriv_t to edge5
-    const auto params_dt7 = std::make_tuple(
-        y_value, a_value, v_value, w_value, t0_value, sv_value, sw_value,
-        st0_value, log_error_absolute - LOG_TWO - 9 * LOG_TWO);
+
     // computation of derivatives and precision checks
     if (!is_constant_all<T_y>::value || !is_constant_all<T_t0>::value) {
       const T_partials_return deriv_t_7

--- a/stan/math/prim/prob/wiener_full_lcdf_defective.hpp
+++ b/stan/math/prim/prob/wiener_full_lcdf_defective.hpp
@@ -265,14 +265,14 @@ inline auto wiener_lcdf_defective(const T_y& y, const T_a& a, const T_t0& t0,
                                   const T_sw& sw, const T_st0& st0,
                                   const double& precision_derivatives = 1e-8) {
   using ret_t = return_type_t<T_y, T_a, T_t0, T_w, T_v, T_sv, T_sw, T_st0>;
-  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
-  using T_a_ref = ref_type_if_t<!is_constant<T_a>::value, T_a>;
-  using T_v_ref = ref_type_if_t<!is_constant<T_v>::value, T_v>;
-  using T_w_ref = ref_type_if_t<!is_constant<T_w>::value, T_w>;
-  using T_t0_ref = ref_type_if_t<!is_constant<T_t0>::value, T_t0>;
-  using T_sv_ref = ref_type_if_t<!is_constant<T_sv>::value, T_sv>;
-  using T_sw_ref = ref_type_if_t<!is_constant<T_sw>::value, T_sw>;
-  using T_st0_ref = ref_type_if_t<!is_constant<T_st0>::value, T_st0>;
+  using T_y_ref = ref_type_t<T_y>;
+  using T_a_ref = ref_type_t<T_a>;
+  using T_v_ref = ref_type_t<T_v>;
+  using T_w_ref = ref_type_t<T_w>;
+  using T_t0_ref = ref_type_t<T_t0>;
+  using T_sv_ref = ref_type_t<T_sv>;
+  using T_sw_ref = ref_type_t<T_sw>;
+  using T_st0_ref = ref_type_t<T_st0>;
   using internal::GradientCalc;
   using T_partials_return
       = partials_return_t<T_y, T_a, T_t0, T_w, T_v, T_sv, T_sw, T_st0>;

--- a/stan/math/prim/prob/wiener_full_lcdf_defective.hpp
+++ b/stan/math/prim/prob/wiener_full_lcdf_defective.hpp
@@ -445,9 +445,7 @@ inline auto wiener_lcdf_defective(const T_y& y, const T_a& a, const T_t0& t0,
 
     // computation of derivative for t and precision check in order to give
     // the value as deriv_t to edge1 and as -deriv_t to edge5
-    const auto params_dt7 = std::make_tuple(
-        y_value, a_value, v_value, w_value, t0_value, sv_value, sw_value,
-        st0_value, log_error_absolute - LOG_TWO - 9 * LOG_TWO);
+
     if (!is_constant_all<T_y>::value || !is_constant_all<T_t0>::value) {
       T_partials_return deriv_t_7
           = internal::wiener7_integrate_cdf<

--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -145,7 +145,7 @@ special_arg_values = {
     "uniform_lcdf": [None, 0.2, 0.9],
     "uniform_lpdf": [None, 0.2, 0.9],
     "uniform_rng": [0.2, 1.9, None],
-    "wiener_lpdf": [0.8, None, 0.4, None, None, None, None, None],
+    "wiener_lpdf": [0.8, None, 0.4, None, None, None, None, None, 1e-4],
 }
 
 # list of functions we do not test. These are mainly functions implemented in compiler
@@ -180,6 +180,9 @@ non_differentiable_args = {
     "ode_adams_tol": [4, 5, 6],
     "ode_bdf_tol": [4, 5, 6],
     "ode_rk45_tol": [4, 5, 6],
+    "wiener_lpdf": [6, 8],
+    "wiener_lccdf_defective": [5, 8],
+    "wiener_lcdf_defective": [5, 8],
 }
 
 # lists of functions that do not support fwd or rev autodiff

--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -145,9 +145,9 @@ special_arg_values = {
     "uniform_lcdf": [None, 0.2, 0.9],
     "uniform_lpdf": [None, 0.2, 0.9],
     "uniform_rng": [0.2, 1.9, None],
-    "wiener_lpdf": [0.8, None, 0.4, None, None, None, None, None, 1e-4],
-    "wiener_lccdf_defective": [0.8, None, 0.4, None, None, None, None, 1e-4],
-    "wiener_lcdf_defective": [0.8, None, 0.4, None, None, None, None, 1e-4],
+    "wiener_lpdf":            [0.8, None, 0.4, None, None, None, None, None, 1e-4],
+    "wiener_lccdf_defective": [0.8, None, 0.4, None, None, None, None, None, 1e-4],
+    "wiener_lcdf_defective":  [0.8, None, 0.4, None, None, None, None, None, 1e-4],
 }
 
 # list of functions we do not test. These are mainly functions implemented in compiler

--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -146,6 +146,8 @@ special_arg_values = {
     "uniform_lpdf": [None, 0.2, 0.9],
     "uniform_rng": [0.2, 1.9, None],
     "wiener_lpdf": [0.8, None, 0.4, None, None, None, None, None, 1e-4],
+    "wiener_lccdf_defective": [0.8, None, 0.4, None, None, None, None, 1e-4],
+    "wiener_lcdf_defective": [0.8, None, 0.4, None, None, None, None, 1e-4],
 }
 
 # list of functions we do not test. These are mainly functions implemented in compiler


### PR DESCRIPTION
## Summary

This unblocks the new wiener cdf functions from #3042 for inclusion in the language (https://github.com/stan-dev/stanc3/pull/1576). 

1. Adds [missing precision default](https://github.com/stan-dev/math/pull/3258#issuecomment-3646722307).
2. Cleans up an [unused variable warning](https://github.com/stan-dev/math/pull/3258#issuecomment-3646736730).
3. Updates our expression test generation code to correctly generate test cases for these new functions
4. Updates some of the ref logic to avoid double-evaluation of expression templates (same as #3112)

## Tests

Expression tests now passing.

## Side Effects

None

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
