### PR TITLE
minor change to use constant

### DIFF
--- a/stan/math/prim/fun/log1m_exp.hpp
+++ b/stan/math/prim/fun/log1m_exp.hpp
@@ -49,7 +49,7 @@ inline double log1m_exp(double a) {
   using std::log;
   if (a > 0) {
     return NOT_A_NUMBER;
-  } else if (a > -0.693147) {
+  } else if (a > LOG_HALF) {
     return log(-expm1(a));  // 0.693147 ~= log(2)
   } else {
     return log1m(exp(a));


### PR DESCRIPTION
## Summary

It's slightly more accurate and readable to use the constant `LOG_HALF` instead of a hard coded value.

## Checklist

- [x] Copyright holder: Sean Pinkney, Publicis Groupe

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
