### PR TITLE
Fix for clang-7 test failure in laplace tests

### DIFF
--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -13,6 +13,7 @@
 #include <stan/math/prim/functor/iter_tuple_nested.hpp>
 #include <unsupported/Eigen/MatrixFunctions>
 #include <cmath>
+#include <mutex>
 
 /**
  * @file
@@ -1018,7 +1019,8 @@ inline void log_solver_fallback(const bool allow_fallthrough,
      << "  " << std::left << std::setw(12) << "failed:" << failed_solver << "\n"
      << "  " << std::left << std::setw(12) << "reason:" << e.what() << "\n"
      << "  " << std::left << std::setw(12) << "action:"
-     << "trying " << next_solver << "\n";
+     << "trying " << next_solver << "\n"
+     << "note: this warning message will only be displayed once." << "\n";
   if (allow_fallthrough && msgs) {
     (*msgs) << os.str();
   } else {
@@ -1086,6 +1088,7 @@ inline auto create_update_fun(ObjFun&& obj_fun, ThetaGradFun&& theta_grad_f,
       };
 }
 
+static STAN_THREADS_DEF std::once_flag fallback_warning;
 /**
  * For a latent Gaussian model with hyperparameters phi and
  * latent variables theta, and observations y, this function computes
@@ -1175,12 +1178,14 @@ inline auto laplace_marginal_density_est(
       }
     }
   } catch (const std::exception& e) {
-    std::string solver_type
+    const std::string solver_type
         = (options.hessian_block_size == 1) ? "Diagonal" : "Block";
     std::string failed = "solver 1 (" + solver_type + " Hessian-root Cholesky)";
-    log_solver_fallback(options.allow_fallthrough, msgs,
-                        "laplace_marginal_density", step_iter, failed,
-                        "solver 2 (Covariance-root Cholesky)", e);
+    std::call_once(fallback_warning, [](auto&&... args) {
+      log_solver_fallback(std::forward<decltype(args)>(args)...);
+    }, options.allow_fallthrough, msgs,
+      "laplace_marginal_density", step_iter, std::move(failed),
+      "solver 2 (Covariance-root Cholesky)", e);
   }
   try {
     if (options.solver == 2 || options.allow_fallthrough) {
@@ -1189,10 +1194,12 @@ inline auto laplace_marginal_density_est(
                              covariance, update_fun, msgs);
     }
   } catch (const std::exception& e) {
-    log_solver_fallback(options.allow_fallthrough, msgs,
-                        "laplace_marginal_density", step_iter,
-                        "solver 2 (Covariance-root Cholesky)",
-                        "solver 3 (General LU solver)", e);
+    std::call_once(fallback_warning, [](auto&&... args) {
+      log_solver_fallback(std::forward<decltype(args)>(args)...);
+    }, options.allow_fallthrough, msgs,
+      "laplace_marginal_density", step_iter,
+      "solver 2 (Covariance-root Cholesky)",
+      "solver 3 (General LU solver)", e);
   }
   if (options.solver == 3 || options.allow_fallthrough) {
     LUSolver solver;

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -1020,7 +1020,8 @@ inline void log_solver_fallback(const bool allow_fallthrough,
      << "  " << std::left << std::setw(12) << "reason:" << e.what() << "\n"
      << "  " << std::left << std::setw(12) << "action:"
      << "trying " << next_solver << "\n"
-     << "note: this warning message will only be displayed once." << "\n";
+     << "note: this warning message will only be displayed once."
+     << "\n";
   if (allow_fallthrough && msgs) {
     (*msgs) << os.str();
   } else {
@@ -1181,11 +1182,13 @@ inline auto laplace_marginal_density_est(
     const std::string solver_type
         = (options.hessian_block_size == 1) ? "Diagonal" : "Block";
     std::string failed = "solver 1 (" + solver_type + " Hessian-root Cholesky)";
-    std::call_once(fallback_warning, [](auto&&... args) {
-      log_solver_fallback(std::forward<decltype(args)>(args)...);
-    }, options.allow_fallthrough, msgs,
-      "laplace_marginal_density", step_iter, std::move(failed),
-      "solver 2 (Covariance-root Cholesky)", e);
+    std::call_once(
+        fallback_warning,
+        [](auto&&... args) {
+          log_solver_fallback(std::forward<decltype(args)>(args)...);
+        },
+        options.allow_fallthrough, msgs, "laplace_marginal_density", step_iter,
+        std::move(failed), "solver 2 (Covariance-root Cholesky)", e);
   }
   try {
     if (options.solver == 2 || options.allow_fallthrough) {
@@ -1194,12 +1197,14 @@ inline auto laplace_marginal_density_est(
                              covariance, update_fun, msgs);
     }
   } catch (const std::exception& e) {
-    std::call_once(fallback_warning, [](auto&&... args) {
-      log_solver_fallback(std::forward<decltype(args)>(args)...);
-    }, options.allow_fallthrough, msgs,
-      "laplace_marginal_density", step_iter,
-      "solver 2 (Covariance-root Cholesky)",
-      "solver 3 (General LU solver)", e);
+    std::call_once(
+        fallback_warning,
+        [](auto&&... args) {
+          log_solver_fallback(std::forward<decltype(args)>(args)...);
+        },
+        options.allow_fallthrough, msgs, "laplace_marginal_density", step_iter,
+        "solver 2 (Covariance-root Cholesky)", "solver 3 (General LU solver)",
+        e);
   }
   if (options.solver == 3 || options.allow_fallthrough) {
     LUSolver solver;

--- a/test/unit/math/laplace/laplace_marginal_bernoulli_logit_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_bernoulli_logit_lpmf_test.cpp
@@ -23,9 +23,9 @@ TEST_P(laplace_marginal_bernoulli_logit_lpmf, phi_dim500) {
   using stan::math::test::flag_test;
   constexpr int dim_theta = 500;
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   // LAPLACE_SKIP_ZERO_STEPS(max_steps_line_search);
 

--- a/test/unit/math/laplace/laplace_marginal_bernoulli_logit_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_bernoulli_logit_lpmf_test.cpp
@@ -22,8 +22,10 @@ TEST_P(laplace_marginal_bernoulli_logit_lpmf, phi_dim500) {
   using stan::math::var;
   using stan::math::test::flag_test;
   constexpr int dim_theta = 500;
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   // LAPLACE_SKIP_ZERO_STEPS(max_steps_line_search);
 

--- a/test/unit/math/laplace/laplace_marginal_lpdf_moto_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_lpdf_moto_test.cpp
@@ -140,8 +140,10 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle_val) {
   using stan::math::laplace_marginal_tol;
   constexpr double tolerance = 1e-12;
   constexpr int max_num_steps = 1000;
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   constexpr int dim_theta = 2 * n_obs;
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
@@ -168,8 +170,10 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle_ad) {
   auto phi_1 = phi_dbl(1);
   Eigen::VectorXd phi_rest = phi_dbl.tail(2);
   Eigen::VectorXd phi_01{{phi_0, phi_1}};
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   constexpr int dim_theta = 2 * n_obs;
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   constexpr stan::test::ad_tolerances tols{
@@ -244,8 +248,10 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle2_val) {
   Eigen::VectorXd sigma_vec = phi_dbl.tail(2);
   constexpr double tolerance = 1e-12;
   constexpr int max_num_steps = 300;
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   constexpr int dim_theta = 2 * n_obs;
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   laplace_marginal_tol<false>(
@@ -271,8 +277,10 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle2_ad) {
   constexpr int max_num_steps = 1000;
   Eigen::VectorXd length_scale_vec = phi_dbl.head(2);
   Eigen::VectorXd sigma_vec = phi_dbl.tail(2);
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   constexpr int dim_theta = 2 * n_obs;
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   constexpr stan::test::ad_tolerances tols{

--- a/test/unit/math/laplace/laplace_marginal_lpdf_moto_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_lpdf_moto_test.cpp
@@ -141,9 +141,9 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle_val) {
   constexpr double tolerance = 1e-12;
   constexpr int max_num_steps = 1000;
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   constexpr int dim_theta = 2 * n_obs;
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
@@ -171,9 +171,9 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle_ad) {
   Eigen::VectorXd phi_rest = phi_dbl.tail(2);
   Eigen::VectorXd phi_01{{phi_0, phi_1}};
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   constexpr int dim_theta = 2 * n_obs;
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   constexpr stan::test::ad_tolerances tols{
@@ -249,9 +249,9 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle2_val) {
   constexpr double tolerance = 1e-12;
   constexpr int max_num_steps = 300;
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   constexpr int dim_theta = 2 * n_obs;
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   laplace_marginal_tol<false>(
@@ -278,9 +278,9 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle2_ad) {
   Eigen::VectorXd length_scale_vec = phi_dbl.head(2);
   Eigen::VectorXd sigma_vec = phi_dbl.tail(2);
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   constexpr int dim_theta = 2 * n_obs;
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   constexpr stan::test::ad_tolerances tols{

--- a/test/unit/math/laplace/laplace_marginal_lpdf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_lpdf_test.cpp
@@ -47,8 +47,10 @@ TEST_P(laplace_marginal_lpdf, poisson_log_phi_dim_2) {
 
   std::vector<int> n_samples = {1, 1};
   std::vector<int> sums = {1, 0};
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   double target = laplace_marginal<false>(
@@ -123,8 +125,10 @@ TEST_P(laplace_disease_map_test, laplace_marginal) {
   using stan::math::laplace_marginal_tol;
   using stan::math::value_of;
   using stan::math::var;
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   {
@@ -192,8 +196,10 @@ TEST_P(laplace_marginal_lpdf, bernoulli_logit_phi_dim500) {
   Eigen::VectorXd delta_L;
   std::vector<double> delta;
   Eigen::Matrix<double, Eigen::Dynamic, 1> phi_dbl{{1.6, 1}};
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   double target = laplace_marginal<false>(
       bernoulli_logit_likelihood{}, std::forward_as_tuple(y),

--- a/test/unit/math/laplace/laplace_marginal_lpdf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_lpdf_test.cpp
@@ -48,9 +48,9 @@ TEST_P(laplace_marginal_lpdf, poisson_log_phi_dim_2) {
   std::vector<int> n_samples = {1, 1};
   std::vector<int> sums = {1, 0};
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   double target = laplace_marginal<false>(
@@ -126,9 +126,9 @@ TEST_P(laplace_disease_map_test, laplace_marginal) {
   using stan::math::value_of;
   using stan::math::var;
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   {
@@ -197,9 +197,9 @@ TEST_P(laplace_marginal_lpdf, bernoulli_logit_phi_dim500) {
   std::vector<double> delta;
   Eigen::Matrix<double, Eigen::Dynamic, 1> phi_dbl{{1.6, 1}};
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   double target = laplace_marginal<false>(
       bernoulli_logit_likelihood{}, std::forward_as_tuple(y),

--- a/test/unit/math/laplace/laplace_marginal_neg_binomial_log_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_neg_binomial_log_lpmf_test.cpp
@@ -33,8 +33,10 @@ TEST_P(laplace_marginal_neg_binomial_log_lpmf, phi_dim_2) {
   std::vector<int> y{1, 0};
   std::vector<int> y_index{1, 2};
   constexpr double eta_dbl = 100;
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   constexpr double tolerance = 1e-12;
@@ -72,8 +74,10 @@ TEST_P(laplace_disease_map_test, laplace_marginal_neg_binomial_2_log_lpmf) {
   using stan::math::to_vector;
   using stan::math::value_of;
   using stan::math::var;
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   constexpr double eta = 1;
 

--- a/test/unit/math/laplace/laplace_marginal_neg_binomial_log_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_neg_binomial_log_lpmf_test.cpp
@@ -34,9 +34,9 @@ TEST_P(laplace_marginal_neg_binomial_log_lpmf, phi_dim_2) {
   std::vector<int> y_index{1, 2};
   constexpr double eta_dbl = 100;
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   constexpr double tolerance = 1e-12;
@@ -75,9 +75,9 @@ TEST_P(laplace_disease_map_test, laplace_marginal_neg_binomial_2_log_lpmf) {
   using stan::math::value_of;
   using stan::math::var;
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   constexpr double eta = 1;
 

--- a/test/unit/math/laplace/laplace_marginal_neg_binomial_log_summary_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_neg_binomial_log_summary_lpmf_test.cpp
@@ -40,8 +40,10 @@ TEST_P(laplace_marginal_neg_binomial_log_summary_lpmf, phi_dim_2) {
     n_per_group[y_index[i] - 1]++;
     counts_per_group[y_index[i] - 1] += y[i];
   }
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   constexpr double tolerance = 1e-12;
   constexpr int max_num_steps = 1000;
@@ -81,8 +83,10 @@ TEST_P(laplace_disease_map_test,
   using stan::math::to_vector;
   using stan::math::value_of;
   using stan::math::var;
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   constexpr double eta = 1;
   std::vector<int> n_per_group(theta_0.size(), 0);

--- a/test/unit/math/laplace/laplace_marginal_neg_binomial_log_summary_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_neg_binomial_log_summary_lpmf_test.cpp
@@ -41,9 +41,9 @@ TEST_P(laplace_marginal_neg_binomial_log_summary_lpmf, phi_dim_2) {
     counts_per_group[y_index[i] - 1] += y[i];
   }
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   constexpr double tolerance = 1e-12;
   constexpr int max_num_steps = 1000;
@@ -84,9 +84,9 @@ TEST_P(laplace_disease_map_test,
   using stan::math::value_of;
   using stan::math::var;
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   constexpr double eta = 1;
   std::vector<int> n_per_group(theta_0.size(), 0);

--- a/test/unit/math/laplace/laplace_marginal_poisson_log_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_poisson_log_lpmf_test.cpp
@@ -15,8 +15,10 @@ class laplace_marginal_poisson_log_lpmf : public LaplaceAdTest {};
 
 TEST_P(laplace_marginal_poisson_log_lpmf, phi_dim_2) {
   constexpr int dim_theta = 2;
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   using stan::math::laplace_marginal_poisson_log_lpmf;
@@ -76,8 +78,10 @@ TEST_P(laplace_marginal_poisson_log_lpmf, phi_dim_2) {
 
 TEST_P(laplace_marginal_poisson_log_lpmf, log_phi_dim_2) {
   constexpr int dim_theta = 2;
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   using stan::math::laplace_marginal_poisson_log_lpmf;
   using stan::math::laplace_marginal_tol_poisson_log_lpmf;
@@ -148,8 +152,10 @@ struct diag_covariance {
 
 TEST_P(laplace_marginal_poisson_log_lpmf, mean_argument) {
   constexpr int dim_theta = 1;
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   // working example from
@@ -179,8 +185,10 @@ TEST_P(laplace_marginal_poisson_log_lpmf, mean_argument) {
 LAPLACE_INSTANTIATE_TEST_SUITE_P(laplace_marginal_poisson_log_lpmf);
 
 TEST_P(laplace_disease_map_test, laplace_marginal_poisson_log_lpmf) {
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   using stan::math::laplace_marginal_poisson_log_lpmf;

--- a/test/unit/math/laplace/laplace_marginal_poisson_log_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_poisson_log_lpmf_test.cpp
@@ -16,9 +16,9 @@ class laplace_marginal_poisson_log_lpmf : public LaplaceAdTest {};
 TEST_P(laplace_marginal_poisson_log_lpmf, phi_dim_2) {
   constexpr int dim_theta = 2;
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   using stan::math::laplace_marginal_poisson_log_lpmf;
@@ -79,9 +79,9 @@ const auto max_steps_line_search = std::get<2>(test_params);
 TEST_P(laplace_marginal_poisson_log_lpmf, log_phi_dim_2) {
   constexpr int dim_theta = 2;
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   using stan::math::laplace_marginal_poisson_log_lpmf;
   using stan::math::laplace_marginal_tol_poisson_log_lpmf;
@@ -153,9 +153,9 @@ struct diag_covariance {
 TEST_P(laplace_marginal_poisson_log_lpmf, mean_argument) {
   constexpr int dim_theta = 1;
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   // working example from
@@ -186,9 +186,9 @@ LAPLACE_INSTANTIATE_TEST_SUITE_P(laplace_marginal_poisson_log_lpmf);
 
 TEST_P(laplace_disease_map_test, laplace_marginal_poisson_log_lpmf) {
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   using stan::math::laplace_marginal_poisson_log_lpmf;

--- a/test/unit/math/laplace/laplace_types_test.cpp
+++ b/test/unit/math/laplace/laplace_types_test.cpp
@@ -136,9 +136,9 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_tuple_extended) {
   std::vector<int> n_samples = {1, 1};
   std::vector<int> sums = {1, 0};
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   constexpr double tolerance = 1e-12;
@@ -204,9 +204,9 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_tuple) {
   std::vector<int> n_samples = {1, 1};
   std::vector<int> sums = {1, 0};
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   constexpr double tolerance = 1e-12;
@@ -301,9 +301,9 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_array_tuple) {
   std::vector<int> n_samples = {1, 1};
   std::vector<int> sums = {1, 0};
   const auto test_params = GetParam();
-const auto solver_num = std::get<0>(test_params);
-const auto hessian_block_size = std::get<1>(test_params);
-const auto max_steps_line_search = std::get<2>(test_params);
+  const auto solver_num = std::get<0>(test_params);
+  const auto hessian_block_size = std::get<1>(test_params);
+  const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   constexpr double tolerance = 1e-12;

--- a/test/unit/math/laplace/laplace_types_test.cpp
+++ b/test/unit/math/laplace/laplace_types_test.cpp
@@ -135,8 +135,10 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_tuple_extended) {
 
   std::vector<int> n_samples = {1, 1};
   std::vector<int> sums = {1, 0};
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   constexpr double tolerance = 1e-12;
@@ -201,8 +203,10 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_tuple) {
 
   std::vector<int> n_samples = {1, 1};
   std::vector<int> sums = {1, 0};
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   constexpr double tolerance = 1e-12;
@@ -296,8 +300,10 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_array_tuple) {
 
   std::vector<int> n_samples = {1, 1};
   std::vector<int> sums = {1, 0};
-  const auto [solver_num, hessian_block_size, max_steps_line_search]
-      = GetParam();
+  const auto test_params = GetParam();
+const auto solver_num = std::get<0>(test_params);
+const auto hessian_block_size = std::get<1>(test_params);
+const auto max_steps_line_search = std::get<2>(test_params);
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   constexpr double tolerance = 1e-12;


### PR DESCRIPTION

## Summary

clang-7 does not support the C++17 syntax of 

```cpp
auto [x, y, z] = function(...);
```

We use clang-7 in the CI for threading, so I just changed those places in the tests to just return a tuple.

## Tests

no new tests

## Checklist

- [x] Copyright holder: Steve Bronder 

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
