### PR TITLE
Fix missing parameter 'y' documentation in apply_scalar_binary

### DIFF
--- a/stan/math/rev/functor/apply_scalar_binary.hpp
+++ b/stan/math/rev/functor/apply_scalar_binary.hpp
@@ -63,7 +63,7 @@ inline auto apply_scalar_binary(F&& f, T1&& x, T2&& y) {
  * @param f functor to apply to inputs.
  * @param x Either a var matrix or nested integer std::vector input to which
  * operation is applied.
- * @param x Either a var matrix or nested integer std::vector input to which
+ * @param y Either a var matrix or nested integer std::vector input to which
  * operation is applied.
  * @return Eigen object with result of applying functor to inputs.
  */
@@ -86,7 +86,7 @@ inline auto apply_scalar_binary(F&& f, T1&& x, T2&& y) {
  * functor is applied.
  * @param f functor to apply to var matrix and scalar inputs.
  * @param x Matrix or Scalar input to which operation is applied.
- * @param x Matrix or Scalar input to which operation is applied.
+ * @param y Matrix or Scalar input to which operation is applied.
  * @return `var_value<Matrix> object with result of applying functor to inputs.
  *
  */


### PR DESCRIPTION
## Summary
Fix a typo that makes doxygen fail

```
mkdir -p doc/api
doxygen -v
1.16.1
doxygen doxygen/doxygen.cfg
/build/stanmath/src/math-5.2.0/stan/math/rev/functor/apply_scalar_binary.hpp:60: error: The following parameter of stan::math::apply_scalar_binary(F &&f, T1 &&x, T2 &&y) is not documented:
  parameter 'y'
/build/stanmath/src/math-5.2.0/stan/math/rev/functor/apply_scalar_binary.hpp:82: error: The following parameter of stan::math::apply_scalar_binary(F &&f, T1 &&x, T2 &&y) is not documented:
  parameter 'y'
make: *** [makefile:81: doxygen] Error 1
```

This PR fixes #3230 