### PR TITLE
add yule_simon_rng

### DIFF
--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -320,5 +320,9 @@
 #include <stan/math/prim/prob/wishart_cholesky_rng.hpp>
 #include <stan/math/prim/prob/wishart_lpdf.hpp>
 #include <stan/math/prim/prob/wishart_rng.hpp>
+#include <stan/math/prim/prob/yule_simon_cdf.hpp>
+#include <stan/math/prim/prob/yule_simon_lccdf.hpp>
+#include <stan/math/prim/prob/yule_simon_lcdf.hpp>
 #include <stan/math/prim/prob/yule_simon_lpmf.hpp>
+#include <stan/math/prim/prob/yule_simon_rng.hpp>
 #endif

--- a/stan/math/prim/prob/yule_simon_rng.hpp
+++ b/stan/math/prim/prob/yule_simon_rng.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_PROB_YULE_SIMON_RNG_HPP
 
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/log1m.hpp>
 #include <stan/math/prim/prob/exponential_rng.hpp>
 #include <stan/math/prim/prob/neg_binomial_rng.hpp>
 
@@ -38,8 +39,9 @@ inline auto yule_simon_rng(const T_alpha &alpha, RNG &rng) {
 
   VectorBuilder<true, int, T_alpha> output(size_w);
   for (size_t n = 0; n < size_w; ++n) {
-    double p = exp(-w_vec.val(n));
-    double odds_ratio_p = exp(log(p) - log1m(p));
+    double p = stan::math::exp(-w_vec.val(n));
+    double odds_ratio_p
+        = stan::math::exp(stan::math::log(p) - stan::math::log1m(p));
     output[n] = neg_binomial_rng(1.0, odds_ratio_p, rng) + 1;
   }
 

--- a/stan/math/prim/prob/yule_simon_rng.hpp
+++ b/stan/math/prim/prob/yule_simon_rng.hpp
@@ -2,6 +2,8 @@
 #define STAN_MATH_PRIM_PROB_YULE_SIMON_RNG_HPP
 
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/exp.hpp>
+#include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/log1m.hpp>
 #include <stan/math/prim/prob/exponential_rng.hpp>
 #include <stan/math/prim/prob/neg_binomial_rng.hpp>

--- a/stan/math/prim/prob/yule_simon_rng.hpp
+++ b/stan/math/prim/prob/yule_simon_rng.hpp
@@ -1,0 +1,51 @@
+#ifndef STAN_MATH_PRIM_PROB_YULE_SIMON_RNG_HPP
+#define STAN_MATH_PRIM_PROB_YULE_SIMON_RNG_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/prob/exponential_rng.hpp>
+#include <stan/math/prim/prob/neg_binomial_rng.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup prob_dists
+ * Return a yule-simon random variate with the given shape parameter,
+ * using the given random number generator.
+ *
+ * alpha can be a scalar or a one-dimensional container.
+ *
+ * @tparam T_alpha type of shape parameter
+ * @tparam RNG type of random number generator
+ *
+ * @param alpha (Sequence of) shape parameter(s)
+ * @param rng random number generator
+ * @return (Sequence of) yule-simon random variate(s)
+ * @throw std::domain_error if alpha is nonpositive
+ */
+template <typename T_alpha, typename RNG>
+inline auto yule_simon_rng(const T_alpha &alpha, RNG &rng) {
+  using T_alpha_ref = ref_type_t<T_alpha>;
+  static constexpr const char *function = "yule_simon_rng";
+
+  T_alpha_ref alpha_ref = alpha;
+  check_positive_finite(function, "Shape parameter", alpha_ref);
+
+  using T_w = decltype(exponential_rng(alpha_ref, rng));
+  T_w w = exponential_rng(alpha_ref, rng);
+
+  scalar_seq_view<T_w> w_vec(w);
+  size_t size_w = stan::math::size(w);
+
+  VectorBuilder<true, int, T_alpha> output(size_w);
+  for (size_t n = 0; n < size_w; ++n) {
+    double p = exp(-w_vec.val(n));
+    double odds_ratio_p = exp(log(p) - log1m(p));
+    output[n] = neg_binomial_rng(1.0, odds_ratio_p, rng) + 1;
+  }
+
+  return output.data();
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/prob/yule_simon_rng.hpp
+++ b/stan/math/prim/prob/yule_simon_rng.hpp
@@ -33,16 +33,14 @@ inline auto yule_simon_rng(const T_alpha &alpha, RNG &rng) {
   T_alpha_ref alpha_ref = alpha;
   check_positive_finite(function, "Shape parameter", alpha_ref);
 
-  using T_w = decltype(exponential_rng(alpha_ref, rng));
-  T_w w = exponential_rng(alpha_ref, rng);
+  auto w = exponential_rng(alpha_ref, rng);
+  scalar_seq_view<decltype(w)> w_vec(w);
 
-  scalar_seq_view<T_w> w_vec(w);
   size_t size_w = stan::math::size(w);
-
   VectorBuilder<true, int, T_alpha> output(size_w);
   for (size_t n = 0; n < size_w; ++n) {
-    double p = stan::math::exp(-w_vec.val(n));
-    double odds_ratio_p
+    const double p = stan::math::exp(-w_vec[n]);
+    const double odds_ratio_p
         = stan::math::exp(stan::math::log(p) - stan::math::log1m(p));
     output[n] = neg_binomial_rng(1.0, odds_ratio_p, rng) + 1;
   }

--- a/stan/math/prim/prob/yule_simon_rng.hpp
+++ b/stan/math/prim/prob/yule_simon_rng.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_PROB_YULE_SIMON_RNG_HPP
 #define STAN_MATH_PRIM_PROB_YULE_SIMON_RNG_HPP
 
+#include <utility>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/exp.hpp>
 #include <stan/math/prim/fun/log.hpp>
@@ -26,26 +27,24 @@ namespace math {
  * @throw std::domain_error if alpha is nonpositive
  */
 template <typename T_alpha, typename RNG>
-inline auto yule_simon_rng(const T_alpha &alpha, RNG &rng) {
-  using T_alpha_ref = ref_type_t<T_alpha>;
-  static constexpr const char *function = "yule_simon_rng";
-
-  T_alpha_ref alpha_ref = alpha;
+inline auto yule_simon_rng(T_alpha&& alpha, RNG& rng) {
+  static constexpr const char* function = "yule_simon_rng";
+  decltype(auto) alpha_ref = to_ref(std::forward<T_alpha>(alpha));
   check_positive_finite(function, "Shape parameter", alpha_ref);
 
-  auto w = exponential_rng(alpha_ref, rng);
-  scalar_seq_view<decltype(w)> w_vec(w);
+  auto w = exponential_rng(std::forward<decltype(alpha_ref)>(alpha_ref), rng);
+  auto w_arr = as_array_or_scalar(w);
+  const auto p = stan::math::exp(-w_arr);
+  const auto odds_ratio_p
+      = stan::math::exp(stan::math::log(p) - stan::math::log1m(p));
 
-  size_t size_w = stan::math::size(w);
-  VectorBuilder<true, int, T_alpha> output(size_w);
-  for (size_t n = 0; n < size_w; ++n) {
-    const double p = stan::math::exp(-w_vec[n]);
-    const double odds_ratio_p
-        = stan::math::exp(stan::math::log(p) - stan::math::log1m(p));
-    output[n] = neg_binomial_rng(1.0, odds_ratio_p, rng) + 1;
+  if constexpr (is_stan_scalar_v<T_alpha>) {
+    return neg_binomial_rng(1.0, odds_ratio_p, rng) + 1;
+  } else {
+    return to_array_1d(
+        as_array_or_scalar(neg_binomial_rng(1.0, std::move(odds_ratio_p), rng))
+        + 1);
   }
-
-  return output.data();
 }
 
 }  // namespace math

--- a/test/unit/math/prim/prob/yule_simon_test.cpp
+++ b/test/unit/math/prim/prob/yule_simon_test.cpp
@@ -1,0 +1,58 @@
+#include <stan/math/prim.hpp>
+#include <stan/math/prim/prob/yule_simon_rng.hpp>
+#include <test/unit/math/prim/prob/vector_rng_test_helper.hpp>
+#include <test/unit/math/prim/prob/VectorIntRNGTestRig.hpp>
+#include <gtest/gtest.h>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/math/distributions.hpp>
+#include <limits>
+#include <vector>
+
+class YuleSimonTestRig : public VectorIntRNGTestRig {
+ public:
+  YuleSimonTestRig()
+      : VectorIntRNGTestRig(10000, 10, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+                            {2.1, 4.1, 10.1}, {1, 2, 3}, {-3.0, -2.0, 0.0},
+                            {-3, -1, 0}) {}
+
+  template <typename T1, typename T2, typename T3, typename T_rng>
+  auto generate_samples(const T1& alpha, const T2&, const T3&,
+                        T_rng& rng) const {
+    return stan::math::yule_simon_rng(alpha, rng);
+  }
+
+  template <typename T1>
+  double pmf(int y, T1 alpha, double, double) const {
+    return std::exp(stan::math::yule_simon_lpmf(y, alpha));
+  }
+};
+
+TEST(ProbDistributionsYuleSimon, errorCheck) {
+  check_dist_throws_all_types(YuleSimonTestRig());
+}
+
+TEST(ProbDistributionsYuleSimon, distributionCheck) {
+  check_counts_real(YuleSimonTestRig());
+}
+
+TEST(ProbDistributionsYuleSimon, error_check) {
+  boost::random::mt19937 rng;
+
+  // Valid parameters should not throw
+  EXPECT_NO_THROW(stan::math::yule_simon_rng(1.0, rng));
+  EXPECT_NO_THROW(stan::math::yule_simon_rng(2.0, rng));
+  EXPECT_NO_THROW(stan::math::yule_simon_rng(10.0, rng));
+
+  // Invalid parameters should throw domain_error
+  EXPECT_THROW(stan::math::yule_simon_rng(-0.5, rng), std::domain_error);
+  EXPECT_THROW(stan::math::yule_simon_rng(0.0, rng), std::domain_error);
+  EXPECT_THROW(stan::math::yule_simon_rng(-10.0, rng), std::domain_error);
+
+  // Infinity should throw
+  EXPECT_THROW(stan::math::yule_simon_rng(stan::math::positive_infinity(), rng),
+               std::domain_error);
+
+  // NaN should throw
+  EXPECT_THROW(stan::math::yule_simon_rng(stan::math::not_a_number(), rng),
+               std::domain_error);
+}

--- a/test/unit/math/prim/prob/yule_simon_test.cpp
+++ b/test/unit/math/prim/prob/yule_simon_test.cpp
@@ -38,21 +38,17 @@ TEST(ProbDistributionsYuleSimon, distributionCheck) {
 TEST(ProbDistributionsYuleSimon, error_check) {
   boost::random::mt19937 rng;
 
-  // Valid parameters should not throw
   EXPECT_NO_THROW(stan::math::yule_simon_rng(1.0, rng));
   EXPECT_NO_THROW(stan::math::yule_simon_rng(2.0, rng));
   EXPECT_NO_THROW(stan::math::yule_simon_rng(10.0, rng));
 
-  // Invalid parameters should throw domain_error
   EXPECT_THROW(stan::math::yule_simon_rng(-0.5, rng), std::domain_error);
   EXPECT_THROW(stan::math::yule_simon_rng(0.0, rng), std::domain_error);
   EXPECT_THROW(stan::math::yule_simon_rng(-10.0, rng), std::domain_error);
 
-  // Infinity should throw
   EXPECT_THROW(stan::math::yule_simon_rng(stan::math::positive_infinity(), rng),
                std::domain_error);
 
-  // NaN should throw
   EXPECT_THROW(stan::math::yule_simon_rng(stan::math::not_a_number(), rng),
                std::domain_error);
 }


### PR DESCRIPTION
## Summary

With this PR the rng of Yule-Simon distribution are added.
See issue #3239 

For $$Y\sim \text{Yule-Simon}(\alpha)$$:

$$
\Pr(Y=y\mid \alpha)= \alpha \mathrm{B}(y,\alpha+1) \quad y\in\{1,2,\dots\}
$$

$$\mathrm{B}$$ is the Beta function.


It has a Beta–Geometric mixture. To sample form $$Y$$, we do:

$$
\begin{align}
Y\mid p &\sim \text{Geometric}(p)\\
p=e^{-W} &\sim \text{Beta}(\alpha,1)\\
W &\sim\text{Exp}(\alpha)
\end{align}
$$


Stan does not have Geometric yet so we use `neg_binomial_rng(1.0, odds_ratio_p)`.


## Tests

Test is written follow the [guide](https://mc-stan.org/math/md_doxygen_2contributor__help__pages_2adding__new__distributions.html).


## Side Effects

No.

## Release notes

`yule_simon_rng` is available if merged.

## Checklist

- [x] Copyright holder: Zhi Ling

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
