### PR TITLE
update laplace api to have hessian_block_size as a non-optional argument

### DIFF
--- a/doxygen/doxygen.cfg
+++ b/doxygen/doxygen.cfg
@@ -2747,7 +2747,6 @@ ALIASES += laplace_options="\
   - theta_0 the initial guess for the Laplace approximation. \
   - tolerance controls the convergence criterion when finding the mode in the Laplace approximation. \
   - max_num_steps maximum number of steps before the Newton solver breaks and returns an error. \
-  - hessian_block_size Block size of Hessian of log likelihood w.r.t latent Gaussian variable theta. \
   - solver Type of Newton solver. Each corresponds to a distinct choice of B matrix (i.e. application SWM formula): \
     1. computes square-root of negative Hessian. \
     2. computes square-root of covariance matrix. \

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -117,7 +117,8 @@ inline auto generate_laplace_options(int theta_0_size) {
 
 /**
  * User function for generating laplace options tuple
- * @param theta_0_size Size of user supplied initial theta
+ * @tparam ThetaVec An Eigen vector type for user supplied initial theta
+ * @param theta_0 User supplied initial theta
  * @return tuple representing laplace options exposed to user.
  */
 template <typename ThetaVec, require_eigen_t<ThetaVec>* = nullptr>

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -103,8 +103,22 @@ using laplace_options_user_supplied = laplace_options<true>;
 inline auto generate_laplace_options(int theta_0_size) {
   auto ops = laplace_options_default{};
   return std::make_tuple(
-      Eigen::VectorXd::Zero(theta_0_size).eval(),  // 0 -> 6
-      ops.tolerance, ops.max_num_steps, ops.hessian_block_size, ops.solver,
+      Eigen::VectorXd::Zero(theta_0_size).eval(),  
+      ops.tolerance, ops.max_num_steps, ops.solver,
+      ops.line_search.max_iterations, static_cast<int>(ops.allow_fallthrough));
+}
+
+/**
+ * User function for generating laplace options tuple
+ * @param theta_0_size Size of user supplied initial theta
+ * @return tuple representing laplace options exposed to user.
+ */
+template <typename ThetaVec, require_eigen_t<ThetaVec>* = nullptr>
+inline auto generate_laplace_options(ThetaVec&& theta_0) {
+  auto ops = laplace_options_default{};
+  return std::make_tuple(
+      std::forward<ThetaVec>(theta_0),  
+      ops.tolerance, ops.max_num_steps, ops.solver,
       ops.line_search.max_iterations, static_cast<int>(ops.allow_fallthrough));
 }
 
@@ -137,39 +151,34 @@ inline constexpr auto tuple_to_laplace_options(Options&& ops) {
     if constexpr (!stan::is_inner_tuple_type_v<3, Ops, int>) {
       static_assert(
           sizeof(std::decay_t<Ops>*) == 0,
-          "ERROR:(laplace_marginal_lpdf) The fifth laplace argument is "
-          "expected to be an int representing the hessian block size.");
+          "ERROR:(laplace_marginal_lpdf) The fourth laplace argument is "
+          "expected to be an int representing the solver.");
     }
     if constexpr (!stan::is_inner_tuple_type_v<4, Ops, int>) {
       static_assert(
           sizeof(std::decay_t<Ops>*) == 0,
-          "ERROR:(laplace_marginal_lpdf) The fourth laplace argument is "
-          "expected to be an int representing the solver.");
-    }
-    if constexpr (!stan::is_inner_tuple_type_v<5, Ops, int>) {
-      static_assert(
-          sizeof(std::decay_t<Ops>*) == 0,
-          "ERROR:(laplace_marginal_lpdf) The sixth laplace argument is "
+          "ERROR:(laplace_marginal_lpdf) The fifth laplace argument is "
           "expected to be an int representing the max steps for the laplace "
           "approximaton's wolfe line search.");
     }
     constexpr bool is_fallthrough
         = stan::is_inner_tuple_type_v<
-              6, Ops, int> || stan::is_inner_tuple_type_v<6, Ops, bool>;
+              5, Ops, int> || stan::is_inner_tuple_type_v<5, Ops, bool>;
     if constexpr (!is_fallthrough) {
       static_assert(
           sizeof(std::decay_t<Ops>*) == 0,
-          "ERROR:(laplace_marginal_lpdf) The seventh laplace argument is "
+          "ERROR:(laplace_marginal_lpdf) The sixth laplace argument is "
           "expected to be an int representing allow fallthrough (0/1).");
     }
+    auto defaults = laplace_options_default{};
     return laplace_options_user_supplied{
         value_of(std::get<0>(std::forward<Ops>(ops))),
         std::get<1>(ops),
         std::get<2>(ops),
+        defaults.hessian_block_size,
         std::get<3>(ops),
         std::get<4>(ops),
-        std::get<5>(ops),
-        (std::get<6>(ops) > 0) ? true : false,
+        (std::get<5>(ops) > 0) ? true : false,
     };
   } else {
     return std::forward<Ops>(ops);

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -58,7 +58,7 @@ struct laplace_options_base {
    */
   double tolerance{internal::laplace_default_tolerance};  // 2
   /* Maximum number of steps*/
-  int max_num_steps{internal::laplace_default_max_num_steps};  // 3
+  int max_num_steps{internal::laplace_default_max_num_steps};          // 3
   int allow_fallthrough{internal::laplace_default_allow_fallthrough};  // 4
   laplace_line_search_options line_search{
       internal::laplace_default_max_steps_line_search};  // 5

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -10,6 +10,7 @@
 #include <stan/math/mix/functor/barzilai_borwein_step_size.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/quad_form_diag.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
 #include <stan/math/prim/functor/iter_tuple_nested.hpp>
 #include <unsupported/Eigen/MatrixFunctions>
 #include <cmath>
@@ -75,7 +76,13 @@ template <bool HasInitTheta>
 struct laplace_options;
 
 template <>
-struct laplace_options<false> : public laplace_options_base {};
+struct laplace_options<false> : public laplace_options_base {
+  laplace_options() = default;
+
+  explicit laplace_options(int hessian_block_size_) {
+    hessian_block_size = hessian_block_size_;
+  }
+};
 
 template <>
 struct laplace_options<true> : public laplace_options_base {
@@ -89,7 +96,7 @@ struct laplace_options<true> : public laplace_options_base {
       : laplace_options_base(hessian_block_size_, solver_, tolerance_,
                              max_num_steps_, allow_fallthrough_,
                              max_steps_line_search_),
-        theta_0(std::forward<ThetaVec>(theta_0_)) {}
+        theta_0(value_of(std::forward<ThetaVec>(theta_0_))) {}
 };
 
 using laplace_options_default = laplace_options<false>;

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_MIX_FUNCTOR_LAPLACE_MARGINAL_DENSITY_ESTIMATOR_HPP
 #define STAN_MATH_MIX_FUNCTOR_LAPLACE_MARGINAL_DENSITY_ESTIMATOR_HPP
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/generate_laplace_options.hpp>
 #include <stan/math/mix/functor/laplace_likelihood.hpp>
 #include <stan/math/mix/functor/wolfe_line_search.hpp>
 #include <stan/math/rev/meta.hpp>
@@ -31,7 +32,7 @@ namespace math {
  */
 struct laplace_options_base {
   /* Size of the blocks in block diagonal hessian*/
-  int hessian_block_size{1};  // 0
+  int hessian_block_size{internal::laplace_default_hessian_block_size};  // 0
   /**
    * Which linear solver to use inside the Newton step.
    *
@@ -47,7 +48,7 @@ struct laplace_options_base {
    *    `Sigma = K_root * K_root^T` and form `B = I + K_root^T * W * K_root`.
    * 3. General LU: form `B = I + Sigma * W` and factorize with LU.
    */
-  int solver{1};  // 1
+  int solver{internal::laplace_default_solver};  // 1
   /**
    * Iterations end when the absolute change in the optimization objective
    * is less than this tolerance.
@@ -55,11 +56,12 @@ struct laplace_options_base {
    * Note: the objective used for convergence is the one optimized by the
    * Newton/Wolfe loop (not the final Laplace-corrected log marginal density).
    */
-  double tolerance{1.49012e-08};  // 2
+  double tolerance{internal::laplace_default_tolerance};  // 2
   /* Maximum number of steps*/
-  int max_num_steps{500};                   // 3
-  int allow_fallthrough{true};              // 4
-  laplace_line_search_options line_search;  // 5
+  int max_num_steps{internal::laplace_default_max_num_steps};  // 3
+  int allow_fallthrough{internal::laplace_default_allow_fallthrough};  // 4
+  laplace_line_search_options line_search{
+      internal::laplace_default_max_steps_line_search};  // 5
   laplace_options_base() = default;
   laplace_options_base(int hessian_block_size_, int solver_, double tolerance_,
                        int max_num_steps_, bool allow_fallthrough_,
@@ -101,34 +103,6 @@ struct laplace_options<true> : public laplace_options_base {
 
 using laplace_options_default = laplace_options<false>;
 using laplace_options_user_supplied = laplace_options<true>;
-
-/**
- * User function for generating laplace options tuple
- * @param theta_0_size Size of user supplied initial theta
- * @return tuple representing laplace options exposed to user.
- */
-inline auto generate_laplace_options(int theta_0_size) {
-  auto ops = laplace_options_default{};
-  return std::make_tuple(Eigen::VectorXd::Zero(theta_0_size).eval(),
-                         ops.tolerance, ops.max_num_steps, ops.solver,
-                         ops.line_search.max_iterations,
-                         static_cast<int>(ops.allow_fallthrough));
-}
-
-/**
- * User function for generating laplace options tuple
- * @tparam ThetaVec An Eigen vector type for user supplied initial theta
- * @param theta_0 User supplied initial theta
- * @return tuple representing laplace options exposed to user.
- */
-template <typename ThetaVec, require_eigen_t<ThetaVec>* = nullptr>
-inline auto generate_laplace_options(ThetaVec&& theta_0) {
-  auto ops = laplace_options_default{};
-  return std::make_tuple(std::forward<ThetaVec>(theta_0), ops.tolerance,
-                         ops.max_num_steps, ops.solver,
-                         ops.line_search.max_iterations,
-                         static_cast<int>(ops.allow_fallthrough));
-}
 
 namespace internal {
 

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -109,10 +109,10 @@ using laplace_options_user_supplied = laplace_options<true>;
  */
 inline auto generate_laplace_options(int theta_0_size) {
   auto ops = laplace_options_default{};
-  return std::make_tuple(
-      Eigen::VectorXd::Zero(theta_0_size).eval(),  
-      ops.tolerance, ops.max_num_steps, ops.solver,
-      ops.line_search.max_iterations, static_cast<int>(ops.allow_fallthrough));
+  return std::make_tuple(Eigen::VectorXd::Zero(theta_0_size).eval(),
+                         ops.tolerance, ops.max_num_steps, ops.solver,
+                         ops.line_search.max_iterations,
+                         static_cast<int>(ops.allow_fallthrough));
 }
 
 /**
@@ -123,10 +123,10 @@ inline auto generate_laplace_options(int theta_0_size) {
 template <typename ThetaVec, require_eigen_t<ThetaVec>* = nullptr>
 inline auto generate_laplace_options(ThetaVec&& theta_0) {
   auto ops = laplace_options_default{};
-  return std::make_tuple(
-      std::forward<ThetaVec>(theta_0),  
-      ops.tolerance, ops.max_num_steps, ops.solver,
-      ops.line_search.max_iterations, static_cast<int>(ops.allow_fallthrough));
+  return std::make_tuple(std::forward<ThetaVec>(theta_0), ops.tolerance,
+                         ops.max_num_steps, ops.solver,
+                         ops.line_search.max_iterations,
+                         static_cast<int>(ops.allow_fallthrough));
 }
 
 namespace internal {

--- a/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
@@ -34,8 +34,8 @@ template <typename Mean, typename CovarFun, typename CovarArgs,
           typename OpsTuple, typename RNG>
 inline Eigen::VectorXd laplace_latent_tol_bernoulli_logit_rng(
     const std::vector<int>& y, const std::vector<int>& n_samples, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
+    int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
   auto options
       = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
@@ -70,8 +70,8 @@ inline Eigen::VectorXd laplace_latent_tol_bernoulli_logit_rng(
 template <typename Mean, typename CovarFun, typename CovarArgs, typename RNG>
 inline Eigen::VectorXd laplace_latent_bernoulli_logit_rng(
     const std::vector<int>& y, const std::vector<int>& n_samples, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, RNG& rng, std::ostream* msgs) {
+    int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, RNG& rng, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_base_rng(
       bernoulli_logit_likelihood{},

--- a/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
@@ -36,7 +36,8 @@ inline Eigen::VectorXd laplace_latent_tol_bernoulli_logit_rng(
     const std::vector<int>& y, const std::vector<int>& n_samples, Mean&& mean,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size, OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
-  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  auto options
+      = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
   return laplace_base_rng(
       bernoulli_logit_likelihood{},
@@ -70,8 +71,7 @@ template <typename Mean, typename CovarFun, typename CovarArgs, typename RNG>
 inline Eigen::VectorXd laplace_latent_bernoulli_logit_rng(
     const std::vector<int>& y, const std::vector<int>& n_samples, Mean&& mean,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, RNG& rng,
-    std::ostream* msgs) {
+    int hessian_block_size, RNG& rng, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_base_rng(
       bernoulli_logit_likelihood{},

--- a/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
@@ -24,6 +24,8 @@ namespace math {
  * @param[in] n_samples Vector of number of trials.
  * @param[in] mean the mean of the latent normal variable.
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \laplace_options
  * \rng_arg
  * \msg_arg
@@ -32,15 +34,15 @@ template <typename Mean, typename CovarFun, typename CovarArgs,
           typename OpsTuple, typename RNG>
 inline Eigen::VectorXd laplace_latent_tol_bernoulli_logit_rng(
     const std::vector<int>& y, const std::vector<int>& n_samples, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args, OpsTuple&& ops,
-    RNG& rng, std::ostream* msgs) {
+    CovarFun&& covariance_function, CovarArgs&& covar_args,
+    int hessian_block_size, OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
+  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  options.hessian_block_size = hessian_block_size;
   return laplace_base_rng(
       bernoulli_logit_likelihood{},
       std::forward_as_tuple(to_vector(y), n_samples, std::forward<Mean>(mean)),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args),
-      internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops)), rng,
-      msgs);
+      std::forward<CovarArgs>(covar_args), std::move(options), rng, msgs);
 }
 
 /**
@@ -59,20 +61,24 @@ inline Eigen::VectorXd laplace_latent_tol_bernoulli_logit_rng(
  * @param[in] n_samples Vector of number of trials.
  * @param[in] mean the mean of the latent normal variable.
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \rng_arg
  * \msg_arg
  */
 template <typename Mean, typename CovarFun, typename CovarArgs, typename RNG>
 inline Eigen::VectorXd laplace_latent_bernoulli_logit_rng(
     const std::vector<int>& y, const std::vector<int>& n_samples, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args, RNG& rng,
+    CovarFun&& covariance_function, CovarArgs&& covar_args,
+    int hessian_block_size, RNG& rng,
     std::ostream* msgs) {
+  auto options = laplace_options_default{};
+  options.hessian_block_size = hessian_block_size;
   return laplace_base_rng(
       bernoulli_logit_likelihood{},
       std::forward_as_tuple(to_vector(y), n_samples, std::forward<Mean>(mean)),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), laplace_options_default{}, rng,
-      msgs);
+      std::forward<CovarArgs>(covar_args), options, rng, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_bernoulli_logit_rng.hpp
@@ -72,8 +72,7 @@ inline Eigen::VectorXd laplace_latent_bernoulli_logit_rng(
     CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size, RNG& rng,
     std::ostream* msgs) {
-  auto options = laplace_options_default{};
-  options.hessian_block_size = hessian_block_size;
+  auto options = laplace_options_default{hessian_block_size};
   return laplace_base_rng(
       bernoulli_logit_likelihood{},
       std::forward_as_tuple(to_vector(y), n_samples, std::forward<Mean>(mean)),

--- a/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
@@ -43,7 +43,8 @@ inline Eigen::VectorXd laplace_latent_tol_neg_binomial_2_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Eta&& eta,
     Mean&& mean, CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size, OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
-  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  auto options
+      = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
   return laplace_base_rng(
       neg_binomial_2_log_likelihood{},

--- a/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
@@ -31,6 +31,8 @@ namespace math {
  * @param[in] eta Overdisperison parameter.
  * @param[in] mean The mean of the latent normal variable.
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \laplace_options
  * \rng_arg
  * \msg_arg
@@ -40,15 +42,15 @@ template <typename Eta, typename Mean, typename CovarFun, typename CovarArgs,
 inline Eigen::VectorXd laplace_latent_tol_neg_binomial_2_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Eta&& eta,
     Mean&& mean, CovarFun&& covariance_function, CovarArgs&& covar_args,
-    OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
+    int hessian_block_size, OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
+  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  options.hessian_block_size = hessian_block_size;
   return laplace_base_rng(
       neg_binomial_2_log_likelihood{},
       std::forward_as_tuple(std::forward<Eta>(eta), y, y_index,
                             std::forward<Mean>(mean)),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args),
-      internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops)), rng,
-      msgs);
+      std::forward<CovarArgs>(covar_args), std::move(options), rng, msgs);
 }
 
 /**
@@ -72,6 +74,8 @@ inline Eigen::VectorXd laplace_latent_tol_neg_binomial_2_log_rng(
  * @param[in] eta Overdisperison parameter.
  * @param[in] mean The mean of the latent normal variable.
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \rng_arg
  * \msg_arg
  */
@@ -80,14 +84,15 @@ template <typename Eta, typename Mean, typename CovarFun, typename CovarArgs,
 inline Eigen::VectorXd laplace_latent_neg_binomial_2_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Eta&& eta,
     Mean&& mean, CovarFun&& covariance_function, CovarArgs&& covar_args,
-    RNG& rng, std::ostream* msgs) {
+    int hessian_block_size, RNG& rng, std::ostream* msgs) {
+  auto options = laplace_options_default{};
+  options.hessian_block_size = hessian_block_size;
   return laplace_base_rng(
       neg_binomial_2_log_likelihood{},
       std::forward_as_tuple(std::forward<Eta>(eta), y, y_index,
                             std::forward<Mean>(mean)),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), laplace_options_default{}, rng,
-      msgs);
+      std::forward<CovarArgs>(covar_args), options, rng, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
@@ -85,8 +85,7 @@ inline Eigen::VectorXd laplace_latent_neg_binomial_2_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Eta&& eta,
     Mean&& mean, CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size, RNG& rng, std::ostream* msgs) {
-  auto options = laplace_options_default{};
-  options.hessian_block_size = hessian_block_size;
+  auto options = laplace_options_default{hessian_block_size};
   return laplace_base_rng(
       neg_binomial_2_log_likelihood{},
       std::forward_as_tuple(std::forward<Eta>(eta), y, y_index,

--- a/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_neg_binomial_2_log_rng.hpp
@@ -41,8 +41,8 @@ template <typename Eta, typename Mean, typename CovarFun, typename CovarArgs,
           typename OpsTuple, typename RNG>
 inline Eigen::VectorXd laplace_latent_tol_neg_binomial_2_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Eta&& eta,
-    Mean&& mean, CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
+    Mean&& mean, int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
   auto options
       = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
@@ -84,8 +84,8 @@ template <typename Eta, typename Mean, typename CovarFun, typename CovarArgs,
           typename RNG>
 inline Eigen::VectorXd laplace_latent_neg_binomial_2_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Eta&& eta,
-    Mean&& mean, CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, RNG& rng, std::ostream* msgs) {
+    Mean&& mean, int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, RNG& rng, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_base_rng(
       neg_binomial_2_log_likelihood{},

--- a/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
@@ -38,7 +38,8 @@ inline Eigen::VectorXd laplace_latent_tol_poisson_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Mean&& mean,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size, OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
-  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  auto options
+      = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
   return laplace_base_rng(
       poisson_log_likelihood{},
@@ -73,8 +74,7 @@ template <typename CovarFun, typename CovarArgs, typename RNG, typename Mean>
 inline Eigen::VectorXd laplace_latent_poisson_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Mean&& mean,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, RNG& rng,
-    std::ostream* msgs) {
+    int hessian_block_size, RNG& rng, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_base_rng(
       poisson_log_likelihood{},

--- a/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
@@ -75,8 +75,7 @@ inline Eigen::VectorXd laplace_latent_poisson_log_rng(
     CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size, RNG& rng,
     std::ostream* msgs) {
-  auto options = laplace_options_default{};
-  options.hessian_block_size = hessian_block_size;
+  auto options = laplace_options_default{hessian_block_size};
   return laplace_base_rng(
       poisson_log_likelihood{},
       std::forward_as_tuple(y, y_index, std::forward<Mean>(mean)),

--- a/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
@@ -26,6 +26,8 @@ namespace math {
  * @param[in] y_index Index indicating which group each observation belongs to.
  * @param[in] mean The mean of the latent normal variable.
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \laplace_options
  * \rng_arg
  * \msg_arg
@@ -34,15 +36,15 @@ template <typename Mean, typename CovarFun, typename CovarArgs,
           typename OpsTuple, typename RNG>
 inline Eigen::VectorXd laplace_latent_tol_poisson_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args, OpsTuple&& ops,
-    RNG& rng, std::ostream* msgs) {
+    CovarFun&& covariance_function, CovarArgs&& covar_args,
+    int hessian_block_size, OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
+  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  options.hessian_block_size = hessian_block_size;
   return laplace_base_rng(
       poisson_log_likelihood{},
       std::forward_as_tuple(y, y_index, std::forward<Mean>(mean)),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args),
-      internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops)), rng,
-      msgs);
+      std::forward<CovarArgs>(covar_args), std::move(options), rng, msgs);
 }
 
 /**
@@ -62,20 +64,24 @@ inline Eigen::VectorXd laplace_latent_tol_poisson_log_rng(
  * @param[in] y_index Index indicating which group each observation belongs to.
  * @param[in] mean The mean of the latent normal variable.
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \rng_arg
  * \msg_arg
  */
 template <typename CovarFun, typename CovarArgs, typename RNG, typename Mean>
 inline Eigen::VectorXd laplace_latent_poisson_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args, RNG& rng,
+    CovarFun&& covariance_function, CovarArgs&& covar_args,
+    int hessian_block_size, RNG& rng,
     std::ostream* msgs) {
+  auto options = laplace_options_default{};
+  options.hessian_block_size = hessian_block_size;
   return laplace_base_rng(
       poisson_log_likelihood{},
       std::forward_as_tuple(y, y_index, std::forward<Mean>(mean)),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), laplace_options_default{}, rng,
-      msgs);
+      std::forward<CovarArgs>(covar_args), options, rng, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_poisson_log_rng.hpp
@@ -36,8 +36,8 @@ template <typename Mean, typename CovarFun, typename CovarArgs,
           typename OpsTuple, typename RNG>
 inline Eigen::VectorXd laplace_latent_tol_poisson_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
+    int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, OpsTuple&& ops, RNG& rng, std::ostream* msgs) {
   auto options
       = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
@@ -73,8 +73,8 @@ inline Eigen::VectorXd laplace_latent_tol_poisson_log_rng(
 template <typename CovarFun, typename CovarArgs, typename RNG, typename Mean>
 inline Eigen::VectorXd laplace_latent_poisson_log_rng(
     const std::vector<int>& y, const std::vector<int>& y_index, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, RNG& rng, std::ostream* msgs) {
+    int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, RNG& rng, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_base_rng(
       poisson_log_likelihood{},

--- a/stan/math/mix/prob/laplace_latent_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_rng.hpp
@@ -72,8 +72,8 @@ template <typename LLFunc, typename LLArgs, typename CovarFun,
 inline auto laplace_latent_rng(LLFunc&& L_f, LLArgs&& ll_args,
                                int hessian_block_size,
                                CovarFun&& covariance_function,
-                               CovarArgs&& covar_args,
-                               RNG& rng, std::ostream* msgs) {
+                               CovarArgs&& covar_args, RNG& rng,
+                               std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_base_rng(
       std::forward<LLFunc>(L_f), std::forward<LLArgs>(ll_args),

--- a/stan/math/mix/prob/laplace_latent_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_rng.hpp
@@ -25,6 +25,8 @@ namespace math {
  * @param[in] L_f Function that returns log likelihood.
  * @param[in] ll_args Arguments for likelihood function.
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \laplace_options
  * \rng_arg
  * \msg_arg
@@ -33,14 +35,15 @@ template <typename LLFunc, typename LLArgs, typename CovarFun,
           typename CovarArgs, typename OpsTuple, typename RNG>
 inline auto laplace_latent_tol_rng(LLFunc&& L_f, LLArgs&& ll_args,
                                    CovarFun&& covariance_function,
-                                   CovarArgs&& covar_args, OpsTuple&& ops,
+                                   CovarArgs&& covar_args,
+                                   int hessian_block_size, OpsTuple&& ops,
                                    RNG& rng, std::ostream* msgs) {
+  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  options.hessian_block_size = hessian_block_size;
   return laplace_base_rng(
       std::forward<LLFunc>(L_f), std::forward<LLArgs>(ll_args),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args),
-      internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops)), rng,
-      msgs);
+      std::forward<CovarArgs>(covar_args), std::move(options), rng, msgs);
 }
 
 /**
@@ -58,6 +61,8 @@ inline auto laplace_latent_tol_rng(LLFunc&& L_f, LLArgs&& ll_args,
  * @param[in] L_f Function that returns log likelihood.
  * @param[in] ll_args Arguments for likelihood function.
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \rng_arg
  * \msg_arg
  */
@@ -65,13 +70,16 @@ template <typename LLFunc, typename LLArgs, typename CovarFun,
           typename CovarArgs, typename RNG>
 inline auto laplace_latent_rng(LLFunc&& L_f, LLArgs&& ll_args,
                                CovarFun&& covariance_function,
-                               CovarArgs&& covar_args, RNG& rng,
+                               CovarArgs&& covar_args, int hessian_block_size,
+                               RNG& rng,
                                std::ostream* msgs) {
+  auto options = laplace_options_default{};
+  options.hessian_block_size = hessian_block_size;
   return laplace_base_rng(std::forward<LLFunc>(L_f),
                           std::forward<LLArgs>(ll_args),
                           std::forward<CovarFun>(covariance_function),
-                          std::forward<CovarArgs>(covar_args),
-                          laplace_options_default{}, rng, msgs);
+                          std::forward<CovarArgs>(covar_args), options, rng,
+                          msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_latent_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_rng.hpp
@@ -34,9 +34,9 @@ namespace math {
 template <typename LLFunc, typename LLArgs, typename CovarFun,
           typename CovarArgs, typename OpsTuple, typename RNG>
 inline auto laplace_latent_tol_rng(LLFunc&& L_f, LLArgs&& ll_args,
+                                   int hessian_block_size,
                                    CovarFun&& covariance_function,
-                                   CovarArgs&& covar_args,
-                                   int hessian_block_size, OpsTuple&& ops,
+                                   CovarArgs&& covar_args, OpsTuple&& ops,
                                    RNG& rng, std::ostream* msgs) {
   auto options
       = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
@@ -70,8 +70,9 @@ inline auto laplace_latent_tol_rng(LLFunc&& L_f, LLArgs&& ll_args,
 template <typename LLFunc, typename LLArgs, typename CovarFun,
           typename CovarArgs, typename RNG>
 inline auto laplace_latent_rng(LLFunc&& L_f, LLArgs&& ll_args,
+                               int hessian_block_size,
                                CovarFun&& covariance_function,
-                               CovarArgs&& covar_args, int hessian_block_size,
+                               CovarArgs&& covar_args,
                                RNG& rng, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_base_rng(

--- a/stan/math/mix/prob/laplace_latent_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_rng.hpp
@@ -73,8 +73,7 @@ inline auto laplace_latent_rng(LLFunc&& L_f, LLArgs&& ll_args,
                                CovarArgs&& covar_args, int hessian_block_size,
                                RNG& rng,
                                std::ostream* msgs) {
-  auto options = laplace_options_default{};
-  options.hessian_block_size = hessian_block_size;
+  auto options = laplace_options_default{hessian_block_size};
   return laplace_base_rng(std::forward<LLFunc>(L_f),
                           std::forward<LLArgs>(ll_args),
                           std::forward<CovarFun>(covariance_function),

--- a/stan/math/mix/prob/laplace_latent_rng.hpp
+++ b/stan/math/mix/prob/laplace_latent_rng.hpp
@@ -38,7 +38,8 @@ inline auto laplace_latent_tol_rng(LLFunc&& L_f, LLArgs&& ll_args,
                                    CovarArgs&& covar_args,
                                    int hessian_block_size, OpsTuple&& ops,
                                    RNG& rng, std::ostream* msgs) {
-  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  auto options
+      = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
   return laplace_base_rng(
       std::forward<LLFunc>(L_f), std::forward<LLArgs>(ll_args),
@@ -71,14 +72,12 @@ template <typename LLFunc, typename LLArgs, typename CovarFun,
 inline auto laplace_latent_rng(LLFunc&& L_f, LLArgs&& ll_args,
                                CovarFun&& covariance_function,
                                CovarArgs&& covar_args, int hessian_block_size,
-                               RNG& rng,
-                               std::ostream* msgs) {
+                               RNG& rng, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
-  return laplace_base_rng(std::forward<LLFunc>(L_f),
-                          std::forward<LLArgs>(ll_args),
-                          std::forward<CovarFun>(covariance_function),
-                          std::forward<CovarArgs>(covar_args), options, rng,
-                          msgs);
+  return laplace_base_rng(
+      std::forward<LLFunc>(L_f), std::forward<LLArgs>(ll_args),
+      std::forward<CovarFun>(covariance_function),
+      std::forward<CovarArgs>(covar_args), options, rng, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_marginal.hpp
+++ b/stan/math/mix/prob/laplace_marginal.hpp
@@ -30,8 +30,9 @@ namespace math {
 template <bool propto = false, typename LFun, typename LArgs, typename CovarFun,
           typename CovarArgs, typename OpsTuple>
 inline auto laplace_marginal_tol(LFun&& L_f, LArgs&& l_args,
+                                 int hessian_block_size,
                                  CovarFun&& covariance_function,
-                                 CovarArgs&& covar_args, int hessian_block_size,
+                                 CovarArgs&& covar_args,
                                  OpsTuple&& ops, std::ostream* msgs) {
   auto options
       = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
@@ -64,8 +65,9 @@ inline auto laplace_marginal_tol(LFun&& L_f, LArgs&& l_args,
 template <bool propto = false, typename LFun, typename LArgs, typename CovarFun,
           typename CovarArgs>
 inline auto laplace_marginal(LFun&& L_f, LArgs&& l_args,
+                             int hessian_block_size,
                              CovarFun&& covariance_function,
-                             CovarArgs&& covar_args, int hessian_block_size,
+                             CovarArgs&& covar_args,
                              std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(

--- a/stan/math/mix/prob/laplace_marginal.hpp
+++ b/stan/math/mix/prob/laplace_marginal.hpp
@@ -22,6 +22,8 @@ namespace math {
  * @param[in] L_f a function which returns the log likelihood.
  * @param[in] l_args A tuple of arguments to pass to the log likelihood.
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \laplace_options
  * \msg_arg
  */
@@ -29,13 +31,15 @@ template <bool propto = false, typename LFun, typename LArgs, typename CovarFun,
           typename CovarArgs, typename OpsTuple>
 inline auto laplace_marginal_tol(LFun&& L_f, LArgs&& l_args,
                                  CovarFun&& covariance_function,
-                                 CovarArgs&& covar_args, OpsTuple&& ops,
+                                 CovarArgs&& covar_args,
+                                 int hessian_block_size, OpsTuple&& ops,
                                  std::ostream* msgs) {
+  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       std::forward<LFun>(L_f), std::forward<LArgs>(l_args),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args),
-      internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops)), msgs);
+      std::forward<CovarArgs>(covar_args), std::move(options), msgs);
 }
 
 /**
@@ -53,17 +57,22 @@ inline auto laplace_marginal_tol(LFun&& L_f, LArgs&& l_args,
  * @param[in] L_f a function which returns the log likelihood.
  * @param[in] l_args A tuple of arguments to pass to the log likelihood
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \msg_arg
  */
 template <bool propto = false, typename LFun, typename LArgs, typename CovarFun,
           typename CovarArgs>
 inline auto laplace_marginal(LFun&& L_f, LArgs&& l_args,
                              CovarFun&& covariance_function,
-                             CovarArgs&& covar_args, std::ostream* msgs) {
+                             CovarArgs&& covar_args, int hessian_block_size,
+                             std::ostream* msgs) {
+  auto options = laplace_options_default{};
+  options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       std::forward<LFun>(L_f), std::forward<LArgs>(l_args),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), laplace_options_default{}, msgs);
+      std::forward<CovarArgs>(covar_args), options, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_marginal.hpp
+++ b/stan/math/mix/prob/laplace_marginal.hpp
@@ -31,10 +31,10 @@ template <bool propto = false, typename LFun, typename LArgs, typename CovarFun,
           typename CovarArgs, typename OpsTuple>
 inline auto laplace_marginal_tol(LFun&& L_f, LArgs&& l_args,
                                  CovarFun&& covariance_function,
-                                 CovarArgs&& covar_args,
-                                 int hessian_block_size, OpsTuple&& ops,
-                                 std::ostream* msgs) {
-  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+                                 CovarArgs&& covar_args, int hessian_block_size,
+                                 OpsTuple&& ops, std::ostream* msgs) {
+  auto options
+      = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       std::forward<LFun>(L_f), std::forward<LArgs>(l_args),

--- a/stan/math/mix/prob/laplace_marginal.hpp
+++ b/stan/math/mix/prob/laplace_marginal.hpp
@@ -67,8 +67,7 @@ inline auto laplace_marginal(LFun&& L_f, LArgs&& l_args,
                              CovarFun&& covariance_function,
                              CovarArgs&& covar_args, int hessian_block_size,
                              std::ostream* msgs) {
-  auto options = laplace_options_default{};
-  options.hessian_block_size = hessian_block_size;
+  auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(
       std::forward<LFun>(L_f), std::forward<LArgs>(l_args),
       std::forward<CovarFun>(covariance_function),

--- a/stan/math/mix/prob/laplace_marginal.hpp
+++ b/stan/math/mix/prob/laplace_marginal.hpp
@@ -32,8 +32,8 @@ template <bool propto = false, typename LFun, typename LArgs, typename CovarFun,
 inline auto laplace_marginal_tol(LFun&& L_f, LArgs&& l_args,
                                  int hessian_block_size,
                                  CovarFun&& covariance_function,
-                                 CovarArgs&& covar_args,
-                                 OpsTuple&& ops, std::ostream* msgs) {
+                                 CovarArgs&& covar_args, OpsTuple&& ops,
+                                 std::ostream* msgs) {
   auto options
       = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
@@ -64,11 +64,9 @@ inline auto laplace_marginal_tol(LFun&& L_f, LArgs&& l_args,
  */
 template <bool propto = false, typename LFun, typename LArgs, typename CovarFun,
           typename CovarArgs>
-inline auto laplace_marginal(LFun&& L_f, LArgs&& l_args,
-                             int hessian_block_size,
+inline auto laplace_marginal(LFun&& L_f, LArgs&& l_args, int hessian_block_size,
                              CovarFun&& covariance_function,
-                             CovarArgs&& covar_args,
-                             std::ostream* msgs) {
+                             CovarArgs&& covar_args, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(
       std::forward<LFun>(L_f), std::forward<LArgs>(l_args),

--- a/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
@@ -58,8 +58,8 @@ template <bool propto = false, typename Mean, typename CovarFun,
           typename CovarArgs, typename OpsTuple>
 inline auto laplace_marginal_tol_bernoulli_logit_lpmf(
     const std::vector<int>& y, const std::vector<int>& n_samples, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, OpsTuple&& ops, std::ostream* msgs) {
+    int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, OpsTuple&& ops, std::ostream* msgs) {
   auto options
       = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
@@ -93,8 +93,8 @@ template <bool propto = false, typename Mean, typename CovarFun,
           typename CovarArgs>
 inline auto laplace_marginal_bernoulli_logit_lpmf(
     const std::vector<int>& y, const std::vector<int>& n_samples, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, std::ostream* msgs) {
+    int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(
       bernoulli_logit_likelihood{},

--- a/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
@@ -95,8 +95,7 @@ inline auto laplace_marginal_bernoulli_logit_lpmf(
     CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size,
     std::ostream* msgs) {
-  auto options = laplace_options_default{};
-  options.hessian_block_size = hessian_block_size;
+  auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(
       bernoulli_logit_likelihood{},
       std::forward_as_tuple(to_vector(y), n_samples, std::forward<Mean>(mean)),

--- a/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
@@ -49,6 +49,8 @@ struct bernoulli_logit_likelihood {
  * statistics.
  * @param[in] mean the mean of the latent normal variable.
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \laplace_options
  * \msg_arg
  */
@@ -56,14 +58,15 @@ template <bool propto = false, typename Mean, typename CovarFun,
           typename CovarArgs, typename OpsTuple>
 inline auto laplace_marginal_tol_bernoulli_logit_lpmf(
     const std::vector<int>& y, const std::vector<int>& n_samples, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args, OpsTuple&& ops,
-    std::ostream* msgs) {
+    CovarFun&& covariance_function, CovarArgs&& covar_args,
+    int hessian_block_size, OpsTuple&& ops, std::ostream* msgs) {
+  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       bernoulli_logit_likelihood{},
       std::forward_as_tuple(to_vector(y), n_samples, std::forward<Mean>(mean)),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args),
-      internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops)), msgs);
+      std::forward<CovarArgs>(covar_args), std::move(options), msgs);
 }
 
 /**
@@ -81,6 +84,8 @@ inline auto laplace_marginal_tol_bernoulli_logit_lpmf(
  * statistics.
  * @param[in] mean the mean of the latent normal variable.
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \msg_arg
  */
 template <bool propto = false, typename Mean, typename CovarFun,
@@ -88,12 +93,15 @@ template <bool propto = false, typename Mean, typename CovarFun,
 inline auto laplace_marginal_bernoulli_logit_lpmf(
     const std::vector<int>& y, const std::vector<int>& n_samples, Mean&& mean,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
+    int hessian_block_size,
     std::ostream* msgs) {
+  auto options = laplace_options_default{};
+  options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       bernoulli_logit_likelihood{},
       std::forward_as_tuple(to_vector(y), n_samples, std::forward<Mean>(mean)),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), laplace_options_default{}, msgs);
+      std::forward<CovarArgs>(covar_args), options, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_bernoulli_logit_lpmf.hpp
@@ -60,7 +60,8 @@ inline auto laplace_marginal_tol_bernoulli_logit_lpmf(
     const std::vector<int>& y, const std::vector<int>& n_samples, Mean&& mean,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size, OpsTuple&& ops, std::ostream* msgs) {
-  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  auto options
+      = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       bernoulli_logit_likelihood{},
@@ -93,8 +94,7 @@ template <bool propto = false, typename Mean, typename CovarFun,
 inline auto laplace_marginal_bernoulli_logit_lpmf(
     const std::vector<int>& y, const std::vector<int>& n_samples, Mean&& mean,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size,
-    std::ostream* msgs) {
+    int hessian_block_size, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(
       bernoulli_logit_likelihood{},

--- a/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
@@ -84,7 +84,8 @@ inline auto laplace_marginal_tol_neg_binomial_2_log_lpmf(
     const std::vector<int>& y, const std::vector<int>& y_index, const Eta& eta,
     Mean&& mean, CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size, OpsTuple&& ops, std::ostream* msgs) {
-  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  auto options
+      = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood{},
@@ -185,7 +186,8 @@ inline auto laplace_marginal_tol_neg_binomial_2_log_summary_lpmf(
     const std::vector<int>& counts_per_group, const Eta& eta, Mean&& mean,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size, OpsTuple&& ops, std::ostream* msgs) {
-  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  auto options
+      = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood_summary{},

--- a/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
@@ -119,8 +119,7 @@ inline auto laplace_marginal_neg_binomial_2_log_lpmf(
     const std::vector<int>& y, const std::vector<int>& y_index, const Eta& eta,
     Mean&& mean, CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size, std::ostream* msgs) {
-  auto options = laplace_options_default{};
-  options.hessian_block_size = hessian_block_size;
+  auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood{},
       std::forward_as_tuple(eta, y, y_index, std::forward<Mean>(mean)),
@@ -223,8 +222,7 @@ inline auto laplace_marginal_neg_binomial_2_log_summary_lpmf(
     const std::vector<int>& counts_per_group, const Eta& eta, Mean&& mean,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size, std::ostream* msgs) {
-  auto options = laplace_options_default{};
-  options.hessian_block_size = hessian_block_size;
+  auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood_summary{},
       std::forward_as_tuple(eta, y, n_per_group, counts_per_group,

--- a/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
@@ -82,8 +82,8 @@ template <bool propto = false, typename Eta, typename Mean, typename CovarFun,
           typename CovarArgs, typename OpsTuple>
 inline auto laplace_marginal_tol_neg_binomial_2_log_lpmf(
     const std::vector<int>& y, const std::vector<int>& y_index, const Eta& eta,
-    Mean&& mean, CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, OpsTuple&& ops, std::ostream* msgs) {
+    Mean&& mean, int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, OpsTuple&& ops, std::ostream* msgs) {
   auto options
       = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
@@ -118,8 +118,8 @@ template <bool propto = false, typename Eta, typename Mean, typename CovarFun,
           typename CovarArgs>
 inline auto laplace_marginal_neg_binomial_2_log_lpmf(
     const std::vector<int>& y, const std::vector<int>& y_index, const Eta& eta,
-    Mean&& mean, CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, std::ostream* msgs) {
+    Mean&& mean, int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood{},
@@ -184,8 +184,8 @@ template <bool propto = false, typename Eta, typename Mean, typename CovarFun,
 inline auto laplace_marginal_tol_neg_binomial_2_log_summary_lpmf(
     const std::vector<int>& y, const std::vector<int>& n_per_group,
     const std::vector<int>& counts_per_group, const Eta& eta, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, OpsTuple&& ops, std::ostream* msgs) {
+    int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, OpsTuple&& ops, std::ostream* msgs) {
   auto options
       = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
@@ -222,8 +222,8 @@ template <bool propto = false, typename Eta, typename Mean, typename CovarFun,
 inline auto laplace_marginal_neg_binomial_2_log_summary_lpmf(
     const std::vector<int>& y, const std::vector<int>& n_per_group,
     const std::vector<int>& counts_per_group, const Eta& eta, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, std::ostream* msgs) {
+    int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood_summary{},

--- a/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_neg_binomial_2_log_lpmf.hpp
@@ -73,6 +73,8 @@ struct neg_binomial_2_log_likelihood {
  * @param[in] eta non-marginalized model parameters for the likelihood.
  * @param[in] mean the mean of the latent normal variable
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \laplace_options
  * \msg_arg
  */
@@ -81,13 +83,14 @@ template <bool propto = false, typename Eta, typename Mean, typename CovarFun,
 inline auto laplace_marginal_tol_neg_binomial_2_log_lpmf(
     const std::vector<int>& y, const std::vector<int>& y_index, const Eta& eta,
     Mean&& mean, CovarFun&& covariance_function, CovarArgs&& covar_args,
-    OpsTuple&& ops, std::ostream* msgs) {
+    int hessian_block_size, OpsTuple&& ops, std::ostream* msgs) {
+  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood{},
       std::forward_as_tuple(eta, y, y_index, std::forward<Mean>(mean)),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args),
-      internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops)), msgs);
+      std::forward<CovarArgs>(covar_args), std::move(options), msgs);
 }
 
 /**
@@ -106,6 +109,8 @@ inline auto laplace_marginal_tol_neg_binomial_2_log_lpmf(
  * @param[in] eta Parameter argument for likelihood function.
  * @param[in] mean the mean of the latent normal variable
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \msg_arg
  */
 template <bool propto = false, typename Eta, typename Mean, typename CovarFun,
@@ -113,12 +118,14 @@ template <bool propto = false, typename Eta, typename Mean, typename CovarFun,
 inline auto laplace_marginal_neg_binomial_2_log_lpmf(
     const std::vector<int>& y, const std::vector<int>& y_index, const Eta& eta,
     Mean&& mean, CovarFun&& covariance_function, CovarArgs&& covar_args,
-    std::ostream* msgs) {
+    int hessian_block_size, std::ostream* msgs) {
+  auto options = laplace_options_default{};
+  options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood{},
       std::forward_as_tuple(eta, y, y_index, std::forward<Mean>(mean)),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), laplace_options_default{}, msgs);
+      std::forward<CovarArgs>(covar_args), options, msgs);
 }
 
 struct neg_binomial_2_log_likelihood_summary {
@@ -167,6 +174,8 @@ struct neg_binomial_2_log_likelihood_summary {
  * @param[in] eta non-marginalized model parameters for the likelihood.
  * @param[in] mean the mean of the latent normal variable
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \laplace_options
  * \msg_arg
  */
@@ -175,15 +184,16 @@ template <bool propto = false, typename Eta, typename Mean, typename CovarFun,
 inline auto laplace_marginal_tol_neg_binomial_2_log_summary_lpmf(
     const std::vector<int>& y, const std::vector<int>& n_per_group,
     const std::vector<int>& counts_per_group, const Eta& eta, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args, OpsTuple&& ops,
-    std::ostream* msgs) {
+    CovarFun&& covariance_function, CovarArgs&& covar_args,
+    int hessian_block_size, OpsTuple&& ops, std::ostream* msgs) {
+  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood_summary{},
       std::forward_as_tuple(eta, y, n_per_group, counts_per_group,
                             std::forward<Mean>(mean)),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args),
-      internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops)), msgs);
+      std::forward<CovarArgs>(covar_args), std::move(options), msgs);
 }
 
 /**
@@ -202,6 +212,8 @@ inline auto laplace_marginal_tol_neg_binomial_2_log_summary_lpmf(
  * @param[in] eta non-marginalized model parameters for the likelihood.
  * @param[in] mean the mean of the latent normal variable
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \msg_arg
  */
 template <bool propto = false, typename Eta, typename Mean, typename CovarFun,
@@ -210,13 +222,15 @@ inline auto laplace_marginal_neg_binomial_2_log_summary_lpmf(
     const std::vector<int>& y, const std::vector<int>& n_per_group,
     const std::vector<int>& counts_per_group, const Eta& eta, Mean&& mean,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
-    std::ostream* msgs) {
+    int hessian_block_size, std::ostream* msgs) {
+  auto options = laplace_options_default{};
+  options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       neg_binomial_2_log_likelihood_summary{},
       std::forward_as_tuple(eta, y, n_per_group, counts_per_group,
                             std::forward<Mean>(mean)),
       std::forward<CovarFun>(covariance_function),
-      std::forward<CovarArgs>(covar_args), laplace_options_default{}, msgs);
+      std::forward<CovarArgs>(covar_args), options, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
@@ -112,8 +112,7 @@ inline auto laplace_marginal_poisson_log_lpmf(const std::vector<int>& y,
                                               CovarArgs&& covar_args,
                                               int hessian_block_size,
                                               std::ostream* msgs) {
-  auto options = laplace_options_default{};
-  options.hessian_block_size = hessian_block_size;
+  auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(
       poisson_log_likelihood{},
       std::forward_as_tuple(y, y_index, std::forward<Mean>(mean)),

--- a/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
@@ -76,7 +76,8 @@ inline auto laplace_marginal_tol_poisson_log_lpmf(
     const std::vector<int>& y, const std::vector<int>& y_index, Mean&& mean,
     CovarFun&& covariance_function, CovarArgs&& covar_args,
     int hessian_block_size, OpsTuple&& ops, std::ostream* msgs) {
-  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  auto options
+      = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       poisson_log_likelihood{},
@@ -105,19 +106,15 @@ inline auto laplace_marginal_tol_poisson_log_lpmf(
  */
 template <bool propto = false, typename CovarFun, typename CovarArgs,
           typename Mean>
-inline auto laplace_marginal_poisson_log_lpmf(const std::vector<int>& y,
-                                              const std::vector<int>& y_index,
-                                              Mean&& mean,
-                                              CovarFun&& covariance_function,
-                                              CovarArgs&& covar_args,
-                                              int hessian_block_size,
-                                              std::ostream* msgs) {
+inline auto laplace_marginal_poisson_log_lpmf(
+    const std::vector<int>& y, const std::vector<int>& y_index, Mean&& mean,
+    CovarFun&& covariance_function, CovarArgs&& covar_args,
+    int hessian_block_size, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(
       poisson_log_likelihood{},
       std::forward_as_tuple(y, y_index, std::forward<Mean>(mean)),
-      covariance_function, std::forward<CovarArgs>(covar_args),
-      options, msgs);
+      covariance_function, std::forward<CovarArgs>(covar_args), options, msgs);
 }
 
 }  // namespace math

--- a/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
@@ -74,8 +74,8 @@ template <bool propto = false, typename Mean, typename CovarFun,
           typename CovarArgs, typename OpsTuple>
 inline auto laplace_marginal_tol_poisson_log_lpmf(
     const std::vector<int>& y, const std::vector<int>& y_index, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, OpsTuple&& ops, std::ostream* msgs) {
+    int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, OpsTuple&& ops, std::ostream* msgs) {
   auto options
       = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
   options.hessian_block_size = hessian_block_size;
@@ -108,8 +108,8 @@ template <bool propto = false, typename CovarFun, typename CovarArgs,
           typename Mean>
 inline auto laplace_marginal_poisson_log_lpmf(
     const std::vector<int>& y, const std::vector<int>& y_index, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args,
-    int hessian_block_size, std::ostream* msgs) {
+    int hessian_block_size, CovarFun&& covariance_function,
+    CovarArgs&& covar_args, std::ostream* msgs) {
   auto options = laplace_options_default{hessian_block_size};
   return laplace_marginal_density(
       poisson_log_likelihood{},

--- a/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
+++ b/stan/math/mix/prob/laplace_marginal_poisson_log_lpmf.hpp
@@ -65,6 +65,8 @@ struct poisson_log_likelihood {
  * @param[in] y_index group to which each observation belongs
  * @param[in] mean the mean of the latent normal variable
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \laplace_options
  * \msg_arg
  */
@@ -72,13 +74,15 @@ template <bool propto = false, typename Mean, typename CovarFun,
           typename CovarArgs, typename OpsTuple>
 inline auto laplace_marginal_tol_poisson_log_lpmf(
     const std::vector<int>& y, const std::vector<int>& y_index, Mean&& mean,
-    CovarFun&& covariance_function, CovarArgs&& covar_args, OpsTuple&& ops,
-    std::ostream* msgs) {
+    CovarFun&& covariance_function, CovarArgs&& covar_args,
+    int hessian_block_size, OpsTuple&& ops, std::ostream* msgs) {
+  auto options = internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops));
+  options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       poisson_log_likelihood{},
       std::forward_as_tuple(y, y_index, std::forward<Mean>(mean)),
       covariance_function, std::forward<CovarArgs>(covar_args),
-      internal::tuple_to_laplace_options(std::forward<OpsTuple>(ops)), msgs);
+      std::move(options), msgs);
 }
 
 /**
@@ -95,6 +99,8 @@ inline auto laplace_marginal_tol_poisson_log_lpmf(
  * @param[in] y_index group to which each observation belongs
  * @param[in] mean the mean of the latent normal variable
  * \laplace_common_args
+ * @param[in] hessian_block_size Block size for the Hessian approximation with
+ * respect to the latent gaussian variable theta.
  * \msg_arg
  */
 template <bool propto = false, typename CovarFun, typename CovarArgs,
@@ -104,12 +110,15 @@ inline auto laplace_marginal_poisson_log_lpmf(const std::vector<int>& y,
                                               Mean&& mean,
                                               CovarFun&& covariance_function,
                                               CovarArgs&& covar_args,
+                                              int hessian_block_size,
                                               std::ostream* msgs) {
+  auto options = laplace_options_default{};
+  options.hessian_block_size = hessian_block_size;
   return laplace_marginal_density(
       poisson_log_likelihood{},
       std::forward_as_tuple(y, y_index, std::forward<Mean>(mean)),
       covariance_function, std::forward<CovarArgs>(covar_args),
-      laplace_options_default{}, msgs);
+      options, msgs);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -102,6 +102,7 @@
 #include <stan/math/prim/fun/fmod.hpp>
 #include <stan/math/prim/fun/gamma_p.hpp>
 #include <stan/math/prim/fun/gamma_q.hpp>
+#include <stan/math/prim/fun/generate_laplace_options.hpp>
 #include <stan/math/prim/fun/generalized_inverse.hpp>
 #include <stan/math/prim/fun/get.hpp>
 #include <stan/math/prim/fun/get_base1.hpp>

--- a/stan/math/prim/fun/generate_laplace_options.hpp
+++ b/stan/math/prim/fun/generate_laplace_options.hpp
@@ -24,13 +24,12 @@ inline constexpr int laplace_default_max_steps_line_search = 1000;
  * @return tuple representing laplace options exposed to user.
  */
 inline auto generate_laplace_options(int theta_0_size) {
-  return std::make_tuple(
-      Eigen::VectorXd::Zero(theta_0_size).eval(),
-      internal::laplace_default_tolerance,
-      internal::laplace_default_max_num_steps,
-      internal::laplace_default_solver,
-      internal::laplace_default_max_steps_line_search,
-      internal::laplace_default_allow_fallthrough);
+  return std::make_tuple(Eigen::VectorXd::Zero(theta_0_size).eval(),
+                         internal::laplace_default_tolerance,
+                         internal::laplace_default_max_num_steps,
+                         internal::laplace_default_solver,
+                         internal::laplace_default_max_steps_line_search,
+                         internal::laplace_default_allow_fallthrough);
 }
 
 /**
@@ -43,8 +42,7 @@ template <typename ThetaVec, require_eigen_t<ThetaVec>* = nullptr>
 inline auto generate_laplace_options(ThetaVec&& theta_0) {
   return std::make_tuple(
       std::forward<ThetaVec>(theta_0), internal::laplace_default_tolerance,
-      internal::laplace_default_max_num_steps,
-      internal::laplace_default_solver,
+      internal::laplace_default_max_num_steps, internal::laplace_default_solver,
       internal::laplace_default_max_steps_line_search,
       internal::laplace_default_allow_fallthrough);
 }

--- a/stan/math/prim/fun/generate_laplace_options.hpp
+++ b/stan/math/prim/fun/generate_laplace_options.hpp
@@ -41,11 +41,12 @@ inline auto generate_laplace_options(int theta_0_size) {
  */
 template <typename ThetaVec, require_eigen_t<ThetaVec>* = nullptr>
 inline auto generate_laplace_options(ThetaVec&& theta_0) {
-  return std::make_tuple(
-      stan::math::eval(std::forward<ThetaVec>(theta_0)), internal::laplace_default_tolerance,
-      internal::laplace_default_max_num_steps, internal::laplace_default_solver,
-      internal::laplace_default_max_steps_line_search,
-      internal::laplace_default_allow_fallthrough);
+  return std::make_tuple(stan::math::eval(std::forward<ThetaVec>(theta_0)),
+                         internal::laplace_default_tolerance,
+                         internal::laplace_default_max_num_steps,
+                         internal::laplace_default_solver,
+                         internal::laplace_default_max_steps_line_search,
+                         internal::laplace_default_allow_fallthrough);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/generate_laplace_options.hpp
+++ b/stan/math/prim/fun/generate_laplace_options.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/eval.hpp>
 #include <tuple>
 #include <utility>
 
@@ -41,7 +42,7 @@ inline auto generate_laplace_options(int theta_0_size) {
 template <typename ThetaVec, require_eigen_t<ThetaVec>* = nullptr>
 inline auto generate_laplace_options(ThetaVec&& theta_0) {
   return std::make_tuple(
-      std::forward<ThetaVec>(theta_0), internal::laplace_default_tolerance,
+      stan::math::eval(std::forward<ThetaVec>(theta_0)), internal::laplace_default_tolerance,
       internal::laplace_default_max_num_steps, internal::laplace_default_solver,
       internal::laplace_default_max_steps_line_search,
       internal::laplace_default_allow_fallthrough);

--- a/stan/math/prim/fun/generate_laplace_options.hpp
+++ b/stan/math/prim/fun/generate_laplace_options.hpp
@@ -1,0 +1,55 @@
+#ifndef STAN_MATH_PRIM_FUN_GENERATE_LAPLACE_OPTIONS_HPP
+#define STAN_MATH_PRIM_FUN_GENERATE_LAPLACE_OPTIONS_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <tuple>
+#include <utility>
+
+namespace stan {
+namespace math {
+
+namespace internal {
+inline constexpr int laplace_default_hessian_block_size = 1;
+inline constexpr int laplace_default_solver = 1;
+inline constexpr double laplace_default_tolerance = 1.49012e-08;
+inline constexpr int laplace_default_max_num_steps = 500;
+inline constexpr int laplace_default_allow_fallthrough = 1;
+inline constexpr int laplace_default_max_steps_line_search = 1000;
+}  // namespace internal
+
+/**
+ * User function for generating laplace options tuple
+ * @param theta_0_size Size of user supplied initial theta
+ * @return tuple representing laplace options exposed to user.
+ */
+inline auto generate_laplace_options(int theta_0_size) {
+  return std::make_tuple(
+      Eigen::VectorXd::Zero(theta_0_size).eval(),
+      internal::laplace_default_tolerance,
+      internal::laplace_default_max_num_steps,
+      internal::laplace_default_solver,
+      internal::laplace_default_max_steps_line_search,
+      internal::laplace_default_allow_fallthrough);
+}
+
+/**
+ * User function for generating laplace options tuple
+ * @tparam ThetaVec An Eigen vector type for user supplied initial theta
+ * @param theta_0 User supplied initial theta
+ * @return tuple representing laplace options exposed to user.
+ */
+template <typename ThetaVec, require_eigen_t<ThetaVec>* = nullptr>
+inline auto generate_laplace_options(ThetaVec&& theta_0) {
+  return std::make_tuple(
+      std::forward<ThetaVec>(theta_0), internal::laplace_default_tolerance,
+      internal::laplace_default_max_num_steps,
+      internal::laplace_default_solver,
+      internal::laplace_default_max_steps_line_search,
+      internal::laplace_default_allow_fallthrough);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -156,6 +156,7 @@ ignored = [
     "std_normal_qf",  # synonym for inv_Phi
     "if_else",
     "hypergeometric_3F2",  # requires arguments of specific lengths
+    "generate_laplace_options",
 ]
 
 # these are all slight renames compared to stan math

--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -156,7 +156,6 @@ ignored = [
     "std_normal_qf",  # synonym for inv_Phi
     "if_else",
     "hypergeometric_3F2",  # requires arguments of specific lengths
-    "generate_laplace_options",
 ]
 
 # these are all slight renames compared to stan math

--- a/test/unit/math/laplace/aki_ex_test.cpp
+++ b/test/unit/math/laplace/aki_ex_test.cpp
@@ -86,7 +86,7 @@ TEST(WriteArrayBodySimple, ExceededIteration) {
     try {
       ll_laplace_val = stan::math::laplace_marginal(
           poisson_re_log_ll_functor(), std::forward_as_tuple(y, mu),
-          cov_fun_functor(), std::tuple<double, int>(sigmaz, 1), pstream);
+          cov_fun_functor(), std::tuple<double, int>(sigmaz, 1), 1, pstream);
     } catch (const std::domain_error& e) {
       // Log bad values to CSV files
       ADD_FAILURE() << "Laplace failed"
@@ -136,7 +136,7 @@ TEST(WriteArrayBodySimple, ExecutesBodyWithHardcodedData) {
         ll_laplace_val = stan::math::laplace_marginal(
             poisson_re_log_ll_functor(),
             std::forward_as_tuple(y[i - 1], mu[i - 1]), cov_fun_functor(),
-            std::tuple<double, int>(sigmaz, 1), pstream);
+            std::tuple<double, int>(sigmaz, 1), 1, pstream);
       } catch (const std::domain_error& e) {
         ADD_FAILURE() << "LAPLACE FAILURE: y and mu for i = " << i << ": ("
                       << y[i - 1] << ", " << mu[i - 1] << ")"
@@ -165,7 +165,7 @@ TEST(WriteArrayBodySimple, ExecutesBodyWithHardcodedData) {
     }
     auto ll_laplace_all = stan::math::laplace_marginal(
         poisson_re_log_ll_functor(), std::forward_as_tuple(y, mu),
-        cov_fun_functor(), std::tuple<double, int>(sigmaz, N), pstream);
+        cov_fun_functor(), std::tuple<double, int>(sigmaz, N), 1, pstream);
     stan::test::relative_tolerance sum_rel_tol(3e-2);
     expect_near_rel("sum laplace vs integrated sum", ll_laplace,
                     ll_integrate_1d, sum_rel_tol, "laplace_sum",

--- a/test/unit/math/laplace/aki_ex_test.cpp
+++ b/test/unit/math/laplace/aki_ex_test.cpp
@@ -86,7 +86,7 @@ TEST(WriteArrayBodySimple, ExceededIteration) {
     try {
       ll_laplace_val = stan::math::laplace_marginal(
           poisson_re_log_ll_functor(), std::forward_as_tuple(y, mu),
-          cov_fun_functor(), std::tuple<double, int>(sigmaz, 1), 1, pstream);
+          1, cov_fun_functor(), std::tuple<double, int>(sigmaz, 1), pstream);
     } catch (const std::domain_error& e) {
       // Log bad values to CSV files
       ADD_FAILURE() << "Laplace failed"
@@ -135,8 +135,8 @@ TEST(WriteArrayBodySimple, ExecutesBodyWithHardcodedData) {
       try {
         ll_laplace_val = stan::math::laplace_marginal(
             poisson_re_log_ll_functor(),
-            std::forward_as_tuple(y[i - 1], mu[i - 1]), cov_fun_functor(),
-            std::tuple<double, int>(sigmaz, 1), 1, pstream);
+            std::forward_as_tuple(y[i - 1], mu[i - 1]), 1, cov_fun_functor(),
+            std::tuple<double, int>(sigmaz, 1), pstream);
       } catch (const std::domain_error& e) {
         ADD_FAILURE() << "LAPLACE FAILURE: y and mu for i = " << i << ": ("
                       << y[i - 1] << ", " << mu[i - 1] << ")"
@@ -165,7 +165,7 @@ TEST(WriteArrayBodySimple, ExecutesBodyWithHardcodedData) {
     }
     auto ll_laplace_all = stan::math::laplace_marginal(
         poisson_re_log_ll_functor(), std::forward_as_tuple(y, mu),
-        cov_fun_functor(), std::tuple<double, int>(sigmaz, N), 1, pstream);
+        1, cov_fun_functor(), std::tuple<double, int>(sigmaz, N), pstream);
     stan::test::relative_tolerance sum_rel_tol(3e-2);
     expect_near_rel("sum laplace vs integrated sum", ll_laplace,
                     ll_integrate_1d, sum_rel_tol, "laplace_sum",

--- a/test/unit/math/laplace/aki_ex_test.cpp
+++ b/test/unit/math/laplace/aki_ex_test.cpp
@@ -85,8 +85,8 @@ TEST(WriteArrayBodySimple, ExceededIteration) {
     double ll_laplace_val{0};
     try {
       ll_laplace_val = stan::math::laplace_marginal(
-          poisson_re_log_ll_functor(), std::forward_as_tuple(y, mu),
-          1, cov_fun_functor(), std::tuple<double, int>(sigmaz, 1), pstream);
+          poisson_re_log_ll_functor(), std::forward_as_tuple(y, mu), 1,
+          cov_fun_functor(), std::tuple<double, int>(sigmaz, 1), pstream);
     } catch (const std::domain_error& e) {
       // Log bad values to CSV files
       ADD_FAILURE() << "Laplace failed"
@@ -164,8 +164,8 @@ TEST(WriteArrayBodySimple, ExecutesBodyWithHardcodedData) {
       }
     }
     auto ll_laplace_all = stan::math::laplace_marginal(
-        poisson_re_log_ll_functor(), std::forward_as_tuple(y, mu),
-        1, cov_fun_functor(), std::tuple<double, int>(sigmaz, N), pstream);
+        poisson_re_log_ll_functor(), std::forward_as_tuple(y, mu), 1,
+        cov_fun_functor(), std::tuple<double, int>(sigmaz, N), pstream);
     stan::test::relative_tolerance sum_rel_tol(3e-2);
     expect_near_rel("sum laplace vs integrated sum", ll_laplace,
                     ll_integrate_1d, sum_rel_tol, "laplace_sum",

--- a/test/unit/math/laplace/generate_laplace_options_test.cpp
+++ b/test/unit/math/laplace/generate_laplace_options_test.cpp
@@ -1,0 +1,44 @@
+#include <stan/math/mix/functor/laplace_marginal_density_estimator.hpp>
+#include <gtest/gtest.h>
+
+namespace stan::math::test {
+
+TEST(LaplaceMarginalDensityEstimator, GenerateLaplaceOptionsFromSizeDefaults) {
+  constexpr int theta_0_size = 4;
+  const auto defaults = laplace_options_default{};
+
+  const auto options = stan::math::generate_laplace_options(theta_0_size);
+  const auto& theta_0 = std::get<0>(options);
+
+  EXPECT_EQ(theta_0_size, theta_0.size());
+  EXPECT_TRUE(theta_0.isApprox(Eigen::VectorXd::Zero(theta_0_size)));
+  EXPECT_DOUBLE_EQ(defaults.tolerance, std::get<1>(options));
+  EXPECT_EQ(defaults.max_num_steps, std::get<2>(options));
+  EXPECT_EQ(defaults.solver, std::get<3>(options));
+  EXPECT_EQ(defaults.line_search.max_iterations, std::get<4>(options));
+  EXPECT_EQ(static_cast<int>(defaults.allow_fallthrough), std::get<5>(options));
+}
+
+TEST(LaplaceMarginalDensityEstimator, GenerateLaplaceOptionsFromSizeZero) {
+  const auto options = stan::math::generate_laplace_options(0);
+  const auto& theta_0 = std::get<0>(options);
+
+  EXPECT_EQ(0, theta_0.size());
+}
+
+TEST(LaplaceMarginalDensityEstimator, GenerateLaplaceOptionsFromThetaDefaults) {
+  Eigen::VectorXd theta_0(3);
+  theta_0 << -1.2, 0.5, 2.3;
+  const auto defaults = laplace_options_default{};
+
+  const auto options = stan::math::generate_laplace_options(theta_0);
+
+  EXPECT_TRUE(theta_0.isApprox(std::get<0>(options)));
+  EXPECT_DOUBLE_EQ(defaults.tolerance, std::get<1>(options));
+  EXPECT_EQ(defaults.max_num_steps, std::get<2>(options));
+  EXPECT_EQ(defaults.solver, std::get<3>(options));
+  EXPECT_EQ(defaults.line_search.max_iterations, std::get<4>(options));
+  EXPECT_EQ(static_cast<int>(defaults.allow_fallthrough), std::get<5>(options));
+}
+
+}  // namespace stan::math::test

--- a/test/unit/math/laplace/generate_laplace_options_test.cpp
+++ b/test/unit/math/laplace/generate_laplace_options_test.cpp
@@ -1,22 +1,20 @@
-#include <stan/math/mix/functor/laplace_marginal_density_estimator.hpp>
+#include <stan/math/prim/fun/generate_laplace_options.hpp>
 #include <gtest/gtest.h>
 
 namespace stan::math::test {
 
 TEST(LaplaceMarginalDensityEstimator, GenerateLaplaceOptionsFromSizeDefaults) {
   constexpr int theta_0_size = 4;
-  const auto defaults = laplace_options_default{};
-
   const auto options = stan::math::generate_laplace_options(theta_0_size);
   const auto& theta_0 = std::get<0>(options);
 
   EXPECT_EQ(theta_0_size, theta_0.size());
   EXPECT_TRUE(theta_0.isApprox(Eigen::VectorXd::Zero(theta_0_size)));
-  EXPECT_DOUBLE_EQ(defaults.tolerance, std::get<1>(options));
-  EXPECT_EQ(defaults.max_num_steps, std::get<2>(options));
-  EXPECT_EQ(defaults.solver, std::get<3>(options));
-  EXPECT_EQ(defaults.line_search.max_iterations, std::get<4>(options));
-  EXPECT_EQ(static_cast<int>(defaults.allow_fallthrough), std::get<5>(options));
+  EXPECT_DOUBLE_EQ(1.49012e-08, std::get<1>(options));
+  EXPECT_EQ(500, std::get<2>(options));
+  EXPECT_EQ(1, std::get<3>(options));
+  EXPECT_EQ(1000, std::get<4>(options));
+  EXPECT_EQ(1, std::get<5>(options));
 }
 
 TEST(LaplaceMarginalDensityEstimator, GenerateLaplaceOptionsFromSizeZero) {
@@ -29,16 +27,14 @@ TEST(LaplaceMarginalDensityEstimator, GenerateLaplaceOptionsFromSizeZero) {
 TEST(LaplaceMarginalDensityEstimator, GenerateLaplaceOptionsFromThetaDefaults) {
   Eigen::VectorXd theta_0(3);
   theta_0 << -1.2, 0.5, 2.3;
-  const auto defaults = laplace_options_default{};
-
   const auto options = stan::math::generate_laplace_options(theta_0);
 
   EXPECT_TRUE(theta_0.isApprox(std::get<0>(options)));
-  EXPECT_DOUBLE_EQ(defaults.tolerance, std::get<1>(options));
-  EXPECT_EQ(defaults.max_num_steps, std::get<2>(options));
-  EXPECT_EQ(defaults.solver, std::get<3>(options));
-  EXPECT_EQ(defaults.line_search.max_iterations, std::get<4>(options));
-  EXPECT_EQ(static_cast<int>(defaults.allow_fallthrough), std::get<5>(options));
+  EXPECT_DOUBLE_EQ(1.49012e-08, std::get<1>(options));
+  EXPECT_EQ(500, std::get<2>(options));
+  EXPECT_EQ(1, std::get<3>(options));
+  EXPECT_EQ(1000, std::get<4>(options));
+  EXPECT_EQ(1, std::get<5>(options));
 }
 
 }  // namespace stan::math::test

--- a/test/unit/math/laplace/laplace_bernoulli_logit_rng_test.cpp
+++ b/test/unit/math/laplace/laplace_bernoulli_logit_rng_test.cpp
@@ -77,7 +77,7 @@ TEST(laplace_bernoulli_logit_rng, two_dim_diag) {
   rng.seed(1954);
   Eigen::MatrixXd theta_pred = laplace_latent_bernoulli_logit_rng(
       sums, n_samples, mean, diagonal_kernel_functor{},
-      std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
+      std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
 
   // Compute exact mean and covariance
   Eigen::VectorXd theta_root

--- a/test/unit/math/laplace/laplace_bernoulli_logit_rng_test.cpp
+++ b/test/unit/math/laplace/laplace_bernoulli_logit_rng_test.cpp
@@ -76,8 +76,8 @@ TEST(laplace_bernoulli_logit_rng, two_dim_diag) {
   boost::random::mt19937 rng;
   rng.seed(1954);
   Eigen::MatrixXd theta_pred = laplace_latent_bernoulli_logit_rng(
-      sums, n_samples, mean, diagonal_kernel_functor{},
-      std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
+      sums, n_samples, mean, 1, diagonal_kernel_functor{},
+      std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
 
   // Compute exact mean and covariance
   Eigen::VectorXd theta_root

--- a/test/unit/math/laplace/laplace_marginal_bernoulli_logit_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_bernoulli_logit_lpmf_test.cpp
@@ -44,8 +44,8 @@ TEST_P(laplace_marginal_bernoulli_logit_lpmf, phi_dim500) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> phi_dbl{{1.6, 1}};
   using stan::math::test::sqr_exp_kernel_functor;
   double target = laplace_marginal_bernoulli_logit_lpmf(
-      y, n_samples, 0, sqr_exp_kernel_functor{},
-      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), hessian_block_size,
+      y, n_samples, 0, hessian_block_size, sqr_exp_kernel_functor{},
+      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)),
       nullptr);
   // Benchmark against gpstuff.
   constexpr double tol = 8e-4;
@@ -57,8 +57,8 @@ TEST_P(laplace_marginal_bernoulli_logit_lpmf, phi_dim500) {
   auto f = [&](auto&& alpha, auto&& rho) {
     try {
       return laplace_marginal_tol_bernoulli_logit_lpmf(
-          y, n_samples, mean, sqr_exp_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          y, n_samples, mean, hessian_block_size, sqr_exp_kernel_functor{},
+          std::forward_as_tuple(x, alpha, rho),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);

--- a/test/unit/math/laplace/laplace_marginal_bernoulli_logit_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_bernoulli_logit_lpmf_test.cpp
@@ -45,8 +45,7 @@ TEST_P(laplace_marginal_bernoulli_logit_lpmf, phi_dim500) {
   using stan::math::test::sqr_exp_kernel_functor;
   double target = laplace_marginal_bernoulli_logit_lpmf(
       y, n_samples, 0, hessian_block_size, sqr_exp_kernel_functor{},
-      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)),
-      nullptr);
+      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), nullptr);
   // Benchmark against gpstuff.
   constexpr double tol = 8e-4;
   EXPECT_NEAR(-195.368, target, tol);

--- a/test/unit/math/laplace/laplace_marginal_bernoulli_logit_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_bernoulli_logit_lpmf_test.cpp
@@ -45,7 +45,8 @@ TEST_P(laplace_marginal_bernoulli_logit_lpmf, phi_dim500) {
   using stan::math::test::sqr_exp_kernel_functor;
   double target = laplace_marginal_bernoulli_logit_lpmf(
       y, n_samples, 0, sqr_exp_kernel_functor{},
-      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), nullptr);
+      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), hessian_block_size,
+      nullptr);
   // Benchmark against gpstuff.
   constexpr double tol = 8e-4;
   EXPECT_NEAR(-195.368, target, tol);
@@ -57,9 +58,9 @@ TEST_P(laplace_marginal_bernoulli_logit_lpmf, phi_dim500) {
     try {
       return laplace_marginal_tol_bernoulli_logit_lpmf(
           y, n_samples, mean, sqr_exp_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;

--- a/test/unit/math/laplace/laplace_marginal_lpdf_moto_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_lpdf_moto_test.cpp
@@ -149,10 +149,9 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle_val) {
 
   laplace_marginal_tol<false>(
       normal_likelihood{}, std::forward_as_tuple(y, n_obs),
-      covariance_motorcycle_functor{},
+      hessian_block_size, covariance_motorcycle_functor{},
       std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1), phi_dbl(2), phi_dbl(3),
                             n_obs),
-      hessian_block_size,
       std::make_tuple(theta0, tolerance, max_num_steps, solver_num,
                       max_steps_line_search, true),
       &output_stream);
@@ -183,10 +182,9 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle_ad) {
     try {
       return laplace_marginal_tol<false>(
           normal_likelihood{}, std::forward_as_tuple(y, n_obs),
-          covariance_motorcycle_functor{},
+          hessian_block_size, covariance_motorcycle_functor{},
           std::forward_as_tuple(x, phi_01_v(0), phi_01_v(1), phi_rest_v(0),
                                 phi_rest_v(1), n_obs),
-          hessian_block_size,
           std::make_tuple(theta0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);
@@ -258,10 +256,9 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle2_val) {
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   laplace_marginal_tol<false>(
       normal_likelihood2{}, std::forward_as_tuple(y, n_obs, sigma_global),
-      covariance_motorcycle_functor{},
+      hessian_block_size, covariance_motorcycle_functor{},
       std::forward_as_tuple(x, length_scale_f, length_scale_g, sigma_f, sigma_g,
                             n_obs),
-      hessian_block_size,
       std::make_tuple(theta0, tolerance, max_num_steps, solver_num,
                       max_steps_line_search, true),
       &output_stream);
@@ -292,10 +289,9 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle2_ad) {
     try {
       return laplace_marginal_tol<false>(
           normal_likelihood2{}, std::forward_as_tuple(y, n_obs, sigma_global_v),
-          covariance_motorcycle_functor{},
+          hessian_block_size, covariance_motorcycle_functor{},
           std::forward_as_tuple(x, length_scale_v(0), length_scale_v(1),
                                 sigma_v(0), sigma_v(1), n_obs),
-          hessian_block_size,
           std::make_tuple(theta0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);

--- a/test/unit/math/laplace/laplace_marginal_lpdf_moto_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_lpdf_moto_test.cpp
@@ -152,8 +152,9 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle_val) {
       covariance_motorcycle_functor{},
       std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1), phi_dbl(2), phi_dbl(3),
                             n_obs),
-      std::make_tuple(theta0, tolerance, max_num_steps, hessian_block_size,
-                      solver_num, max_steps_line_search, true),
+      hessian_block_size,
+      std::make_tuple(theta0, tolerance, max_num_steps, solver_num,
+                      max_steps_line_search, true),
       &output_stream);
 }
 
@@ -185,8 +186,9 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle_ad) {
           covariance_motorcycle_functor{},
           std::forward_as_tuple(x, phi_01_v(0), phi_01_v(1), phi_rest_v(0),
                                 phi_rest_v(1), n_obs),
-          std::make_tuple(theta0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          hessian_block_size,
+          std::make_tuple(theta0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;
@@ -259,8 +261,9 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle2_val) {
       covariance_motorcycle_functor{},
       std::forward_as_tuple(x, length_scale_f, length_scale_g, sigma_f, sigma_g,
                             n_obs),
-      std::make_tuple(theta0, tolerance, max_num_steps, hessian_block_size,
-                      solver_num, max_steps_line_search, true),
+      hessian_block_size,
+      std::make_tuple(theta0, tolerance, max_num_steps, solver_num,
+                      max_steps_line_search, true),
       &output_stream);
 }
 
@@ -292,8 +295,9 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle2_ad) {
           covariance_motorcycle_functor{},
           std::forward_as_tuple(x, length_scale_v(0), length_scale_v(1),
                                 sigma_v(0), sigma_v(1), n_obs),
-          std::make_tuple(theta0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          hessian_block_size,
+          std::make_tuple(theta0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;

--- a/test/unit/math/laplace/laplace_marginal_lpdf_moto_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_lpdf_moto_test.cpp
@@ -148,8 +148,8 @@ TEST_P(laplace_motorcyle_gp_test, gp_motorcycle_val) {
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
 
   laplace_marginal_tol<false>(
-      normal_likelihood{}, std::forward_as_tuple(y, n_obs),
-      hessian_block_size, covariance_motorcycle_functor{},
+      normal_likelihood{}, std::forward_as_tuple(y, n_obs), hessian_block_size,
+      covariance_motorcycle_functor{},
       std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1), phi_dbl(2), phi_dbl(3),
                             n_obs),
       std::make_tuple(theta0, tolerance, max_num_steps, solver_num,

--- a/test/unit/math/laplace/laplace_marginal_lpdf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_lpdf_test.cpp
@@ -56,7 +56,8 @@ TEST_P(laplace_marginal_lpdf, poisson_log_phi_dim_2) {
   double target = laplace_marginal<false>(
       poisson_log_likelihood2{}, std::forward_as_tuple(sums),
       stan::math::test::squared_kernel_functor{},
-      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), &output_stream);
+      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), hessian_block_size,
+      &output_stream);
 
   // TODO(Charles): benchmark target against gpstuff.
   constexpr double tol = 1e-4;
@@ -73,9 +74,9 @@ TEST_P(laplace_marginal_lpdf, poisson_log_phi_dim_2) {
     target = laplace_marginal_tol<false>(
         poisson_log_likelihood2{}, std::forward_as_tuple(sums),
         stan::math::test::squared_kernel_functor{},
-        std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)),
-        std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                        solver, max_steps_line_search, true),
+        std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), hessian_block_size,
+        std::make_tuple(theta_0, tolerance, max_num_steps, solver,
+                        max_steps_line_search, true),
         &output_stream);
     EXPECT_NEAR(-2.53056, value_of(target), tol);
   }
@@ -92,9 +93,9 @@ TEST_P(laplace_marginal_lpdf, poisson_log_phi_dim_2) {
       return laplace_marginal_tol<false>(
           poisson_log_likelihood2{}, std::forward_as_tuple(sums),
           stan::math::test::squared_kernel_functor{},
-          std::forward_as_tuple(x_v, alpha, rho),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          std::forward_as_tuple(x_v, alpha, rho), hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;
@@ -135,7 +136,8 @@ TEST_P(laplace_disease_map_test, laplace_marginal) {
     double marginal_density = laplace_marginal<false>(
         poisson_log_exposure_likelihood{}, std::forward_as_tuple(ye, y),
         stan::math::test::sqr_exp_kernel_functor{},
-        std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), &output_stream);
+        std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), hessian_block_size,
+        &output_stream);
 
     constexpr double tol = 6e-4;
     // Benchmark from GPStuff.
@@ -150,9 +152,9 @@ TEST_P(laplace_disease_map_test, laplace_marginal) {
       return laplace_marginal_tol<false>(
           poisson_log_exposure_likelihood{}, std::forward_as_tuple(ye, y),
           stan::math::test::sqr_exp_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;
@@ -204,7 +206,8 @@ TEST_P(laplace_marginal_lpdf, bernoulli_logit_phi_dim500) {
   double target = laplace_marginal<false>(
       bernoulli_logit_likelihood{}, std::forward_as_tuple(y),
       stan::math::test::sqr_exp_kernel_functor{},
-      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), &output_stream);
+      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), hessian_block_size,
+      &output_stream);
 
   constexpr double tol = 3e-4;
   // Benchmark against gpstuff.
@@ -219,9 +222,9 @@ TEST_P(laplace_marginal_lpdf, bernoulli_logit_phi_dim500) {
       return laplace_marginal_tol<false>(
           bernoulli_logit_likelihood{}, std::forward_as_tuple(y),
           stan::math::test::sqr_exp_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;

--- a/test/unit/math/laplace/laplace_marginal_lpdf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_lpdf_test.cpp
@@ -55,9 +55,8 @@ TEST_P(laplace_marginal_lpdf, poisson_log_phi_dim_2) {
 
   double target = laplace_marginal<false>(
       poisson_log_likelihood2{}, std::forward_as_tuple(sums),
-      stan::math::test::squared_kernel_functor{},
-      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), hessian_block_size,
-      &output_stream);
+      hessian_block_size, stan::math::test::squared_kernel_functor{},
+      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), &output_stream);
 
   // TODO(Charles): benchmark target against gpstuff.
   constexpr double tol = 1e-4;
@@ -73,8 +72,8 @@ TEST_P(laplace_marginal_lpdf, poisson_log_phi_dim_2) {
 
     target = laplace_marginal_tol<false>(
         poisson_log_likelihood2{}, std::forward_as_tuple(sums),
-        stan::math::test::squared_kernel_functor{},
-        std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), hessian_block_size,
+        hessian_block_size, stan::math::test::squared_kernel_functor{},
+        std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)),
         std::make_tuple(theta_0, tolerance, max_num_steps, solver,
                         max_steps_line_search, true),
         &output_stream);
@@ -92,8 +91,8 @@ TEST_P(laplace_marginal_lpdf, poisson_log_phi_dim_2) {
     try {
       return laplace_marginal_tol<false>(
           poisson_log_likelihood2{}, std::forward_as_tuple(sums),
-          stan::math::test::squared_kernel_functor{},
-          std::forward_as_tuple(x_v, alpha, rho), hessian_block_size,
+          hessian_block_size, stan::math::test::squared_kernel_functor{},
+          std::forward_as_tuple(x_v, alpha, rho),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);
@@ -135,9 +134,8 @@ TEST_P(laplace_disease_map_test, laplace_marginal) {
   {
     double marginal_density = laplace_marginal<false>(
         poisson_log_exposure_likelihood{}, std::forward_as_tuple(ye, y),
-        stan::math::test::sqr_exp_kernel_functor{},
-        std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), hessian_block_size,
-        &output_stream);
+        hessian_block_size, stan::math::test::sqr_exp_kernel_functor{},
+        std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), &output_stream);
 
     constexpr double tol = 6e-4;
     // Benchmark from GPStuff.
@@ -151,8 +149,8 @@ TEST_P(laplace_disease_map_test, laplace_marginal) {
     try {
       return laplace_marginal_tol<false>(
           poisson_log_exposure_likelihood{}, std::forward_as_tuple(ye, y),
-          stan::math::test::sqr_exp_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          hessian_block_size, stan::math::test::sqr_exp_kernel_functor{},
+          std::forward_as_tuple(x, alpha, rho),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);
@@ -205,9 +203,8 @@ TEST_P(laplace_marginal_lpdf, bernoulli_logit_phi_dim500) {
   LAPLACE_SKIP_IF_INVALID_TEST_COMBO(hessian_block_size, dim_theta);
   double target = laplace_marginal<false>(
       bernoulli_logit_likelihood{}, std::forward_as_tuple(y),
-      stan::math::test::sqr_exp_kernel_functor{},
-      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), hessian_block_size,
-      &output_stream);
+      hessian_block_size, stan::math::test::sqr_exp_kernel_functor{},
+      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), &output_stream);
 
   constexpr double tol = 3e-4;
   // Benchmark against gpstuff.
@@ -221,8 +218,8 @@ TEST_P(laplace_marginal_lpdf, bernoulli_logit_phi_dim500) {
     try {
       return laplace_marginal_tol<false>(
           bernoulli_logit_likelihood{}, std::forward_as_tuple(y),
-          stan::math::test::sqr_exp_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          hessian_block_size, stan::math::test::sqr_exp_kernel_functor{},
+          std::forward_as_tuple(x, alpha, rho),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);

--- a/test/unit/math/laplace/laplace_marginal_neg_binomial_log_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_neg_binomial_log_lpmf_test.cpp
@@ -46,8 +46,9 @@ TEST_P(laplace_marginal_neg_binomial_log_lpmf, phi_dim_2) {
   auto f = [&](auto&& alpha, auto&& rho, auto&& eta) {
     try {
       return laplace_marginal_tol_neg_binomial_2_log_lpmf(
-          y, y_index, eta, 0, stan::math::test::squared_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          y, y_index, eta, 0, hessian_block_size,
+          stan::math::test::squared_kernel_functor{},
+          std::forward_as_tuple(x, alpha, rho),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);
@@ -86,8 +87,9 @@ TEST_P(laplace_disease_map_test, laplace_marginal_neg_binomial_2_log_lpmf) {
   constexpr int max_num_steps = 1000;
   auto smoke = [&](auto&& alpha, auto&& rho, auto&& eta_arg) {
     return laplace_marginal_tol_neg_binomial_2_log_lpmf(
-        y, y_index, eta_arg, mean, stan::math::test::sqr_exp_kernel_functor{},
-        std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+        y, y_index, eta_arg, mean, hessian_block_size,
+        stan::math::test::sqr_exp_kernel_functor{},
+        std::forward_as_tuple(x, alpha, rho),
         std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                         max_steps_line_search, true),
         &output_stream);
@@ -96,8 +98,9 @@ TEST_P(laplace_disease_map_test, laplace_marginal_neg_binomial_2_log_lpmf) {
   auto f = [&](auto&& alpha, auto&& rho, auto&& eta_arg) {
     try {
       return laplace_marginal_tol_neg_binomial_2_log_lpmf(
-          y, y_index, eta_arg, mean, stan::math::test::sqr_exp_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          y, y_index, eta_arg, mean, hessian_block_size,
+          stan::math::test::sqr_exp_kernel_functor{},
+          std::forward_as_tuple(x, alpha, rho),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);

--- a/test/unit/math/laplace/laplace_marginal_neg_binomial_log_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_neg_binomial_log_lpmf_test.cpp
@@ -47,9 +47,9 @@ TEST_P(laplace_marginal_neg_binomial_log_lpmf, phi_dim_2) {
     try {
       return laplace_marginal_tol_neg_binomial_2_log_lpmf(
           y, y_index, eta, 0, stan::math::test::squared_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;
@@ -87,9 +87,9 @@ TEST_P(laplace_disease_map_test, laplace_marginal_neg_binomial_2_log_lpmf) {
   auto smoke = [&](auto&& alpha, auto&& rho, auto&& eta_arg) {
     return laplace_marginal_tol_neg_binomial_2_log_lpmf(
         y, y_index, eta_arg, mean, stan::math::test::sqr_exp_kernel_functor{},
-        std::forward_as_tuple(x, alpha, rho),
-        std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                        solver_num, max_steps_line_search, true),
+        std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+        std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                        max_steps_line_search, true),
         &output_stream);
   };
   smoke(phi_dbl[0], phi_dbl[1], eta);
@@ -97,9 +97,9 @@ TEST_P(laplace_disease_map_test, laplace_marginal_neg_binomial_2_log_lpmf) {
     try {
       return laplace_marginal_tol_neg_binomial_2_log_lpmf(
           y, y_index, eta_arg, mean, stan::math::test::sqr_exp_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;

--- a/test/unit/math/laplace/laplace_marginal_neg_binomial_log_summary_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_neg_binomial_log_summary_lpmf_test.cpp
@@ -54,9 +54,9 @@ TEST_P(laplace_marginal_neg_binomial_log_summary_lpmf, phi_dim_2) {
       return laplace_marginal_tol_neg_binomial_2_log_summary_lpmf(
           y, n_per_group, counts_per_group, eta, 0,
           stan::math::test::squared_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;
@@ -102,9 +102,9 @@ TEST_P(laplace_disease_map_test,
     return laplace_marginal_tol_neg_binomial_2_log_summary_lpmf(
         y, n_per_group, counts_per_group, eta_arg, 0,
         stan::math::test::sqr_exp_kernel_functor{},
-        std::forward_as_tuple(x, alpha, rho),
-        std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                        solver_num, max_steps_line_search, true),
+        std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+        std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                        max_steps_line_search, true),
         &output_stream);
   };
   smoke(phi_dbl[0], phi_dbl[1], eta);
@@ -113,9 +113,9 @@ TEST_P(laplace_disease_map_test,
       return laplace_marginal_tol_neg_binomial_2_log_summary_lpmf(
           y, n_per_group, counts_per_group, eta_arg, mean,
           stan::math::test::sqr_exp_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;

--- a/test/unit/math/laplace/laplace_marginal_neg_binomial_log_summary_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_neg_binomial_log_summary_lpmf_test.cpp
@@ -52,9 +52,9 @@ TEST_P(laplace_marginal_neg_binomial_log_summary_lpmf, phi_dim_2) {
   auto f = [&](auto&& alpha, auto&& rho, auto&& eta) {
     try {
       return laplace_marginal_tol_neg_binomial_2_log_summary_lpmf(
-          y, n_per_group, counts_per_group, eta, 0,
+          y, n_per_group, counts_per_group, eta, 0, hessian_block_size,
           stan::math::test::squared_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          std::forward_as_tuple(x, alpha, rho),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);
@@ -100,9 +100,9 @@ TEST_P(laplace_disease_map_test,
   constexpr int max_num_steps = 1000;
   auto smoke = [&](auto&& alpha, auto&& rho, auto&& eta_arg) {
     return laplace_marginal_tol_neg_binomial_2_log_summary_lpmf(
-        y, n_per_group, counts_per_group, eta_arg, 0,
+        y, n_per_group, counts_per_group, eta_arg, 0, hessian_block_size,
         stan::math::test::sqr_exp_kernel_functor{},
-        std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+        std::forward_as_tuple(x, alpha, rho),
         std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                         max_steps_line_search, true),
         &output_stream);
@@ -111,9 +111,9 @@ TEST_P(laplace_disease_map_test,
   auto f = [&](auto&& alpha, auto&& rho, auto&& eta_arg) {
     try {
       return laplace_marginal_tol_neg_binomial_2_log_summary_lpmf(
-          y, n_per_group, counts_per_group, eta_arg, mean,
+          y, n_per_group, counts_per_group, eta_arg, mean, hessian_block_size,
           stan::math::test::sqr_exp_kernel_functor{},
-          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          std::forward_as_tuple(x, alpha, rho),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);

--- a/test/unit/math/laplace/laplace_marginal_poisson_log_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_poisson_log_lpmf_test.cpp
@@ -59,8 +59,8 @@ TEST_P(laplace_marginal_poisson_log_lpmf, phi_dim_2) {
   auto f = [&](auto&& alpha, auto&& rho) {
     try {
       return laplace_marginal_tol_poisson_log_lpmf(
-          y, y_index, 0, sq_kernel, std::forward_as_tuple(x, alpha, rho),
-          hessian_block_size,
+          y, y_index, 0, hessian_block_size, sq_kernel,
+          std::forward_as_tuple(x, alpha, rho),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, allow_fallthrough),
           &output_stream);
@@ -125,8 +125,8 @@ TEST_P(laplace_marginal_poisson_log_lpmf, log_phi_dim_2) {
   auto f = [&](auto&& alpha, auto&& rho) {
     try {
       return laplace_marginal_tol_poisson_log_lpmf(
-          y, y_index, log(ye), sq_kernel, std::forward_as_tuple(x, alpha, rho),
-          hessian_block_size,
+          y, y_index, log(ye), hessian_block_size, sq_kernel,
+          std::forward_as_tuple(x, alpha, rho),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);
@@ -176,8 +176,8 @@ TEST_P(laplace_marginal_poisson_log_lpmf, mean_argument) {
   constexpr double tolerance = 1e-12;
   constexpr int max_num_steps = 500;
   double marginal_density = laplace_marginal_tol_poisson_log_lpmf(
-      y, y_index, mu, diag_covariance{},
-      std::tuple<double, int>(sigmaz, dim_theta), hessian_block_size,
+      y, y_index, mu, hessian_block_size, diag_covariance{},
+      std::tuple<double, int>(sigmaz, dim_theta),
       std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                       max_steps_line_search, true),
       &output_stream);
@@ -202,8 +202,9 @@ TEST_P(laplace_disease_map_test, laplace_marginal_poisson_log_lpmf) {
   constexpr int max_num_steps = 500;
 
   double marginal_density = laplace_marginal_tol_poisson_log_lpmf(
-      y, y_index, log(ye), stan::math::test::sqr_exp_kernel_functor(),
-      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), hessian_block_size,
+      y, y_index, log(ye), hessian_block_size,
+      stan::math::test::sqr_exp_kernel_functor(),
+      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)),
       std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                       max_steps_line_search, true),
       &output_stream);
@@ -214,8 +215,9 @@ TEST_P(laplace_disease_map_test, laplace_marginal_poisson_log_lpmf) {
   auto f = [&](auto&& alpha, auto&& rho) {
     try {
       return laplace_marginal_tol_poisson_log_lpmf(
-          y, y_index, log(ye), stan::math::test::sqr_exp_kernel_functor(),
-          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          y, y_index, log(ye), hessian_block_size,
+          stan::math::test::sqr_exp_kernel_functor(),
+          std::forward_as_tuple(x, alpha, rho),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);

--- a/test/unit/math/laplace/laplace_marginal_poisson_log_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_poisson_log_lpmf_test.cpp
@@ -177,8 +177,7 @@ TEST_P(laplace_marginal_poisson_log_lpmf, mean_argument) {
   constexpr int max_num_steps = 500;
   double marginal_density = laplace_marginal_tol_poisson_log_lpmf(
       y, y_index, mu, diag_covariance{},
-      std::tuple<double, int>(sigmaz, dim_theta),
-      hessian_block_size,
+      std::tuple<double, int>(sigmaz, dim_theta), hessian_block_size,
       std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                       max_steps_line_search, true),
       &output_stream);
@@ -204,8 +203,7 @@ TEST_P(laplace_disease_map_test, laplace_marginal_poisson_log_lpmf) {
 
   double marginal_density = laplace_marginal_tol_poisson_log_lpmf(
       y, y_index, log(ye), stan::math::test::sqr_exp_kernel_functor(),
-      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)),
-      hessian_block_size,
+      std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)), hessian_block_size,
       std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                       max_steps_line_search, true),
       &output_stream);

--- a/test/unit/math/laplace/laplace_marginal_poisson_log_lpmf_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_poisson_log_lpmf_test.cpp
@@ -60,8 +60,9 @@ TEST_P(laplace_marginal_poisson_log_lpmf, phi_dim_2) {
     try {
       return laplace_marginal_tol_poisson_log_lpmf(
           y, y_index, 0, sq_kernel, std::forward_as_tuple(x, alpha, rho),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, allow_fallthrough),
+          hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, allow_fallthrough),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;
@@ -125,8 +126,9 @@ TEST_P(laplace_marginal_poisson_log_lpmf, log_phi_dim_2) {
     try {
       return laplace_marginal_tol_poisson_log_lpmf(
           y, y_index, log(ye), sq_kernel, std::forward_as_tuple(x, alpha, rho),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;
@@ -176,8 +178,9 @@ TEST_P(laplace_marginal_poisson_log_lpmf, mean_argument) {
   double marginal_density = laplace_marginal_tol_poisson_log_lpmf(
       y, y_index, mu, diag_covariance{},
       std::tuple<double, int>(sigmaz, dim_theta),
-      std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                      solver_num, max_steps_line_search, true),
+      hessian_block_size,
+      std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                      max_steps_line_search, true),
       &output_stream);
 
   EXPECT_FLOAT_EQ(-6.7098737, marginal_density);
@@ -202,8 +205,9 @@ TEST_P(laplace_disease_map_test, laplace_marginal_poisson_log_lpmf) {
   double marginal_density = laplace_marginal_tol_poisson_log_lpmf(
       y, y_index, log(ye), stan::math::test::sqr_exp_kernel_functor(),
       std::forward_as_tuple(x, phi_dbl(0), phi_dbl(1)),
-      std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                      solver_num, max_steps_line_search, true),
+      hessian_block_size,
+      std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                      max_steps_line_search, true),
       &output_stream);
 
   double tol = 6e-4;
@@ -213,9 +217,9 @@ TEST_P(laplace_disease_map_test, laplace_marginal_poisson_log_lpmf) {
     try {
       return laplace_marginal_tol_poisson_log_lpmf(
           y, y_index, log(ye), stan::math::test::sqr_exp_kernel_functor(),
-          std::forward_as_tuple(x, alpha, rho),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          std::forward_as_tuple(x, alpha, rho), hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;

--- a/test/unit/math/laplace/laplace_neg_binomial_2_log_rng_test.cpp
+++ b/test/unit/math/laplace/laplace_neg_binomial_2_log_rng_test.cpp
@@ -103,8 +103,8 @@ TEST(laplace_latent_neg_binomial_2_log_rng, count_two_dim_diag) {
 
   rng.seed(1954);
   Eigen::MatrixXd theta_pred = laplace_latent_neg_binomial_2_log_rng(
-      y, y_index, eta, 0, diagonal_kernel_nb_functor{},
-      std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
+      y, y_index, eta, 0, 1, diagonal_kernel_nb_functor{},
+      std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
 
   double tol = 1e-3;
   EXPECT_NEAR(theta_benchmark(0), theta_pred(0), tol);
@@ -116,8 +116,8 @@ TEST(laplace_latent_neg_binomial_2_log_rng, count_two_dim_diag) {
   for (int i = 0; i < n_sim; i++) {
     rng.seed(2025 + i);
     Eigen::MatrixXd theta_pred = laplace_latent_neg_binomial_2_log_rng(
-        y, y_index, eta, 0, diagonal_kernel_nb_functor{},
-        std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
+        y, y_index, eta, 0, 1, diagonal_kernel_nb_functor{},
+        std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
 
     theta_dim0(i) = theta_pred(0);
     theta_dim1(i) = theta_pred(1);

--- a/test/unit/math/laplace/laplace_neg_binomial_2_log_rng_test.cpp
+++ b/test/unit/math/laplace/laplace_neg_binomial_2_log_rng_test.cpp
@@ -104,7 +104,7 @@ TEST(laplace_latent_neg_binomial_2_log_rng, count_two_dim_diag) {
   rng.seed(1954);
   Eigen::MatrixXd theta_pred = laplace_latent_neg_binomial_2_log_rng(
       y, y_index, eta, 0, diagonal_kernel_nb_functor{},
-      std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
+      std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
 
   double tol = 1e-3;
   EXPECT_NEAR(theta_benchmark(0), theta_pred(0), tol);
@@ -117,7 +117,7 @@ TEST(laplace_latent_neg_binomial_2_log_rng, count_two_dim_diag) {
     rng.seed(2025 + i);
     Eigen::MatrixXd theta_pred = laplace_latent_neg_binomial_2_log_rng(
         y, y_index, eta, 0, diagonal_kernel_nb_functor{},
-        std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
+        std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
 
     theta_dim0(i) = theta_pred(0);
     theta_dim1(i) = theta_pred(1);

--- a/test/unit/math/laplace/laplace_poisson_log_rng_test.cpp
+++ b/test/unit/math/laplace/laplace_poisson_log_rng_test.cpp
@@ -23,8 +23,8 @@ TEST_F(laplace_count_two_dim_diag_test, poisson_log_likelihood) {
   boost::random::mt19937 rng;
   rng.seed(1954);
   Eigen::MatrixXd theta_pred = laplace_latent_poisson_log_rng(
-      y, y_index, 0, stan::math::test::diagonal_kernel_functor{},
-      std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
+      y, y_index, 0, 1, stan::math::test::diagonal_kernel_functor{},
+      std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
 
   // double tol = 1e-3;
   EXPECT_NEAR(theta_benchmark(0), theta_pred(0), tol);
@@ -36,8 +36,8 @@ TEST_F(laplace_count_two_dim_diag_test, poisson_log_likelihood) {
   for (int i = 0; i < n_sim; i++) {
     rng.seed(2025 + i);
     Eigen::MatrixXd theta_pred = laplace_latent_poisson_log_rng(
-        y, y_index, 0, stan::math::test::diagonal_kernel_functor{},
-        std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
+        y, y_index, 0, 1, stan::math::test::diagonal_kernel_functor{},
+        std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
 
     theta_dim0(i) = theta_pred(0);
     theta_dim1(i) = theta_pred(1);
@@ -73,8 +73,8 @@ TEST_F(laplace_count_two_dim_diag_test, poisson_log_exp_likelihood) {
 
   rng.seed(1954);
   Eigen::MatrixXd theta_pred_exp = laplace_latent_poisson_log_rng(
-      y, y_index, log(ye), stan::math::test::diagonal_kernel_functor{},
-      std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
+      y, y_index, log(ye), 1, stan::math::test::diagonal_kernel_functor{},
+      std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
 
   EXPECT_NEAR(theta_benchmark(0), theta_pred_exp(0), tol);
   EXPECT_NEAR(theta_benchmark(1), theta_pred_exp(1), tol);
@@ -84,8 +84,8 @@ TEST_F(laplace_count_two_dim_diag_test, poisson_log_exp_likelihood) {
   for (int i = 0; i < n_sim; i++) {
     rng.seed(2025 + i);
     Eigen::MatrixXd theta_pred = laplace_latent_poisson_log_rng(
-        y, y_index, log(ye), stan::math::test::diagonal_kernel_functor{},
-        std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
+        y, y_index, log(ye), 1, stan::math::test::diagonal_kernel_functor{},
+        std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
 
     theta_dim0(i) = theta_pred(0);
     theta_dim1(i) = theta_pred(1);

--- a/test/unit/math/laplace/laplace_poisson_log_rng_test.cpp
+++ b/test/unit/math/laplace/laplace_poisson_log_rng_test.cpp
@@ -24,7 +24,7 @@ TEST_F(laplace_count_two_dim_diag_test, poisson_log_likelihood) {
   rng.seed(1954);
   Eigen::MatrixXd theta_pred = laplace_latent_poisson_log_rng(
       y, y_index, 0, stan::math::test::diagonal_kernel_functor{},
-      std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
+      std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
 
   // double tol = 1e-3;
   EXPECT_NEAR(theta_benchmark(0), theta_pred(0), tol);
@@ -37,7 +37,7 @@ TEST_F(laplace_count_two_dim_diag_test, poisson_log_likelihood) {
     rng.seed(2025 + i);
     Eigen::MatrixXd theta_pred = laplace_latent_poisson_log_rng(
         y, y_index, 0, stan::math::test::diagonal_kernel_functor{},
-        std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
+        std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
 
     theta_dim0(i) = theta_pred(0);
     theta_dim1(i) = theta_pred(1);
@@ -74,7 +74,7 @@ TEST_F(laplace_count_two_dim_diag_test, poisson_log_exp_likelihood) {
   rng.seed(1954);
   Eigen::MatrixXd theta_pred_exp = laplace_latent_poisson_log_rng(
       y, y_index, log(ye), stan::math::test::diagonal_kernel_functor{},
-      std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
+      std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
 
   EXPECT_NEAR(theta_benchmark(0), theta_pred_exp(0), tol);
   EXPECT_NEAR(theta_benchmark(1), theta_pred_exp(1), tol);
@@ -85,7 +85,7 @@ TEST_F(laplace_count_two_dim_diag_test, poisson_log_exp_likelihood) {
     rng.seed(2025 + i);
     Eigen::MatrixXd theta_pred = laplace_latent_poisson_log_rng(
         y, y_index, log(ye), stan::math::test::diagonal_kernel_functor{},
-        std::forward_as_tuple(phi(0), phi(1)), rng, nullptr);
+        std::forward_as_tuple(phi(0), phi(1)), 1, rng, nullptr);
 
     theta_dim0(i) = theta_pred(0);
     theta_dim1(i) = theta_pred(1);

--- a/test/unit/math/laplace/laplace_types_test.cpp
+++ b/test/unit/math/laplace/laplace_types_test.cpp
@@ -94,7 +94,7 @@ TEST(laplace, theta_0_as_expression_issue_3196) {
       std::tuple<const std::vector<int>&, Eigen::Matrix<double, -1, 1>>(
           y, stan::math::add(stan::math::add(offset, alpha),
                              stan::math::multiply(X, beta))),
-      cov_fun(), std::tuple<double, int>(sigmaz, N), hessian_block_size,
+      hessian_block_size, cov_fun(), std::tuple<double, int>(sigmaz, N),
       std::tuple{stan::math::rep_vector(0.0, N), tolerance, max_num_steps,
                  solver_num, max_steps_line_search, 1},
       nullptr));
@@ -104,7 +104,7 @@ TEST(laplace, theta_0_as_expression_issue_3196) {
       std::tuple<const std::vector<int>&, Eigen::Matrix<double, -1, 1>>(
           y, stan::math::add(stan::math::add(offset, alpha),
                              stan::math::multiply(X, beta))),
-      cov_fun(), std::tuple(sigmaz, N), hessian_block_size,
+      hessian_block_size, cov_fun(), std::tuple(sigmaz, N),
       std::make_tuple(arena_init, tolerance, max_num_steps, solver_num,
                       max_steps_line_search, true),
       nullptr));
@@ -156,9 +156,8 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_tuple_extended) {
       return laplace_marginal_tol<false>(
           poisson_log_likelihood_tuple_expanded{},
           std::forward_as_tuple(sums, eta1_tuple, eta2, eta3),
-          stan::math::test::squared_kernel_functor{},
+          hessian_block_size, stan::math::test::squared_kernel_functor{},
           std::forward_as_tuple(x, std::make_tuple(phi_dbl(0), phi_dbl(1))),
-          hessian_block_size,
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);
@@ -223,9 +222,8 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_tuple) {
     try {
       return laplace_marginal_tol<false>(
           poisson_log_likelihood2{}, std::forward_as_tuple(sums),
-          stan::math::test::squared_kernel_functor{},
+          hessian_block_size, stan::math::test::squared_kernel_functor{},
           std::forward_as_tuple(x_v, std::make_tuple(alpha, rho)),
-          hessian_block_size,
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);
@@ -246,9 +244,8 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_tuple) {
       return laplace_marginal_tol<false>(
           poisson_log_likelihood_tuple{},
           std::forward_as_tuple(sums, std::make_tuple(eta1, eta2)),
-          stan::math::test::squared_kernel_functor{},
+          hessian_block_size, stan::math::test::squared_kernel_functor{},
           std::forward_as_tuple(x, std::make_tuple(alpha_rho(0), alpha_rho(1))),
-          hessian_block_size,
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);
@@ -330,8 +327,8 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_array_tuple) {
       return laplace_marginal_tol<false>(
           poisson_log_likelihood_array_tuple{},
           std::forward_as_tuple(sums, eta_tuple),
-          stan::math::test::squared_kernel_functor{},
-          std::forward_as_tuple(x, alpha_tuple), hessian_block_size,
+          hessian_block_size, stan::math::test::squared_kernel_functor{},
+          std::forward_as_tuple(x, alpha_tuple),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);

--- a/test/unit/math/laplace/laplace_types_test.cpp
+++ b/test/unit/math/laplace/laplace_types_test.cpp
@@ -95,8 +95,9 @@ TEST(laplace, theta_0_as_expression_issue_3196) {
           y, stan::math::add(stan::math::add(offset, alpha),
                              stan::math::multiply(X, beta))),
       cov_fun(), std::tuple<double, int>(sigmaz, N),
+      hessian_block_size,
       std::tuple{stan::math::rep_vector(0.0, N), tolerance, max_num_steps,
-                 hessian_block_size, solver_num, max_steps_line_search, 1},
+                 solver_num, max_steps_line_search, 1},
       nullptr));
   auto arena_init = stan::math::to_arena(stan::math::rep_vector(0.0, N));
   EXPECT_NO_THROW(stan::math::laplace_marginal_tol<false>(
@@ -105,8 +106,9 @@ TEST(laplace, theta_0_as_expression_issue_3196) {
           y, stan::math::add(stan::math::add(offset, alpha),
                              stan::math::multiply(X, beta))),
       cov_fun(), std::tuple(sigmaz, N),
-      std::make_tuple(arena_init, tolerance, max_num_steps, hessian_block_size,
-                      solver_num, max_steps_line_search, true),
+      hessian_block_size,
+      std::make_tuple(arena_init, tolerance, max_num_steps, solver_num,
+                      max_steps_line_search, true),
       nullptr));
 }
 
@@ -158,8 +160,9 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_tuple_extended) {
           std::forward_as_tuple(sums, eta1_tuple, eta2, eta3),
           stan::math::test::squared_kernel_functor{},
           std::forward_as_tuple(x, std::make_tuple(phi_dbl(0), phi_dbl(1))),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;
@@ -224,8 +227,9 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_tuple) {
           poisson_log_likelihood2{}, std::forward_as_tuple(sums),
           stan::math::test::squared_kernel_functor{},
           std::forward_as_tuple(x_v, std::make_tuple(alpha, rho)),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;
@@ -246,8 +250,9 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_tuple) {
           std::forward_as_tuple(sums, std::make_tuple(eta1, eta2)),
           stan::math::test::squared_kernel_functor{},
           std::forward_as_tuple(x, std::make_tuple(alpha_rho(0), alpha_rho(1))),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;
@@ -329,8 +334,9 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_array_tuple) {
           std::forward_as_tuple(sums, eta_tuple),
           stan::math::test::squared_kernel_functor{},
           std::forward_as_tuple(x, alpha_tuple),
-          std::make_tuple(theta_0, tolerance, max_num_steps, hessian_block_size,
-                          solver_num, max_steps_line_search, true),
+          hessian_block_size,
+          std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
+                          max_steps_line_search, true),
           &output_stream);
     } catch (const std::exception& e) {
       std::stringstream fail_msg;

--- a/test/unit/math/laplace/laplace_types_test.cpp
+++ b/test/unit/math/laplace/laplace_types_test.cpp
@@ -326,8 +326,8 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_array_tuple) {
       alpha_tuple.push_back(std::make_tuple(alpha_rho(0), alpha_rho(1)));
       return laplace_marginal_tol<false>(
           poisson_log_likelihood_array_tuple{},
-          std::forward_as_tuple(sums, eta_tuple),
-          hessian_block_size, stan::math::test::squared_kernel_functor{},
+          std::forward_as_tuple(sums, eta_tuple), hessian_block_size,
+          stan::math::test::squared_kernel_functor{},
           std::forward_as_tuple(x, alpha_tuple),
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),

--- a/test/unit/math/laplace/laplace_types_test.cpp
+++ b/test/unit/math/laplace/laplace_types_test.cpp
@@ -94,8 +94,7 @@ TEST(laplace, theta_0_as_expression_issue_3196) {
       std::tuple<const std::vector<int>&, Eigen::Matrix<double, -1, 1>>(
           y, stan::math::add(stan::math::add(offset, alpha),
                              stan::math::multiply(X, beta))),
-      cov_fun(), std::tuple<double, int>(sigmaz, N),
-      hessian_block_size,
+      cov_fun(), std::tuple<double, int>(sigmaz, N), hessian_block_size,
       std::tuple{stan::math::rep_vector(0.0, N), tolerance, max_num_steps,
                  solver_num, max_steps_line_search, 1},
       nullptr));
@@ -105,8 +104,7 @@ TEST(laplace, theta_0_as_expression_issue_3196) {
       std::tuple<const std::vector<int>&, Eigen::Matrix<double, -1, 1>>(
           y, stan::math::add(stan::math::add(offset, alpha),
                              stan::math::multiply(X, beta))),
-      cov_fun(), std::tuple(sigmaz, N),
-      hessian_block_size,
+      cov_fun(), std::tuple(sigmaz, N), hessian_block_size,
       std::make_tuple(arena_init, tolerance, max_num_steps, solver_num,
                       max_steps_line_search, true),
       nullptr));
@@ -333,8 +331,7 @@ TEST_P(laplace_types, poisson_log_phi_dim_2_array_tuple) {
           poisson_log_likelihood_array_tuple{},
           std::forward_as_tuple(sums, eta_tuple),
           stan::math::test::squared_kernel_functor{},
-          std::forward_as_tuple(x, alpha_tuple),
-          hessian_block_size,
+          std::forward_as_tuple(x, alpha_tuple), hessian_block_size,
           std::make_tuple(theta_0, tolerance, max_num_steps, solver_num,
                           max_steps_line_search, true),
           &output_stream);


### PR DESCRIPTION

## Summary

Based on feedback from @avehtari and @charlesm93, this moves `hessian_block_size` to be a non-optional argument for the laplace api. 

This also adds the `generate_laplace_options(Vector)` signature so users can pass
## Tests

Tests modified for new api but no new tests added. 

## Side Effects

For stanc3 we will have to update all the signatures for the PR to pass.

## Checklist

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
