### PR TITLE
Fix typos in error messages, comments

### DIFF
--- a/stan/math/fwd/fun/atan.hpp
+++ b/stan/math/fwd/fun/atan.hpp
@@ -22,7 +22,7 @@ inline fvar<T> atan(const fvar<T>& x) {
  *
  * @tparam T autodiff value type
  * @param[in] z argument
- * @return arc tanget of the argument
+ * @return arc tangent of the argument
  */
 template <typename T>
 inline std::complex<fvar<T>> atan(const std::complex<fvar<T>>& z) {

--- a/stan/math/fwd/fun/read_fvar.hpp
+++ b/stan/math/fwd/fun/read_fvar.hpp
@@ -32,7 +32,7 @@ class read_fvar_functor {
 
 /**
  * Function applying the read_fvar_functor to extract the values
- * and tangets of a given fvar matrix into separate matrices.
+ * and tangents of a given fvar matrix into separate matrices.
  *
  * @tparam EigFvar type of the Eigen container of fvar.
  * @tparam EigOut type of the Eigen containers to copy to

--- a/stan/math/fwd/functor/finite_diff.hpp
+++ b/stan/math/fwd/functor/finite_diff.hpp
@@ -51,7 +51,7 @@ inline auto aggregate_tangent(const FuncTangent& tangent, const InputArg& arg) {
 
 /**
  * Construct an fvar<T> where the tangent is calculated by finite-differencing.
- * Finite-differencing is only perfomed where the scalar type to be evaluated is
+ * Finite-differencing is only performed where the scalar type to be evaluated is
  * `fvar<T>.
  *
  * Higher-order inputs (i.e., fvar<var> & fvar<fvar<T>>) are also implicitly
@@ -95,7 +95,7 @@ inline auto finite_diff(const F& func, const TArgs&... args) {
 
 /**
  * Construct an fvar<T> where the tangent is calculated by finite-differencing.
- * Finite-differencing is only perfomed where the scalar type to be evaluated is
+ * Finite-differencing is only performed where the scalar type to be evaluated is
  * `fvar<T>.
  *
  * This overload is used when no fvar<T> arguments are passed and simply

--- a/stan/math/fwd/functor/finite_diff.hpp
+++ b/stan/math/fwd/functor/finite_diff.hpp
@@ -51,8 +51,8 @@ inline auto aggregate_tangent(const FuncTangent& tangent, const InputArg& arg) {
 
 /**
  * Construct an fvar<T> where the tangent is calculated by finite-differencing.
- * Finite-differencing is only performed where the scalar type to be evaluated is
- * `fvar<T>.
+ * Finite-differencing is only performed where the scalar type to be evaluated
+ * is `fvar<T>.
  *
  * Higher-order inputs (i.e., fvar<var> & fvar<fvar<T>>) are also implicitly
  * supported through auto-diffing the finite-differencing process.
@@ -95,8 +95,8 @@ inline auto finite_diff(const F& func, const TArgs&... args) {
 
 /**
  * Construct an fvar<T> where the tangent is calculated by finite-differencing.
- * Finite-differencing is only performed where the scalar type to be evaluated is
- * `fvar<T>.
+ * Finite-differencing is only performed where the scalar type to be evaluated
+ * is `fvar<T>.
  *
  * This overload is used when no fvar<T> arguments are passed and simply
  * evaluates the functor with the provided arguments.

--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -254,7 +254,7 @@ class stack_alloc {
   /**
    * Return number of bytes allocated to this instance by the heap.
    * This is not the same as the number of bytes allocated through
-   * calls to memalloc_.  The latter number is not calculatable
+   * calls to memalloc_.  The latter number is not calculable
    * because space is wasted at the end of blocks if the next
    * alloc request doesn't fit.  (Perhaps we could trim down to
    * what is actually used?)

--- a/stan/math/opencl/kernel_generator.hpp
+++ b/stan/math/opencl/kernel_generator.hpp
@@ -10,7 +10,7 @@
  * into a single OpenCL kernel. This is much simpler than writing
  * multi-operation kernels by hand.
  *
- * Because global GPU memory loads and stores are relativly slow compared to
+ * Because global GPU memory loads and stores are relatively slow compared to
  * calculations in a kernel, using one kernel for multiple operations is faster
  * than using one kernel per operation.
  *
@@ -27,13 +27,13 @@
  * Element-wise functions can be added using one of the macros in
  * `elt_functions.hpp`.
  *
- * New kernel generator classes must satsify the conditions below:
+ * New kernel generator classes must satisfy the conditions below:
  *
  * 1. The class must be derived from a class inheriting from `operation_cl`.
  * Optionally, if the operation should support being assigned to, it can be
  * derived from a class inheriting `operation_cl_lhs` instead.
  * 2. It's parent template arguments should be set to derived type, type of
- *  scalar and types of any expression arguements.
+ *  scalar and types of any expression arguments.
  * 3. Member type `Scalar` should be defined as scalar type of the result of
  * the operation.
  * 4. Member function `deep_copy` should make a copy of the expression.
@@ -97,7 +97,7 @@
  *
  * A new operation should also have a user-facing function that accepts
  * arguments to the operation and returns the operation object. Arguments should
- * be passed trough function `as_operation_cl` so that they are wrapped in
+ * be passed through function `as_operation_cl` so that they are wrapped in
  * operations if they are not operations themselves. If the operation defines
  * `modify_argument_indices` this function should make copies of arguments by
  * calling `deep_copy()` on them internally.

--- a/stan/math/opencl/kernel_generator/broadcast.hpp
+++ b/stan/math/opencl/kernel_generator/broadcast.hpp
@@ -61,7 +61,7 @@ class broadcast_
   }
 
   /**
-   * Sets index/indices along broadcasted dimmension(s) to 0.
+   * Sets index/indices along broadcasted dimension(s) to 0.
    * @param[in, out] row_index_name row index
    * @param[in, out] col_index_name column index
    */
@@ -129,7 +129,7 @@ inline auto broadcast(T&& a) {
 }
 
 /**
- * Broadcast an expression in rowwise dimmension. The argument must have single
+ * Broadcast an expression in rowwise dimension. The argument must have single
  * column. Further expressions can use this expression as if it had any number
  * of columns, repeating the values.
  *
@@ -147,7 +147,7 @@ inline auto rowwise_broadcast(T&& a) {
 }
 
 /**
- * Broadcast an expression in colwise dimmension. The argument must have single
+ * Broadcast an expression in colwise dimension. The argument must have single
  * row. Further expressions can use this expression as if it had any number of
  * rows, repeating the values.
  *

--- a/stan/math/opencl/kernel_generator/check_cl.hpp
+++ b/stan/math/opencl/kernel_generator/check_cl.hpp
@@ -142,7 +142,7 @@ class check_cl_ : public operation_cl_lhs<check_cl_<T>, bool> {
 
   /**
    * Adds all write events on any matrices used by nested expression to a list.
-   * Ignores read events anc clears no events.
+   * Ignores read events and clears no events.
    * @param[out] events List of all events.
    */
   inline void get_clear_read_write_events(
@@ -189,7 +189,7 @@ class check_cl_ : public operation_cl_lhs<check_cl_<T>, bool> {
   /**
    * Assignment of a scalar bool triggers the scalar check.
    * @param condition whether the state is ok.
-   * @throws std::domain_error condition is false (chack failed).
+   * @throws std::domain_error condition is false (check failed).
    */
   void operator=(bool condition);  // implemented in multi_result_kernel.hpp
 };

--- a/stan/math/opencl/kernel_generator/colwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/colwise_reduction.hpp
@@ -26,10 +26,10 @@ namespace internal {
 class colwise_reduction_base {};
 
 /**
- * Determine number of work groups in rows direction that will be run fro
+ * Determine number of work groups in rows direction that will be run for
  * colwise reduction of given size.
- * @param n_rows number of rows of expression to resuce
- * @param n_cols number of columns of expression to resuce
+ * @param n_rows number of rows of expression to reduce
+ * @param n_cols number of columns of expression to reduce
  * @return number of work groups in rows direction
  */
 inline int colwise_reduction_wgs_rows(int n_rows, int n_cols) {

--- a/stan/math/opencl/kernel_generator/constant.hpp
+++ b/stan/math/opencl/kernel_generator/constant.hpp
@@ -118,7 +118,7 @@ class constant_ : public operation_cl<constant_<T>, T> {
  *
  * In most cases scalars should be directly used instead of this. This is,
  * however, useful for initializing some expression to specific value if that
- * expresssion could also be plain `matrix_cl`.
+ * expression could also be plain `matrix_cl`.
  *
  * @tparam T type of argument
  * @param a input argument

--- a/stan/math/opencl/kernel_generator/elt_function_cl.hpp
+++ b/stan/math/opencl/kernel_generator/elt_function_cl.hpp
@@ -190,7 +190,7 @@ class elt_function_cl : public operation_cl<Derived, Scal, T...> {
 
 /**
  * Generates a class and function for an unary function, defined by OpenCL with
- * special property that it passes trough zero. That is \f$ f(0)=0 \f$. Such a
+ * special property that it passes through zero. That is \f$ f(0)=0 \f$. Such a
  * function can have triangular view equal to its argument's.
  * @param fun function name
  */

--- a/stan/math/opencl/kernel_generator/holder_cl.hpp
+++ b/stan/math/opencl/kernel_generator/holder_cl.hpp
@@ -74,7 +74,7 @@ namespace internal {
  * Second step in implementation of construction `holder_cl` from a functor.
  * @tparam T type of the result expression
  * @tparam Is index sequence for `ptrs`
- * @tparam Args types of pointes to heap
+ * @tparam Args types of points to heap
  * @param expr result expression
  * @param ptrs pointers to heap that need to be released when the expression is
  * destructed

--- a/stan/math/opencl/kernel_generator/matrix_cl_conversion.hpp
+++ b/stan/math/opencl/kernel_generator/matrix_cl_conversion.hpp
@@ -15,16 +15,16 @@ template <typename T>
 template <typename Expr,
           require_all_kernel_expressions_and_none_scalar_t<Expr>*,
           require_not_matrix_cl_t<Expr>*>
-matrix_cl<T>::matrix_cl(const Expr& expresion) : rows_(0), cols_(0) {
-  results(*this) = expressions(expresion);
+matrix_cl<T>::matrix_cl(const Expr& expression) : rows_(0), cols_(0) {
+  results(*this) = expressions(expression);
 }
 
 template <typename T>
 template <typename Expr,
           require_all_kernel_expressions_and_none_scalar_t<Expr>*,
           require_not_matrix_cl_t<Expr>*>
-matrix_cl<T>& matrix_cl<T>::operator=(const Expr& expresion) {
-  results(*this) = expressions(expresion);
+matrix_cl<T>& matrix_cl<T>::operator=(const Expr& expression) {
+  results(*this) = expressions(expression);
   return *this;
 }
 /** @}*/

--- a/stan/math/opencl/kernel_generator/opencl_code.hpp
+++ b/stan/math/opencl/kernel_generator/opencl_code.hpp
@@ -24,7 +24,7 @@ namespace math {
  */
 /**
  * Represents output variable of custom code in kernel generator expressions.
- * @tparam T_code intantiation of `opencl_code_` class template this is output
+ * @tparam T_code instantiation of `opencl_code_` class template this is output
  * of
  * @tparam T_scalar scalar type of the output variable
  */
@@ -319,7 +319,7 @@ class opencl_code_ : public operation_cl_base {
   }
 
   /**
-   * Get object representing output variable of ccustom code.
+   * Get object representing output variable of custom code.
    * @param var_name name of the variable output object represents
    */
   template <typename T_scalar>

--- a/stan/math/opencl/kernel_generator/optional_broadcast.hpp
+++ b/stan/math/opencl/kernel_generator/optional_broadcast.hpp
@@ -76,7 +76,7 @@ class optional_broadcast_
   }
 
   /**
-   * Sets index/indices along broadcasted dimmension(s) to 0.
+   * Sets index/indices along broadcasted dimension(s) to 0.
    * @param[in, out] row_idx_name row index
    * @param[in, out] col_idx_name  column index
    */
@@ -207,7 +207,7 @@ optional_broadcast(T&& a) {
 }
 
 /**
- * Broadcast an expression in rowwise dimmension if the number of columns equals
+ * Broadcast an expression in rowwise dimension if the number of columns equals
  * to 1. In that case further expressions can use this expression as if had any
  * number of columns, repeating the values.
  *
@@ -225,7 +225,7 @@ inline auto rowwise_optional_broadcast(T&& a) {
 }
 
 /**
- * Broadcast an expression in colwise dimmension if the number of rows equals
+ * Broadcast an expression in colwise dimension if the number of rows equals
  * to 1. In that case further expressions can use this expression as if had any
  * number of rows, repeating the values.
  *

--- a/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
@@ -59,7 +59,7 @@ struct matvec_mul_opt<elt_multiply_<Mat, broadcast_<VecT, true, false>>> {
   /**
    * Generates kernel code for the argument of rowwise reduction, applying the
    * optimization - ignoring the triangular view of the vector, as it is already
-   * handeled by rowwise reduction.
+   * handled by rowwise reduction.
    * @param mul argument of the rowwise reduction
    * @param[in,out] generated map from (pointer to) already generated local
    * operations to variable names
@@ -116,7 +116,7 @@ struct matvec_mul_opt<elt_multiply_<Mat, broadcast_<VecT, true, false>>> {
  * @tparam T type of first argument
  * @tparam operation type with member function generate that accepts two
  * variable names and returns OpenCL source code for reduction operation_cl
- * @tparam PassZero whether \c operation passes trough zeros
+ * @tparam PassZero whether \c operation passes through zeros
  */
 template <typename Derived, typename T, typename operation, bool PassZero>
 class rowwise_reduction

--- a/stan/math/opencl/kernels/mrrr.hpp
+++ b/stan/math/opencl/kernels/mrrr.hpp
@@ -202,7 +202,7 @@ static constexpr const char* get_eigenvectors_kernel_code = STRINGIFY(
     /**
      * Calculates shifted LDL and UDU factorizations. Combined with twist index
      * they form twisted factorization for calculation of an eigenvector
-     * corresponding to eigenvalue that is equal to the shift. Tha algorithm is
+     * corresponding to eigenvalue that is equal to the shift. The algorithm is
      * sometimes called diferential twisted quotient-differences with shifts
      * (dtwqds). L * D * L^T - shift * I = L+ * D+ * L+^T = U- * D- * U-^T D, D+
      * and D- are diagonal, L and L+ are lower unit triangular (diagonal

--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -62,7 +62,7 @@
  * `C` and `D`. When executing `C`'s operation, `A` and `B` are assigned
  * events to their read event stack while `C` is assigned an event to it's write
  *event stack. Once `A` and `B` have finished their write event the kernel to
- *compute `C` can begin. The excution to create `D` also waits for the write
+ *compute `C` can begin. The execution to create `D` also waits for the write
  *events of `A` and `B`, but does not have to wait for the execution of `C` to
  *finish. Executing `E` requires waiting for for the write events of both `C`
  *and `D`.

--- a/stan/math/opencl/prim/add_diag.hpp
+++ b/stan/math/opencl/prim/add_diag.hpp
@@ -19,7 +19,7 @@ namespace math {
  * @param mat input kernel generator expression
  * @param to_add scalar value or input kernel generator expression to add along
  * the diagonal
- * @return a kernel generator expressio with to_add added along main diagonal
+ * @return a kernel generator expression with to_add added along main diagonal
  */
 template <typename T_m, typename T_a,
           require_all_kernel_expressions_and_none_scalar_t<T_m>* = nullptr,

--- a/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
@@ -30,7 +30,7 @@ namespace math {
  * that is implemented in OpenCL.
  * @tparam T_y_cl type of independent variable;
  * this can be a `matrix_cl` vector of intercepts or a single
- * value (wich will be broadcast - used for all instances);
+ * value (which will be broadcast - used for all instances);
  * @tparam T_x_cl type of the design matrix
  * @tparam T_alpha_cl type of the intercept(s);
  * this can be a vector (of the same length as y) of intercepts or a single

--- a/stan/math/opencl/prim/beta_lpdf.hpp
+++ b/stan/math/opencl/prim/beta_lpdf.hpp
@@ -85,7 +85,7 @@ inline return_type_t<T_y_cl, T_scale_succ_cl, T_scale_fail_cl> beta_lpdf(
   auto alpha_beta_expr = alpha_val + beta_val;
 
   auto zero_expr
-      = as_operation_cl(0);  // simplifiy the kernel by only using one zero
+      = as_operation_cl(0);  // simplify the kernel by only using one zero
   auto logp_expr = colwise_sum(
       static_select<include_summand<propto, T_scale_succ_cl>::value>(
           -lgamma(alpha_val), zero_expr)

--- a/stan/math/opencl/prim/beta_proportion_lpdf.hpp
+++ b/stan/math/opencl/prim/beta_proportion_lpdf.hpp
@@ -30,7 +30,7 @@ namespace math {
  * @tparam T_loc_cl type of prior location
  * @tparam T_prec_cl type of prior precision
  *
- * @param y (Sequence of) dependant variable(s)
+ * @param y (Sequence of) dependent variable(s)
  * @param mu (Sequence of) location parameter(s)
  * @param kappa (Sequence of) precision parameter(s)
  * @return The log of the product of densities.

--- a/stan/math/opencl/prim/exp_mod_normal_lpdf.hpp
+++ b/stan/math/opencl/prim/exp_mod_normal_lpdf.hpp
@@ -46,7 +46,7 @@ exp_mod_normal_lpdf(const T_y_cl& y, const T_loc_cl& mu,
   using std::isnan;
 
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Inv_scale paramter",
+                         mu, "Scale parameter", sigma, "Inv_scale parameter",
                          lambda);
   const size_t N = max_size(y, mu, sigma, lambda);
   if (N == 0) {

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -38,7 +38,7 @@ namespace math {
  * prim/prob/neg_binomial_2_log_glm_lpdf.hpp that is implemented in OpenCL.
  * @tparam T_y_cl type of independent variable;
  * this can be a `matrix_cl` vector of intercepts or a single
- * value (wich will be broadcast - used for all instances);
+ * value (which will be broadcast - used for all instances);
  * @tparam T_x_cl type of the design matrix
  * @tparam T_alpha_cl type of the intercept(s);
  * this can be a vector (of the same length as y) of intercepts or a single

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -31,7 +31,7 @@ namespace math {
  * that is implemented in OpenCL.
  * @tparam T_y_cl type of independent variable;
  * this can be a `matrix_cl` vector of intercepts or a single
- * value (wich will be broadcast - used for all instances);
+ * value (which will be broadcast - used for all instances);
  * @tparam T_x_cl type of the design matrix
  * @tparam T_alpha_cl type of the intercept(s);
  * this can be a (optionally `var_value` containing) `matrix_cl` column vector

--- a/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
@@ -29,7 +29,7 @@ namespace math {
  * that is implemented in OpenCL.
  * @tparam T_y_cl type of independent variable;
  * this can be a `matrix_cl` vector of intercepts or a single
- * value (wich will be broadcast - used for all instances);
+ * value (which will be broadcast - used for all instances);
  * @tparam T_x_cl type of the design matrix
  * @tparam T_alpha_cl type of the intercept(s);
  * this can be a `matrix_cl` vector (of the same length as y) of intercepts or a

--- a/stan/math/opencl/prim/prod.hpp
+++ b/stan/math/opencl/prim/prod.hpp
@@ -13,7 +13,7 @@ namespace math {
 /**
  * Calculates product of given kernel generator expression elements.
  * @tparam T type of the expression
- * @param m expression to calcualte product of
+ * @param m expression to calculate product of
  * @return product of given expression
  */
 template <typename T,

--- a/stan/math/opencl/prim/skew_double_exponential_lpdf.hpp
+++ b/stan/math/opencl/prim/skew_double_exponential_lpdf.hpp
@@ -48,7 +48,7 @@ skew_double_exponential_lpdf(const T_y_cl& y, const T_loc_cl& mu,
   using std::isnan;
 
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Inv_scale paramter",
+                         mu, "Scale parameter", sigma, "Inv_scale parameter",
                          tau);
   const size_t N = max_size(y, mu, sigma, tau);
   if (N == 0) {

--- a/stan/math/opencl/prim/skew_normal_lpdf.hpp
+++ b/stan/math/opencl/prim/skew_normal_lpdf.hpp
@@ -49,7 +49,7 @@ inline return_type_t<T_y_cl, T_loc_cl, T_scale_cl, T_shape_cl> skew_normal_lpdf(
   using std::isnan;
 
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Shape paramter", alpha);
+                         mu, "Scale parameter", sigma, "Shape parameter", alpha);
   const size_t N = max_size(y, mu, sigma, alpha);
   if (N == 0) {
     return 0.0;

--- a/stan/math/opencl/prim/skew_normal_lpdf.hpp
+++ b/stan/math/opencl/prim/skew_normal_lpdf.hpp
@@ -49,7 +49,8 @@ inline return_type_t<T_y_cl, T_loc_cl, T_scale_cl, T_shape_cl> skew_normal_lpdf(
   using std::isnan;
 
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Shape parameter", alpha);
+                         mu, "Scale parameter", sigma, "Shape parameter",
+                         alpha);
   const size_t N = max_size(y, mu, sigma, alpha);
   if (N == 0) {
     return 0.0;

--- a/stan/math/opencl/rev/add_diag.hpp
+++ b/stan/math/opencl/rev/add_diag.hpp
@@ -22,7 +22,7 @@ namespace math {
  * @param mat input kernel generator expression
  * @param to_add scalar value or input kernel generator expression to add along
  * the diagonal
- * @return a kernel generator expressio with to_add added along main diagonal
+ * @return a kernel generator expression with to_add added along main diagonal
  */
 template <typename T_m, typename T_a,
           require_all_nonscalar_prim_or_rev_kernel_expression_t<T_m>* = nullptr,

--- a/stan/math/opencl/rev/arena_matrix_cl.hpp
+++ b/stan/math/opencl/rev/arena_matrix_cl.hpp
@@ -94,7 +94,7 @@ class arena_matrix_cl : public matrix_cl_base {
   matrix_cl<T> eval() const& { return *impl_; }
   matrix_cl<T> eval() && { return std::move(*impl_); }
 
-  // Wrapers to functions with explicit template parameters are implemented
+  // Wrappers to functions with explicit template parameters are implemented
   // without macros.
   template <matrix_cl_view matrix_view = matrix_cl_view::Entire>
   inline void zeros_strict_tri() {

--- a/stan/math/opencl/tridiagonalization.hpp
+++ b/stan/math/opencl/tridiagonalization.hpp
@@ -20,7 +20,7 @@ namespace internal {
  * @param A Input matrix
  * @param[out] packed Packed form of the tridiagonal matrix. Elements of the
  * resulting symmetric tridiagonal matrix T are in the diagonal and first
- * superdiagonal. Columns bellow diagonal contain householder vectors that can
+ * superdiagonal. Columns below diagonal contain householder vectors that can
  * be used to construct orthogonal matrix Q.
  * @param r Block size. Affects only performance of the algorithm. Optimal value
  * depends on the size of A and cache of the processor. For larger matrices or
@@ -89,7 +89,7 @@ inline void block_householder_tridiag_cl(const matrix_cl<double>& A,
  * as input A.
  *
  * @param packed_cl Packed result of tridiagonalization that contains
- * householder vectors that define Q in columns bellow the diagonal. Usually
+ * householder vectors that define Q in columns below the diagonal. Usually
  * result of a call to `block_householder_tridiag_cl`.
  * @param[in,out] A On input a matrix to multiply with Q. On output the product
  * Q*A.

--- a/stan/math/prim/constraint/cholesky_corr_constrain.hpp
+++ b/stan/math/prim/constraint/cholesky_corr_constrain.hpp
@@ -100,7 +100,7 @@ inline auto cholesky_corr_constrain(T&& y, int K) {
  * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
  * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @tparam Lp Scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param y Linearly Serialized vector of size `(K * (K - 1))/2` holding the
  *  column major order elements of the lower triangurlar
  * @param K The size of the matrix to return
@@ -126,7 +126,7 @@ inline auto cholesky_corr_constrain(T&& y, int K, Lp& lp) {
  *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
  *  and 1 column, or a standard vector thereof
  * @tparam Lp A scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param y Linearly Serialized vector of size `(K * (K - 1))/2` holding the
  *  column major order elements of the lower triangurlar
  * @param K The size of the matrix to return

--- a/stan/math/prim/constraint/cholesky_factor_constrain.hpp
+++ b/stan/math/prim/constraint/cholesky_factor_constrain.hpp
@@ -117,7 +117,7 @@ inline auto cholesky_factor_constrain(T&& x, int M, int N) {
  * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
  * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @tparam Lp Scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x Vector of unconstrained values
  * @param M number of rows
  * @param N number of columns
@@ -148,7 +148,7 @@ inline auto cholesky_factor_constrain(T&& x, int M, int N, Lp& lp) {
  *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
  *  and 1 column
  * @tparam Lp A scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x Vector of unconstrained values
  * @param M number of rows
  * @param N number of columns

--- a/stan/math/prim/constraint/corr_matrix_constrain.hpp
+++ b/stan/math/prim/constraint/corr_matrix_constrain.hpp
@@ -62,7 +62,7 @@ corr_matrix_constrain(T&& x, Eigen::Index k) {
  * @tparam T type of the vector (must be derived from \c Eigen::MatrixBase and
  * have one compile-time dimension equal to 1)
  * @tparam Lp A scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x Vector of unconstrained partial correlations.
  * @param k Dimensionality of returned correlation matrix.
  * @param lp Log probability reference to increment.
@@ -108,7 +108,7 @@ inline auto corr_matrix_constrain(T&& y, int K) {
  * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
  * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @tparam Lp Scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param y Vector of unconstrained partial correlations
  * @param K Dimensionality of returned correlation matrix
  * @param[in, out] lp log density accumulator o
@@ -137,7 +137,7 @@ inline auto corr_matrix_constrain(T&& y, int K, Lp& lp) {
  *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
  *  and 1 column or standard vector thereof
  * @tparam Lp A scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x Vector of unconstrained partial correlations
  * @param k Dimensionality of returned correlation matrix
  * @param[in,out] lp log density accumulator

--- a/stan/math/prim/constraint/cov_matrix_constrain.hpp
+++ b/stan/math/prim/constraint/cov_matrix_constrain.hpp
@@ -56,7 +56,7 @@ cov_matrix_constrain(const T& x, Eigen::Index K) {
  * @tparam T type of the vector (must be derived from \c Eigen::MatrixBase and
  * have one compile-time dimension equal to 1)
  * @tparam Lp A scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x The vector to convert to a covariance matrix.
  * @param K The dimensions of the resulting covariance matrix.
  * @param lp Reference
@@ -117,7 +117,7 @@ inline auto cov_matrix_constrain(T&& x, Eigen::Index K) {
  * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
  * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @tparam Lp Scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x The vector to convert to a covariance matrix
  * @param K The dimensions of the resulting covariance matrix
  * @param[in, out] lp log density accumulator
@@ -145,7 +145,7 @@ inline auto cov_matrix_constrain(T&& x, Eigen::Index K, Lp& lp) {
  *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
  *  and 1 column, or standard vector thereof
  * @tparam Lp A scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x The vector to convert to a covariance matrix
  * @param K The dimensions of the resulting covariance matrix
  * @param[in, out] lp log density accumulator

--- a/stan/math/prim/constraint/lub_constrain.hpp
+++ b/stan/math/prim/constraint/lub_constrain.hpp
@@ -387,7 +387,7 @@ inline auto lub_constrain(const std::vector<T>& x, const std::vector<L>& lb,
  * type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
  * @tparam U A type inheriting from `Eigen::EigenBase`, a `var_value` with inner
  * type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
- * @tparam Lp Scalar, convertable from the scalar types of T, L, and U
+ * @tparam Lp Scalar, convertible from the scalar types of T, L, and U
  * @param[in] x Free scalar to transform
  * @param[in] lb Lower bound
  * @param[in] ub Upper bound

--- a/stan/math/prim/constraint/offset_multiplier_constrain.hpp
+++ b/stan/math/prim/constraint/offset_multiplier_constrain.hpp
@@ -80,7 +80,7 @@ inline auto offset_multiplier_constrain(const T& x, const M& mu,
  * @tparam T type of scalar
  * @tparam M type of offset
  * @tparam S type of multiplier
- * @tparam Lp Scalar type, convertable from T, M, and S
+ * @tparam Lp Scalar type, convertible from T, M, and S
  * @param[in] x Unconstrained scalar input
  * @param[in] mu offset of constrained output
  * @param[in] sigma multiplier of constrained output
@@ -291,7 +291,7 @@ inline auto offset_multiplier_constrain(const std::vector<T>& x,
  * type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
  * @tparam S A type inheriting from `Eigen::EigenBase`, a `var_value` with inner
  * type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
- * @tparam Lp Scalar, the scalar types of T, M, and S should be convertable to
+ * @tparam Lp Scalar, the scalar types of T, M, and S should be convertible to
  * this
  * @param[in] x Unconstrained scalar input
  * @param[in] mu offset of constrained output

--- a/stan/math/prim/constraint/ordered_constrain.hpp
+++ b/stan/math/prim/constraint/ordered_constrain.hpp
@@ -47,7 +47,7 @@ inline plain_type_t<EigVec> ordered_constrain(EigVec&& x) {
  *
  * @tparam T type of the vector
  * @tparam Lp A scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x Free vector of scalars.
  * @param lp Log probability reference.
  * @return Positive, increasing ordered vector.
@@ -92,7 +92,7 @@ inline auto ordered_constrain(T&& x) {
  * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
  * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @tparam Lp Scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x Free vector of scalars
  * @param[in, out] lp log density accumulator or empty
  * @return Positive, increasing ordered vector.
@@ -120,7 +120,7 @@ inline auto ordered_constrain(T&& x, Lp& lp) {
  *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
  *  and 1 column, or a standard vector thereof
  * @tparam Lp A scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x Free vector of scalars
  * @param[in, out] lp log density accumulator
  * @return Positive, increasing ordered vector.

--- a/stan/math/prim/constraint/positive_constrain.hpp
+++ b/stan/math/prim/constraint/positive_constrain.hpp
@@ -59,7 +59,7 @@ inline auto positive_constrain(T&& x, S& lp) {
  * @tparam T A type inheriting from `Eigen::EigenBase`, a `var_value` with inner
  * type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
  * @tparam Lp A scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x unconstrained value or container
  * @param[in, out] lp log density accumulator
  * @return positive constrained version of unconstrained value(s)
@@ -88,7 +88,7 @@ inline auto positive_constrain(T&& x, Lp& lp) {
  * `Eigen::EigenBase`, a `var_value` with inner type inheriting from
  * `Eigen::EigenBase`, a standard vector, or a scalar
  * @tparam Lp A scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x unconstrained value or container
  * @param[in, out] lp log density accumulator
  * @return positive constrained version of unconstrained value(s)

--- a/stan/math/prim/constraint/positive_ordered_constrain.hpp
+++ b/stan/math/prim/constraint/positive_ordered_constrain.hpp
@@ -45,7 +45,7 @@ inline auto positive_ordered_constrain(const EigVec& x) {
  *
  * @tparam Vec type of the vector
  * @tparam Lp A scalar type for the lp argument. The scalar type of Vec should
- * be convertable to this.
+ * be convertible to this.
  * @param x Free vector of scalars.
  * @param lp Log probability reference.
  * @return Positive, increasing ordered vector.
@@ -86,7 +86,7 @@ inline auto positive_ordered_constrain(T&& x) {
  * `Eigen::EigenBase`, a `var_value` with inner type inheriting from
  * `Eigen::EigenBase`
  * @tparam Lp Scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param x Free vector of scalars
  * @param[in, out] lp log density accumulator
  * @return Positive, increasing ordered vector
@@ -113,9 +113,9 @@ inline auto positive_ordered_constrain(T&& x, Lp& lp) {
  * @tparam Vec A type inheriting from `Eigen::EigenBase`, a `var_value` with
  * inner type inheriting from `Eigen::EigenBase`, or a vector thereof
  * @tparam Lp A scalar type for the lp argument. The scalar type of Vec should
- * be convertable to this.
+ * be convertible to this.
  * @param x Free vector of scalars
- * @param[in, out] lp log density accumulato
+ * @param[in, out] lp log density accumulation
  * @return Positive, increasing ordered vector
  */
 template <bool Jacobian, typename Vec, typename Lp,

--- a/stan/math/prim/constraint/simplex_constrain.hpp
+++ b/stan/math/prim/constraint/simplex_constrain.hpp
@@ -83,7 +83,7 @@ inline plain_type_t<Vec> simplex_constrain(const Vec& y) {
  *
  * @tparam Vec type of the vector
  * @tparam Lp A scalar type for the lp argument. The scalar type of Vec should
- * be convertable to this.
+ * be convertible to this.
  * @param y Free vector input of dimensionality K - 1.
  * @param lp Log probability reference to increment.
  * @return Simplex of dimensionality K.
@@ -159,7 +159,7 @@ inline auto simplex_constrain(T&& y) {
  * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
  * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @tparam Lp Scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param[in] y free vector
  * @param[in, out] lp log density accumulator
  * @return simplex of dimensionality one greater than `y`
@@ -185,7 +185,7 @@ inline auto simplex_constrain(T&& y, Lp& lp) {
  *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
  *  and 1 column
  * @tparam Lp A scalar type for the lp argument. The scalar type of Vec should
- * be convertable to this.
+ * be convertible to this.
  * @param[in] y free vector
  * @param[in, out] lp log density accumulator
  * @return simplex of dimensionality one greater than `y`

--- a/stan/math/prim/constraint/stochastic_column_constrain.hpp
+++ b/stan/math/prim/constraint/stochastic_column_constrain.hpp
@@ -41,7 +41,7 @@ inline plain_type_t<Mat> stochastic_column_constrain(const Mat& y) {
  *
  * @tparam Mat type of the Matrix
  * @tparam Lp A scalar type for the lp argument. The scalar type of Mat should
- * be convertable to this.
+ * be convertible to this.
  * @param y Free Matrix input of dimensionality (K - 1, M)
  * @param lp Log probability reference to increment.
  * @return Matrix with stochastic columns of dimensionality (K, M)
@@ -85,7 +85,7 @@ inline auto stochastic_column_constrain(T&& y) {
  * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
  * `Eigen::DenseBase` with compile time dynamic rows and dynamic columns
  * @tparam Lp Scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param[in] y free vector
  * @param[in, out] lp log density accumulator
  * @return Standard vector containing matrices with simplex columns of
@@ -112,7 +112,7 @@ inline auto stochastic_column_constrain(T&& y, Lp& lp) {
  *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
  *  and dynamic columns, or a standard vector thereof
  * @tparam Lp A scalar type for the lp argument. The scalar type of Mat should
- * be convertable to this.
+ * be convertible to this.
  * @param y Free Matrix input of dimensionality (K - 1, M).
  * @param[in, out] lp log density accumulator
  * @return Matrix with simplex columns of dimensionality (K, M).

--- a/stan/math/prim/constraint/stochastic_row_constrain.hpp
+++ b/stan/math/prim/constraint/stochastic_row_constrain.hpp
@@ -38,7 +38,7 @@ inline plain_type_t<Mat> stochastic_row_constrain(const Mat& y) {
  *
  * @tparam Mat type of the matrix
  * @tparam Lp A scalar type for the lp argument. The scalar type of Mat should
- * be convertable to this.
+ * be convertible to this.
  * @param y Free matrix input of dimensionality (N, K - 1).
  * @param lp Log probability reference to increment.
  * @return Matrix with simplexes along the rows of dimensionality (N, K).
@@ -82,7 +82,7 @@ inline auto stochastic_row_constrain(T&& y) {
  * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
  * `Eigen::DenseBase` with compile time dynamic rows and dynamic columns
  * @tparam Lp Scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param[in] y free vector with matrices of size (N, K - 1)
  * @param[in, out] lp log density accumulator
  * @return vector of matrices with simplex rows of dimensionality (N, K)
@@ -108,7 +108,7 @@ inline auto stochastic_row_constrain(T&& y, Lp& lp) {
  *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
  *  and dynamic columns, or a standard vector thereof
  * @tparam Lp A scalar type for the lp argument. The scalar type of Mat should
- * be convertable to this.
+ * be convertible to this.
  * @param[in] y free matrix
  * @param[in, out] lp log density accumulator
  * @return Matrix with simplexes along the rows of dimensionality (N, K).

--- a/stan/math/prim/constraint/ub_constrain.hpp
+++ b/stan/math/prim/constraint/ub_constrain.hpp
@@ -56,7 +56,7 @@ inline auto ub_constrain(const T& x, const U& ub) {
  *
  * @tparam T type of scalar
  * @tparam U type of upper bound
- * @tparam Lp Scalar, should be convertable from T and U
+ * @tparam Lp Scalar, should be convertible from T and U
  * @param[in] x free scalar
  * @param[in] ub upper bound
  * @param[in,out] lp log density
@@ -98,7 +98,7 @@ inline auto ub_constrain(const T& x, const U& ub) {
  *
  * @tparam T A type inheriting from `EigenBase`.
  * @tparam U Scalar.
- * @tparam Lp Scalar, should be convertable from U and the scalar type of T.
+ * @tparam Lp Scalar, should be convertible from U and the scalar type of T.
  * @param[in] x unconstrained input
  * @param[in] ub upper bound on output
  * @param[in,out] lp reference to log probability to increment
@@ -137,7 +137,7 @@ inline auto ub_constrain(const T& x, const U& ub) {
  *
  * @tparam T A type inheriting from `EigenBase`.
  * @tparam U A type inheriting from `EigenBase`.
- * @tparam Lp Scalar, should be convertable from the scalar types of T and U.
+ * @tparam Lp Scalar, should be convertible from the scalar types of T and U.
  * @param[in] x unconstrained input
  * @param[in] ub upper bound on output
  * @param[in,out] lp reference to log probability to increment
@@ -178,7 +178,7 @@ inline auto ub_constrain(const std::vector<T>& x, const U& ub) {
  *
  * @tparam T A Any type with a Scalar `scalar_type`.
  * @tparam U Scalar.
- * @tparam Lp Scalar, should be convertable from T and U.
+ * @tparam Lp Scalar, should be convertible from T and U.
  * @param[in] x unconstrained input
  * @param[in] ub upper bound on output
  * @param[in,out] lp reference to log probability to increment
@@ -221,7 +221,7 @@ inline auto ub_constrain(const std::vector<T>& x, const std::vector<U>& ub) {
  *
  * @tparam T A Any type with a Scalar `scalar_type`.
  * @tparam U A type inheriting from `EigenBase` or a standard vector.
- * @tparam Lp Scalar, should be convertable from T and the scalar type of U
+ * @tparam Lp Scalar, should be convertible from T and the scalar type of U
  * @param[in] x unconstrained input
  * @param[in] ub upper bound on output
  * @param[in,out] lp reference to log probability to increment
@@ -253,7 +253,7 @@ inline auto ub_constrain(const std::vector<T>& x, const std::vector<U>& ub,
  * @tparam U A type inheriting from `Eigen::EigenBase`, a `var_value` with inner
  * type inheriting from `Eigen::EigenBase`, a standard vector, or a scalar
  * @tparam Lp A scalar type for the lp argument. The scalar type of T and U
- * should be convertable to this.
+ * should be convertible to this.
  * @param[in] x unconstrained input
  * @param[in] ub upper bound on output
  * @param[in, out] lp log density accumulator

--- a/stan/math/prim/constraint/unit_vector_constrain.hpp
+++ b/stan/math/prim/constraint/unit_vector_constrain.hpp
@@ -80,7 +80,7 @@ inline auto unit_vector_constrain(T&& y) {
  * `Eigen::DenseBase` or a `var_value` with inner type inheriting from
  * `Eigen::DenseBase` with compile time dynamic rows and 1 column
  * @tparam Lp Scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param y vector of K unrestricted variables
  * @param[in, out] lp log density accumulator
  * @return Unit length vector of dimension K
@@ -106,7 +106,7 @@ inline auto unit_vector_constrain(T&& y, Lp& lp) {
  *  inner type inheriting from `Eigen::DenseBase` with compile time dynamic rows
  *  and 1 column
  * @tparam Lp A scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param y vector of K unrestricted variables
  * @param[in, out] lp log density accumulator
  * @return Unit length vector of dimension K

--- a/stan/math/prim/err/check_cholesky_factor_corr.hpp
+++ b/stan/math/prim/err/check_cholesky_factor_corr.hpp
@@ -60,7 +60,7 @@ inline void check_cholesky_factor_corr(const char* function, const char* name,
  * be equal to 1
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
- * @param y Standard vector of matrics to test
+ * @param y Standard vector of matrices to test
  * @throw `std::domain_error` if y[i] is not a valid Cholesky factor, if number
  * of rows is less than the number of columns, if there are 0 columns, or if any
  * element in matrix is NaN

--- a/stan/math/prim/err/check_flag_sundials.hpp
+++ b/stan/math/prim/err/check_flag_sundials.hpp
@@ -155,9 +155,9 @@ inline std::array<std::string, 2> cvodes_flag_msg(int flag) {
                  "checkpoint"};
           break;  // NOLINT
         case -106:
-          msg = {
-              "CV_FWD_FAIL",
-              "An error occurred during the integration of the forward problem"};
+          msg = {"CV_FWD_FAIL",
+                 "An error occurred during the integration of the forward "
+                 "problem"};
           break;  // NOLINT
         case -107:
           msg = {"CV_BAD_ITASK", "Wrong task for backward integration"};

--- a/stan/math/prim/err/check_flag_sundials.hpp
+++ b/stan/math/prim/err/check_flag_sundials.hpp
@@ -15,7 +15,7 @@ namespace math {
 #define CHECK_KINSOL_CALL(call) kinsol_check(call, #call)
 
 /**
- * Map cvodes error flag to acutally error msg. The most frequent
+ * Map cvodes error flag to actually error msg. The most frequent
  * errors are put at the top. An alternative would be to use std::map
  * but in our case the difference would be negligible. Note that we
  * don't use CVGetReturnFlagName function to retrieve the constant
@@ -23,7 +23,7 @@ namespace math {
  *
  * @param flag
  *
- * @return error msg string constant and actuall informative msg
+ * @return error msg string constant and actually informative msg
  */
 inline std::array<std::string, 2> cvodes_flag_msg(int flag) {
   std::array<std::string, 2> msg;
@@ -57,7 +57,7 @@ inline std::array<std::string, 2> cvodes_flag_msg(int flag) {
       break;  // NOLINT
     case -10:
       msg = {"CV_REPTD_RHSFUNC_ERR",
-             "The right-hand side function had repetead recoverable errors"};
+             "The right-hand side function had repeated recoverable errors"};
       break;  // NOLINT
     case -11:
       msg = {"CV_UNREC_RHSFUNC_ERR",
@@ -129,7 +129,7 @@ inline std::array<std::string, 2> cvodes_flag_msg(int flag) {
           break;  // NOLINT
         case -44:
           msg = {"CV_REPTD_SRHSFUNC_ER",
-                 "The sensitivity ight-hand side function had repetead "
+                 "The sensitivity right-hand side function had repeated "
                  "recoverable errors"};
           break;  // NOLINT
         case -45:
@@ -157,7 +157,7 @@ inline std::array<std::string, 2> cvodes_flag_msg(int flag) {
         case -106:
           msg = {
               "CV_FWD_FAIL",
-              "An error occured during the integration of the forward problem"};
+              "An error occurred during the integration of the forward problem"};
           break;  // NOLINT
         case -107:
           msg = {"CV_BAD_ITASK", "Wrong task for backward integration"};

--- a/stan/math/prim/err/check_positive_ordered.hpp
+++ b/stan/math/prim/err/check_positive_ordered.hpp
@@ -41,7 +41,7 @@ inline void check_positive_ordered(const char* function, const char* name,
           << " The element at " << stan::error_index::value << " is ";
       std::string msg_str(msg.str());
       throw_domain_error(function, name, value_of_rec(to_ref(y).coeff(0)),
-                         msg_str.c_str(), ", but should be postive.");
+                         msg_str.c_str(), ", but should be positive.");
     }();
   }
   check_ordered(function, name, y_ref);

--- a/stan/math/prim/err/elementwise_check.hpp
+++ b/stan/math/prim/err/elementwise_check.hpp
@@ -71,7 +71,7 @@ inline void pipe_in(std::stringstream& ss) {}
  * @tparam Args types of remaining arguments
  * @param ss stringstream to pipe arguments in
  * @param arg0 the first argument
- * @param args remining arguments
+ * @param args remaining arguments
  */
 template <typename Arg0, typename... Args>
 inline void pipe_in(std::stringstream& ss, Arg0 arg0, const Args... args) {

--- a/stan/math/prim/err/hmm_check.hpp
+++ b/stan/math/prim/err/hmm_check.hpp
@@ -10,7 +10,7 @@ namespace math {
 /**
  * Check arguments for hidden Markov model functions with a discrete
  * latent state (lpdf, rng for latent states, and marginal probabilities
- * for latent sates).
+ * for latent states).
  *
  * @tparam T_omega type of the log likelihood matrix
  * @tparam T_Gamma type of the transition matrix

--- a/stan/math/prim/fun/as_column_vector_or_scalar.hpp
+++ b/stan/math/prim/fun/as_column_vector_or_scalar.hpp
@@ -25,7 +25,7 @@ inline T as_column_vector_or_scalar(const T& a) {
 
 /**
  * No-op used when working with operands and partials.
- * This is not implimented so it cannot be invoked and only exists so the
+ * This is not implemented so it cannot be invoked and only exists so the
  * compiler can resolve it's output type.
  */
 template <typename T, typename S>

--- a/stan/math/prim/fun/copysign.hpp
+++ b/stan/math/prim/fun/copysign.hpp
@@ -55,7 +55,7 @@ inline T copysign_non_zero(const T& x, const U& y) {
  * with signs copied from the real and complex parts of the first
  * arguments to the real and complex parts of the second.
  *
- * This is an overload of the standard libary `copysign` for complex
+ * This is an overload of the standard library `copysign` for complex
  * numbers that will be used with argument-dependent lookup.  Rather
  * than using the standard library `copysign`, it uses
  * `copysign_non_zero`, which does not change sign if the reference

--- a/stan/math/prim/fun/diag_matrix.hpp
+++ b/stan/math/prim/fun/diag_matrix.hpp
@@ -12,7 +12,7 @@ namespace math {
  * coefficients as the diagonal values.
  *
  * @tparam EigVec type of the vector (must be derived from \c Eigen::MatrixBase
- * and have one compile time dimmension equal to 1)
+ * and have one compile time dimension equal to 1)
  * @param[in] v Specified vector.
  * @return Diagonal matrix with vector as diagonal values.
  */

--- a/stan/math/prim/fun/fft.hpp
+++ b/stan/math/prim/fun/fft.hpp
@@ -101,7 +101,7 @@ inline Eigen::Matrix<scalar_type_t<M>, -1, -1> fft2(const M& x) {
  * FFT and inverse FFT (or vice-versa) is the identity.
  *
  * @tparam M type of complex matrix argument
- * @param[in] y matrix to inverse trnasform
+ * @param[in] y matrix to inverse transform
  * @return inverse discrete 2D Fourier transform of `y`
  */
 template <typename M, require_eigen_dense_dynamic_vt<is_complex, M>* = nullptr,

--- a/stan/math/prim/fun/get_base1.hpp
+++ b/stan/math/prim/fun/get_base1.hpp
@@ -211,7 +211,7 @@ inline const T& get_base1(
  * @param i5 Fifth index plus 1.
  * @param i6 Sixth index plus 1.
  * @param i7 Seventh index plus 1.
- * @param i8 Eigth index plus 1.
+ * @param i8 Eighth index plus 1.
  * @param error_msg Error message if an index is out of range.
  * @param idx Nested index level to report in error message if
  * the index is out of range.

--- a/stan/math/prim/fun/get_base1_lhs.hpp
+++ b/stan/math/prim/fun/get_base1_lhs.hpp
@@ -208,7 +208,7 @@ inline T& get_base1_lhs(
  * @param i5 Fifth index plus 1.
  * @param i6 Sixth index plus 1.
  * @param i7 Seventh index plus 1.
- * @param i8 Eigth index plus 1.
+ * @param i8 Eighth index plus 1.
  * @param error_msg Error message if an index is out of range.
  * @param idx Nested index level to report in error message if
  * the index is out of range.

--- a/stan/math/prim/fun/i_times.hpp
+++ b/stan/math/prim/fun/i_times.hpp
@@ -9,12 +9,12 @@ namespace math {
 /**
  * Return the specified complex number multiplied by `i`.
  *
- * This compound function is more efficient than mulitplying by a
+ * This compound function is more efficient than multiplying by a
  * constant `i` because it involves only a single arithmetic negation.
  *
  * @tparam value type of complex argument
  * @param[in] z complex argument
- * @return argument multipled by `i`
+ * @return argument multiplied by `i`
  */
 template <typename T>
 inline std::complex<T> i_times(const std::complex<T>& z) {
@@ -24,13 +24,13 @@ inline std::complex<T> i_times(const std::complex<T>& z) {
 /**
  * Return the specified complex number multiplied by `-i`.
  *
- * This compound function is more efficient than mulitplying by the
+ * This compound function is more efficient than multiplying by the
  * constant `-i` because it involves only a single arithmetic
  * negation.
  *
  * @tparam value type of complex argument
  * @param[in] z complex argument
- * @return argument multipled by `-i`
+ * @return argument multiplied by `-i`
  */
 template <typename T>
 inline std::complex<T> neg_i_times(const std::complex<T>& z) {

--- a/stan/math/prim/fun/matrix_exp_pade.hpp
+++ b/stan/math/prim/fun/matrix_exp_pade.hpp
@@ -35,9 +35,9 @@ matrix_exp_pade(const EigMat& arg) {
   Eigen::matrix_exp_computeUV<MatrixType>::run(arg, U, V, squarings, arg(0, 0));
   // Pade approximant is
   // (U+V) / (-U+V)
-  MatrixType numer = U + V;
+  MatrixType number = U + V;
   MatrixType denom = -U + V;
-  MatrixType pade_approximation = denom.partialPivLu().solve(numer);
+  MatrixType pade_approximation = denom.partialPivLu().solve(number);
   for (int i = 0; i < squarings; ++i) {
     pade_approximation *= pade_approximation;  // undo scaling by
   }

--- a/stan/math/prim/fun/read_corr_L.hpp
+++ b/stan/math/prim/fun/read_corr_L.hpp
@@ -90,7 +90,7 @@ read_corr_L(const T& CPCs,  // on (-1, 1)
  * @tparam T type of the array (must be derived from \c Eigen::ArrayBase and
  * have one compile-time dimension equal to 1)
  * @tparam Lp A scalar type for the lp argument. The scalar type of T should be
- * convertable to this.
+ * convertible to this.
  * @param CPCs The (K choose 2) canonical partial correlations in
  * (-1, 1).
  * @param K Dimensionality of correlation matrix.

--- a/stan/math/prim/fun/read_corr_matrix.hpp
+++ b/stan/math/prim/fun/read_corr_matrix.hpp
@@ -45,7 +45,7 @@ read_corr_matrix(const T_CPCs& CPCs, size_t K) {
  * @tparam T_CPCs type of the array (must be derived from \c Eigen::ArrayBase
  * and have one compile-time dimension equal to 1)
  * @tparam Lp A scalar type for the lp argument. The scalar type of T_CPCs
- * should be convertable to this.
+ * should be convertible to this.
  * @param CPCs The (K choose 2) canonical partial correlations in
  * (-1, 1).
  * @param K Dimensionality of correlation matrix.

--- a/stan/math/prim/fun/rep_array.hpp
+++ b/stan/math/prim/fun/rep_array.hpp
@@ -34,7 +34,7 @@ inline std::vector<std::vector<std::vector<plain_type_t<In>>>> rep_array(
     const In& x, int k, int m, int n) {
   using std::vector;
   using T = plain_type_t<In>;
-  check_nonnegative("rep_array", "shelfs", k);
+  check_nonnegative("rep_array", "shelves", k);
   check_nonnegative("rep_array", "rows", m);
   check_nonnegative("rep_array", "cols", n);
   return vector<vector<vector<T>>>(k, vector<vector<T>>(m, vector<T>(n, x)));

--- a/stan/math/prim/fun/rep_matrix.hpp
+++ b/stan/math/prim/fun/rep_matrix.hpp
@@ -13,7 +13,7 @@ namespace math {
  * type equal to the input scalar type.
  * @tparam Ret An Eigen type.
  * @tparam T A Scalar type.
- * @param x A Scalar whose values are propogated to all values in the return
+ * @param x A Scalar whose values are propagated to all values in the return
  * matrix.
  * @param m Number or rows.
  * @param n Number of columns.
@@ -31,7 +31,7 @@ inline auto rep_matrix(const T& x, int m, int n) {
  * Default Implementation of rep_matrix returning an Eigen matrix with scalar
  * type equal to the input scalar type.
  * @tparam T A Scalar type.
- * @param x A Scalar whose values are propogated to all values in the return
+ * @param x A Scalar whose values are propagated to all values in the return
  * matrix.
  * @param m Number or rows.
  * @param n Number of columns.
@@ -46,7 +46,7 @@ inline auto rep_matrix(const T& x, int m, int n) {
  * Implementation of rep_matrix returning an Eigen matrix from an Eigen
  * vector.
  * @tparam Vec An Eigen vector.
- * @param x An Eigen vector. For Row vectors the values are replacated rowwise.
+ * @param x An Eigen vector. For Row vectors the values are replicated rowwise.
  * and for column vectors the values are repliacated colwise.
  * @param n Number of rows or columns.
  */

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -26,7 +26,7 @@ inline auto sqrt(T&& x) {
 /**
  * Return the square root of the complex argument.
  *
- * @tparam V `complex<Aritmetic>` argument
+ * @tparam V `complex<Arithmetic>` argument
  * @param[in] x argument
  * @return square root of the argument
  */

--- a/stan/math/prim/functor/filter_map.hpp
+++ b/stan/math/prim/functor/filter_map.hpp
@@ -52,7 +52,7 @@ inline constexpr bool inspect_tuple_v
  * itself to inner containers as long as it sees a tuple in type type.
  *  So for instance if your type is a
  * `tuple<vector<tuple<vector<vector<double>>>>` your functor `f` must support
- * operationg on `vector<vector<double>>` types.
+ * operating on `vector<vector<double>>` types.
  * @tparam Filter a struct that accepts one template parameter and has a static
  *  constexpr bool member named value that is true if the type should be
  *  included in the output tuple.

--- a/stan/math/prim/functor/mpi_parallel_call.hpp
+++ b/stan/math/prim/functor/mpi_parallel_call.hpp
@@ -97,7 +97,7 @@ bool mpi_parallel_call_cache<call_id, member, T>::is_valid_ = false;
  * information from the root node to all worker nodes. The class
  * discriminates between parameters and static data. The static data
  * is only transmitted a single time and cached on each worker locally
- * after the inital transfer.
+ * after the initial transfer.
  *
  * The flow of commands are:
  *
@@ -113,7 +113,7 @@ bool mpi_parallel_call_cache<call_id, member, T>::is_valid_ = false;
  *    cluster. Static data (including meta information on data shapes)
  *    are locally cached such that static data is only transferred on
  *    the first evaluation. Note that the work is equally distributed
- *    among the workers. That is N jobs are distributed ot a cluster
+ *    among the workers. That is N jobs are distributed to a cluster
  *    of size W in N/W chunks (the remainder is allocated to node 1
  *    onwards which ensures that the root node 0 has one job less).
  * 5. Once the parameters and static data is distributed, the reduce
@@ -145,7 +145,7 @@ bool mpi_parallel_call_cache<call_id, member, T>::is_valid_ = false;
  * computed on each worker. This information is then cached for all
  * subsequent evaluations. However, caching this information can
  * occur if and only if the evaluation of all functions was
- * successfull on all workers during the first run. Thus, the first
+ * successful on all workers during the first run. Thus, the first
  * evaluation is handled with special care to ensure that caching of
  * this meta info is only done when all workers have successfully
  * evaluated the function and otherwise an exception is raised.

--- a/stan/math/prim/functor/ode_ckrk.hpp
+++ b/stan/math/prim/functor/ode_ckrk.hpp
@@ -233,7 +233,7 @@ ode_ckrk_tol(const F& f, const T_y0& y0_arg, T_t0 t0,
  * @param y0 Initial state
  * @param t0 Initial time
  * @param ts Times at which to solve the ODE at. All values must be sorted and
- *   greather than t0.
+ *   greater than t0.
  * @param[in, out] msgs the print stream for warning messages
  * @param args Extra arguments passed unmodified through to ODE right hand side
  * @return Solution to ODE at times \p ts

--- a/stan/math/prim/functor/ode_rk45.hpp
+++ b/stan/math/prim/functor/ode_rk45.hpp
@@ -235,7 +235,7 @@ ode_rk45_tol(const F& f, const T_y0& y0_arg, T_t0 t0,
  * @param y0 Initial state
  * @param t0 Initial time
  * @param ts Times at which to solve the ODE at. All values must be sorted and
- *   greather than t0.
+ *   greater than t0.
  * @param[in, out] msgs the print stream for warning messages
  * @param args Extra arguments passed unmodified through to ODE right hand side
  * @return Solution to ODE at times \p ts

--- a/stan/math/prim/meta/holder.hpp
+++ b/stan/math/prim/meta/holder.hpp
@@ -43,7 +43,7 @@
  * ```
  * This function will return back a `CwiseBinaryOp` Eigen expression, which is
  * then evaluated out of the function scope when assigned to `X`. The expression
- * references `x_ref`, which was created withing function and destroyed when
+ * references `x_ref`, which was created within function and destroyed when
  * the function returned. The returned expression is evaluated after the
  * function returned, so its evaluation references a matrix that was already
  * deleted. In other words the returned expression contains a dangling
@@ -60,7 +60,7 @@
  * `make_holder`, which will move any rvalues to heap first.
  */
 
-// This was implenmented following the tutorial on edding new expressions to
+// This was implemented following the tutorial on edding new expressions to
 // Eigen: https://eigen.tuxfamily.org/dox/TopicNewExpressionType.html
 
 namespace stan {
@@ -156,7 +156,7 @@ class Holder
       : m_arg(std::forward<ArgType>(arg)),
         m_unique_ptrs(std::unique_ptr<Ptrs>(pointers)...) {}
 
-  // we need to explicitely default copy and move constructors as we are
+  // we need to explicitly default copy and move constructors as we are
   // defining copy and move assignment operators
   Holder(const Holder<ArgType, Ptrs...>&) = default;
   Holder(Holder<ArgType, Ptrs...>&&) = default;
@@ -170,7 +170,7 @@ class Holder
   const auto* data() const { return m_arg.data(); }
 
   /**
-   * Assignment operator assigns expresssions.
+   * Assignment operator assigns expressions.
    * @param other expression to assign  to this
    * @return *this
    */
@@ -386,7 +386,7 @@ inline auto holder_handle_element(T&& a, T*& res) {
  * Constructs holder object form given expression and tuple of pointers.
  * @tparam T type of the result expression
  * @tparam Is index sequence for `ptrs`
- * @tparam Args types of pointes to heap
+ * @tparam Args types of points to heap
  * @param expr result expression
  * @param ptrs pointers to heap that need to be released when the expression is
  * destructed

--- a/stan/math/prim/meta/possibly_sum.hpp
+++ b/stan/math/prim/meta/possibly_sum.hpp
@@ -24,7 +24,7 @@ inline auto possibly_sum(T&& x) {
  * @tparam CondSum A struct with a static boolean member `value` which if false
  *  will pass the input to the output.
  * @tparam T A scalar, Eigen type, or standard vector with inner scalar type.
- * @param x The value to be passed trhough.
+ * @param x The value to be passed through.
  */
 template <typename CondSum, typename T1, require_not_t<CondSum>* = nullptr>
 inline auto possibly_sum(T1&& x) {

--- a/stan/math/prim/meta/static_select.hpp
+++ b/stan/math/prim/meta/static_select.hpp
@@ -17,7 +17,7 @@ namespace math {
  *
  * @param a first argument; returned if the `Condition` is true
  * @param b second argument; returned if the `Condition` is false
- * @return One of the arguemtns, depending on the `Condition`
+ * @return One of the arguments, depending on the `Condition`
  */
 template <bool Condition, typename T1, typename T2,
           std::enable_if_t<Condition>* = nullptr>

--- a/stan/math/prim/prob/dirichlet_multinomial_rng.hpp
+++ b/stan/math/prim/prob/dirichlet_multinomial_rng.hpp
@@ -16,7 +16,7 @@ namespace math {
  * parameters \f$\alpha\f$ and \f$N\f$ and pseudo-random number generator rng.
  *
  * The Dirichlet-Multinomial distribution is a continuous mixture of
- * Multinomial distirbutions, where the mixing distribution is the Dirichlet
+ * Multinomial distributions, where the mixing distribution is the Dirichlet
  * distribution. This fact is used for generating DirMult random draws.
  * First, we sample a probability vector
  * \f$\theta \sim \mbox{Dirichlet}(\alpha)\f$.

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -36,7 +36,7 @@ inline return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
   using T_lambda_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static constexpr const char* function = "exp_mod_normal_cdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Inv_scale paramter",
+                         mu, "Scale parameter", sigma, "Inv_scale parameter",
                          lambda);
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;

--- a/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
@@ -38,7 +38,7 @@ inline return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
   using T_lambda_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static constexpr const char* function = "exp_mod_normal_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Inv_scale paramter",
+                         mu, "Scale parameter", sigma, "Inv_scale parameter",
                          lambda);
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -38,7 +38,7 @@ inline return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
   using T_lambda_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static constexpr const char* function = "exp_mod_normal_lcdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Inv_scale paramter",
+                         mu, "Scale parameter", sigma, "Inv_scale parameter",
                          lambda);
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;

--- a/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
@@ -36,7 +36,7 @@ inline return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
   using T_lambda_ref = ref_type_if_not_constant_t<T_inv_scale>;
   static constexpr const char* function = "exp_mod_normal_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Inv_scale paramter",
+                         mu, "Scale parameter", sigma, "Inv_scale parameter",
                          lambda);
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;

--- a/stan/math/prim/prob/gaussian_dlm_obs_rng.hpp
+++ b/stan/math/prim/prob/gaussian_dlm_obs_rng.hpp
@@ -44,7 +44,7 @@ inline Eigen::VectorXd multi_normal_semidefinite_rng(
 
   Eigen::VectorXd Y
       = mu + (S_ldlt.transpositionsP().transpose() * (S_ldlt.matrixL() * z));
-  // The inner paranthesis matter, transpositionsP() gives a
+  // The inner parenthesis matter, transpositionsP() gives a
   // permutation matrix from pivoting and matrixL() gives a lower
   // triangular matrix. The types cannot be directly multiplied.
 

--- a/stan/math/prim/prob/skew_normal_cdf.hpp
+++ b/stan/math/prim/prob/skew_normal_cdf.hpp
@@ -34,7 +34,8 @@ inline return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_cdf(
   using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static constexpr const char* function = "skew_normal_cdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Shape parameter", alpha);
+                         mu, "Scale parameter", sigma, "Shape parameter",
+                         alpha);
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;
   T_sigma_ref sigma_ref = sigma;

--- a/stan/math/prim/prob/skew_normal_cdf.hpp
+++ b/stan/math/prim/prob/skew_normal_cdf.hpp
@@ -34,7 +34,7 @@ inline return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_cdf(
   using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static constexpr const char* function = "skew_normal_cdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Shape paramter", alpha);
+                         mu, "Scale parameter", sigma, "Shape parameter", alpha);
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;
   T_sigma_ref sigma_ref = sigma;

--- a/stan/math/prim/prob/skew_normal_lccdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lccdf.hpp
@@ -32,7 +32,8 @@ inline return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lccdf(
   using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static constexpr const char* function = "skew_normal_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Shape parameter", alpha);
+                         mu, "Scale parameter", sigma, "Shape parameter",
+                         alpha);
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;
   T_sigma_ref sigma_ref = sigma;

--- a/stan/math/prim/prob/skew_normal_lccdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lccdf.hpp
@@ -32,7 +32,7 @@ inline return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lccdf(
   using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static constexpr const char* function = "skew_normal_lccdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Shape paramter", alpha);
+                         mu, "Scale parameter", sigma, "Shape parameter", alpha);
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;
   T_sigma_ref sigma_ref = sigma;

--- a/stan/math/prim/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lpdf.hpp
@@ -35,7 +35,8 @@ inline return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
   using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static constexpr const char* function = "skew_normal_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Shape parameter", alpha);
+                         mu, "Scale parameter", sigma, "Shape parameter",
+                         alpha);
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;
   T_sigma_ref sigma_ref = sigma;

--- a/stan/math/prim/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lpdf.hpp
@@ -35,7 +35,7 @@ inline return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
   using T_alpha_ref = ref_type_if_not_constant_t<T_shape>;
   static constexpr const char* function = "skew_normal_lpdf";
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
-                         mu, "Scale parameter", sigma, "Shape paramter", alpha);
+                         mu, "Scale parameter", sigma, "Shape parameter", alpha);
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;
   T_sigma_ref sigma_ref = sigma;

--- a/stan/math/rev/constraint/cholesky_corr_constrain.hpp
+++ b/stan/math/rev/constraint/cholesky_corr_constrain.hpp
@@ -14,7 +14,7 @@ namespace stan {
 namespace math {
 
 /**
- * Return the Cholesky factor of the correlation matrix of the sepcified
+ * Return the Cholesky factor of the correlation matrix of the specified
  * size read from the unconstrained vector `y`. A total of K choose 2
  * elements are required to build a K by K Cholesky factor.
  *
@@ -77,7 +77,7 @@ inline var_value<Eigen::MatrixXd> cholesky_corr_constrain(const T& y, int K) {
 }
 
 /**
- * Return the Cholesky factor of the correlation matrix of the sepcified
+ * Return the Cholesky factor of the correlation matrix of the specified
  * size read from the unconstrained vector `y`. A total of K choose 2
  * elements are required to build a K by K Cholesky factor.
  *

--- a/stan/math/rev/core/callback_vari.hpp
+++ b/stan/math/rev/core/callback_vari.hpp
@@ -25,7 +25,7 @@ struct callback_vari : public vari_value<T> {
 
 /**
  * Creates a new vari with given value and a callback that implements the
- * reverse pass (chain). The callback needs to accept a referenct to the vari.
+ * reverse pass (chain). The callback needs to accept a referenced to the vari.
  * If it needs any other data it should be implemented as a lambda capturing the
  * variables it needs.
  *

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -368,7 +368,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
   /**
    * Copy constructor for var_val when the vari_type from `other` is directly
    * assignable.
-   * @tparam S type of the value in the `var_value` to assing
+   * @tparam S type of the value in the `var_value` to assign
    * @param other the value to assign
    * @return this
    */
@@ -403,7 +403,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
   /**
    * Construct a `var_value` with a plain type
    *  from another `var_value` containing an expression.
-   * @tparam S type of the value in the `var_value` to assing
+   * @tparam S type of the value in the `var_value` to assign
    * @param other the value to assign
    * @return this
    */
@@ -421,7 +421,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
   /**
    * Construct a `var_value` with premade @ref arena_matrix types.
    *  The values and adjoint matrices passed here will be shallow copied.
-   * @tparam S type of the value in the `var_value` to assing
+   * @tparam S type of the value in the `var_value` to assign
    * @param val The value matrix to go into the vari
    * @param adj the adjoint matrix to go into the vari
    */
@@ -739,7 +739,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
   /**
    * View element of eigen matrices. This creates a new
    * vari_value<double> so unlike the other views this subset will not
-   * have the same adjoints as the original matrix and must be propogated
+   * have the same adjoints as the original matrix and must be propagated
    * back.
    * @param i Element to access
    */
@@ -763,7 +763,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
   /**
    * View element of eigen matrices. This creates a new
    * vari_value<double> so unlike the other views this subset will not
-   * have the same adjoints as the original matrix and must be propogated
+   * have the same adjoints as the original matrix and must be propagated
    * back.
    * @param i Row to access
    * @param j Column to access
@@ -788,7 +788,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
   /**
    * View element of eigen matrices. This creates a new
    * vari_value<double> so unlike the other views this subset will not
-   * have the same adjoints as the original matrix and must be propogated
+   * have the same adjoints as the original matrix and must be propagated
    * back.
    * @param i Element to access
    */
@@ -798,7 +798,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
   /**
    * View element of eigen matrices. This creates a new
    * vari_value<double> so unlike the other views this subset will not
-   * have the same adjoints as the original matrix and must be propogated
+   * have the same adjoints as the original matrix and must be propagated
    * back.
    * @param i Row to access
    * @param j Column to access
@@ -813,7 +813,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
   /**
    * View element of eigen matrices. This creates a new
    * vari_value<double> so unlike the other views this subset will not
-   * have the same adjoints as the original matrix and must be propogated
+   * have the same adjoints as the original matrix and must be propagated
    * back.
    * @param i Element to access
    */
@@ -823,7 +823,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
   /**
    * View element of eigen matrices. This creates a new
    * vari_value<double> so unlike the other views this subset will not
-   * have the same adjoints as the original matrix and must be propogated
+   * have the same adjoints as the original matrix and must be propagated
    * back.
    * @param i Row to access
    * @param j Column to access
@@ -1036,7 +1036,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
   /**
    * Assignment of another plain var value, when this also contains a plain
    * type.
-   * @tparam S type of the value in the `var_value` to assing
+   * @tparam S type of the value in the `var_value` to assign
    * @param other the value to assign
    * @return this
    */
@@ -1097,7 +1097,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
           this_vi->val_.deep_copy(prev_val);
 
           // we have no way of detecting aliasing between this->vi_->adj_ and
-          // other.vi_->adj_, so we must copy adjoint before reseting to zero
+          // other.vi_->adj_, so we must copy adjoint before resetting to zero
 
           // we can reuse prev_val instead of allocating a new matrix
           prev_val.deep_copy(this_vi->adj_);
@@ -1139,7 +1139,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
           this_vi->val_ = prev_val;
 
           // we have no way of detecting aliasing between this->vi_->adj_ and
-          // other.vi_->adj_, so we must copy adjoint before reseting to zero
+          // other.vi_->adj_, so we must copy adjoint before resetting to zero
 
           // we can reuse prev_val instead of allocating a new matrix
           prev_val = this_vi->adj_;
@@ -1183,7 +1183,7 @@ class var_value<T, internal::require_matrix_var_value<T>> {
   }
 };
 
-// For backwards compatability the default value is double
+// For backwards compatibility the default value is double
 using var = var_value<double>;
 
 }  // namespace math

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -193,7 +193,7 @@ class vari_value<T, require_t<std::is_floating_point<T>>> : public vari_base {
   friend class var_value;
 };
 
-// For backwards compatability the default is double
+// For backwards compatibility the default is double
 using vari = vari_value<double>;
 
 /**

--- a/stan/math/rev/fun/accumulator.hpp
+++ b/stan/math/rev/fun/accumulator.hpp
@@ -86,7 +86,7 @@ class accumulator<T, require_var_t<T>> {
   }
 
   /**
-   * Recursively add each entry in the specified standard vector containint
+   * Recursively add each entry in the specified standard vector containing
    * containers to the buffer.
    *
    * @tparam S Type of value to recursively add.

--- a/stan/math/rev/fun/fft.hpp
+++ b/stan/math/rev/fun/fft.hpp
@@ -146,7 +146,7 @@ inline plain_type_t<M> fft2(const M& x) {
  * ```
  *
  * @tparam M type of complex matrix argument
- * @param[in] y matrix to inverse trnasform
+ * @param[in] y matrix to inverse transform
  * @return inverse discrete 2D Fourier transform of `y`
  */
 template <typename M, require_eigen_dense_dynamic_vt<is_complex, M>* = nullptr,

--- a/stan/math/rev/fun/from_var_value.hpp
+++ b/stan/math/rev/fun/from_var_value.hpp
@@ -45,7 +45,7 @@ inline T from_var_value(T&& a) {
  * Convert the elements of the `std::vector` input to `var_value` types
  * if possible
  *
- * @tparam T type of elemnts of the input vector
+ * @tparam T type of elements of the input vector
  * @param a std::vector of elements to convert
  */
 template <typename T>

--- a/stan/math/rev/fun/initialize_fill.hpp
+++ b/stan/math/rev/fun/initialize_fill.hpp
@@ -12,7 +12,7 @@ namespace math {
 
 /**
  * Fill the specified container with the specified value. This function does
- * not perform a callback to propogate the adjoints upward
+ * not perform a callback to propagate the adjoints upward
  *
  * The specified matrix is filled by element.
  *

--- a/stan/math/rev/fun/rep_matrix.hpp
+++ b/stan/math/rev/fun/rep_matrix.hpp
@@ -15,7 +15,7 @@ namespace math {
  * type.
  * @tparam Ret A `var_value` with inner Eigen type.
  * @tparam T A Scalar type.
- * @param x A Scalar whose values are propogated to all values in the return
+ * @param x A Scalar whose values are propagated to all values in the return
  * matrix.
  * @param m Number or rows.
  * @param n Number of columns.
@@ -36,7 +36,7 @@ inline auto rep_matrix(const T& x, int m, int n) {
  * @tparam Ret A `var_value` with inner Eigen dynamic matrix type.
  * @tparam Vec A `var_value` with an inner Eigen vector type.
  * @param x A `var_value` with inner Eigen vector type. For Row vectors the
- * values are replacated rowwise and for column vectors the values are
+ * values are replicated rowwise and for column vectors the values are
  * repliacated colwise.
  * @param n Number of rows or columns.
  */

--- a/stan/math/rev/fun/rep_row_vector.hpp
+++ b/stan/math/rev/fun/rep_row_vector.hpp
@@ -14,7 +14,7 @@ namespace math {
  * Overload for `var_value<Vector>`.
  * @tparam T_ret The user supplied return type.
  * @tparam T A double or var type
- * @param x The type to be propogated through the new vector.
+ * @param x The type to be propagated through the new vector.
  * @param n The size of the new vector.
  */
 template <typename T_ret, require_var_matrix_t<T_ret>* = nullptr,

--- a/stan/math/rev/fun/rep_vector.hpp
+++ b/stan/math/rev/fun/rep_vector.hpp
@@ -14,7 +14,7 @@ namespace math {
  * Overload for `var_value<Vector>`.
  * @tparam T_ret The user supplied return type.
  * @tparam T A double or var type
- * @param x The type to be propogated through the new vector.
+ * @param x The type to be propagated through the new vector.
  * @param n The size of the new vector.
  */
 template <typename T_ret, require_var_matrix_t<T_ret>* = nullptr,

--- a/stan/math/rev/fun/to_var_value.hpp
+++ b/stan/math/rev/fun/to_var_value.hpp
@@ -43,7 +43,7 @@ inline T to_var_value(T&& a) {
  * Convert the elements of the `std::vector` input to `var_value` types
  * if possible
  *
- * @tparam T type of elemnts of the input vector
+ * @tparam T type of elements of the input vector
  * @param a std::vector of elements to convert
  */
 template <typename T>

--- a/stan/math/rev/functor/algebra_system.hpp
+++ b/stan/math/rev/functor/algebra_system.hpp
@@ -52,7 +52,7 @@ struct hybrj_functor_solver : nlo_functor<double> {
   explicit hybrj_functor_solver(const S& fs) : fs_(fs) {}
 
   /**
-   * Computes the value the algebraic function, f, when pluging in the
+   * Computes the value the algebraic function, f, when plugging in the
    * independent variables, and the Jacobian w.r.t unknowns.
    *
    * @param [in] iv independent variables

--- a/stan/math/rev/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/functor/coupled_ode_system.hpp
@@ -42,7 +42,7 @@ namespace math {
  * \f]
  *
  * <p>The next N + M states correspond to the sensitivities
- * of the initial conditions followed by the sensitivites of the
+ * of the initial conditions followed by the sensitivities of the
  * parameters with respect to the second base system equation, and
  * so on through the last base system equation.
  *

--- a/stan/math/rev/functor/idas_service.hpp
+++ b/stan/math/rev/functor/idas_service.hpp
@@ -20,7 +20,7 @@ namespace math {
 
 /**
  * For each type of Ode(with different rhs functor F and
- * senstivity parameters), we allocate mem and workspace for
+ * sensitivity parameters), we allocate mem and workspace for
  * idas. This service manages the
  * allocation/deallocation, so ODE systems only request
  * service by injection.

--- a/stan/math/rev/functor/map_rect_concurrent.hpp
+++ b/stan/math/rev/functor/map_rect_concurrent.hpp
@@ -48,7 +48,7 @@ map_rect_concurrent(
 #ifdef STAN_THREADS
   // we must use task isolation as described here:
   // https://software.intel.com/content/www/us/en/develop/documentation/tbb-documentation/top/intel-threading-building-blocks-developer-guide/task-isolation.html
-  // this is to ensure that the thread local AD tape ressource is
+  // this is to ensure that the thread local AD tape resource is
   // not being modified from a different task which may happen
   // whenever this function is being used itself in a parallel
   // context (like running multiple chains for Stan)

--- a/stan/math/rev/functor/reduce_sum.hpp
+++ b/stan/math/rev/functor/reduce_sum.hpp
@@ -250,7 +250,7 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
 
     // we must use task isolation as described here:
     // https://software.intel.com/content/www/us/en/develop/documentation/tbb-documentation/top/intel-threading-building-blocks-developer-guide/task-isolation.html
-    // this is to ensure that the thread local AD tape ressource is
+    // this is to ensure that the thread local AD tape resource is
     // not being modified from a different task which may happen
     // whenever this function is being used itself in a parallel
     // context (like running multiple chains for Stan)


### PR DESCRIPTION
## Summary

This fixes some misspellings in the codebase, mainly in developer-facing comments but a few in actual error messages.

## Tests


## Side Effects



## Release notes


## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
