### PR TITLE
fix laplace_marginal optimization

### DIFF
--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -381,6 +381,31 @@ struct NewtonState {
   }
 
   /**
+   * @brief Constructs Newton state with a consistent (a_init, theta_init) pair.
+   *
+   * When the caller supplies a non-zero theta_init, a_init = Sigma^{-1} *
+   * theta_init must be provided to maintain the invariant theta = Sigma * a.
+   *
+   * @param theta_size Dimension of the latent space
+   * @param obj_fun Objective function: (a, theta) -> double
+   * @param theta_grad_f Gradient function: theta -> grad
+   * @param a_init Initial a value consistent with theta_init
+   * @param theta_init Initial theta value
+   */
+  template <typename ObjFun, typename ThetaGradFun, typename ThetaInitializer>
+  NewtonState(int theta_size, ObjFun&& obj_fun, ThetaGradFun&& theta_grad_f,
+              const Eigen::VectorXd& a_init,
+              ThetaInitializer&& theta_init)
+      : wolfe_info(std::forward<ObjFun>(obj_fun), a_init,
+                   std::forward<ThetaInitializer>(theta_init),
+                   std::forward<ThetaGradFun>(theta_grad_f), 0),
+        b(theta_size),
+        B(theta_size, theta_size),
+        prev_g(theta_size) {
+    wolfe_status.num_backtracks_ = -1;  // Safe initial value for BB step
+  }
+
+  /**
    * @brief Access the current step state (mutable).
    * @return Reference to current WolfeStep
    */
@@ -426,9 +451,13 @@ inline void llt_with_jitter(LLT& llt_B, B_t& B, double min_jitter = 1e-10,
                             double max_jitter = 1e-5) {
   llt_B.compute(B);
   if (llt_B.info() != Eigen::Success) {
+    double prev_jitter = 0.0;
     double jitter_try = min_jitter;
     for (; jitter_try < max_jitter; jitter_try *= 10) {
-      B.diagonal().array() += jitter_try;
+      // Remove previously added jitter before adding the new (larger) amount,
+      // so that the total diagonal perturbation is exactly jitter_try.
+      B.diagonal().array() += (jitter_try - prev_jitter);
+      prev_jitter = jitter_try;
       llt_B.compute(B);
       if (llt_B.info() == Eigen::Success) {
         break;
@@ -935,6 +964,9 @@ inline auto run_newton_loop(SolverPolicy& solver, NewtonStateT& state,
       scratch.alpha() = 1.0;
       update_fun(scratch, state.curr(), state.prev(), scratch.eval_,
                  state.wolfe_info.p_);
+      // Save the full Newton step objective before the Wolfe line search
+      // overwrites scratch with intermediate trial points.
+      const double full_newton_obj = scratch.eval_.obj();
       if (scratch.alpha() <= options.line_search.min_alpha) {
         state.wolfe_status.accept_ = false;
         finish_update = true;
@@ -953,15 +985,42 @@ inline auto run_newton_loop(SolverPolicy& solver, NewtonStateT& state,
         state.wolfe_status = internal::wolfe_line_search(
             state.wolfe_info, update_fun, options.line_search, msgs);
       }
+      // When the Wolfe line search rejects, don't immediately terminate.
+      // Instead, let the Newton loop try at least one more iteration.
+      // The original code compared the stale curr.obj() (which equalled
+      // prev.obj() after the swap in update_next_step) and would always
+      // terminate on ANY Wolfe rejection — even on the very first Newton
+      // step.  Now we only declare search_failed if the full Newton step
+      // itself didn't improve the objective.
+      bool search_failed;
+      if (!state.wolfe_status.accept_) {
+        if (full_newton_obj > state.prev().obj()) {
+          // The full Newton step (evaluated before Wolfe ran) improved
+          // the objective.  Re-evaluate scratch at the full Newton step
+          // so we can accept it as the current iterate.
+          scratch.eval_.alpha() = 1.0;
+          update_fun(scratch, state.curr(), state.prev(), scratch.eval_,
+                     state.wolfe_info.p_);
+          state.curr().update(scratch);
+          state.wolfe_status.accept_ = true;
+          search_failed = false;
+        } else {
+          search_failed = true;
+        }
+      } else {
+        search_failed = false;
+      }
       /**
-       * Stop when objective change is small, or when a rejected Wolfe step
-       * fails to improve; finish_update then exits the Newton loop.
+       * Stop when objective change is small (absolute AND relative), or when
+       * a rejected Wolfe step fails to improve; finish_update then exits the
+       * Newton loop.
        */
+      double obj_change = std::abs(state.curr().obj() - state.prev().obj());
       bool objective_converged
-          = std::abs(state.curr().obj() - state.prev().obj())
-            < options.tolerance;
-      bool search_failed = (!state.wolfe_status.accept_
-                            && state.curr().obj() <= state.prev().obj());
+          = obj_change < options.tolerance
+            && obj_change
+                   < options.tolerance
+                         * std::abs(state.prev().obj());
       finish_update = objective_converged || search_failed;
     }
     if (finish_update) {
@@ -1152,7 +1211,23 @@ inline auto laplace_marginal_density_est(
     return laplace_likelihood::theta_grad(ll_fun, theta_val, ll_args, msgs);
   };
   decltype(auto) theta_init = theta_init_impl<InitTheta>(theta_size, options);
-  internal::NewtonState state(theta_size, obj_fun, theta_grad_f, theta_init);
+  // When the user supplies a non-zero theta_init, we must initialise a
+  // consistently so that the invariant theta = Sigma * a holds.  Otherwise
+  // the prior term -0.5 * a'*theta vanishes (a=0 while theta!=0), inflating
+  // the initial objective and causing the Wolfe line search to reject the
+  // first Newton step.
+  auto make_state = [&](auto&& theta_0) {
+    if constexpr (InitTheta) {
+      Eigen::VectorXd a_init = covariance.llt().solve(
+          Eigen::VectorXd(theta_0));
+      return internal::NewtonState(theta_size, obj_fun, theta_grad_f,
+                                   a_init, theta_0);
+    } else {
+      return internal::NewtonState(theta_size, obj_fun, theta_grad_f,
+                                   theta_0);
+    }
+  };
+  auto state = make_state(theta_init);
   // Start with safe step size
   auto update_fun = create_update_fun(
       std::move(obj_fun), std::move(theta_grad_f), covariance, options);

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -374,10 +374,12 @@ struct NewtonState {
    * @param a_init Initial a value consistent with theta_init
    * @param theta_init Initial theta value
    */
-  template <typename ObjFun, typename ThetaGradFun, typename CovarianceT, typename ThetaInitializer>
+  template <typename ObjFun, typename ThetaGradFun, typename CovarianceT,
+            typename ThetaInitializer>
   NewtonState(int theta_size, ObjFun&& obj_fun, ThetaGradFun&& theta_grad_f,
               CovarianceT&& covariance, ThetaInitializer&& theta_init)
-      : wolfe_info(std::forward<ObjFun>(obj_fun), covariance.llt().solve(theta_init),
+      : wolfe_info(std::forward<ObjFun>(obj_fun),
+                   covariance.llt().solve(theta_init),
                    std::forward<ThetaInitializer>(theta_init),
                    std::forward<ThetaGradFun>(theta_grad_f)),
         proposal(theta_size),
@@ -950,9 +952,9 @@ inline auto run_newton_loop(SolverPolicy& solver, NewtonStateT& state,
       state.wolfe_info.flip_direction();
       auto&& scratch = state.wolfe_info.scratch_;
       proposal.eval_.alpha() = 1.0;
-      const bool proposal_valid = update_fun(
-          proposal, state.curr(), state.prev(), proposal.eval_,
-          state.wolfe_info.p_);
+      const bool proposal_valid
+          = update_fun(proposal, state.curr(), state.prev(), proposal.eval_,
+                       state.wolfe_info.p_);
       const bool cached_proposal_ok
           = proposal_valid && std::isfinite(proposal.obj())
             && std::isfinite(proposal.dir())
@@ -979,14 +981,13 @@ inline auto run_newton_loop(SolverPolicy& solver, NewtonStateT& state,
       const bool proposal_armijo_ok
           = cached_proposal_ok
             && internal::check_armijo(
-                   proposal.obj(), state.prev().obj(), proposal.alpha(),
-                   state.wolfe_info.init_dir_, options.line_search);
+                proposal.obj(), state.prev().obj(), proposal.alpha(),
+                state.wolfe_info.init_dir_, options.line_search);
       if (search_failed && proposal_armijo_ok) {
         state.curr().update(proposal);
-        state.wolfe_status = WolfeStatus{WolfeReturn::Armijo,
-                                         state.wolfe_status.num_evals_,
-                                         state.wolfe_status.num_backtracks_,
-                                         true};
+        state.wolfe_status
+            = WolfeStatus{WolfeReturn::Armijo, state.wolfe_status.num_evals_,
+                          state.wolfe_status.num_backtracks_, true};
         search_failed = false;
       }
       bool objective_converged
@@ -1187,7 +1188,8 @@ inline auto laplace_marginal_density_est(
   // the prior term -0.5 * a'*theta vanishes (a=0 while theta!=0), inflating
   // the initial objective and causing the Wolfe line search to reject the
   // first Newton step.
-  auto state = NewtonState(theta_size, obj_fun, theta_grad_f, covariance, theta_init);
+  auto state
+      = NewtonState(theta_size, obj_fun, theta_grad_f, covariance, theta_init);
   // Start with safe step size
   auto update_fun = create_update_fun(
       std::move(obj_fun), std::move(theta_grad_f), covariance, options);

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -342,6 +342,9 @@ struct NewtonState {
   /** @brief Status of the most recent Wolfe line search */
   WolfeStatus wolfe_status;
 
+  /** @brief Cached proposal evaluated before the Wolfe line search. */
+  WolfeData proposal;
+
   /** @brief Workspace vector: b = W * theta + grad(log_lik) */
   Eigen::VectorXd b;
 
@@ -377,6 +380,7 @@ struct NewtonState {
       : wolfe_info(std::forward<ObjFun>(obj_fun), covariance.llt().solve(theta_init),
                    std::forward<ThetaInitializer>(theta_init),
                    std::forward<ThetaGradFun>(theta_grad_f)),
+        proposal(theta_size),
         b(theta_size),
         B(theta_size, theta_size),
         prev_g(theta_size) {
@@ -407,9 +411,12 @@ struct NewtonState {
    */
   const auto& prev() const& { return wolfe_info.prev_; }
   auto&& prev() && { return std::move(wolfe_info).prev(); }
+  auto& proposal_step() & { return proposal; }
+  const auto& proposal_step() const& { return proposal; }
+  auto&& proposal_step() && { return std::move(proposal); }
   template <typename Options>
   inline void update_next_step(const Options& options) {
-    this->prev().update(this->curr());
+    this->prev().swap(this->curr());
     this->curr().alpha()
         = std::clamp(this->curr().alpha(), 0.0, options.line_search.max_alpha);
   }
@@ -485,7 +492,8 @@ struct CholeskyWSolverDiag {
    * @tparam LLFun Type of the log-likelihood functor
    * @tparam LLTupleArgs Type of the likelihood arguments tuple
    * @tparam CovarMat Type of the covariance matrix
-   * @param[in,out] state Shared Newton state (modified: B, b, curr().a())
+   * @param[in,out] state Shared Newton state (modified: B, b,
+   * proposal_step().a())
    * @param[in] ll_fun Log-likelihood functor
    * @param[in,out] ll_args Additional arguments for the likelihood
    * @param[in] covariance Prior covariance matrix Sigma
@@ -521,12 +529,12 @@ struct CholeskyWSolverDiag {
 
     // 3. Factorize B with jittering fallback
     llt_with_jitter(llt_B, state.B);
-    // 4. Solve for curr.a
+    // 4. Solve for the raw Newton proposal in a-space.
     state.b.noalias() = (W_diag.array() * state.prev().theta().array()).matrix()
                         + state.prev().theta_grad();
     auto L = llt_B.matrixL();
     auto LT = llt_B.matrixU();
-    state.curr().a().noalias()
+    state.proposal_step().a().noalias()
         = state.b
           - W_r_diag.asDiagonal()
                 * LT.solve(
@@ -615,7 +623,8 @@ struct CholeskyWSolverBlock {
    * @tparam LLFun Type of the log-likelihood functor
    * @tparam LLTupleArgs Type of the likelihood arguments tuple
    * @tparam CovarMat Type of the covariance matrix
-   * @param[in,out] state Shared Newton state (modified: B, b, curr().a())
+   * @param[in,out] state Shared Newton state (modified: B, b,
+   * proposal_step().a())
    * @param[in] ll_fun Log-likelihood functor
    * @param[in,out] ll_args Additional arguments for the likelihood
    * @param[in] covariance Prior covariance matrix Sigma
@@ -653,12 +662,12 @@ struct CholeskyWSolverBlock {
     // 4. Factorize B with jittering fallback
     llt_with_jitter(llt_B, state.B);
 
-    // 5. Solve for curr.a
+    // 5. Solve for the raw Newton proposal in a-space.
     state.b.noalias()
         = W_block * state.prev().theta() + state.prev().theta_grad();
     auto L = llt_B.matrixL();
     auto LT = llt_B.matrixU();
-    state.curr().a().noalias()
+    state.proposal_step().a().noalias()
         = state.b - W_r * LT.solve(L.solve(W_r * (covariance * state.b)));
   }
 
@@ -736,7 +745,7 @@ struct CholeskyKSolver {
    * @tparam LLFun Type of the log-likelihood functor
    * @tparam LLTupleArgs Type of the likelihood arguments tuple
    * @tparam CovarMat Type of the covariance matrix
-   * @param[in] state Shared Newton state (modified: B, b, curr().a())
+   * @param[in] state Shared Newton state (modified: B, b, proposal_step().a())
    * @param[in] ll_fun Log-likelihood functor
    * @param[in] ll_args Additional arguments for the likelihood
    * @param[in] covariance Prior covariance matrix Sigma
@@ -763,12 +772,12 @@ struct CholeskyKSolver {
     // 3. Factorize B with jittering fallback
     llt_with_jitter(llt_B, state.B);
 
-    // 4. Solve for curr.a
+    // 4. Solve for the raw Newton proposal in a-space.
     state.b.noalias()
         = W_full * state.prev().theta() + state.prev().theta_grad();
     auto L = llt_B.matrixL();
     auto LT = llt_B.matrixU();
-    state.curr().a().noalias()
+    state.proposal_step().a().noalias()
         = K_root.transpose().template triangularView<Eigen::Upper>().solve(
             LT.solve(L.solve(K_root.transpose() * state.b)));
   }
@@ -833,7 +842,7 @@ struct LUSolver {
    * @tparam LLFun Type of the log-likelihood functor
    * @tparam LLTupleArgs Type of the likelihood arguments tuple
    * @tparam CovarMat Type of the covariance matrix
-   * @param[in,out] state Shared Newton state (modified: b, curr().a())
+   * @param[in,out] state Shared Newton state (modified: b, proposal_step().a())
    * @param[in] ll_fun Log-likelihood functor
    * @param[in,out] ll_args Additional arguments for the likelihood
    * @param[in] covariance Prior covariance matrix Sigma
@@ -855,10 +864,10 @@ struct LUSolver {
     lu.compute(Eigen::MatrixXd::Identity(theta_size, theta_size)
                + covariance * W_full);
 
-    // 3. Solve for curr.a
+    // 3. Solve for the raw Newton proposal in a-space.
     state.b.noalias()
         = W_full * state.prev().theta() + state.prev().theta_grad();
-    state.curr().a().noalias()
+    state.proposal_step().a().noalias()
         = state.b - W_full * lu.solve(covariance * state.b);
   }
 
@@ -932,29 +941,32 @@ inline auto run_newton_loop(SolverPolicy& solver, NewtonStateT& state,
     solver.solve_step(state, ll_fun, ll_args, covariance,
                       options.hessian_block_size, msgs);
     if (!state.final_loop) {
-      state.wolfe_info.p_ = state.curr().a() - state.prev().a();
+      auto&& proposal = state.proposal_step();
+      state.wolfe_info.p_ = proposal.a() - state.prev().a();
       state.prev_g.noalias() = -covariance * state.prev().a()
                                + covariance * state.prev().theta_grad();
       state.wolfe_info.init_dir_ = state.prev_g.dot(state.wolfe_info.p_);
       // Flip direction if not ascending
       state.wolfe_info.flip_direction();
       auto&& scratch = state.wolfe_info.scratch_;
-      scratch.alpha() = 1.0;
-      update_fun(scratch, state.curr(), state.prev(), scratch.eval_,
-                 state.wolfe_info.p_);
-      // Save the full Newton step objective before the Wolfe line search
-      // overwrites scratch with intermediate trial points.
-      const double full_newton_obj = scratch.eval_.obj();
-      if (scratch.alpha() <= options.line_search.min_alpha) {
-        state.wolfe_status.accept_ = false;
-        finish_update = true;
+      proposal.eval_.alpha() = 1.0;
+      const bool proposal_valid = update_fun(
+          proposal, state.curr(), state.prev(), proposal.eval_,
+          state.wolfe_info.p_);
+      const bool cached_proposal_ok
+          = proposal_valid && std::isfinite(proposal.obj())
+            && std::isfinite(proposal.dir())
+            && proposal.alpha() > options.line_search.min_alpha;
+      if (!cached_proposal_ok) {
+        state.wolfe_status
+            = WolfeStatus{WolfeReturn::StepTooSmall, 1, 0, false};
       } else if (options.line_search.max_iterations == 0) {
-        state.curr().update(scratch);
-        state.wolfe_status.accept_ = true;
+        state.curr().update(proposal);
+        state.wolfe_status = WolfeStatus{WolfeReturn::Continue, 1, 0, true};
       } else {
-        Eigen::VectorXd s = scratch.a() - state.prev().a();
+        Eigen::VectorXd s = proposal.a() - state.prev().a();
         auto full_step_grad
-            = (-covariance * scratch.a() + covariance * scratch.theta_grad())
+            = (-covariance * proposal.a() + covariance * proposal.theta_grad())
                   .eval();
         state.curr().alpha() = barzilai_borwein_step_size(
             s, full_step_grad, state.prev_g, state.prev().alpha(),
@@ -963,47 +975,30 @@ inline auto run_newton_loop(SolverPolicy& solver, NewtonStateT& state,
         state.wolfe_status = internal::wolfe_line_search(
             state.wolfe_info, update_fun, options.line_search, msgs);
       }
-      // When the Wolfe line search rejects, don't immediately terminate.
-      // Instead, let the Newton loop try at least one more iteration.
-      // The original code compared the stale curr.obj() (which equalled
-      // prev.obj() after the swap in update_next_step) and would always
-      // terminate on ANY Wolfe rejection — even on the very first Newton
-      // step.  Now we only declare search_failed if the full Newton step
-      // itself didn't improve the objective.
-      bool search_failed;
-      if (!state.wolfe_status.accept_) {
-        if (full_newton_obj > state.prev().obj()) {
-          // The full Newton step (evaluated before Wolfe ran) improved
-          // the objective.  Re-evaluate scratch at the full Newton step
-          // so we can accept it as the current iterate.
-          scratch.eval_.alpha() = 1.0;
-          update_fun(scratch, state.curr(), state.prev(), scratch.eval_,
-                     state.wolfe_info.p_);
-          state.curr().update(scratch);
-          state.wolfe_status.accept_ = true;
-          search_failed = false;
-        } else {
-          search_failed = true;
-        }
-      } else {
+      bool search_failed = !state.wolfe_status.accept_;
+      const bool proposal_armijo_ok
+          = cached_proposal_ok
+            && internal::check_armijo(
+                   proposal.obj(), state.prev().obj(), proposal.alpha(),
+                   state.wolfe_info.init_dir_, options.line_search);
+      if (search_failed && proposal_armijo_ok) {
+        state.curr().update(proposal);
+        state.wolfe_status = WolfeStatus{WolfeReturn::Armijo,
+                                         state.wolfe_status.num_evals_,
+                                         state.wolfe_status.num_backtracks_,
+                                         true};
         search_failed = false;
       }
-      /**
-       * Stop when objective change is small (absolute AND relative), or when
-       * a rejected Wolfe step fails to improve; finish_update then exits the
-       * Newton loop.
-       */
-      double obj_change = std::abs(state.curr().obj() - state.prev().obj());
       bool objective_converged
-          = obj_change < options.tolerance
-            && obj_change < options.tolerance * std::abs(state.prev().obj());
+          = state.wolfe_status.accept_
+            && std::abs(state.curr().obj() - state.prev().obj())
+                   < options.tolerance;
       finish_update = objective_converged || search_failed;
     }
     if (finish_update) {
       if (!state.final_loop && state.wolfe_status.accept_) {
         // Do one final loop with exact wolfe conditions
         state.final_loop = true;
-        // NOTE: Swapping here so we need to swap prev and curr later
         state.update_next_step(options);
         continue;
       }

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -394,8 +394,7 @@ struct NewtonState {
    */
   template <typename ObjFun, typename ThetaGradFun, typename ThetaInitializer>
   NewtonState(int theta_size, ObjFun&& obj_fun, ThetaGradFun&& theta_grad_f,
-              const Eigen::VectorXd& a_init,
-              ThetaInitializer&& theta_init)
+              const Eigen::VectorXd& a_init, ThetaInitializer&& theta_init)
       : wolfe_info(std::forward<ObjFun>(obj_fun), a_init,
                    std::forward<ThetaInitializer>(theta_init),
                    std::forward<ThetaGradFun>(theta_grad_f), 0),
@@ -1018,9 +1017,7 @@ inline auto run_newton_loop(SolverPolicy& solver, NewtonStateT& state,
       double obj_change = std::abs(state.curr().obj() - state.prev().obj());
       bool objective_converged
           = obj_change < options.tolerance
-            && obj_change
-                   < options.tolerance
-                         * std::abs(state.prev().obj());
+            && obj_change < options.tolerance * std::abs(state.prev().obj());
       finish_update = objective_converged || search_failed;
     }
     if (finish_update) {
@@ -1218,13 +1215,11 @@ inline auto laplace_marginal_density_est(
   // first Newton step.
   auto make_state = [&](auto&& theta_0) {
     if constexpr (InitTheta) {
-      Eigen::VectorXd a_init = covariance.llt().solve(
-          Eigen::VectorXd(theta_0));
-      return internal::NewtonState(theta_size, obj_fun, theta_grad_f,
-                                   a_init, theta_0);
-    } else {
-      return internal::NewtonState(theta_size, obj_fun, theta_grad_f,
+      Eigen::VectorXd a_init = covariance.llt().solve(Eigen::VectorXd(theta_0));
+      return internal::NewtonState(theta_size, obj_fun, theta_grad_f, a_init,
                                    theta_0);
+    } else {
+      return internal::NewtonState(theta_size, obj_fun, theta_grad_f, theta_0);
     }
   };
   auto state = make_state(theta_init);

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -360,27 +360,6 @@ struct NewtonState {
   bool final_loop = false;
 
   /**
-   * @brief Constructs Newton state with given dimensions and functors.
-   *
-   * @tparam ThetaInitializer Type of the initial theta provider
-   * @param theta_size Dimension of the latent space
-   * @param obj_fun Objective function: (a, theta) -> double
-   * @param theta_grad_f Gradient function: theta -> grad
-   * @param theta_init Initial theta value or provider
-   */
-  template <typename ObjFun, typename ThetaGradFun, typename ThetaInitializer>
-  NewtonState(int theta_size, ObjFun&& obj_fun, ThetaGradFun&& theta_grad_f,
-              ThetaInitializer&& theta_init)
-      : wolfe_info(std::forward<ObjFun>(obj_fun), theta_size,
-                   std::forward<ThetaInitializer>(theta_init),
-                   std::forward<ThetaGradFun>(theta_grad_f)),
-        b(theta_size),
-        B(theta_size, theta_size),
-        prev_g(theta_size) {
-    wolfe_status.num_backtracks_ = -1;  // Safe initial value for BB step
-  }
-
-  /**
    * @brief Constructs Newton state with a consistent (a_init, theta_init) pair.
    *
    * When the caller supplies a non-zero theta_init, a_init = Sigma^{-1} *
@@ -392,12 +371,12 @@ struct NewtonState {
    * @param a_init Initial a value consistent with theta_init
    * @param theta_init Initial theta value
    */
-  template <typename ObjFun, typename ThetaGradFun, typename ThetaInitializer>
+  template <typename ObjFun, typename ThetaGradFun, typename CovarianceT, typename ThetaInitializer>
   NewtonState(int theta_size, ObjFun&& obj_fun, ThetaGradFun&& theta_grad_f,
-              const Eigen::VectorXd& a_init, ThetaInitializer&& theta_init)
-      : wolfe_info(std::forward<ObjFun>(obj_fun), a_init,
+              CovarianceT&& covariance, ThetaInitializer&& theta_init)
+      : wolfe_info(std::forward<ObjFun>(obj_fun), covariance.llt().solve(theta_init),
                    std::forward<ThetaInitializer>(theta_init),
-                   std::forward<ThetaGradFun>(theta_grad_f), 0),
+                   std::forward<ThetaGradFun>(theta_grad_f)),
         b(theta_size),
         B(theta_size, theta_size),
         prev_g(theta_size) {
@@ -1213,16 +1192,7 @@ inline auto laplace_marginal_density_est(
   // the prior term -0.5 * a'*theta vanishes (a=0 while theta!=0), inflating
   // the initial objective and causing the Wolfe line search to reject the
   // first Newton step.
-  auto make_state = [&](auto&& theta_0) {
-    if constexpr (InitTheta) {
-      Eigen::VectorXd a_init = covariance.llt().solve(Eigen::VectorXd(theta_0));
-      return internal::NewtonState(theta_size, obj_fun, theta_grad_f, a_init,
-                                   theta_0);
-    } else {
-      return internal::NewtonState(theta_size, obj_fun, theta_grad_f, theta_0);
-    }
-  };
-  auto state = make_state(theta_init);
+  auto state = NewtonState(theta_size, obj_fun, theta_grad_f, covariance, theta_init);
   // Start with safe step size
   auto update_fun = create_update_fun(
       std::move(obj_fun), std::move(theta_grad_f), covariance, options);

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -367,10 +367,14 @@ struct NewtonState {
    *
    * When the caller supplies a non-zero theta_init, a_init = Sigma^{-1} *
    * theta_init must be provided to maintain the invariant theta = Sigma * a.
-   *
+   * @tparam ObjFun A callable type for the objective function
+   * @tparam ThetaGradFun A callable type for the theta gradient function
+   * @tparam CovarianceT A matrix type for the covariance (must support LLT solve)
+   * @tparam ThetaInitializer A type for the initial theta (e.g., Eigen vector)
    * @param theta_size Dimension of the latent space
    * @param obj_fun Objective function: (a, theta) -> double
    * @param theta_grad_f Gradient function: theta -> grad
+   * @param covariance Covariance matrix for the latent variables
    * @param a_init Initial a value consistent with theta_init
    * @param theta_init Initial theta value
    */

--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -369,7 +369,8 @@ struct NewtonState {
    * theta_init must be provided to maintain the invariant theta = Sigma * a.
    * @tparam ObjFun A callable type for the objective function
    * @tparam ThetaGradFun A callable type for the theta gradient function
-   * @tparam CovarianceT A matrix type for the covariance (must support LLT solve)
+   * @tparam CovarianceT A matrix type for the covariance (must support LLT
+   * solve)
    * @tparam ThetaInitializer A type for the initial theta (e.g., Eigen vector)
    * @param theta_size Dimension of the latent space
    * @param obj_fun Objective function: (a, theta) -> double

--- a/stan/math/mix/functor/wolfe_line_search.hpp
+++ b/stan/math/mix/functor/wolfe_line_search.hpp
@@ -515,7 +515,8 @@ struct WolfeInfo {
    * an inflated initial objective (the prior term -0.5 * a'*theta would
    * otherwise vanish when a is zero but theta is not).
    */
-  template <typename ObjFun, typename Theta0, typename AInit, typename ThetaGradF>
+  template <typename ObjFun, typename Theta0, typename AInit,
+            typename ThetaGradF>
   WolfeInfo(ObjFun&& obj_fun, AInit&& a_init, Theta0&& theta0,
             ThetaGradF&& theta_grad_f)
       : curr_(std::forward<ObjFun>(obj_fun), std::forward<AInit>(a_init),

--- a/stan/math/mix/functor/wolfe_line_search.hpp
+++ b/stan/math/mix/functor/wolfe_line_search.hpp
@@ -499,19 +499,7 @@ struct WolfeInfo {
   Eigen::VectorXd p_;
   // Initial directional derivative
   double init_dir_;
-  template <typename ObjFun, typename Theta0, typename ThetaGradF>
-  WolfeInfo(ObjFun&& obj_fun, Eigen::Index n, Theta0&& theta0,
-            ThetaGradF&& theta_grad_f)
-      : curr_(std::forward<ObjFun>(obj_fun), n, std::forward<Theta0>(theta0),
-              std::forward<ThetaGradF>(theta_grad_f)),
-        prev_(curr_),
-        scratch_(n) {
-    if (!std::isfinite(curr_.obj())) {
-      throw std::domain_error(
-          "laplace_marginal_density: log likelihood is not finite at initial "
-          "theta and likelihood arguments.");
-    }
-  }
+
   /**
    * Construct WolfeInfo with a consistent (a_init, theta_init) pair.
    *
@@ -521,10 +509,10 @@ struct WolfeInfo {
    * an inflated initial objective (the prior term -0.5 * a'*theta would
    * otherwise vanish when a is zero but theta is not).
    */
-  template <typename ObjFun, typename Theta0, typename ThetaGradF>
-  WolfeInfo(ObjFun&& obj_fun, const Eigen::VectorXd& a_init, Theta0&& theta0,
-            ThetaGradF&& theta_grad_f, int /*tag*/)
-      : curr_(std::forward<ObjFun>(obj_fun), a_init,
+  template <typename ObjFun, typename Theta0, typename AInit, typename ThetaGradF>
+  WolfeInfo(ObjFun&& obj_fun, AInit&& a_init, Theta0&& theta0,
+            ThetaGradF&& theta_grad_f)
+      : curr_(std::forward<ObjFun>(obj_fun), std::forward<AInit>(a_init),
               std::forward<Theta0>(theta0),
               std::forward<ThetaGradF>(theta_grad_f)),
         prev_(curr_),

--- a/stan/math/mix/functor/wolfe_line_search.hpp
+++ b/stan/math/mix/functor/wolfe_line_search.hpp
@@ -512,6 +512,29 @@ struct WolfeInfo {
           "theta and likelihood arguments.");
     }
   }
+  /**
+   * Construct WolfeInfo with a consistent (a_init, theta_init) pair.
+   *
+   * When the caller supplies a non-zero theta_init, the corresponding
+   * a_init = Sigma^{-1} * theta_init must be provided so that the
+   * invariant theta = Sigma * a holds at initialization.  This avoids
+   * an inflated initial objective (the prior term -0.5 * a'*theta would
+   * otherwise vanish when a is zero but theta is not).
+   */
+  template <typename ObjFun, typename Theta0, typename ThetaGradF>
+  WolfeInfo(ObjFun&& obj_fun, const Eigen::VectorXd& a_init, Theta0&& theta0,
+            ThetaGradF&& theta_grad_f, int /*tag*/)
+      : curr_(std::forward<ObjFun>(obj_fun), a_init,
+              std::forward<Theta0>(theta0),
+              std::forward<ThetaGradF>(theta_grad_f)),
+        prev_(curr_),
+        scratch_(a_init.size()) {
+    if (!std::isfinite(curr_.obj())) {
+      throw std::domain_error(
+          "laplace_marginal_density: log likelihood is not finite at initial "
+          "theta and likelihood arguments.");
+    }
+  }
   WolfeInfo(WolfeData&& curr, WolfeData&& prev)
       : curr_(std::move(curr)),
         prev_(std::move(prev)),
@@ -902,9 +925,10 @@ inline WolfeStatus wolfe_line_search(Info& wolfe_info, UpdateFun&& update_fun,
         } else {  // [3]
           high = mid;
         }
+      } else {
+        // [4]
+        high = mid;
       }
-      // [4]
-      high = mid;
     } else {
       // [5]
       high = mid;

--- a/stan/math/mix/functor/wolfe_line_search.hpp
+++ b/stan/math/mix/functor/wolfe_line_search.hpp
@@ -461,6 +461,12 @@ struct WolfeData {
     a_.swap(other.a_);
     eval_ = other.eval_;
   }
+  void swap(WolfeData& other) {
+    theta_.swap(other.theta_);
+    theta_grad_.swap(other.theta_grad_);
+    a_.swap(other.a_);
+    std::swap(eval_, other.eval_);
+  }
   void update(WolfeData& other, const Eval& eval) {
     theta_.swap(other.theta_);
     a_.swap(other.a_);

--- a/test/unit/math/laplace/laplace_marginal_density_estimator_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_density_estimator_test.cpp
@@ -69,10 +69,10 @@ TEST(LaplaceMarginalDensityEstimator, PublicLineSearchMatchesDirectStep) {
   std::ostringstream no_search_msgs;
   std::ostringstream wolfe_msgs;
 
-  const double no_search = run_laplace(QuarticLikelihood{}, 2.0, 1e-12, 50, 0,
-                                       &no_search_msgs);
-  const double with_wolfe = run_laplace(QuarticLikelihood{}, 2.0, 1e-12, 50,
-                                        1000, &wolfe_msgs);
+  const double no_search
+      = run_laplace(QuarticLikelihood{}, 2.0, 1e-12, 50, 0, &no_search_msgs);
+  const double with_wolfe
+      = run_laplace(QuarticLikelihood{}, 2.0, 1e-12, 50, 1000, &wolfe_msgs);
 
   EXPECT_TRUE(std::isfinite(no_search));
   EXPECT_TRUE(std::isfinite(with_wolfe));
@@ -93,12 +93,9 @@ TEST(LaplaceMarginalDensityEstimator,
      InvalidCachedProposalDoesNotTriggerArmijoFallback) {
   Eigen::MatrixXd covariance = Eigen::MatrixXd::Identity(1, 1);
   Eigen::VectorXd theta0 = Eigen::VectorXd::Zero(1);
-  auto obj_fun = [](const auto& /*a*/, const auto& /*theta*/) {
-    return -1.0;
-  };
-  auto theta_grad_f = [](const auto& theta) {
-    return Eigen::VectorXd::Zero(theta.size());
-  };
+  auto obj_fun = [](const auto& /*a*/, const auto& /*theta*/) { return -1.0; };
+  auto theta_grad_f
+      = [](const auto& theta) { return Eigen::VectorXd::Zero(theta.size()); };
   internal::NewtonState state(1, obj_fun, theta_grad_f, covariance, theta0);
   laplace_options_base options;
   options.hessian_block_size = 1;
@@ -115,14 +112,12 @@ TEST(LaplaceMarginalDensityEstimator,
     eval_in.alpha() = 0.5 * min_alpha;
     return false;
   };
-  auto unused_ll = [](const auto& /*theta*/, std::ostream* /*msgs*/) {
-    return 0.0;
-  };
+  auto unused_ll
+      = [](const auto& /*theta*/, std::ostream* /*msgs*/) { return 0.0; };
 
-  const double result
-      = internal::run_newton_loop(solver, state, options, step_iter, unused_ll,
-                                  std::tuple<>{}, covariance, failing_update,
-                                  nullptr);
+  const double result = internal::run_newton_loop(
+      solver, state, options, step_iter, unused_ll, std::tuple<>{}, covariance,
+      failing_update, nullptr);
 
   EXPECT_DOUBLE_EQ(result, 0.0);
   EXPECT_FALSE(state.wolfe_status.accept_);

--- a/test/unit/math/laplace/laplace_marginal_density_estimator_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_density_estimator_test.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+#include <stan/math.hpp>
+#include <stan/math/mix.hpp>
+
+#include <cmath>
+#include <sstream>
+#include <tuple>
+
+namespace stan::math {
+namespace {
+
+struct IdentityCovariance {
+  template <typename Stream>
+  Eigen::MatrixXd operator()(Stream* /*msgs*/) const {
+    return Eigen::MatrixXd::Identity(1, 1);
+  }
+};
+
+struct QuarticLikelihood {
+  template <typename Theta>
+  auto operator()(const Theta& theta, std::ostream* /*msgs*/) const {
+    const auto& x = theta(0);
+    const auto x_sq = stan::math::square(x);
+    return 2.0 * x - 0.5 * x_sq - 0.5 * stan::math::square(x_sq);
+  }
+};
+
+struct TinyQuarticLikelihood {
+  template <typename Theta>
+  auto operator()(const Theta& theta, std::ostream* /*msgs*/) const {
+    return 1e-8 * QuarticLikelihood{}(theta, nullptr);
+  }
+};
+
+struct StubNewtonSolver {
+  double proposal_a;
+
+  template <typename NewtonStateT, typename LLFun, typename LLTupleArgs,
+            typename CovarMat>
+  void solve_step(NewtonStateT& state, const LLFun& /*ll_fun*/,
+                  const LLTupleArgs& /*ll_args*/,
+                  const CovarMat& /*covariance*/, int /*hessian_block_size*/,
+                  std::ostream* /*msgs*/) const {
+    state.proposal_step().a()(0) = proposal_a;
+  }
+
+  double compute_log_determinant() const { return 0.0; }
+
+  template <typename NewtonStateT>
+  double build_result(NewtonStateT& state, double /*log_det*/) const {
+    return state.prev().a()(0);
+  }
+};
+
+template <typename Likelihood>
+double run_laplace(const Likelihood& ll_fun, double theta0_value,
+                   double tolerance, int max_num_steps,
+                   int max_steps_line_search, std::ostream* msgs) {
+  Eigen::VectorXd theta0(1);
+  theta0 << theta0_value;
+  return stan::math::laplace_marginal_tol<false>(
+      ll_fun, std::tuple<>{}, 1, IdentityCovariance{}, std::tuple<>{},
+      std::make_tuple(theta0, tolerance, max_num_steps, 1,
+                      max_steps_line_search, true),
+      msgs);
+}
+
+TEST(LaplaceMarginalDensityEstimator, PublicLineSearchMatchesDirectStep) {
+  std::ostringstream no_search_msgs;
+  std::ostringstream wolfe_msgs;
+
+  const double no_search = run_laplace(QuarticLikelihood{}, 2.0, 1e-12, 50, 0,
+                                       &no_search_msgs);
+  const double with_wolfe = run_laplace(QuarticLikelihood{}, 2.0, 1e-12, 50,
+                                        1000, &wolfe_msgs);
+
+  EXPECT_TRUE(std::isfinite(no_search));
+  EXPECT_TRUE(std::isfinite(with_wolfe));
+  EXPECT_NEAR(no_search, with_wolfe, 1e-8);
+}
+
+TEST(LaplaceMarginalDensityEstimator, AbsoluteObjectiveToleranceStopsNearZero) {
+  std::ostringstream msgs;
+
+  const double result
+      = run_laplace(TinyQuarticLikelihood{}, 0.0, 1e-8, 6, 1000, &msgs);
+
+  EXPECT_TRUE(std::isfinite(result));
+  EXPECT_EQ(msgs.str().find("max number of iterations"), std::string::npos);
+}
+
+TEST(LaplaceMarginalDensityEstimator,
+     InvalidCachedProposalDoesNotTriggerArmijoFallback) {
+  Eigen::MatrixXd covariance = Eigen::MatrixXd::Identity(1, 1);
+  Eigen::VectorXd theta0 = Eigen::VectorXd::Zero(1);
+  auto obj_fun = [](const auto& /*a*/, const auto& /*theta*/) {
+    return -1.0;
+  };
+  auto theta_grad_f = [](const auto& theta) {
+    return Eigen::VectorXd::Zero(theta.size());
+  };
+  internal::NewtonState state(1, obj_fun, theta_grad_f, covariance, theta0);
+  laplace_options_base options;
+  options.hessian_block_size = 1;
+  options.max_num_steps = 1;
+  options.tolerance = 1e-12;
+  options.line_search.max_iterations = 5;
+  options.line_search.min_alpha = 1e-8;
+
+  StubNewtonSolver solver{5.0};
+  Eigen::Index step_iter = 1;
+  auto failing_update = [min_alpha = options.line_search.min_alpha](
+                            auto& /*proposal*/, auto&& /*curr*/,
+                            auto&& /*prev*/, auto& eval_in, auto&& /*p*/) {
+    eval_in.alpha() = 0.5 * min_alpha;
+    return false;
+  };
+  auto unused_ll = [](const auto& /*theta*/, std::ostream* /*msgs*/) {
+    return 0.0;
+  };
+
+  const double result
+      = internal::run_newton_loop(solver, state, options, step_iter, unused_ll,
+                                  std::tuple<>{}, covariance, failing_update,
+                                  nullptr);
+
+  EXPECT_DOUBLE_EQ(result, 0.0);
+  EXPECT_FALSE(state.wolfe_status.accept_);
+  EXPECT_EQ(state.wolfe_status.stop_, internal::WolfeReturn::StepTooSmall);
+}
+
+}  // namespace
+}  // namespace stan::math

--- a/test/unit/math/laplace/laplace_marginal_density_estimator_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_density_estimator_test.cpp
@@ -28,7 +28,7 @@ struct QuarticLikelihood {
 struct TinyQuarticLikelihood {
   template <typename Theta>
   auto operator()(const Theta& theta, std::ostream* /*msgs*/) const {
-    return 1e-8 * QuarticLikelihood{}(theta, nullptr);
+    return 1e-8 * QuarticLikelihood{}(theta, nullptr); // NOLINT
   }
 };
 

--- a/test/unit/math/laplace/laplace_marginal_density_estimator_test.cpp
+++ b/test/unit/math/laplace/laplace_marginal_density_estimator_test.cpp
@@ -28,7 +28,7 @@ struct QuarticLikelihood {
 struct TinyQuarticLikelihood {
   template <typename Theta>
   auto operator()(const Theta& theta, std::ostream* /*msgs*/) const {
-    return 1e-8 * QuarticLikelihood{}(theta, nullptr); // NOLINT
+    return 1e-8 * QuarticLikelihood{}(theta, nullptr);  // NOLINT
   }
 };
 

--- a/test/unit/math/laplace/wolfe_line_search_test.cpp
+++ b/test/unit/math/laplace/wolfe_line_search_test.cpp
@@ -781,6 +781,64 @@ TEST(WolfeLineSearch, HonorsMaxAlphaBound) {
   EXPECT_NE(status.stop_, WolfeReturn::Fail);
 }
 
+// Checks that zoom case 2 updates the low endpoint, not the high endpoint.
+TEST(WolfeLineSearch, ZoomPreservesCaseTwoLowUpdate) {
+  using internal::Eval;
+
+  WolfeInfo info(1);
+  info.prev_.a()(0) = 0.0;
+  info.prev_.theta()(0) = 0.0;
+  info.prev_.theta_grad()(0) = 0.0;
+  info.prev_.obj() = 0.0;
+  info.prev_.alpha() = 0.0;
+  info.curr_.a()(0) = 1.0;
+  info.curr_.theta()(0) = 1.0;
+  info.curr_.theta_grad()(0) = 0.0;
+  info.curr_.obj() = 0.0;
+  info.curr_.alpha() = 0.25;  // alpha_start = 0.5
+  info.p_(0) = 1.0;
+  info.init_dir_ = 4.0;
+
+  laplace_line_search_options opt{};
+  opt.c1 = 0.5;
+  opt.c2 = 0.1;
+  opt.scale_up = 2.0;
+  opt.max_alpha = 1.0;
+
+  auto scripted_update = [](auto& proposal, auto&&, auto&&, Eval& eval,
+                            auto&&) {
+    proposal.a()(0) = eval.alpha();
+    proposal.theta()(0) = eval.alpha();
+    proposal.theta_grad()(0) = 0.0;
+    const double alpha = eval.alpha();
+    if (std::abs(alpha - 0.5) < 1e-12) {
+      eval.obj() = 0.5;
+      eval.dir() = -2.0;
+    } else if (std::abs(alpha - 0.25) < 1e-12) {
+      eval.obj() = 0.75;
+      eval.dir() = 1.0;
+    } else if (std::abs(alpha - 0.375) < 1e-12) {
+      eval.obj() = 0.95;
+      eval.dir() = 0.0;
+    } else if (std::abs(alpha - 0.125) < 1e-12) {
+      eval.obj() = 0.6;
+      eval.dir() = 0.0;
+    } else {
+      ADD_FAILURE() << "Unexpected alpha " << alpha;
+      eval.obj() = -1.0;
+      eval.dir() = -2.0;
+    }
+  };
+
+  auto status = wolfe_line_search(info, scripted_update, opt,
+                                  static_cast<std::ostream*>(nullptr));
+
+  EXPECT_TRUE(status.accept_);
+  EXPECT_EQ(status.stop_, WolfeReturn::Wolfe);
+  EXPECT_DOUBLE_EQ(info.curr_.alpha(), 0.375);
+  EXPECT_DOUBLE_EQ(info.curr_.a()(0), 0.375);
+}
+
 // Checks that the cubic-or-bisect chooser returns an interior maximiser.
 TEST(CubicOrBisect, ReturnsInteriorMaximiser) {
   using stan::math::internal::cubic_spline;

--- a/test/unit/math/laplace/wolfe_line_search_test.cpp
+++ b/test/unit/math/laplace/wolfe_line_search_test.cpp
@@ -805,30 +805,30 @@ TEST(WolfeLineSearch, ZoomPreservesCaseTwoLowUpdate) {
   opt.scale_up = 2.0;
   opt.max_alpha = 1.0;
 
-  auto scripted_update = [](auto& proposal, auto&&, auto&&, Eval& eval,
-                            auto&&) {
-    proposal.a()(0) = eval.alpha();
-    proposal.theta()(0) = eval.alpha();
-    proposal.theta_grad()(0) = 0.0;
-    const double alpha = eval.alpha();
-    if (std::abs(alpha - 0.5) < 1e-12) {
-      eval.obj() = 0.5;
-      eval.dir() = -2.0;
-    } else if (std::abs(alpha - 0.25) < 1e-12) {
-      eval.obj() = 0.75;
-      eval.dir() = 1.0;
-    } else if (std::abs(alpha - 0.375) < 1e-12) {
-      eval.obj() = 0.95;
-      eval.dir() = 0.0;
-    } else if (std::abs(alpha - 0.125) < 1e-12) {
-      eval.obj() = 0.6;
-      eval.dir() = 0.0;
-    } else {
-      ADD_FAILURE() << "Unexpected alpha " << alpha;
-      eval.obj() = -1.0;
-      eval.dir() = -2.0;
-    }
-  };
+  auto scripted_update
+      = [](auto& proposal, auto&&, auto&&, Eval& eval, auto&&) {
+          proposal.a()(0) = eval.alpha();
+          proposal.theta()(0) = eval.alpha();
+          proposal.theta_grad()(0) = 0.0;
+          const double alpha = eval.alpha();
+          if (std::abs(alpha - 0.5) < 1e-12) {
+            eval.obj() = 0.5;
+            eval.dir() = -2.0;
+          } else if (std::abs(alpha - 0.25) < 1e-12) {
+            eval.obj() = 0.75;
+            eval.dir() = 1.0;
+          } else if (std::abs(alpha - 0.375) < 1e-12) {
+            eval.obj() = 0.95;
+            eval.dir() = 0.0;
+          } else if (std::abs(alpha - 0.125) < 1e-12) {
+            eval.obj() = 0.6;
+            eval.dir() = 0.0;
+          } else {
+            ADD_FAILURE() << "Unexpected alpha " << alpha;
+            eval.obj() = -1.0;
+            eval.dir() = -2.0;
+          }
+        };
 
   auto status = wolfe_line_search(info, scripted_update, opt,
                                   static_cast<std::ostream*>(nullptr));


### PR DESCRIPTION
## Summary

laplace_marginal was failing with normal-normal model, in which case Newton should get to the mode in one step.
This fix was made with Claude assistance and the sufficiently detailed prompt was based on previous detailed analysis of behavior of Stan model included.

All code changes are by Claude. Below I have also included summary of fixes by Claude. I have looked at the changes and summaries and they make sense. All existing Stan math tests for laplace_marginal pass and my Stan model example works well now, too. The code should still be carefully checked.

## Checklist

- [x] Copyright holder: I think the changes are so minor that there is no claim on copyright. Just in case, I'd be holder for my copyright.

By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - [x] unit tests pass (to run, use: `./runTests.py test/unit`)
    - [x] header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested

## Previously problematic model and data

R code and data
```r
library(loo)
library(brms)
library(cmdstanr)

# Data
data("sleepstudy", package = "lme4")
conditions <- make_conditions(sleepstudy, "Subject", incl_vars = FALSE)
sleepstudy <- sleepstudy |>
  filter(Days >= 2) |>
  mutate(Days = Days - 2)
standata4 <- standata(
  Reaction ~ 1 + Days + (1 + Days | Subject), 
  data = sleepstudy,
  family = gaussian()
)

# Model and posterior
mod4_la <- cmdstan_model("sleep4.stan", force_recompile=TRUE)
fit_4_la <- mod4_la$sample(data = standata4, chains = 4, refresh = 0, seed  = 1)

# The following should be the same when Laplace works:

# LOGO-CV with Laplace integrated importance sampling
(logo_4_la <- fit_4_la$loo(variables = "log_lik_g"))

# LOGO-CV with analytically integrated importance sampling
(logo_4 <- fit_4_la$loo(variables = "log_lik_ga"))
```

Stan code
```stan
// generated with brms 2.23.1
functions {
 /* compute correlated group-level effects
  * Args:
  *   z: matrix of unscaled group-level effects
  *   SD: vector of standard deviation parameters
  *   L: cholesky factor correlation matrix
  * Returns:
  *   matrix of scaled group-level effects
  */
  matrix scale_r_cor(matrix z, vector SD, matrix L) {
    // r is stored in another dimension order than z
    return transpose(diag_pre_multiply(SD, L) * z);
  }

  // Log-likelihood function for a single group
  // theta = [r_1, r_2] (group-level intercept and slope)
  real normal_group_ll(vector theta,
                          data int n_g, data vector Y_g,
                          data vector Z_1_1_g, data vector Z_1_2_g,
                          data vector mu_fixed_g, data real sigma) {
    real r_1 = theta[1];  // group-level intercept
    real r_2 = theta[2];  // group-level slope
    vector[n_g] mu = mu_fixed_g[1:n_g] + r_1 * Z_1_1_g[1:n_g] + r_2 * Z_1_2_g[1:n_g];
    return normal_lpdf(Y_g[1:n_g] | mu, sigma);
  }

  // Covariance function for bivariate group-level effects
  matrix cov_group(vector sd_1, matrix L_1) {
    return multiply_lower_tri_self_transpose(diag_pre_multiply(sd_1, L_1));
  }
}
data {
  int<lower=1> N;  // total number of observations
  vector[N] Y;  // response variable
  int<lower=1> K;  // number of population-level effects
  matrix[N, K] X;  // population-level design matrix
  int<lower=1> Kc;  // number of population-level effects after centering
  // data for group-level effects of ID 1
  int<lower=1> N_1;  // number of grouping levels
  int<lower=1> M_1;  // number of coefficients per level
  array[N] int<lower=1> J_1;  // grouping indicator per observation
  // group-level predictor values
  vector[N] Z_1_1;
  vector[N] Z_1_2;
  int<lower=1> NC_1;  // number of group-level correlations
  int prior_only;  // should the likelihood be ignored?
}
transformed data {
  matrix[N, Kc] Xc;  // centered version of X without an intercept
  vector[Kc] means_X;  // column means of X before centering
  for (i in 2:K) {
    means_X[i - 1] = mean(X[, i]);
    Xc[, i - 1] = X[, i] - means_X[i - 1];
  }
  // Prepare group-specific data arrays (fixed at data time)
  array[N_1] int n_g;  // number of observations per group
  array[N_1, N] real Y_g_arr;  // Y values per group (padded)
  array[N_1, N] real Z_1_1_g_arr;  // Z_1_1 values per group (padded)
  array[N_1, N] real Z_1_2_g_arr;  // Z_1_2 values per group (padded)
  array[N_1, N] int obs_idx_g;  // observation indices per group

  // initialize counts
  for (g in 1:N_1) {
    n_g[g] = 0;
  }
  // populate group-specific arrays
  for (n in 1:N) {
    int g = J_1[n];
    n_g[g] += 1;
    Y_g_arr[g, n_g[g]] = Y[n];
    Z_1_1_g_arr[g, n_g[g]] = Z_1_1[n];
    Z_1_2_g_arr[g, n_g[g]] = Z_1_2[n];
    obs_idx_g[g, n_g[g]] = n;
  }
  // control parameters for Laplace approximation
  real tolerance = 1e-6;
  int max_num_steps = 100, solver = 1, max_steps_line_search = 100;
}
parameters {
  vector[Kc] b;  // regression coefficients
  real Intercept;  // temporary intercept for centered predictors
  real<lower=0> sigma;  // dispersion parameter
  vector<lower=0>[M_1] sd_1;  // group-level standard deviations
  matrix[M_1, N_1] z_1;  // standardized group-level effects
  cholesky_factor_corr[M_1] L_1;  // cholesky factor of correlation matrix
}
transformed parameters {
  matrix[N_1, M_1] r_1;  // actual group-level effects
  // using vectors speeds up indexing in loops
  vector[N_1] r_1_1;
  vector[N_1] r_1_2;
  // prior contributions to the log posterior
  real lprior = 0;
  // compute actual group-level effects
  r_1 = scale_r_cor(z_1, sd_1, L_1);
  r_1_1 = r_1[, 1];
  r_1_2 = r_1[, 2];
  lprior += normal_lpdf(b | 0, 20);
  lprior += normal_lpdf(Intercept | 250, 100);
  lprior += exponential_lpdf(sigma | 0.04);
  lprior += exponential_lpdf(sd_1[1] | 0.04);
  lprior += exponential_lpdf(sd_1[2] | 1.0/15);
  lprior += lkj_corr_cholesky_lpdf(L_1 | 1);
}
model {
  // likelihood including constants
  if (!prior_only) {
    // initialize linear predictor term
    vector[N] mu = rep_vector(0.0, N);
    mu += Intercept + Xc * b;
    for (n in 1:N) {
      // add more terms to the linear predictor
      mu[n] += r_1_1[J_1[n]] * Z_1_1[n] + r_1_2[J_1[n]] * Z_1_2[n];
    }
    target += normal_lpdf(Y | mu, sigma);
  }
  // priors including constants
  target += lprior;
  target += std_normal_lpdf(to_vector(z_1));
}
generated quantities {
  // actual population-level intercept
  real b_Intercept = Intercept - dot_product(means_X, b);
  // compute group-level correlations
  corr_matrix[M_1] Cor_1 = multiply_lower_tri_self_transpose(L_1);
  vector<lower=-1,upper=1>[NC_1] cor_1;
  // extract upper diagonal of correlation matrix
  for (k in 1:M_1) {
    for (j in 1:(k - 1)) {
      cor_1[choose(k - 1, 2) + j] = Cor_1[j, k];
    }
  }
  vector[N] log_lik;
  vector[N] mu = rep_vector(0.0, N);
  mu += Intercept + Xc * b;
  for (n in 1:N) {
    mu[n] += r_1_1[J_1[n]] * Z_1_1[n] + r_1_2[J_1[n]] * Z_1_2[n];
    log_lik[n] = normal_lpdf(Y[n] | mu[n], sigma);
  }

  // group-level log-likelihoods using Laplace approximation
  vector[N_1] log_lik_g;
  {
    // fixed part of linear predictor for all observations
    vector[N] mu_fixed = Intercept + Xc * b;

    for (g in 1:N_1) {
      // Prepare group-specific vectors
      vector[N] Z_1_1_g_vec = to_vector(Z_1_1_g_arr[g]);
      vector[N] Z_1_2_g_vec = to_vector(Z_1_2_g_arr[g]);
      vector[N] Y_g_vec = to_vector(Y_g_arr[g]);
      vector[N] mu_fixed_g;
      for (i in 1:n_g[g]) {
        mu_fixed_g[i] = mu_fixed[obs_idx_g[g, i]];
      }

      // Use sampled group effects as starting point for Newton solver
      vector[2] theta_init = [r_1_1[g], r_1_2[g]]';
      // vector[2] theta_init = [0.0, 0.0]';

      log_lik_g[g] = laplace_marginal_tol(
        normal_group_ll,
        (n_g[g], Y_g_vec, Z_1_1_g_vec, Z_1_2_g_vec, mu_fixed_g, sigma),
        2,
        cov_group,
        (sd_1, L_1),
        (theta_init, tolerance, max_num_steps, solver, max_steps_line_search, 1));
    }
  }
  // group-level log-likelihoods using analytic integration
  vector[N_1] log_lik_ga;
  {
    // Group-level covariance matrix (M_1 x M_1)
    matrix[M_1, M_1] Sigma_group = multiply_lower_tri_self_transpose(diag_pre_multiply(sd_1, L_1));
    // Fixed part of linear predictor for all observations
    vector[N] mu_fixed = Intercept + Xc * b;
    for (g in 1:N_1) {
      int ng = n_g[g];

      // Build group-specific design matrix and vectors
      matrix[ng, M_1] Z_g;
      vector[ng] Y_g;
      vector[ng] mu_g;
      for (i in 1:ng) {
        Z_g[i, 1] = Z_1_1_g_arr[g, i];
        Z_g[i, 2] = Z_1_2_g_arr[g, i];
        Y_g[i] = Y_g_arr[g, i];
        mu_g[i] = mu_fixed[obs_idx_g[g, i]];
      }

      // Marginal covariance: sigma^2 * I_{ng} + Z_g * Sigma_group * Z_g'
      matrix[ng, ng] Cov_g = add_diag(Z_g * Sigma_group * Z_g', square(sigma));

      log_lik_ga[g] = multi_normal_lpdf(Y_g | mu_g, Cov_g);
    }
  }
}
```

----------
# Claude's summary of the fixes

# Bug Report: `laplace_marginal_tol()` Erratically Fails to Find the Mode

## Symptom

When `laplace_marginal_tol()` is called with a user-supplied non-zero
`theta_init`, the Newton optimizer sometimes:

1. **Stays near the initial values** without actually optimizing,
2. **Converges to `[0, 0]`**, or
3. **Finds the correct mode** (unpredictably).

This happens across all three solvers (1, 2, 3) and is not related to
the Laplace equations themselves — when the mode is found, the marginal
density matches the analytic result.

## Root Cause

**The invariant `theta = Sigma * a` is violated at initialization.**

The Newton solver operates in the `a`-parameterization where
`theta = Sigma * a` and maximizes the objective:

```
obj(a, theta) = -0.5 * a' * theta + log_likelihood(theta)
```

In `wolfe_line_search.hpp`, the `WolfeData` constructor (line ~449)
unconditionally sets `a = 0` regardless of the user-supplied `theta_init`:

```cpp
WolfeData(obj_fun, n, theta0, theta_grad_f)
    : theta_(theta0),                       // theta = user-supplied init
      theta_grad_(theta_grad_f(theta_)),
      a_(Eigen::VectorXd::Zero(n)),          // a = 0  ← BUG
      eval_(1.0, obj_fun(a_, theta_), 0.0)
```

When `theta_init != 0` and `a = 0`, the initial objective evaluates to:

```
obj_init = -0.5 * 0' * theta_init + LL(theta_init) = LL(theta_init)
```

The prior penalty term `-0.5 * theta' * Sigma^{-1} * theta` (which
equals `-0.5 * a' * theta` when `a = Sigma^{-1} * theta`) is entirely
missing.  The initial objective is artificially inflated by
`0.5 * theta_init' * Sigma^{-1} * theta_init`.

### Why This Causes Three Failure Modes

**Mode A — "Stays near initial values":**  When `theta_init` is near the
true mode, the first Newton step proposes a consistent `(a_new, theta_new)`
with `theta_new ≈ theta_init`.  But `obj_new` includes the prior penalty
while `obj_init` does not, so `obj_new < obj_init`.  The Wolfe line search
rejects the step (`accept_ = false`), and `search_failed = true` fires
immediately.  The optimizer returns after 0–1 iterations.

**Mode B — "Converges to `[0, 0]`":**  When the rejected step causes
`build_result` to return `state.prev()` with `a = [0, 0]`, downstream
code that recomputes `theta = Sigma * a` gets `theta = [0, 0]`.

**Mode C — "Sometimes finds the mode":**  When `theta_init ≈ 0`, the
inflation `0.5 * theta_init' * Sigma^{-1} * theta_init` is negligible, so
the inconsistency doesn't prevent the solver from making progress.

The severity depends on the magnitude of `theta_init` relative to the
prior, which varies across MCMC draws and groups — explaining the erratic
pattern.

### Secondary Issue: Corrupted First-Iteration Gradient

The first-iteration search direction gradient is computed as:

```cpp
prev_g = -covariance * state.prev().a() + covariance * state.prev().theta_grad();
```

With `a = 0`, the `-covariance * a` term vanishes, so the gradient
direction is purely likelihood-driven with no prior pull.  This can cause
the Newton step to overshoot or go in a suboptimal direction even if the
line search doesn't reject outright.

## Fix

### Approach

Compute the consistent `a_init = Sigma^{-1} * theta_init` before
constructing `NewtonState`, and pass it through the constructor chain
so that both `a` and `theta` are initialized consistently.

### Changed Files

#### `stan/math/mix/functor/wolfe_line_search.hpp`

Added a new `WolfeInfo` constructor overload that accepts both `a_init`
and `theta_init`, forwarding to the existing `WolfeData` constructor
that takes an explicit `a` argument:

```cpp
WolfeInfo(ObjFun&& obj_fun, const Eigen::VectorXd& a_init, Theta0&& theta0,
          ThetaGradF&& theta_grad_f, int /*tag*/)
    : curr_(std::forward<ObjFun>(obj_fun), a_init,
            std::forward<Theta0>(theta0),
            std::forward<ThetaGradF>(theta_grad_f)),
      prev_(curr_),
      scratch_(a_init.size()) { ... }
```

A trailing `int /*tag*/` parameter disambiguates from the existing
`(obj_fun, n, theta0, theta_grad_f)` overload.

#### `stan/math/mix/functor/laplace_marginal_density_estimator.hpp`

1. Added a new `NewtonState` constructor overload that accepts
   `(theta_size, obj_fun, theta_grad_f, a_init, theta_init)` and
   forwards to the new `WolfeInfo` constructor.

2. In `laplace_marginal_density_est`, when `InitTheta = true`, compute:

   ```cpp
   Eigen::VectorXd a_init = covariance.llt().solve(theta_init);
   ```

   and construct `NewtonState` with both `a_init` and `theta_init`.
   When `InitTheta = false`, the existing zero-initialization path is
   unchanged.

### What the Fix Does NOT Change

- The `InitTheta = false` path (zero initialization) is identical.
- All solver policies (1, 2, 3) are unaffected — the fix is upstream
  in the shared initialization code.
- The `update_fun` lambda already correctly enforces
  `theta = Sigma * a` for all subsequent proposals.
- The Wolfe line search, Barzilai-Borwein step size, and convergence
  criteria are all unchanged.

## Verification

All Laplace test suites compile and pass:

| Test suite | Tests | Result |
|---|---|---|
| `laplace_marginal_lpdf_moto_test` (non-zero `theta_init`) | 48 run, 24 skipped | **All passed** |
| `laplace_types_test` | 55 | **All passed** |
| `wolfe_line_search_test` | 18 | **All passed** |
| `generate_laplace_options_test` | 3 | **All passed** |
| `aki_ex_test` | 2 | **All passed** |
| `laplace_marginal_bernoulli_logit_lpmf_test` | compiles | OK |
| `laplace_marginal_poisson_log_lpmf_test` | compiles | OK |
| `laplace_marginal_neg_binomial_log_lpmf_test` | compiles | OK |
| `laplace_marginal_neg_binomial_log_summary_lpmf_test` | compiles | OK |

## Other Observations (Not Fixed Here)

During the code examination, several additional issues were noted that
are not related to the primary bug but may warrant separate attention:

1. **`llt_with_jitter` accumulates jitter.**  Each retry adds increasing
   diagonal jitter (`1e-10` to `1e-5`) without removing the previous
   jitter.  The resulting `B` matrix differs from the theoretical `B`,
   but the log-determinant is computed from the jittered matrix without
   correction.

2. **`std::once_flag` masks repeated fallbacks.**  The solver fallback
   warning uses `static std::once_flag`, so it fires at most once per
   process lifetime.  Repeated fallbacks across calls are silently
   suppressed.

3. **LU log-determinant ignores permutation sign.**
   `LUSolver::compute_log_determinant()` takes `log()` of the LU
   diagonal entries.  If any entry is negative (possible when `B` is not
   positive definite — the reason solver 3 was needed), this produces
   NaN.

4. **Absolute-only convergence tolerance.**
   `|curr.obj - prev.obj| < tolerance` has no relative component.  For
   objectives with large magnitude the threshold may trigger too easily;
   for near-zero objectives it may be too loose.

5. **`block_matrix_sqrt` uses `.isFinite().any()` instead of `.all()`.**
   The check `!local_block.array().isFinite().any()` only catches blocks
   where *every* element is non-finite; a mix of finite and NaN values
   passes silently.

# Fixes for `laplace_marginal_tol()` Newton Solver Convergence

## Context

After applying the initial `a_init` fix (documented in
`laplace_marginal_tol_bug.md`), many `log_lik_g` values from
`laplace_marginal_tol()` still disagreed with the analytic closed-form
marginal likelihood.  The `a_init` fix corrected the initialization
invariant (`theta = Sigma * a`) but three additional bugs in the Newton
solver prevented reliable convergence to the true mode.

All fixes are in
`stan/math/mix/functor/laplace_marginal_density_estimator.hpp` and
`stan/math/mix/functor/wolfe_line_search.hpp`.

---

## Fix 1: Consistent `a_init` initialization (prior fix, included for completeness)

**Files:** `laplace_marginal_density_estimator.hpp`, `wolfe_line_search.hpp`

When `InitTheta = true`, `WolfeData` unconditionally set `a = 0`
regardless of the user-supplied `theta_init`, violating the invariant
`theta = Sigma * a`.  This inflated the initial objective by omitting
the prior penalty `-0.5 * a' * theta`, causing the Wolfe line search to
reject the first Newton step.

**Fix:** Compute `a_init = Sigma^{-1} * theta_init` via
`covariance.llt().solve(theta_init)` and pass it through a new
constructor overload chain (`NewtonState` → `WolfeInfo` → `WolfeData`)
so both `a` and `theta` are consistent from the start.

## Fix 2: Wolfe zoom-phase case [4] placement

**File:** `wolfe_line_search.hpp`

In the zoom phase of the Wolfe line search, case [4] (`high = mid`, for
Armijo-OK but `f(mid) <= f(low)`) was placed *outside* the Armijo-true
branch, causing it to execute unconditionally after cases [2] and [3].
This meant every zoom iteration that reached `mid.obj() <= low.obj()`
would collapse the bracket incorrectly.

**Fix:** Nest case [4] inside the `else` of the `mid.obj() > low.obj()`
check, so it only fires when Armijo holds but `f(mid) <= f(low)`:

```cpp
      } else {
        // [4]
        high = mid;
      }
```

## Fix 3: Cumulative jitter in `llt_with_jitter`

**File:** `laplace_marginal_density_estimator.hpp`

Each retry in the jitter loop added `jitter_try` to the diagonal
*without removing the previous jitter*.  After the full retry sequence,
the total perturbation was `1e-10 + 1e-9 + ... + 1e-5 ≈ 1.111e-5`
rather than the intended `1e-5`.  Since `B` is passed by reference and
the jittered matrix is kept, the Cholesky factorization (and hence the
log-determinant used in the final marginal density) was computed from an
over-perturbed matrix.

**Fix:** Track `prev_jitter` and add only the *incremental* difference
each iteration, so the total diagonal perturbation is exactly
`jitter_try`:

```cpp
double prev_jitter = 0.0;
double jitter_try = min_jitter;
for (; jitter_try < max_jitter; jitter_try *= 10) {
    B.diagonal().array() += (jitter_try - prev_jitter);
    prev_jitter = jitter_try;
    llt_B.compute(B);
    if (llt_B.info() == Eigen::Success) break;
}
```

## Fix 4: `search_failed` used stale `curr.obj()`, terminating on every Wolfe rejection

**File:** `laplace_marginal_density_estimator.hpp`

The original convergence check was:

```cpp
bool search_failed = (!state.wolfe_status.accept_
                      && state.curr().obj() <= state.prev().obj());
```

When the Wolfe line search rejects a step (`accept_ = false`), it
leaves `curr_` unchanged — so `curr.obj()` retains the stale value
from the previous `update_next_step` swap, which is typically equal to
`prev.obj()`.  The `<= prev.obj()` comparison is therefore almost
always true, making `search_failed` equivalent to `!accept_`.  This
caused the Newton loop to terminate immediately on *any* Wolfe
rejection, even when the full Newton step would have improved the
objective.

**Fix:** Before the Wolfe line search runs, save the full Newton step's
objective (`full_newton_obj = scratch.eval_.obj()`).  After a Wolfe
rejection, check whether the full Newton step improved the objective.
If so, re-evaluate scratch at alpha = 1, accept it as the current
iterate, and let the Newton loop continue:

```cpp
const double full_newton_obj = scratch.eval_.obj();
// ... Wolfe line search runs, potentially overwriting scratch ...

bool search_failed;
if (!state.wolfe_status.accept_) {
    if (full_newton_obj > state.prev().obj()) {
        // Re-evaluate at the full Newton step and accept it
        scratch.eval_.alpha() = 1.0;
        update_fun(scratch, state.curr(), state.prev(),
                   scratch.eval_, state.wolfe_info.p_);
        state.curr().update(scratch);
        state.wolfe_status.accept_ = true;
        search_failed = false;
    } else {
        search_failed = true;
    }
} else {
    search_failed = false;
}
```

This is necessary because the Wolfe line search overwrites `scratch`
with intermediate trial points; the saved scalar `full_newton_obj` is
the only reliable record of whether the full Newton step was an
improvement.

## Fix 5: Absolute-only convergence tolerance

**File:** `laplace_marginal_density_estimator.hpp`

The Newton loop convergence check used only an absolute tolerance:

```cpp
bool objective_converged
    = std::abs(curr.obj() - prev.obj()) < options.tolerance;
```

For the Laplace objective (which can range from −50 to −200 or beyond),
an absolute threshold of `1e-6` triggers trivially.  The optimizer could
declare convergence after a single iteration if the objective happened
to change by less than `1e-6` — even though the *relative* change was
still significant (e.g., a change of `5e-7` on an objective of `−50` is
`1e-8` relative, but on an objective of `−0.001` would be `5e-4`
relative).

**Fix:** Require both an absolute *and* a relative condition:

```cpp
double obj_change = std::abs(state.curr().obj() - state.prev().obj());
bool objective_converged
    = obj_change < options.tolerance
      && obj_change < options.tolerance * std::abs(state.prev().obj());
```

This prevents premature convergence when the objective magnitude is
large, while preserving the absolute floor for near-zero objectives.

---

## How the Fixes Interact

| # | Bug | Effect on Laplace density | Which draws affected? |
|---|-----|---------------------------|-----------------------|
| 1 | `a = 0` with `theta ≠ 0` | Inflated initial objective → first step rejected → 0–1 iterations | Draws where `theta_init` is far from 0 |
| 2 | Zoom case [4] misplaced | Bracket collapses incorrectly → suboptimal step size | All draws using zoom phase |
| 3 | Cumulative jitter | `log\|B\|` computed from over-perturbed matrix | Draws where Cholesky needs jitter |
| 4 | Stale `curr.obj()` in `search_failed` | Newton loop exits after any Wolfe rejection | Draws where Wolfe line search struggles |
| 5 | Absolute-only tolerance | Premature convergence on large-magnitude objectives | All draws (probabilistic) |

Bugs 1 and 4 had the largest impact: together they meant the Newton
solver would often run only 0–2 iterations for groups where `theta_init`
was far from zero.  Bug 1 prevented the first step from being accepted,
and bug 4 terminated the loop as soon as the line search failed to find
a point satisfying the Wolfe conditions — even when the objective was
clearly improving.

---

## Verification

After all five fixes, `sleep4.stan` (Laplace approximation) and
`sleep4g.stan` (analytic marginal) produce matching `log_lik_g` values
across all 18 groups and 4000 posterior draws.
