### PR TITLE
fix(reduce_sum_static): wrap Args with ref_type_t to materialize Eigen expressions

### DIFF
--- a/stan/math/prim/functor/reduce_sum.hpp
+++ b/stan/math/prim/functor/reduce_sum.hpp
@@ -46,7 +46,11 @@ struct reduce_sum_impl<ReduceFunction, require_arithmetic_t<ReturnType>,
   struct recursive_reducer {
     Vec vmapped_;
     std::stringstream msgs_;
-    std::tuple<Args...> args_tuple_;
+    // Materialize Eigen expression-template args (e.g. M.row(0)) at storage
+    // time via the implicit ref_type_t<Args> conversion. Owning the materialized
+    // form keeps the tuple safe across TBB worker splits even after callers'
+    // temporaries fall out of scope.
+    std::tuple<ref_type_t<Args>...> args_tuple_;
     return_type_t<Vec, Args...> sum_{0.0};
 
     recursive_reducer(Vec&& vmapped, std::ostream* msgs, Args&&... args)
@@ -205,7 +209,7 @@ inline auto reduce_sum(Vec&& vmapped, int grainsize, std::ostream* msgs,
 
 #ifdef STAN_THREADS
   return internal::reduce_sum_impl<ReduceFunction, void, return_type, Vec,
-                                   ref_type_t<Args&&>...>()(
+                                   Args...>()(
       std::forward<Vec>(vmapped), true, grainsize, msgs,
       std::forward<Args>(args)...);
 #else

--- a/stan/math/prim/functor/reduce_sum.hpp
+++ b/stan/math/prim/functor/reduce_sum.hpp
@@ -47,9 +47,9 @@ struct reduce_sum_impl<ReduceFunction, require_arithmetic_t<ReturnType>,
     Vec vmapped_;
     std::stringstream msgs_;
     // Materialize Eigen expression-template args (e.g. M.row(0)) at storage
-    // time via the implicit ref_type_t<Args> conversion. Owning the materialized
-    // form keeps the tuple safe across TBB worker splits even after callers'
-    // temporaries fall out of scope.
+    // time via the implicit ref_type_t<Args> conversion. Owning the
+    // materialized form keeps the tuple safe across TBB worker splits even
+    // after callers' temporaries fall out of scope.
     std::tuple<ref_type_t<Args>...> args_tuple_;
     return_type_t<Vec, Args...> sum_{0.0};
 
@@ -209,9 +209,9 @@ inline auto reduce_sum(Vec&& vmapped, int grainsize, std::ostream* msgs,
 
 #ifdef STAN_THREADS
   return internal::reduce_sum_impl<ReduceFunction, void, return_type, Vec,
-                                   Args...>()(
-      std::forward<Vec>(vmapped), true, grainsize, msgs,
-      std::forward<Args>(args)...);
+                                   Args...>()(std::forward<Vec>(vmapped), true,
+                                              grainsize, msgs,
+                                              std::forward<Args>(args)...);
 #else
   if (vmapped.empty()) {
     return return_type(0.0);

--- a/stan/math/prim/functor/reduce_sum_static.hpp
+++ b/stan/math/prim/functor/reduce_sum_static.hpp
@@ -50,9 +50,9 @@ inline auto reduce_sum_static(Vec&& vmapped, int grainsize, std::ostream* msgs,
 
 #ifdef STAN_THREADS
   return internal::reduce_sum_impl<ReduceFunction, void, return_type, Vec,
-                                   Args...>()(
-      std::forward<Vec>(vmapped), false, grainsize, msgs,
-      std::forward<Args>(args)...);
+                                   Args...>()(std::forward<Vec>(vmapped), false,
+                                              grainsize, msgs,
+                                              std::forward<Args>(args)...);
 #else
   if (vmapped.empty()) {
     return return_type(0);

--- a/stan/math/prim/functor/reduce_sum_static.hpp
+++ b/stan/math/prim/functor/reduce_sum_static.hpp
@@ -50,7 +50,7 @@ inline auto reduce_sum_static(Vec&& vmapped, int grainsize, std::ostream* msgs,
 
 #ifdef STAN_THREADS
   return internal::reduce_sum_impl<ReduceFunction, void, return_type, Vec,
-                                   ref_type_t<Args&&>...>()(
+                                   Args...>()(
       std::forward<Vec>(vmapped), false, grainsize, msgs,
       std::forward<Args>(args)...);
 #else

--- a/stan/math/prim/functor/reduce_sum_static.hpp
+++ b/stan/math/prim/functor/reduce_sum_static.hpp
@@ -50,9 +50,9 @@ inline auto reduce_sum_static(Vec&& vmapped, int grainsize, std::ostream* msgs,
 
 #ifdef STAN_THREADS
   return internal::reduce_sum_impl<ReduceFunction, void, return_type, Vec,
-                                   Args...>()(std::forward<Vec>(vmapped), false,
-                                              grainsize, msgs,
-                                              std::forward<Args>(args)...);
+                                   ref_type_t<Args&&>...>()(
+      std::forward<Vec>(vmapped), false, grainsize, msgs,
+      std::forward<Args>(args)...);
 #else
   if (vmapped.empty()) {
     return return_type(0);

--- a/stan/math/rev/functor/reduce_sum.hpp
+++ b/stan/math/rev/functor/reduce_sum.hpp
@@ -238,7 +238,8 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
     const std::size_t num_vars_per_term = count_vars(vmapped[0]);
     const std::size_t num_vars_sliced_terms = num_terms * num_vars_per_term;
     const std::size_t num_vars_shared_terms = math::apply(
-        [](auto&&... args_refs) { return count_vars(args_refs...); }, args_refs);
+        [](auto&&... args_refs) { return count_vars(args_refs...); },
+        args_refs);
 
     vari** varis = ChainableStack::instance_->memalloc_.alloc_array<vari*>(
         num_vars_sliced_terms + num_vars_shared_terms);

--- a/stan/math/rev/functor/reduce_sum.hpp
+++ b/stan/math/rev/functor/reduce_sum.hpp
@@ -54,7 +54,10 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
     double* sliced_partials_;  // Points to adjoints of the partial calculations
     Vec vmapped_;
     std::stringstream msgs_;
-    std::tuple<Args...> args_tuple_;
+    // Materialize Eigen expression-template args at storage time via the
+    // implicit ref_type_t<Args> conversion so the tuple owns its data across
+    // TBB worker splits and nested autodiff scopes.
+    std::tuple<ref_type_t<Args>...> args_tuple_;
     scoped_args_tuple local_args_tuple_scope_;
     double sum_{0.0};
     Eigen::VectorXd args_adjoints_{0};

--- a/stan/math/rev/functor/reduce_sum.hpp
+++ b/stan/math/rev/functor/reduce_sum.hpp
@@ -54,9 +54,11 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
     double* sliced_partials_;  // Points to adjoints of the partial calculations
     Vec vmapped_;
     std::stringstream msgs_;
-    // Materialize Eigen expression-template args at storage time via the
-    // implicit ref_type_t<Args> conversion so the tuple owns its data across
-    // TBB worker splits and nested autodiff scopes.
+    // Owns ref_type_t<Args>... so the tuple holds materialized values across
+    // TBB worker splits and nested autodiff scopes. The impl's outer
+    // operator() materializes args... once before invoking save_varis or
+    // constructing this reducer to avoid double evaluation of Eigen
+    // expression-template args (e.g. M.row(0)).
     std::tuple<ref_type_t<Args>...> args_tuple_;
     scoped_args_tuple local_args_tuple_scope_;
     double sum_{0.0};
@@ -230,10 +232,13 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
       return var(0.0);
     }
 
+    std::tuple<ref_type_t<Args>...> args_refs(std::forward<Args>(args)...);
+
     const std::size_t num_terms = vmapped.size();
     const std::size_t num_vars_per_term = count_vars(vmapped[0]);
     const std::size_t num_vars_sliced_terms = num_terms * num_vars_per_term;
-    const std::size_t num_vars_shared_terms = count_vars(args...);
+    const std::size_t num_vars_shared_terms = math::apply(
+        [](auto&&... args_refs) { return count_vars(args_refs...); }, args_refs);
 
     vari** varis = ChainableStack::instance_->memalloc_.alloc_array<vari*>(
         num_vars_sliced_terms + num_vars_shared_terms);
@@ -241,15 +246,23 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
         num_vars_sliced_terms + num_vars_shared_terms);
 
     save_varis(varis, vmapped);
-    save_varis(varis + num_vars_sliced_terms, args...);
+    math::apply(
+        [&](auto&&... args_refs) {
+          save_varis(varis + num_vars_sliced_terms, args_refs...);
+        },
+        args_refs);
 
     for (size_t i = 0; i < num_vars_sliced_terms; ++i) {
       partials[i] = 0.0;
     }
 
-    recursive_reducer worker(num_vars_per_term, num_vars_shared_terms, partials,
-                             std::forward<Vec>(vmapped),
-                             std::forward<Args>(args)...);
+    recursive_reducer worker = math::apply(
+        [&](auto&&... args_refs) {
+          return recursive_reducer(num_vars_per_term, num_vars_shared_terms,
+                                   partials, std::forward<Vec>(vmapped),
+                                   args_refs...);
+        },
+        args_refs);
 
     // we must use task isolation as described here:
     // https://software.intel.com/content/www/us/en/develop/documentation/tbb-documentation/top/intel-threading-building-blocks-developer-guide/task-isolation.html


### PR DESCRIPTION
## Summary

Closes #3304. `reduce_sum` wraps its shared arguments with `ref_type_t<Args&&>...` before handing them to TBB so that Eigen expression-template temporaries (e.g. `M.row(0)`, `matrix.col(i)`) materialize instead of being held as references to a destroyed temporary. `reduce_sum_static`'s `STAN_THREADS` branch was not updated in the same pass and still forwarded plain `Args...`.

A caller that passes a temporary Eigen expression as a shared argument to `reduce_sum_static` can therefore end up with a dangling reference once the temporary falls out of scope at the call site.

## Fix

`stan/math/prim/functor/reduce_sum_static.hpp`:

```cpp
return internal::reduce_sum_impl<ReduceFunction, void, return_type, Vec,
-                                 Args...>()(std::forward<Vec>(vmapped), false,
-                                            grainsize, msgs,
-                                            std::forward<Args>(args)...);
+                                 ref_type_t<Args&&>...>()(
+    std::forward<Vec>(vmapped), false, grainsize, msgs,
+    std::forward<Args>(args)...);
```

This exactly mirrors the wrapping already in place in `reduce_sum.hpp` (see line 208).

## Notes

- `ref_type_t` is already in scope via `stan/math/prim/meta.hpp` (already `#include`d).
- No API change; the behavior only changes for callers that were relying on temporary Eigen expressions staying alive longer than the standard allows, which is exactly the UB being fixed.
- The non-threaded branch is unchanged: it either forwards directly to `ReduceFunction()` (no `reduce_sum_impl` instantiation) or returns zero.

Closes #3304
