### PR TITLE
Try to improve error handling of parallel distribution tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -511,12 +511,12 @@ pipeline {
             steps {
                 script {
                     def tests = [:]
-                    for (f in changedDistributionTests.collate(24)) {
+                    for (f in changedDistributionTests.collate(18)) {
                         def names = f.join(" ")
                         tests["Distribution Tests: ${names}"] = { node ("linux && docker && 8core") {
                             deleteDir()
                             docker.image('stanorg/ci:gpu-cpp17').inside {
-                                catchError {
+                                catchError(buildResult: "FAILURE", stageResult: "FAILURE") {
                                     unstash 'MathSetup'
                                     sh """
                                         echo CXX=${CLANG_CXX} > make/local
@@ -536,8 +536,7 @@ pipeline {
                             }
                         } }
                     }
-                    tests.failFast = true
-                    parallel tests
+                    parallel(failfast: true) tests
                 }
             }
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -519,7 +519,7 @@ pipeline {
                     def tests = [:]
 
                     def executors = 10
-                    def tests_per_executor = (changedDistributionTests.size() / executors).setScale(0, /* RoundingMode.CEILING */ 2)
+                    def tests_per_executor = Math.ceil((changedDistributionTests.size() / executors).doubleValue())
                     def idx = 0
                     for (f in changedDistributionTests.collate(tests_per_executor)) {
                         idx = idx + 1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -487,6 +487,12 @@ pipeline {
             steps {
                 script {
                     retry(3) { checkout scm }
+
+                    if (params.withRowVector || isBranch('develop') || isBranch('master')) {
+                        sh "echo CXXFLAGS+=-DSTAN_TEST_ROW_VECTORS >> make/local"
+                        sh "echo CXXFLAGS+=-DSTAN_PROB_TEST_ALL >> make/local"
+                    }
+
                     if (params.runAllDistributions || isBranch('develop') || isBranch('master')) {
                         changedDistributionTests = sh(script:"python3 test/prob/getDependencies.py --pretend-all", returnStdout:true).trim().readLines()
                     } else {
@@ -511,10 +517,10 @@ pipeline {
             steps {
                 script {
                     def tests = [:]
-                    def tests_per_executor = 180
+
+                    def executors = 10
+                    def tests_per_executor = Math.ceil(changedDistributionTests.size() / executors)
                     def idx = 0
-                    // roughly 10 executors when all tests run
-                    def executors = (changedDistributionTests.size() + tests_per_executor - 1) / tests_per_executor
                     for (f in changedDistributionTests.collate(tests_per_executor)) {
                         idx = idx + 1
                         def names = f.join(" ")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -519,7 +519,7 @@ pipeline {
                     def tests = [:]
 
                     def executors = 10
-                    def tests_per_executor = (changedDistributionTests.size() / executors).setScale(0, RoundingMode.CEILING)
+                    def tests_per_executor = (changedDistributionTests.size() / executors).setScale(0, /* RoundingMode.CEILING */ 2)
                     def idx = 0
                     for (f in changedDistributionTests.collate(tests_per_executor)) {
                         idx = idx + 1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -511,9 +511,14 @@ pipeline {
             steps {
                 script {
                     def tests = [:]
-                    for (f in changedDistributionTests.collate(18)) {
+                    def tests_per_executor = 180
+                    def idx = 0
+                    // roughly 10 executors when all tests run
+                    def executors = (changedDistributionTests.size() + tests_per_executor - 1) / tests_per_executor
+                    for (f in changedDistributionTests.collate(tests_per_executor)) {
+                        idx = idx + 1
                         def names = f.join(" ")
-                        tests["Distribution Tests: ${names}"] = { node ("linux && docker && 8core") {
+                        tests["Distribution Tests: ${idx} / ${executors}"] = { node ("linux && docker && 8core") {
                             deleteDir()
                             docker.image('stanorg/ci:gpu-cpp17').inside {
                                 catchError(buildResult: "FAILURE", stageResult: "FAILURE") {
@@ -536,7 +541,8 @@ pipeline {
                             }
                         } }
                     }
-                    parallel(failfast: true) tests
+                    tests.failFast = true
+                    parallel tests
                 }
             }
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -519,7 +519,7 @@ pipeline {
                     def tests = [:]
 
                     def executors = 10
-                    def tests_per_executor = Math.ceil(changedDistributionTests.size() / executors)
+                    def tests_per_executor = (changedDistributionTests.size() / executors).setScale(0, RoundingMode.CEILING)
                     def idx = 0
                     for (f in changedDistributionTests.collate(tests_per_executor)) {
                         idx = idx + 1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -519,7 +519,7 @@ pipeline {
                     def tests = [:]
 
                     def executors = 10
-                    def tests_per_executor = Math.ceil((changedDistributionTests.size() / executors).doubleValue())
+                    def tests_per_executor = Math.ceil((changedDistributionTests.size() / executors).doubleValue()).toInteger()
                     def idx = 0
                     for (f in changedDistributionTests.collate(tests_per_executor)) {
                         idx = idx + 1

--- a/test/prob/frechet/frechet_test.hpp
+++ b/test/prob/frechet/frechet_test.hpp
@@ -30,7 +30,7 @@ class AgradDistributionsFrechet : public AgradDistributionTest {
     param[1] = 3.9;   // alpha
     param[2] = 1.7;   // sigma
     parameters.push_back(param);
-    log_prob.push_back(-1754.93950342517);  // expected log_prob
+    log_prob.push_back(-1754.98950342517);  // expected log_prob
   }
 
   void invalid_values(vector<size_t>& index, vector<double>& value) {

--- a/test/prob/frechet/frechet_test.hpp
+++ b/test/prob/frechet/frechet_test.hpp
@@ -30,7 +30,7 @@ class AgradDistributionsFrechet : public AgradDistributionTest {
     param[1] = 3.9;   // alpha
     param[2] = 1.7;   // sigma
     parameters.push_back(param);
-    log_prob.push_back(-1754.98950342517);  // expected log_prob
+    log_prob.push_back(-1754.93950342517);  // expected log_prob
   }
 
   void invalid_values(vector<size_t>& index, vector<double>& value) {

--- a/test/prob/getDependencies.py
+++ b/test/prob/getDependencies.py
@@ -9,7 +9,7 @@ from typing import Set
 import sys
 import subprocess
 from pathlib import Path
-
+import glob
 
 def get_dependencies(file: Path) -> Set[str]:
     file_dot_d = file.with_suffix(".d")
@@ -36,6 +36,11 @@ def get_changed() -> Set[str]:
     return set(changed_files)
 
 
+def add_tests_from_hpp(tests_to_run, test):
+    pattern = str(test).replace("_test.hpp", "_0*_test.cpp")
+    tests = glob.glob(pattern)
+    tests_to_run.extend(tests)
+
 if __name__ == "__main__":
     if Path("makefile") not in Path(".").iterdir():
         raise ValueError("getDependencies must be ran from the top-level repository")
@@ -47,12 +52,16 @@ if __name__ == "__main__":
 
     distribution_tests = Path("test", "prob")
 
+    subprocess.run(["make", "generate-tests"], stdout=subprocess.DEVNULL)
+
     for dist in distribution_tests.iterdir():
         if not dist.is_dir():
             continue
+        print(f"Considering {dist}.", file=sys.stderr)
         for test in dist.iterdir():
+            if test.suffix != ".hpp": continue
             if pretend:
-                tests_to_run.append(str(test).replace("_test.hpp", "_0*_test.cpp"))
+                add_tests_from_hpp(tests_to_run, test)
             else:
                 deps = get_dependencies(test)
                 intersection = changed & deps
@@ -61,7 +70,6 @@ if __name__ == "__main__":
                         f"{test} has {len(intersection)} changed dependencies out of {len(deps)} files #included.",
                         file=sys.stderr,
                     )
+                    add_tests_from_hpp(tests_to_run, test)
 
-                    tests_to_run.append(str(test).replace("_test.hpp", "_0*_test.cpp"))
-
-    print("\n".join(tests_to_run))
+    print("\n".join(set(tests_to_run)))


### PR DESCRIPTION
## Summary

Some PRs (e.g. #3271) have recently run into an issue where they fail a distribution test but the jenkins UI still turns green. This ends up being confusing, and I think these settings should help 


## Tests


## Side Effects



## Release notes



## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
