### PR TITLE
Implement trace_dot

### DIFF
--- a/stan/math/fwd/fun.hpp
+++ b/stan/math/fwd/fun.hpp
@@ -116,6 +116,7 @@
 #include <stan/math/fwd/fun/tcrossprod.hpp>
 #include <stan/math/fwd/fun/tgamma.hpp>
 #include <stan/math/fwd/fun/to_fvar.hpp>
+#include <stan/math/fwd/fun/trace_dot.hpp>
 #include <stan/math/fwd/fun/trace_quad_form.hpp>
 #include <stan/math/fwd/fun/trigamma.hpp>
 #include <stan/math/fwd/fun/trunc.hpp>

--- a/stan/math/fwd/fun/trace_dot.hpp
+++ b/stan/math/fwd/fun/trace_dot.hpp
@@ -26,8 +26,7 @@ namespace math {
 template <typename EigMat1, typename EigMat2,
           require_all_eigen_t<EigMat1, EigMat2>* = nullptr,
           require_any_vt_fvar<EigMat1, EigMat2>* = nullptr>
-inline return_type_t<EigMat1, EigMat2> trace_dot(EigMat1&& A,
-                                                 EigMat2&& B) {
+inline return_type_t<EigMat1, EigMat2> trace_dot(EigMat1&& A, EigMat2&& B) {
   check_size_match("trace_dot", "A.cols()", A.cols(), "B.rows()", B.rows());
   check_size_match("trace_dot", "A.rows()", A.rows(), "B.cols()", B.cols());
   return trace(multiply(std::forward<EigMat1>(A), std::forward<EigMat2>(B)));

--- a/stan/math/fwd/fun/trace_dot.hpp
+++ b/stan/math/fwd/fun/trace_dot.hpp
@@ -25,7 +25,7 @@ template <typename EigMat1, typename EigMat2,
           require_all_eigen_t<EigMat1, EigMat2>* = nullptr,
           require_any_vt_fvar<EigMat1, EigMat2>* = nullptr>
 inline return_type_t<EigMat1, EigMat2> trace_dot(const EigMat1& A,
-                                                  const EigMat2& B) {
+                                                 const EigMat2& B) {
   check_size_match("trace_dot", "A.cols()", A.cols(), "B.rows()", B.rows());
   check_size_match("trace_dot", "A.rows()", A.rows(), "B.cols()", B.cols());
   return trace(multiply(A, B));

--- a/stan/math/fwd/fun/trace_dot.hpp
+++ b/stan/math/fwd/fun/trace_dot.hpp
@@ -1,0 +1,36 @@
+#ifndef STAN_MATH_FWD_FUN_TRACE_DOT_HPP
+#define STAN_MATH_FWD_FUN_TRACE_DOT_HPP
+
+#include <stan/math/fwd/core.hpp>
+#include <stan/math/fwd/fun/multiply.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/trace.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Compute the trace of the product of two matrices with
+ * forward-mode autodiff support.
+ *
+ * @tparam EigMat1 type of the first matrix
+ * @tparam EigMat2 type of the second matrix
+ *
+ * @param A first matrix (m x n)
+ * @param B second matrix (n x m)
+ * @return trace of A * B
+ * @throw std::invalid_argument if A and B have incompatible dimensions
+ */
+template <typename EigMat1, typename EigMat2,
+          require_all_eigen_t<EigMat1, EigMat2>* = nullptr,
+          require_any_vt_fvar<EigMat1, EigMat2>* = nullptr>
+inline return_type_t<EigMat1, EigMat2> trace_dot(const EigMat1& A,
+                                                  const EigMat2& B) {
+  check_size_match("trace_dot", "A.cols()", A.cols(), "B.rows()", B.rows());
+  check_size_match("trace_dot", "A.rows()", A.rows(), "B.cols()", B.cols());
+  return trace(multiply(A, B));
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/fwd/fun/trace_dot.hpp
+++ b/stan/math/fwd/fun/trace_dot.hpp
@@ -13,8 +13,10 @@ namespace math {
  * Compute the trace of the product of two matrices with
  * forward-mode autodiff support.
  *
- * @tparam EigMat1 type of the first matrix
- * @tparam EigMat2 type of the second matrix
+ * @tparam EigMat1 A type either inheriting from `Eigen::DenseBase` or a
+ * `var_value` with an inner type inheriting from `Eigen::DenseBase`
+ * @tparam EigMat2 A type either inheriting from `Eigen::DenseBase` or a
+ * `var_value` with an inner type inheriting from `Eigen::DenseBase`
  *
  * @param A first matrix (m x n)
  * @param B second matrix (n x m)
@@ -24,11 +26,11 @@ namespace math {
 template <typename EigMat1, typename EigMat2,
           require_all_eigen_t<EigMat1, EigMat2>* = nullptr,
           require_any_vt_fvar<EigMat1, EigMat2>* = nullptr>
-inline return_type_t<EigMat1, EigMat2> trace_dot(const EigMat1& A,
-                                                 const EigMat2& B) {
+inline return_type_t<EigMat1, EigMat2> trace_dot(EigMat1&& A,
+                                                 EigMat2&& B) {
   check_size_match("trace_dot", "A.cols()", A.cols(), "B.rows()", B.rows());
   check_size_match("trace_dot", "A.rows()", A.rows(), "B.cols()", B.cols());
-  return trace(multiply(A, B));
+  return trace(multiply(std::forward<EigMat1>(A), std::forward<EigMat2>(B)));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -328,6 +328,7 @@
 #include <stan/math/prim/fun/to_row_vector.hpp>
 #include <stan/math/prim/fun/to_vector.hpp>
 #include <stan/math/prim/fun/trace.hpp>
+#include <stan/math/prim/fun/trace_dot.hpp>
 #include <stan/math/prim/fun/trace_gen_inv_quad_form_ldlt.hpp>
 #include <stan/math/prim/fun/trace_gen_quad_form.hpp>
 #include <stan/math/prim/fun/trace_inv_quad_form_ldlt.hpp>

--- a/stan/math/prim/fun/trace.hpp
+++ b/stan/math/prim/fun/trace.hpp
@@ -19,8 +19,10 @@ namespace math {
  */
 template <typename T, require_eigen_t<T>* = nullptr,
           require_not_st_var<T>* = nullptr>
-inline value_type_t<T> trace(const T& m) {
-  return m.trace();
+inline auto trace(T&& m) {
+  return make_holder([](auto&& m_) {
+    return m_.trace();
+  }, std::forward<T>(m));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/trace.hpp
+++ b/stan/math/prim/fun/trace.hpp
@@ -20,9 +20,7 @@ namespace math {
 template <typename T, require_eigen_t<T>* = nullptr,
           require_not_st_var<T>* = nullptr>
 inline auto trace(T&& m) {
-  return make_holder([](auto&& m_) {
-    return m_.trace();
-  }, std::forward<T>(m));
+  return make_holder([](auto&& m_) { return m_.trace(); }, std::forward<T>(m));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/trace_dot.hpp
+++ b/stan/math/prim/fun/trace_dot.hpp
@@ -26,7 +26,7 @@ namespace math {
 template <typename EigMat1, typename EigMat2,
           require_all_eigen_vt<std::is_arithmetic, EigMat1, EigMat2>* = nullptr>
 inline return_type_t<EigMat1, EigMat2> trace_dot(const EigMat1& A,
-                                                  const EigMat2& B) {
+                                                 const EigMat2& B) {
   check_size_match("trace_dot", "A.cols()", A.cols(), "B.rows()", B.rows());
   check_size_match("trace_dot", "A.rows()", A.rows(), "B.cols()", B.cols());
   return A.cwiseProduct(B.transpose()).sum();

--- a/stan/math/prim/fun/trace_dot.hpp
+++ b/stan/math/prim/fun/trace_dot.hpp
@@ -30,9 +30,11 @@ template <typename EigMat1, typename EigMat2,
 inline auto trace_dot(EigMat1&& A, EigMat2&& B) {
   check_size_match("trace_dot", "A.cols()", A.cols(), "B.rows()", B.rows());
   check_size_match("trace_dot", "A.rows()", A.rows(), "B.cols()", B.cols());
-  return make_holder([](auto&& A_, auto&& B_) {
-    return A_.cwiseProduct(B_.transpose()).sum();
-  }, std::forward<EigMat1>(A), std::forward<EigMat2>(B));
+  return make_holder(
+      [](auto&& A_, auto&& B_) {
+        return A_.cwiseProduct(B_.transpose()).sum();
+      },
+      std::forward<EigMat1>(A), std::forward<EigMat2>(B));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/trace_dot.hpp
+++ b/stan/math/prim/fun/trace_dot.hpp
@@ -1,0 +1,38 @@
+#ifndef STAN_MATH_PRIM_FUN_TRACE_DOT_HPP
+#define STAN_MATH_PRIM_FUN_TRACE_DOT_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Compute the trace of the product of two matrices,
+ * \f$ \text{tr}(A \cdot B) = \sum_{i,j} A_{ij} B_{ji} \f$.
+ *
+ * This is more efficient than computing the full product and
+ * taking the trace, as it avoids forming the intermediate matrix.
+ *
+ * @tparam EigMat1 type of the first matrix
+ * @tparam EigMat2 type of the second matrix
+ *
+ * @param A first matrix (m x n)
+ * @param B second matrix (n x m)
+ * @return trace of A * B
+ * @throw std::invalid_argument if A and B have incompatible dimensions
+ */
+template <typename EigMat1, typename EigMat2,
+          require_all_eigen_vt<std::is_arithmetic, EigMat1, EigMat2>* = nullptr>
+inline return_type_t<EigMat1, EigMat2> trace_dot(const EigMat1& A,
+                                                  const EigMat2& B) {
+  check_size_match("trace_dot", "A.cols()", A.cols(), "B.rows()", B.rows());
+  check_size_match("trace_dot", "A.rows()", A.rows(), "B.cols()", B.cols());
+  return A.cwiseProduct(B.transpose()).sum();
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/trace_dot.hpp
+++ b/stan/math/prim/fun/trace_dot.hpp
@@ -15,8 +15,10 @@ namespace math {
  * This is more efficient than computing the full product and
  * taking the trace, as it avoids forming the intermediate matrix.
  *
- * @tparam EigMat1 type of the first matrix
- * @tparam EigMat2 type of the second matrix
+ * @tparam EigMat1 A type either inheriting from `Eigen::DenseBase` or a
+ * `var_value` with an inner type inheriting from `Eigen::DenseBase`
+ * @tparam EigMat2 A type either inheriting from `Eigen::DenseBase` or a
+ * `var_value` with an inner type inheriting from `Eigen::DenseBase`
  *
  * @param A first matrix (m x n)
  * @param B second matrix (n x m)
@@ -25,11 +27,12 @@ namespace math {
  */
 template <typename EigMat1, typename EigMat2,
           require_all_eigen_vt<std::is_arithmetic, EigMat1, EigMat2>* = nullptr>
-inline return_type_t<EigMat1, EigMat2> trace_dot(const EigMat1& A,
-                                                 const EigMat2& B) {
+inline auto trace_dot(EigMat1&& A, EigMat2&& B) {
   check_size_match("trace_dot", "A.cols()", A.cols(), "B.rows()", B.rows());
   check_size_match("trace_dot", "A.rows()", A.rows(), "B.cols()", B.cols());
-  return A.cwiseProduct(B.transpose()).sum();
+  return make_holder([](auto&& A_, auto&& B_) {
+    return A_.cwiseProduct(B_.transpose()).sum();
+  }, std::forward<EigMat1>(A), std::forward<EigMat2>(B));
 }
 
 }  // namespace math

--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -172,6 +172,7 @@
 #include <stan/math/rev/fun/to_var_value.hpp>
 #include <stan/math/rev/fun/to_vector.hpp>
 #include <stan/math/rev/fun/trace.hpp>
+#include <stan/math/rev/fun/trace_dot.hpp>
 #include <stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp>
 #include <stan/math/rev/fun/trace_gen_quad_form.hpp>
 #include <stan/math/rev/fun/trace_inv_quad_form_ldlt.hpp>

--- a/stan/math/rev/fun/trace.hpp
+++ b/stan/math/rev/fun/trace.hpp
@@ -21,8 +21,8 @@ namespace math {
  * @return Trace of the matrix.
  */
 template <typename T, require_rev_matrix_t<T>* = nullptr>
-inline auto trace(const T& m) {
-  arena_t<T> arena_m = m;
+inline auto trace(T&& m) {
+  arena_t<T> arena_m(std::forward<T>(m));
 
   return make_callback_var(arena_m.val_op().trace(),
                            [arena_m](const auto& vi) mutable {

--- a/stan/math/rev/fun/trace_dot.hpp
+++ b/stan/math/rev/fun/trace_dot.hpp
@@ -20,8 +20,10 @@ namespace math {
  * \f$ \frac{\partial}{\partial A} \text{tr}(A B) = B^T \f$,
  * \f$ \frac{\partial}{\partial B} \text{tr}(A B) = A^T \f$.
  *
- * @tparam Mat1 type of the first matrix
- * @tparam Mat2 type of the second matrix
+ * @tparam Mat1 A type either inheriting from `Eigen::DenseBase` or a
+ * `var_value` with an inner type inheriting from `Eigen::DenseBase`
+ * @tparam Mat2 A type either inheriting from `Eigen::DenseBase` or a
+ * `var_value` with an inner type inheriting from `Eigen::DenseBase`
  *
  * @param A first matrix (m x n)
  * @param B second matrix (n x m)
@@ -31,37 +33,30 @@ namespace math {
 template <typename Mat1, typename Mat2,
           require_all_matrix_t<Mat1, Mat2>* = nullptr,
           require_any_rev_matrix_t<Mat1, Mat2>* = nullptr>
-inline var trace_dot(const Mat1& A, const Mat2& B) {
+inline var trace_dot(Mat1&& A, Mat2&& B) {
   check_size_match("trace_dot", "A.cols()", A.cols(), "B.rows()", B.rows());
   check_size_match("trace_dot", "A.rows()", A.rows(), "B.cols()", B.cols());
-
-  var res;
-
   if constexpr (is_autodiff_v<Mat1> && is_autodiff_v<Mat2>) {
-    arena_t<promote_scalar_t<var, Mat1>> arena_A = A;
-    arena_t<promote_scalar_t<var, Mat2>> arena_B = B;
-
-    res = value_of(arena_A).cwiseProduct(value_of(arena_B).transpose()).sum();
-
-    reverse_pass_callback([arena_A, arena_B, res]() mutable {
+    arena_t<Mat1> arena_A(std::forward<Mat1>(A));
+    arena_t<Mat2> arena_B(std::forward<Mat2>(B));
+    auto res_val = arena_A.val().cwiseProduct(arena_B.val().transpose()).sum();
+    return make_callback_var(res_val, [arena_A, arena_B](auto&& res) mutable {
       if constexpr (is_var_matrix<Mat1>::value) {
-        arena_A.adj().noalias() += res.adj() * value_of(arena_B).transpose();
+        arena_A.adj().noalias() += res.adj() * arena_B.val().transpose();
       } else {
-        arena_A.adj() += res.adj() * value_of(arena_B).transpose();
+        arena_A.adj() += res.adj() * arena_B.val().transpose();
       }
       if constexpr (is_var_matrix<Mat2>::value) {
-        arena_B.adj().noalias() += res.adj() * value_of(arena_A).transpose();
+        arena_B.adj().noalias() += res.adj() * arena_A.val().transpose();
       } else {
-        arena_B.adj() += res.adj() * value_of(arena_A).transpose();
+        arena_B.adj() += res.adj() * arena_A.val().transpose();
       }
     });
   } else if constexpr (is_autodiff_v<Mat2>) {
-    arena_t<promote_scalar_t<double, Mat1>> arena_A = value_of(A);
-    arena_t<promote_scalar_t<var, Mat2>> arena_B = B;
-
-    res = arena_A.cwiseProduct(value_of(arena_B).transpose()).sum();
-
-    reverse_pass_callback([arena_A, arena_B, res]() mutable {
+    arena_t<Mat1> arena_A(std::forward<Mat1>(A));
+    arena_t<Mat2> arena_B(std::forward<Mat2>(B));
+    auto res_val = arena_A.cwiseProduct(arena_B.val().transpose()).sum();
+    return make_callback_var(res_val, [arena_A, arena_B](auto&& res) mutable {
       if constexpr (is_var_matrix<Mat2>::value) {
         arena_B.adj().noalias() += res.adj() * arena_A.transpose();
       } else {
@@ -69,12 +64,10 @@ inline var trace_dot(const Mat1& A, const Mat2& B) {
       }
     });
   } else {
-    arena_t<promote_scalar_t<var, Mat1>> arena_A = A;
-    arena_t<promote_scalar_t<double, Mat2>> arena_B = value_of(B);
-
-    res = value_of(arena_A).cwiseProduct(arena_B.transpose()).sum();
-
-    reverse_pass_callback([arena_A, arena_B, res]() mutable {
+    arena_t<Mat1> arena_A(std::forward<Mat1>(A));
+    arena_t<Mat2> arena_B(std::forward<Mat2>(B));
+    auto res_val = arena_A.val().cwiseProduct(arena_B.transpose()).sum();
+    return make_callback_var(res_val, [arena_A, arena_B](auto&& res) mutable {
       if constexpr (is_var_matrix<Mat1>::value) {
         arena_A.adj().noalias() += res.adj() * arena_B.transpose();
       } else {
@@ -82,8 +75,6 @@ inline var trace_dot(const Mat1& A, const Mat2& B) {
       }
     });
   }
-
-  return res;
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/trace_dot.hpp
+++ b/stan/math/rev/fun/trace_dot.hpp
@@ -1,0 +1,91 @@
+#ifndef STAN_MATH_REV_FUN_TRACE_DOT_HPP
+#define STAN_MATH_REV_FUN_TRACE_DOT_HPP
+
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/fun/value_of.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/trace_dot.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Compute the trace of the product of two matrices with autodiff support.
+ *
+ * \f$ \text{tr}(A \cdot B) = \sum_{i,j} A_{ij} B_{ji} \f$
+ *
+ * The gradients are:
+ * \f$ \frac{\partial}{\partial A} \text{tr}(A B) = B^T \f$,
+ * \f$ \frac{\partial}{\partial B} \text{tr}(A B) = A^T \f$.
+ *
+ * @tparam Mat1 type of the first matrix
+ * @tparam Mat2 type of the second matrix
+ *
+ * @param A first matrix (m x n)
+ * @param B second matrix (n x m)
+ * @return trace of A * B
+ * @throw std::invalid_argument if A and B have incompatible dimensions
+ */
+template <typename Mat1, typename Mat2,
+          require_all_matrix_t<Mat1, Mat2>* = nullptr,
+          require_any_rev_matrix_t<Mat1, Mat2>* = nullptr>
+inline var trace_dot(const Mat1& A, const Mat2& B) {
+  check_size_match("trace_dot", "A.cols()", A.cols(), "B.rows()", B.rows());
+  check_size_match("trace_dot", "A.rows()", A.rows(), "B.cols()", B.cols());
+
+  var res;
+
+  if constexpr (is_autodiff_v<Mat1> && is_autodiff_v<Mat2>) {
+    arena_t<promote_scalar_t<var, Mat1>> arena_A = A;
+    arena_t<promote_scalar_t<var, Mat2>> arena_B = B;
+
+    res = value_of(arena_A).cwiseProduct(value_of(arena_B).transpose()).sum();
+
+    reverse_pass_callback([arena_A, arena_B, res]() mutable {
+      if constexpr (is_var_matrix<Mat1>::value) {
+        arena_A.adj().noalias() += res.adj() * value_of(arena_B).transpose();
+      } else {
+        arena_A.adj() += res.adj() * value_of(arena_B).transpose();
+      }
+      if constexpr (is_var_matrix<Mat2>::value) {
+        arena_B.adj().noalias() += res.adj() * value_of(arena_A).transpose();
+      } else {
+        arena_B.adj() += res.adj() * value_of(arena_A).transpose();
+      }
+    });
+  } else if constexpr (is_autodiff_v<Mat2>) {
+    arena_t<promote_scalar_t<double, Mat1>> arena_A = value_of(A);
+    arena_t<promote_scalar_t<var, Mat2>> arena_B = B;
+
+    res = arena_A.cwiseProduct(value_of(arena_B).transpose()).sum();
+
+    reverse_pass_callback([arena_A, arena_B, res]() mutable {
+      if constexpr (is_var_matrix<Mat2>::value) {
+        arena_B.adj().noalias() += res.adj() * arena_A.transpose();
+      } else {
+        arena_B.adj() += res.adj() * arena_A.transpose();
+      }
+    });
+  } else {
+    arena_t<promote_scalar_t<var, Mat1>> arena_A = A;
+    arena_t<promote_scalar_t<double, Mat2>> arena_B = value_of(B);
+
+    res = value_of(arena_A).cwiseProduct(arena_B.transpose()).sum();
+
+    reverse_pass_callback([arena_A, arena_B, res]() mutable {
+      if constexpr (is_var_matrix<Mat1>::value) {
+        arena_A.adj().noalias() += res.adj() * arena_B.transpose();
+      } else {
+        arena_A.adj() += res.adj() * arena_B.transpose();
+      }
+    });
+  }
+
+  return res;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/test/unit/math/mix/fun/trace_dot_test.cpp
+++ b/test/unit/math/mix/fun/trace_dot_test.cpp
@@ -46,10 +46,14 @@ TEST(MathMixMatFun, traceDot) {
   stan::test::expect_ad(f, a33, b33);
   stan::test::expect_ad_matvar(f, a33, b33);
 
-  // dimension mismatch exceptions
+  // dimension mismatch: A.cols() != B.rows()
   stan::test::expect_ad(f, a22, b32);
   stan::test::expect_ad(f, a23, b22);
 
   stan::test::expect_ad_matvar(f, a22, b32);
   stan::test::expect_ad_matvar(f, a23, b22);
+
+  // dimension mismatch: A.cols() == B.rows() but A.rows() != B.cols()
+  stan::test::expect_ad(f, a23, a33);
+  stan::test::expect_ad_matvar(f, a23, a33);
 }

--- a/test/unit/math/mix/fun/trace_dot_test.cpp
+++ b/test/unit/math/mix/fun/trace_dot_test.cpp
@@ -6,10 +6,8 @@ TEST(MathMixMatFun, traceDot) {
   };
 
   // 1x1
-  Eigen::MatrixXd a11(1, 1);
-  a11 << 3;
-  Eigen::MatrixXd b11(1, 1);
-  b11 << 7;
+  Eigen::MatrixXd a11{{3}};
+  Eigen::MatrixXd b11{{7}};
   stan::test::expect_ad(f, a11, b11);
   stan::test::expect_ad_matvar(f, a11, b11);
 
@@ -19,18 +17,14 @@ TEST(MathMixMatFun, traceDot) {
   stan::test::expect_ad_matvar(f, m00, m00);
 
   // 2x2
-  Eigen::MatrixXd a22(2, 2);
-  a22 << 1, 2, 3, 4;
-  Eigen::MatrixXd b22(2, 2);
-  b22 << 5, 6, 7, 8;
+  Eigen::MatrixXd a22{{1, 2}, {3, 4}};
+  Eigen::MatrixXd b22{{5, 6}, {7, 8}};
   stan::test::expect_ad(f, a22, b22);
   stan::test::expect_ad_matvar(f, a22, b22);
 
   // 2x3 times 3x2 (rectangular)
-  Eigen::MatrixXd a23(2, 3);
-  a23 << 1, 2, 3, 4, 5, 6;
-  Eigen::MatrixXd b32(3, 2);
-  b32 << 7, 8, 9, 10, 11, 12;
+  Eigen::MatrixXd a23{{1, 2, 3}, {4, 5, 6}};
+  Eigen::MatrixXd b32{{7, 8}, {9, 10}, {11, 12}};
   stan::test::expect_ad(f, a23, b32);
   stan::test::expect_ad_matvar(f, a23, b32);
 
@@ -39,18 +33,16 @@ TEST(MathMixMatFun, traceDot) {
   stan::test::expect_ad_matvar(f, b32, a23);
 
   // 3x3
-  Eigen::MatrixXd a33(3, 3);
-  a33 << 1, -2, 3, 0.5, 7, -1, 2, 0, 4;
-  Eigen::MatrixXd b33(3, 3);
-  b33 << 3, 1, -2, 0, 5, 1, -1, 2, 6;
+  Eigen::MatrixXd a33{{1, -2, 3}, {0.5, 7, -1}, {2, 0, 4}};
+  Eigen::MatrixXd b33{{3, 1, -2}, {0, 5, 1}, {-1, 2, 6}};
   stan::test::expect_ad(f, a33, b33);
   stan::test::expect_ad_matvar(f, a33, b33);
 
   // dimension mismatch: A.cols() != B.rows()
   stan::test::expect_ad(f, a22, b32);
-  stan::test::expect_ad(f, a23, b22);
-
   stan::test::expect_ad_matvar(f, a22, b32);
+
+  stan::test::expect_ad(f, a23, b22);
   stan::test::expect_ad_matvar(f, a23, b22);
 
   // dimension mismatch: A.cols() == B.rows() but A.rows() != B.cols()

--- a/test/unit/math/mix/fun/trace_dot_test.cpp
+++ b/test/unit/math/mix/fun/trace_dot_test.cpp
@@ -1,0 +1,55 @@
+#include <test/unit/math/test_ad.hpp>
+
+TEST(MathMixMatFun, traceDot) {
+  auto f = [](const auto& x, const auto& y) {
+    return stan::math::trace_dot(x, y);
+  };
+
+  // 1x1
+  Eigen::MatrixXd a11(1, 1);
+  a11 << 3;
+  Eigen::MatrixXd b11(1, 1);
+  b11 << 7;
+  stan::test::expect_ad(f, a11, b11);
+  stan::test::expect_ad_matvar(f, a11, b11);
+
+  // 0x0
+  Eigen::MatrixXd m00(0, 0);
+  stan::test::expect_ad(f, m00, m00);
+  stan::test::expect_ad_matvar(f, m00, m00);
+
+  // 2x2
+  Eigen::MatrixXd a22(2, 2);
+  a22 << 1, 2, 3, 4;
+  Eigen::MatrixXd b22(2, 2);
+  b22 << 5, 6, 7, 8;
+  stan::test::expect_ad(f, a22, b22);
+  stan::test::expect_ad_matvar(f, a22, b22);
+
+  // 2x3 times 3x2 (rectangular)
+  Eigen::MatrixXd a23(2, 3);
+  a23 << 1, 2, 3, 4, 5, 6;
+  Eigen::MatrixXd b32(3, 2);
+  b32 << 7, 8, 9, 10, 11, 12;
+  stan::test::expect_ad(f, a23, b32);
+  stan::test::expect_ad_matvar(f, a23, b32);
+
+  // 3x2 times 2x3 (rectangular, transposed shape)
+  stan::test::expect_ad(f, b32, a23);
+  stan::test::expect_ad_matvar(f, b32, a23);
+
+  // 3x3
+  Eigen::MatrixXd a33(3, 3);
+  a33 << 1, -2, 3, 0.5, 7, -1, 2, 0, 4;
+  Eigen::MatrixXd b33(3, 3);
+  b33 << 3, 1, -2, 0, 5, 1, -1, 2, 6;
+  stan::test::expect_ad(f, a33, b33);
+  stan::test::expect_ad_matvar(f, a33, b33);
+
+  // dimension mismatch exceptions
+  stan::test::expect_ad(f, a22, b32);
+  stan::test::expect_ad(f, a23, b22);
+
+  stan::test::expect_ad_matvar(f, a22, b32);
+  stan::test::expect_ad_matvar(f, a23, b22);
+}

--- a/test/unit/math/prim/fun/trace_dot_test.cpp
+++ b/test/unit/math/prim/fun/trace_dot_test.cpp
@@ -1,0 +1,60 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathMatrixPrim, trace_dot) {
+  using stan::math::matrix_d;
+  using stan::math::trace_dot;
+
+  matrix_d a(2, 3);
+  matrix_d b(3, 2);
+  a << 1, 2, 3, 4, 5, 6;
+  b << 7, 8, 9, 10, 11, 12;
+
+  // trace(A * B) = trace([[58,64],[139,154]]) = 58 + 154 = 212
+  EXPECT_FLOAT_EQ(212, trace_dot(a, b));
+}
+
+TEST(MathMatrixPrim, trace_dot_square) {
+  using stan::math::matrix_d;
+  using stan::math::trace_dot;
+
+  matrix_d a(2, 2);
+  matrix_d b(2, 2);
+  a << 1, 2, 3, 4;
+  b << 5, 6, 7, 8;
+
+  // trace(A * B) = trace([[19,22],[43,50]]) = 19 + 50 = 69
+  EXPECT_FLOAT_EQ(69, trace_dot(a, b));
+}
+
+TEST(MathMatrixPrim, trace_dot_1x1) {
+  using stan::math::matrix_d;
+  using stan::math::trace_dot;
+
+  matrix_d a(1, 1);
+  matrix_d b(1, 1);
+  a << 3;
+  b << 7;
+
+  EXPECT_FLOAT_EQ(21, trace_dot(a, b));
+}
+
+TEST(MathMatrixPrim, trace_dot_size_zero) {
+  using stan::math::matrix_d;
+  using stan::math::trace_dot;
+
+  matrix_d a00, b00;
+  EXPECT_FLOAT_EQ(0, trace_dot(a00, b00));
+}
+
+TEST(MathMatrixPrim, trace_dot_dimension_mismatch) {
+  using stan::math::matrix_d;
+  using stan::math::trace_dot;
+
+  matrix_d a(2, 3);
+  matrix_d b(2, 3);
+  a << 1, 2, 3, 4, 5, 6;
+  b << 1, 2, 3, 4, 5, 6;
+
+  EXPECT_THROW(trace_dot(a, b), std::invalid_argument);
+}

--- a/test/unit/math/prim/fun/trace_dot_test.cpp
+++ b/test/unit/math/prim/fun/trace_dot_test.cpp
@@ -56,5 +56,11 @@ TEST(MathMatrixPrim, trace_dot_dimension_mismatch) {
   a << 1, 2, 3, 4, 5, 6;
   b << 1, 2, 3, 4, 5, 6;
 
+  // A.cols() != B.rows()
   EXPECT_THROW(trace_dot(a, b), std::invalid_argument);
+
+  // A.cols() == B.rows() but A.rows() != B.cols() (product not square)
+  matrix_d c(3, 3);
+  c << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  EXPECT_THROW(trace_dot(a, c), std::invalid_argument);
 }

--- a/test/unit/math/prim/fun/trace_dot_test.cpp
+++ b/test/unit/math/prim/fun/trace_dot_test.cpp
@@ -5,11 +5,8 @@ TEST(MathMatrixPrim, trace_dot) {
   using stan::math::matrix_d;
   using stan::math::trace_dot;
 
-  matrix_d a(2, 3);
-  matrix_d b(3, 2);
-  a << 1, 2, 3, 4, 5, 6;
-  b << 7, 8, 9, 10, 11, 12;
-
+  matrix_d a{{1, 2, 3}, {4, 5, 6}};
+  matrix_d b{{7, 8}, {9, 10}, {11, 12}};
   // trace(A * B) = trace([[58,64],[139,154]]) = 58 + 154 = 212
   EXPECT_FLOAT_EQ(212, trace_dot(a, b));
 }
@@ -18,10 +15,8 @@ TEST(MathMatrixPrim, trace_dot_square) {
   using stan::math::matrix_d;
   using stan::math::trace_dot;
 
-  matrix_d a(2, 2);
-  matrix_d b(2, 2);
-  a << 1, 2, 3, 4;
-  b << 5, 6, 7, 8;
+  matrix_d a{{1, 2}, {3, 4}};
+  matrix_d b{{5, 6}, {7, 8}};
 
   // trace(A * B) = trace([[19,22],[43,50]]) = 19 + 50 = 69
   EXPECT_FLOAT_EQ(69, trace_dot(a, b));
@@ -31,10 +26,8 @@ TEST(MathMatrixPrim, trace_dot_1x1) {
   using stan::math::matrix_d;
   using stan::math::trace_dot;
 
-  matrix_d a(1, 1);
-  matrix_d b(1, 1);
-  a << 3;
-  b << 7;
+  matrix_d a{{3}};
+  matrix_d b{{7}};
 
   EXPECT_FLOAT_EQ(21, trace_dot(a, b));
 }
@@ -43,7 +36,8 @@ TEST(MathMatrixPrim, trace_dot_size_zero) {
   using stan::math::matrix_d;
   using stan::math::trace_dot;
 
-  matrix_d a00, b00;
+  matrix_d a00{};
+  matrix_d b00{};
   EXPECT_FLOAT_EQ(0, trace_dot(a00, b00));
 }
 
@@ -51,16 +45,13 @@ TEST(MathMatrixPrim, trace_dot_dimension_mismatch) {
   using stan::math::matrix_d;
   using stan::math::trace_dot;
 
-  matrix_d a(2, 3);
-  matrix_d b(2, 3);
-  a << 1, 2, 3, 4, 5, 6;
-  b << 1, 2, 3, 4, 5, 6;
+  matrix_d a{{1, 2, 3}, {4, 5, 6}};
+  matrix_d b{{1, 2, 3}, {4, 5, 6}};
 
   // A.cols() != B.rows()
   EXPECT_THROW(trace_dot(a, b), std::invalid_argument);
 
   // A.cols() == B.rows() but A.rows() != B.cols() (product not square)
-  matrix_d c(3, 3);
-  c << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  matrix_d c{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
   EXPECT_THROW(trace_dot(a, c), std::invalid_argument);
 }


### PR DESCRIPTION
## Summary

Implements the trace_dot function that computes Tr(A * B) efficiently. This can be used to simplify code on some places.

I requested this in https://github.com/stan-dev/math/issues/3161 and decided to try it myself.

## Tests

Tests for the new functions, inspired by tests for related functions.

## Side Effects

Should not have.

## Release notes

Implement `trace_dot(A, B)`.

## Checklist

- [x] Copyright holder: Me, jachymb@gmail.com
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested

