### PR TITLE
Support softmax for row_vector, matrix types + code simplifications

### DIFF
--- a/stan/math/fwd/fun/log_softmax.hpp
+++ b/stan/math/fwd/fun/log_softmax.hpp
@@ -13,7 +13,6 @@
 namespace stan {
 namespace math {
 
-
 /**
  * Return the log softmax of each vector in a container of `fvar` values.
  *
@@ -36,8 +35,7 @@ inline auto log_softmax(T&& x) {
  * @return log softmax of the vector
  * @throw std::domain_error if the input size is 0
  */
-template <typename Vec,
-          require_eigen_vector_vt<is_fvar, Vec>* = nullptr>
+template <typename Vec, require_eigen_vector_vt<is_fvar, Vec>* = nullptr>
 inline auto log_softmax(Vec&& x) {
   using vec = std::decay_t<Vec>;
   constexpr int Rows = vec::RowsAtCompileTime;

--- a/stan/math/fwd/fun/log_softmax.hpp
+++ b/stan/math/fwd/fun/log_softmax.hpp
@@ -19,7 +19,14 @@ namespace math {
  * @return Softmax of the input.
  * @throw std::domain_error If the input vector is size 0.
  */
-template <typename T, require_vector_st<is_fvar, T>* = nullptr>
+template <typename RowVec, require_eigen_row_vector_t<RowVec>* = nullptr,
+          require_t<is_fvar<value_type_t<RowVec>>>* = nullptr>
+inline auto log_softmax(const RowVec& x) {
+  return log_softmax(x.transpose()).transpose().eval();
+}
+
+template <typename T, require_vector_st<is_fvar, T>* = nullptr,
+          require_not_t<is_eigen_row_vector<std::decay_t<T>>>* = nullptr>
 inline auto log_softmax(T&& x) {
   return apply_vector_unary<T>::apply(std::forward<T>(x), [](auto&& alpha) {
     using T_alpha = decltype(alpha);

--- a/stan/math/fwd/fun/log_softmax.hpp
+++ b/stan/math/fwd/fun/log_softmax.hpp
@@ -31,7 +31,8 @@ inline auto log_softmax(const Mat& m) {
   const auto exp_s = shifted.exp().eval();
   const auto row_sums = exp_s.rowwise().sum().eval();
   const auto lsm_val = (shifted.colwise() - row_sums.log()).matrix().eval();
-  // softmax values needed for the tangent: d_in - softmax(x) ⊙ dot(softmax(x), d_in)
+  // softmax values needed for the tangent: d_in - softmax(x) ⊙ dot(softmax(x),
+  // d_in)
   const auto s = (exp_s.colwise() / row_sums).eval();
   const auto d_in = m_ref.d().eval();
   const auto dots = (s.array() * d_in.array()).rowwise().sum().eval();

--- a/stan/math/fwd/fun/log_softmax.hpp
+++ b/stan/math/fwd/fun/log_softmax.hpp
@@ -12,12 +12,14 @@ namespace stan {
 namespace math {
 
 /**
- * Return the log softmax of the specified vector or container of vectors.
+ * Return the log softmax of the rows of the specified matrix.
+ * Each row is transformed independently; the result has the same shape
+ * as the input.
  *
- * @tparam T Type of input vector or matrix.
- * @param[in] x Unconstrained input vector.
- * @return Softmax of the input.
- * @throw std::domain_error If the input vector is size 0.
+ * @tparam Mat type of input matrix (Eigen matrix with fvar scalar)
+ * @param[in] m Matrix to transform row-wise.
+ * @return Log-softmax applied row-wise.
+ * @throw std::domain_error If the input matrix is size 0.
  */
 template <typename Mat, require_eigen_t<Mat>* = nullptr,
           require_not_eigen_vector_t<Mat>* = nullptr,

--- a/stan/math/fwd/fun/log_softmax.hpp
+++ b/stan/math/fwd/fun/log_softmax.hpp
@@ -5,70 +5,65 @@
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/fwd/meta.hpp>
 #include <stan/math/fwd/fun/softmax.hpp>
+#include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/log_softmax.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/functor/apply_vector_unary.hpp>
 
 namespace stan {
 namespace math {
 
 /**
- * Return the log softmax of the rows of the specified matrix.
- * Each row is transformed independently; the result has the same shape
- * as the input.
+ * Return the log softmax of the specified row vector of `fvar` values.
+ * Delegates to the column-vector overload via transposition.
  *
- * @tparam Mat type of input matrix (Eigen matrix with fvar scalar)
- * @param[in] m Matrix to transform row-wise.
- * @return Log-softmax applied row-wise.
- * @throw std::domain_error If the input matrix is size 0.
+ * @tparam RowVec Eigen row vector with `fvar` scalar
+ * @param x row vector to transform
+ * @return log softmax of the row vector
  */
-template <typename Mat, require_eigen_t<Mat>* = nullptr,
-          require_not_eigen_vector_t<Mat>* = nullptr,
-          require_t<is_fvar<value_type_t<Mat>>>* = nullptr>
-inline auto log_softmax(const Mat& m) {
-  check_nonzero_size("log_softmax", "m", m);
-  const auto& m_ref = to_ref(m);
-  const auto val = m_ref.val().eval();
-  const auto shifted
-      = (val.array().colwise() - val.rowwise().maxCoeff().array()).eval();
-  const auto exp_s = shifted.exp().eval();
-  const auto row_sums = exp_s.rowwise().sum().eval();
-  const auto lsm_val = (shifted.colwise() - row_sums.log()).matrix().eval();
-  // softmax values needed for the tangent: d_in - softmax(x) ⊙ dot(softmax(x),
-  // d_in)
-  const auto s = (exp_s.colwise() / row_sums).eval();
-  const auto d_in = m_ref.d().eval();
-  const auto dots = (s.array() * d_in.array()).rowwise().sum().eval();
-  plain_type_t<Mat> result(m_ref.rows(), m_ref.cols());
-  result.val() = lsm_val;
-  result.d() = (d_in.array().colwise() - dots.array()).matrix();
-  return result;
-}
-
 template <typename RowVec, require_eigen_row_vector_t<RowVec>* = nullptr,
           require_t<is_fvar<value_type_t<RowVec>>>* = nullptr>
 inline auto log_softmax(const RowVec& x) {
   return log_softmax(x.transpose()).transpose().eval();
 }
 
-template <typename T, require_vector_st<is_fvar, T>* = nullptr,
-          require_not_t<is_eigen_row_vector<std::decay_t<T>>>* = nullptr>
+/**
+ * Return the log softmax of each vector in a container of `fvar` values.
+ *
+ * @tparam T `std::vector` whose scalar type is `fvar`
+ * @param x container of vectors to transform
+ * @return container of log softmax results
+ */
+template <typename T, require_std_vector_st<is_fvar, T>* = nullptr>
 inline auto log_softmax(T&& x) {
-  return apply_vector_unary<T>::apply(std::forward<T>(x), [](auto&& alpha) {
-    using T_alpha = std::decay_t<decltype(alpha)>;
-    using T_fvar = value_type_t<T_alpha>;
-    using T_inner = typename T_fvar::Scalar;
-
-    auto&& alpha_ref = to_ref(std::forward<decltype(alpha)>(alpha));
-    const Eigen::Matrix<T_inner, -1, 1> val = alpha_ref.val();
-    const Eigen::Matrix<T_inner, -1, 1> s = softmax(val);
-    const auto d_in = alpha_ref.d().eval();
-    const T_inner dot_sd = s.dot(d_in);
-
-    Eigen::Matrix<T_fvar, -1, 1> result(alpha_ref.size());
-    result.val() = log_softmax(val);
-    result.d() = (d_in.array() - dot_sd).matrix();
-    return result;
+  return apply_vector_unary<T>::apply(std::forward<T>(x), [](auto&& v) {
+    return log_softmax(std::forward<decltype(v)>(v));
   });
+}
+
+/**
+ * Return the log softmax of the specified column vector of `fvar` values.
+ *
+ * @tparam ColVec Eigen column vector with `fvar` scalar
+ * @param x column vector to transform
+ * @return log softmax of the column vector
+ * @throw std::domain_error if the input size is 0
+ */
+template <typename ColVec,
+          require_eigen_col_vector_vt<is_fvar, ColVec>* = nullptr>
+inline auto log_softmax(const ColVec& x) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using T = typename value_type_t<ColVec>::Scalar;
+  check_nonzero_size("log_softmax", "x", x);
+  const auto& x_ref = to_ref(x);
+  const Matrix<T, Dynamic, 1> s = softmax(value_of(x_ref));
+  const auto d_in = x_ref.d().eval();
+  const T dot_sd = s.dot(d_in);
+  Matrix<fvar<T>, Dynamic, 1> result(x_ref.size());
+  result.val() = s.array().log().matrix();
+  result.d() = (d_in.array() - dot_sd).matrix();
+  return result;
 }
 
 }  // namespace math

--- a/stan/math/fwd/fun/log_softmax.hpp
+++ b/stan/math/fwd/fun/log_softmax.hpp
@@ -19,6 +19,28 @@ namespace math {
  * @return Softmax of the input.
  * @throw std::domain_error If the input vector is size 0.
  */
+template <typename Mat, require_eigen_t<Mat>* = nullptr,
+          require_not_eigen_vector_t<Mat>* = nullptr,
+          require_t<is_fvar<value_type_t<Mat>>>* = nullptr>
+inline auto log_softmax(const Mat& m) {
+  check_nonzero_size("log_softmax", "m", m);
+  const auto& m_ref = to_ref(m);
+  const auto val = m_ref.val().eval();
+  const auto shifted
+      = (val.array().colwise() - val.rowwise().maxCoeff().array()).eval();
+  const auto exp_s = shifted.exp().eval();
+  const auto row_sums = exp_s.rowwise().sum().eval();
+  const auto lsm_val = (shifted.colwise() - row_sums.log()).matrix().eval();
+  // softmax values needed for the tangent: d_in - softmax(x) ⊙ dot(softmax(x), d_in)
+  const auto s = (exp_s.colwise() / row_sums).eval();
+  const auto d_in = m_ref.d().eval();
+  const auto dots = (s.array() * d_in.array()).rowwise().sum().eval();
+  plain_type_t<Mat> result(m_ref.rows(), m_ref.cols());
+  result.val() = lsm_val;
+  result.d() = (d_in.array().colwise() - dots.array()).matrix();
+  return result;
+}
+
 template <typename RowVec, require_eigen_row_vector_t<RowVec>* = nullptr,
           require_t<is_fvar<value_type_t<RowVec>>>* = nullptr>
 inline auto log_softmax(const RowVec& x) {
@@ -29,33 +51,20 @@ template <typename T, require_vector_st<is_fvar, T>* = nullptr,
           require_not_t<is_eigen_row_vector<std::decay_t<T>>>* = nullptr>
 inline auto log_softmax(T&& x) {
   return apply_vector_unary<T>::apply(std::forward<T>(x), [](auto&& alpha) {
-    using T_alpha = decltype(alpha);
+    using T_alpha = std::decay_t<decltype(alpha)>;
     using T_fvar = value_type_t<T_alpha>;
-    using T_fvar_inner = typename T_fvar::Scalar;
+    using T_inner = typename T_fvar::Scalar;
 
     auto&& alpha_ref = to_ref(std::forward<decltype(alpha)>(alpha));
-    Eigen::Matrix<T_fvar_inner, -1, 1> alpha_t = alpha_ref.val();
-    Eigen::Matrix<T_fvar_inner, -1, 1> softmax_alpha_t = softmax(alpha_t);
+    const Eigen::Matrix<T_inner, -1, 1> val = alpha_ref.val();
+    const Eigen::Matrix<T_inner, -1, 1> s = softmax(val);
+    const auto d_in = alpha_ref.d().eval();
+    const T_inner dot_sd = s.dot(d_in);
 
-    Eigen::Matrix<T_fvar, -1, 1> log_softmax_alpha(alpha_ref.size());
-    log_softmax_alpha.val() = log_softmax(alpha_t);
-    log_softmax_alpha.d().setZero();
-
-    for (int m = 0; m < alpha_ref.size(); ++m) {
-      T_fvar_inner negative_alpha_m_d_times_softmax_alpha_t_m
-          = -alpha_ref.coeff(m).d_ * softmax_alpha_t(m);
-      for (int k = 0; k < alpha_ref.size(); ++k) {
-        if (m == k) {
-          log_softmax_alpha(k).d_
-              += alpha_ref.coeff(m).d_
-                 + negative_alpha_m_d_times_softmax_alpha_t_m;
-        } else {
-          log_softmax_alpha(k).d_ += negative_alpha_m_d_times_softmax_alpha_t_m;
-        }
-      }
-    }
-
-    return log_softmax_alpha;
+    Eigen::Matrix<T_fvar, -1, 1> result(alpha_ref.size());
+    result.val() = log_softmax(val);
+    result.d() = (d_in.array() - dot_sd).matrix();
+    return result;
   });
 }
 

--- a/stan/math/fwd/fun/log_softmax.hpp
+++ b/stan/math/fwd/fun/log_softmax.hpp
@@ -13,19 +13,6 @@
 namespace stan {
 namespace math {
 
-/**
- * Return the log softmax of the specified row vector of `fvar` values.
- * Delegates to the column-vector overload via transposition.
- *
- * @tparam RowVec Eigen row vector with `fvar` scalar
- * @param x row vector to transform
- * @return log softmax of the row vector
- */
-template <typename RowVec, require_eigen_row_vector_t<RowVec>* = nullptr,
-          require_t<is_fvar<value_type_t<RowVec>>>* = nullptr>
-inline auto log_softmax(const RowVec& x) {
-  return log_softmax(x.transpose()).transpose().eval();
-}
 
 /**
  * Return the log softmax of each vector in a container of `fvar` values.
@@ -42,25 +29,26 @@ inline auto log_softmax(T&& x) {
 }
 
 /**
- * Return the log softmax of the specified column vector of `fvar` values.
+ * Return the log softmax of the specified vector of `fvar` values.
  *
- * @tparam ColVec Eigen column vector with `fvar` scalar
- * @param x column vector to transform
- * @return log softmax of the column vector
+ * @tparam Vec Eigen vector with `fvar` scalar
+ * @param x vector to transform
+ * @return log softmax of the vector
  * @throw std::domain_error if the input size is 0
  */
-template <typename ColVec,
-          require_eigen_col_vector_vt<is_fvar, ColVec>* = nullptr>
-inline auto log_softmax(const ColVec& x) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using T = typename value_type_t<ColVec>::Scalar;
+template <typename Vec,
+          require_eigen_vector_vt<is_fvar, Vec>* = nullptr>
+inline auto log_softmax(Vec&& x) {
+  using vec = std::decay_t<Vec>;
+  constexpr int Rows = vec::RowsAtCompileTime;
+  constexpr int Cols = vec::ColsAtCompileTime;
+  using T = typename value_type_t<Vec>::Scalar;
   check_nonzero_size("log_softmax", "x", x);
-  const auto& x_ref = to_ref(x);
-  const Matrix<T, Dynamic, 1> s = softmax(value_of(x_ref));
-  const auto d_in = x_ref.d().eval();
-  const T dot_sd = s.dot(d_in);
-  Matrix<fvar<T>, Dynamic, 1> result(x_ref.size());
+  decltype(auto) x_ref = to_ref(std::forward<Vec>(x));
+  const auto s = softmax(value_of(x_ref));
+  const auto d_in = x_ref.d();
+  const auto dot_sd = s.dot(d_in);
+  Eigen::Matrix<fvar<T>, Rows, Cols> result(x_ref.size());
   result.val() = s.array().log().matrix();
   result.d() = (d_in.array() - dot_sd).matrix();
   return result;

--- a/stan/math/fwd/fun/softmax.hpp
+++ b/stan/math/fwd/fun/softmax.hpp
@@ -32,8 +32,7 @@ inline auto softmax(T&& x) {
  * @param x column vector to transform
  * @return softmax of the column vector
  */
-template <typename Vec,
-          require_eigen_vector_vt<is_fvar, Vec>* = nullptr>
+template <typename Vec, require_eigen_vector_vt<is_fvar, Vec>* = nullptr>
 inline auto softmax(Vec&& x) {
   using vec = std::decay_t<Vec>;
   constexpr int Rows = vec::RowsAtCompileTime;

--- a/stan/math/fwd/fun/softmax.hpp
+++ b/stan/math/fwd/fun/softmax.hpp
@@ -6,45 +6,60 @@
 #include <stan/math/fwd/fun/value_of.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/softmax.hpp>
+#include <stan/math/prim/functor/apply_vector_unary.hpp>
 
 namespace stan {
 namespace math {
 
-template <typename Mat, require_eigen_t<Mat>* = nullptr,
-          require_not_eigen_vector_t<Mat>* = nullptr,
-          require_t<is_fvar<value_type_t<Mat>>>* = nullptr>
-inline auto softmax(const Mat& m) {
-  const auto& m_ref = to_ref(m);
-  const auto s = softmax(m_ref.val());
-  const auto d_in = m_ref.d().eval();
-  // d/dx softmax(x) applied to tangent: s ⊙ (d_in - s · d_in)  (per row)
-  const auto dots = (s.array() * d_in.array()).rowwise().sum().eval();
-  plain_type_t<Mat> result(m_ref.rows(), m_ref.cols());
-  result.val() = s;
-  result.d() = (s.array() * (d_in.array().colwise() - dots.array())).matrix();
-  return result;
-}
-
+/**
+ * Return the softmax of the specified row vector of `fvar` values.
+ * Delegates to the column-vector overload via transposition.
+ *
+ * @tparam RowVec Eigen row vector with `fvar` scalar
+ * @param x row vector to transform
+ * @return softmax of the row vector
+ */
 template <typename RowVec, require_eigen_row_vector_t<RowVec>* = nullptr,
           require_t<is_fvar<value_type_t<RowVec>>>* = nullptr>
-inline auto softmax(const RowVec& alpha) {
-  return softmax(alpha.transpose()).transpose().eval();
+inline auto softmax(const RowVec& x) {
+  return softmax(x.transpose()).transpose().eval();
 }
 
+/**
+ * Return the softmax of each vector in a container of `fvar` values.
+ *
+ * @tparam T `std::vector` whose scalar type is `fvar`
+ * @param x container of vectors to transform
+ * @return container of softmax results
+ */
+template <typename T, require_std_vector_st<is_fvar, T>* = nullptr>
+inline auto softmax(T&& x) {
+  return apply_vector_unary<T>::apply(std::forward<T>(x), [](auto&& v) {
+    return softmax(std::forward<decltype(v)>(v));
+  });
+}
+
+/**
+ * Return the softmax of the specified column vector of `fvar` values.
+ *
+ * @tparam ColVec Eigen column vector with `fvar` scalar
+ * @param x column vector to transform
+ * @return softmax of the column vector
+ */
 template <typename ColVec,
           require_eigen_col_vector_vt<is_fvar, ColVec>* = nullptr>
-inline auto softmax(const ColVec& alpha) {
+inline auto softmax(const ColVec& x) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using T = typename value_type_t<ColVec>::Scalar;
-  if (alpha.size() == 0) {
+  if (x.size() == 0) {
     return Matrix<fvar<T>, Dynamic, 1>();
   }
-  const auto& alpha_ref = to_ref(alpha);
-  const Matrix<T, Dynamic, 1> s = softmax(value_of(alpha_ref));
-  const auto d_in = alpha_ref.d().eval();
+  const auto& x_ref = to_ref(x);
+  const Matrix<T, Dynamic, 1> s = softmax(value_of(x_ref));
+  const auto d_in = x_ref.d().eval();
   const T dot_sd = s.dot(d_in);
-  Matrix<fvar<T>, Dynamic, 1> result(alpha.size());
+  Matrix<fvar<T>, Dynamic, 1> result(x_ref.size());
   result.val() = s;
   result.d() = (s.array() * (d_in.array() - dot_sd)).matrix();
   return result;

--- a/stan/math/fwd/fun/softmax.hpp
+++ b/stan/math/fwd/fun/softmax.hpp
@@ -12,20 +12,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the softmax of the specified row vector of `fvar` values.
- * Delegates to the column-vector overload via transposition.
- *
- * @tparam RowVec Eigen row vector with `fvar` scalar
- * @param x row vector to transform
- * @return softmax of the row vector
- */
-template <typename RowVec, require_eigen_row_vector_t<RowVec>* = nullptr,
-          require_t<is_fvar<value_type_t<RowVec>>>* = nullptr>
-inline auto softmax(const RowVec& x) {
-  return softmax(x.transpose()).transpose().eval();
-}
-
-/**
  * Return the softmax of each vector in a container of `fvar` values.
  *
  * @tparam T `std::vector` whose scalar type is `fvar`
@@ -46,20 +32,21 @@ inline auto softmax(T&& x) {
  * @param x column vector to transform
  * @return softmax of the column vector
  */
-template <typename ColVec,
-          require_eigen_col_vector_vt<is_fvar, ColVec>* = nullptr>
-inline auto softmax(const ColVec& x) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using T = typename value_type_t<ColVec>::Scalar;
+template <typename Vec,
+          require_eigen_vector_vt<is_fvar, Vec>* = nullptr>
+inline auto softmax(Vec&& x) {
+  using vec = std::decay_t<Vec>;
+  constexpr int Rows = vec::RowsAtCompileTime;
+  constexpr int Cols = vec::ColsAtCompileTime;
+  using T = typename value_type_t<vec>::Scalar;
   if (x.size() == 0) {
-    return Matrix<fvar<T>, Dynamic, 1>();
+    return Eigen::Matrix<fvar<T>, Rows, Cols>();
   }
-  const auto& x_ref = to_ref(x);
-  const Matrix<T, Dynamic, 1> s = softmax(value_of(x_ref));
-  const auto d_in = x_ref.d().eval();
-  const T dot_sd = s.dot(d_in);
-  Matrix<fvar<T>, Dynamic, 1> result(x_ref.size());
+  decltype(auto) x_ref = to_ref(std::forward<Vec>(x));
+  const auto s = softmax(value_of(x_ref));
+  const auto d_in = x_ref.d();
+  const auto dot_sd = s.dot(d_in);
+  Eigen::Matrix<fvar<T>, Rows, Cols> result(x_ref.size());
   result.val() = s;
   result.d() = (s.array() * (d_in.array() - dot_sd)).matrix();
   return result;

--- a/stan/math/fwd/fun/softmax.hpp
+++ b/stan/math/fwd/fun/softmax.hpp
@@ -10,6 +10,21 @@
 namespace stan {
 namespace math {
 
+template <typename Mat, require_eigen_t<Mat>* = nullptr,
+          require_not_eigen_vector_t<Mat>* = nullptr,
+          require_t<is_fvar<value_type_t<Mat>>>* = nullptr>
+inline auto softmax(const Mat& m) {
+  const auto& m_ref = to_ref(m);
+  const auto s = softmax(m_ref.val());
+  const auto d_in = m_ref.d().eval();
+  // d/dx softmax(x) applied to tangent: s ⊙ (d_in - s · d_in)  (per row)
+  const auto dots = (s.array() * d_in.array()).rowwise().sum().eval();
+  plain_type_t<Mat> result(m_ref.rows(), m_ref.cols());
+  result.val() = s;
+  result.d() = (s.array() * (d_in.array().colwise() - dots.array())).matrix();
+  return result;
+}
+
 template <typename RowVec, require_eigen_row_vector_t<RowVec>* = nullptr,
           require_t<is_fvar<value_type_t<RowVec>>>* = nullptr>
 inline auto softmax(const RowVec& alpha) {
@@ -26,33 +41,13 @@ inline auto softmax(const ColVec& alpha) {
     return Matrix<fvar<T>, Dynamic, 1>();
   }
   const auto& alpha_ref = to_ref(alpha);
-
-  Matrix<T, Dynamic, 1> softmax_alpha_t = softmax(value_of(alpha_ref));
-
-  Matrix<fvar<T>, Dynamic, 1> softmax_alpha(alpha.size());
-  for (int k = 0; k < alpha.size(); ++k) {
-    softmax_alpha.coeffRef(k).val_ = softmax_alpha_t.coeff(k);
-    softmax_alpha.coeffRef(k).d_ = 0;
-  }
-
-  for (int m = 0; m < alpha.size(); ++m) {
-    T negative_alpha_m_d_times_softmax_alpha_t_m
-        = -alpha_ref.coeff(m).d_ * softmax_alpha_t.coeff(m);
-    for (int k = 0; k < alpha.size(); ++k) {
-      if (m == k) {
-        softmax_alpha.coeffRef(k).d_
-            += softmax_alpha_t.coeff(k)
-               * (alpha_ref.coeff(m).d_
-                  + negative_alpha_m_d_times_softmax_alpha_t_m);
-      } else {
-        softmax_alpha.coeffRef(k).d_
-            += softmax_alpha_t.coeff(k)
-               * negative_alpha_m_d_times_softmax_alpha_t_m;
-      }
-    }
-  }
-
-  return softmax_alpha;
+  const Matrix<T, Dynamic, 1> s = softmax(value_of(alpha_ref));
+  const auto d_in = alpha_ref.d().eval();
+  const T dot_sd = s.dot(d_in);
+  Matrix<fvar<T>, Dynamic, 1> result(alpha.size());
+  result.val() = s;
+  result.d() = (s.array() * (d_in.array() - dot_sd)).matrix();
+  return result;
 }
 
 }  // namespace math

--- a/stan/math/fwd/fun/softmax.hpp
+++ b/stan/math/fwd/fun/softmax.hpp
@@ -10,6 +10,12 @@
 namespace stan {
 namespace math {
 
+template <typename RowVec, require_eigen_row_vector_t<RowVec>* = nullptr,
+          require_t<is_fvar<value_type_t<RowVec>>>* = nullptr>
+inline auto softmax(const RowVec& alpha) {
+  return softmax(alpha.transpose()).transpose().eval();
+}
+
 template <typename ColVec,
           require_eigen_col_vector_vt<is_fvar, ColVec>* = nullptr>
 inline auto softmax(const ColVec& alpha) {

--- a/stan/math/fwd/fun/softmax.hpp
+++ b/stan/math/fwd/fun/softmax.hpp
@@ -26,11 +26,11 @@ inline auto softmax(T&& x) {
 }
 
 /**
- * Return the softmax of the specified column vector of `fvar` values.
+ * Return the softmax of the specified vector of `fvar` values.
  *
- * @tparam ColVec Eigen column vector with `fvar` scalar
- * @param x column vector to transform
- * @return softmax of the column vector
+ * @tparam Vec Eigen vector with `fvar` scalar
+ * @param x vector to transform
+ * @return softmax of the vector
  */
 template <typename Vec, require_eigen_vector_vt<is_fvar, Vec>* = nullptr>
 inline auto softmax(Vec&& x) {

--- a/stan/math/prim/fun/log_softmax.hpp
+++ b/stan/math/prim/fun/log_softmax.hpp
@@ -41,9 +41,9 @@ namespace math {
  */
 template <typename Container, require_st_arithmetic<Container>* = nullptr,
           require_container_t<Container>* = nullptr,
-          require_not_t<bool_constant<is_eigen<std::decay_t<Container>>::value
-                                      && !is_eigen_vector<std::decay_t<
-                                             Container>>::value>>* = nullptr>
+          require_not_t<bool_constant<
+              is_eigen<std::decay_t<Container>>::value
+              && !is_eigen_vector<std::decay_t<Container>>::value>>* = nullptr>
 inline auto log_softmax(Container&& x) {
   check_nonzero_size("log_softmax", "v", x);
   return make_holder(

--- a/stan/math/prim/fun/log_softmax.hpp
+++ b/stan/math/prim/fun/log_softmax.hpp
@@ -40,7 +40,10 @@ namespace math {
  * @return log unit simplex result of the softmax transform of the vector.
  */
 template <typename Container, require_st_arithmetic<Container>* = nullptr,
-          require_container_t<Container>* = nullptr>
+          require_container_t<Container>* = nullptr,
+          require_not_t<bool_constant<is_eigen<std::decay_t<Container>>::value
+                                      && !is_eigen_vector<std::decay_t<
+                                             Container>>::value>>* = nullptr>
 inline auto log_softmax(Container&& x) {
   check_nonzero_size("log_softmax", "v", x);
   return make_holder(
@@ -50,6 +53,26 @@ inline auto log_softmax(Container&& x) {
             [](auto&& v) { return v.array() - log_sum_exp(v); });
       },
       to_ref(std::forward<Container>(x)));
+}
+
+/**
+ * Return the log softmax of the rows of the specified matrix.
+ * Each row is transformed independently; the result has the same shape
+ * as the input.
+ *
+ * @tparam Mat type of input matrix
+ * @param[in] m Matrix to transform row-wise.
+ * @return Log-softmax applied row-wise.
+ */
+template <typename Mat, require_eigen_vt<std::is_arithmetic, Mat>* = nullptr,
+          require_not_eigen_vector_t<Mat>* = nullptr>
+inline plain_type_t<Mat> log_softmax(const Mat& m) {
+  check_nonzero_size("log_softmax", "m", m);
+  const auto& m_ref = to_ref(m);
+  const auto shifted
+      = (m_ref.array().colwise() - m_ref.rowwise().maxCoeff().array()).eval();
+  const auto exp_s = shifted.exp().eval();
+  return (shifted.colwise() - exp_s.rowwise().sum().log()).matrix();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_softmax.hpp
+++ b/stan/math/prim/fun/log_softmax.hpp
@@ -13,7 +13,7 @@ namespace math {
 
 /**
  * Return the natural logarithm of the softmax of the specified
- * vector.
+ * vector, or of each vector in a container.
  *
  * \f$
  * \log \mbox{softmax}(y)
@@ -23,21 +23,23 @@ namespace math {
  *
  * For the log softmax function, the entries in the Jacobian are
  * \f$
- * \frac{\partial}{\partial y_m} \mbox{softmax}(y)[k]
+ * \frac{\partial}{\partial y_m} \log\mbox{softmax}(y)[k]
  * = \left\{
  * \begin{array}{ll}
  * 1 - \mbox{softmax}(y)[m]
  * & \mbox{ if } m = k, \mbox{ and}
  * \\[6pt]
- * \mbox{softmax}(y)[m]
+ * -\mbox{softmax}(y)[m]
  * & \mbox{ if } m \neq k.
  * \end{array}
  * \right.
  * \f$
  *
- * @tparam Container type of input vector to transform
- * @param[in] x vector to transform
- * @return log unit simplex result of the softmax transform of the vector.
+ * @tparam Container type of input: an Eigen vector, `std::vector` of doubles,
+ *   or nested container whose scalar type is arithmetic
+ * @param[in] x vector or container of vectors to transform
+ * @return log softmax of the input, preserving the container structure
+ * @throw std::domain_error if any input vector is empty
  */
 template <typename Container, require_st_arithmetic<Container>* = nullptr,
           require_container_t<Container>* = nullptr,
@@ -45,7 +47,7 @@ template <typename Container, require_st_arithmetic<Container>* = nullptr,
               is_eigen<std::decay_t<Container>>::value
               && !is_eigen_vector<std::decay_t<Container>>::value>>* = nullptr>
 inline auto log_softmax(Container&& x) {
-  check_nonzero_size("log_softmax", "v", x);
+  check_nonzero_size("log_softmax", "x", x);
   return make_holder(
       [](auto&& a) {
         return apply_vector_unary<ref_type_t<Container>>::apply(
@@ -53,26 +55,6 @@ inline auto log_softmax(Container&& x) {
             [](auto&& v) { return v.array() - log_sum_exp(v); });
       },
       to_ref(std::forward<Container>(x)));
-}
-
-/**
- * Return the log softmax of the rows of the specified matrix.
- * Each row is transformed independently; the result has the same shape
- * as the input.
- *
- * @tparam Mat type of input matrix
- * @param[in] m Matrix to transform row-wise.
- * @return Log-softmax applied row-wise.
- */
-template <typename Mat, require_eigen_vt<std::is_arithmetic, Mat>* = nullptr,
-          require_not_eigen_vector_t<Mat>* = nullptr>
-inline plain_type_t<Mat> log_softmax(const Mat& m) {
-  check_nonzero_size("log_softmax", "m", m);
-  const auto& m_ref = to_ref(m);
-  const auto shifted
-      = (m_ref.array().colwise() - m_ref.rowwise().maxCoeff().array()).eval();
-  const auto exp_s = shifted.exp().eval();
-  return (shifted.colwise() - exp_s.rowwise().sum().log()).matrix();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/softmax.hpp
+++ b/stan/math/prim/fun/softmax.hpp
@@ -45,12 +45,12 @@ namespace math {
  */
 template <typename Vec,
           require_eigen_vector_vt<std::is_arithmetic, Vec>* = nullptr>
-inline plain_type_t<Vec> softmax(const Vec& v) {
+inline plain_type_t<Vec> softmax(Vec&& v) {
   if (v.size() == 0) {
     return v;
   }
-  const auto& v_ref = to_ref(v);
-  const auto theta = (v_ref.array() - v_ref.maxCoeff()).exp().eval();
+  decltype(auto) v_ref = to_ref(std::forward<Vec>(v));
+  const auto theta = (v_ref.array() - v_ref.maxCoeff()).exp();
   return (theta / theta.sum()).matrix();
 }
 

--- a/stan/math/prim/fun/softmax.hpp
+++ b/stan/math/prim/fun/softmax.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/functor/apply_vector_unary.hpp>
 #include <cmath>
 
 namespace stan {
@@ -38,7 +39,7 @@ namespace math {
  * \end{array}
  * \f$
  *
- * @tparam Vec type of elements in the vector
+ * @tparam Vec type of the input vector
  * @param[in] v Vector to transform.
  * @return Unit simplex result of the softmax transform of the vector.
  */
@@ -54,22 +55,17 @@ inline plain_type_t<Vec> softmax(const Vec& v) {
 }
 
 /**
- * Return the softmax of the rows of the specified matrix.
- * Each row is transformed independently; the result is a row-stochastic
- * matrix whose rows each sum to one.
+ * Return the softmax of each vector in an array.
  *
- * @tparam Mat type of input matrix
- * @param[in] m Matrix to transform row-wise.
- * @return Row-stochastic matrix result of applying softmax to each row.
+ * @tparam T `std::vector` whose scalar type is arithmetic
+ * @param[in] x Array of vectors to transform.
+ * @return Array of unit simplex results.
  */
-template <typename Mat, require_eigen_vt<std::is_arithmetic, Mat>* = nullptr,
-          require_not_eigen_vector_t<Mat>* = nullptr>
-inline plain_type_t<Mat> softmax(const Mat& m) {
-  const auto& m_ref = to_ref(m);
-  const auto shifted
-      = (m_ref.array().colwise() - m_ref.rowwise().maxCoeff().array()).eval();
-  const auto exp_s = shifted.exp().eval();
-  return (exp_s.colwise() / exp_s.rowwise().sum()).matrix();
+template <typename T, require_std_vector_st<std::is_arithmetic, T>* = nullptr>
+inline auto softmax(T&& x) {
+  return apply_vector_unary<T>::apply(std::forward<T>(x), [](auto&& v) {
+    return softmax(std::forward<decltype(v)>(v));
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/softmax.hpp
+++ b/stan/math/prim/fun/softmax.hpp
@@ -45,13 +45,31 @@ namespace math {
 template <typename Vec,
           require_eigen_vector_vt<std::is_arithmetic, Vec>* = nullptr>
 inline plain_type_t<Vec> softmax(const Vec& v) {
-  using std::exp;
   if (v.size() == 0) {
     return v;
   }
   const auto& v_ref = to_ref(v);
   const auto theta = (v_ref.array() - v_ref.maxCoeff()).exp().eval();
-  return (theta.array() / theta.sum()).matrix();
+  return (theta / theta.sum()).matrix();
+}
+
+/**
+ * Return the softmax of the rows of the specified matrix.
+ * Each row is transformed independently; the result is a row-stochastic
+ * matrix whose rows each sum to one.
+ *
+ * @tparam Mat type of input matrix
+ * @param[in] m Matrix to transform row-wise.
+ * @return Row-stochastic matrix result of applying softmax to each row.
+ */
+template <typename Mat, require_eigen_vt<std::is_arithmetic, Mat>* = nullptr,
+          require_not_eigen_vector_t<Mat>* = nullptr>
+inline plain_type_t<Mat> softmax(const Mat& m) {
+  const auto& m_ref = to_ref(m);
+  const auto shifted
+      = (m_ref.array().colwise() - m_ref.rowwise().maxCoeff().array()).eval();
+  const auto exp_s = shifted.exp().eval();
+  return (exp_s.colwise() / exp_s.rowwise().sum()).matrix();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/softmax.hpp
+++ b/stan/math/prim/fun/softmax.hpp
@@ -38,20 +38,20 @@ namespace math {
  * \end{array}
  * \f$
  *
- * @tparam ColVec type of elements in the vector
+ * @tparam Vec type of elements in the vector
  * @param[in] v Vector to transform.
  * @return Unit simplex result of the softmax transform of the vector.
  */
-template <typename ColVec,
-          require_eigen_col_vector_vt<std::is_arithmetic, ColVec>* = nullptr>
-inline plain_type_t<ColVec> softmax(const ColVec& v) {
+template <typename Vec,
+          require_eigen_vector_vt<std::is_arithmetic, Vec>* = nullptr>
+inline plain_type_t<Vec> softmax(const Vec& v) {
   using std::exp;
   if (v.size() == 0) {
     return v;
   }
   const auto& v_ref = to_ref(v);
   const auto theta = (v_ref.array() - v_ref.maxCoeff()).exp().eval();
-  return theta.array() / theta.sum();
+  return (theta.array() / theta.sum()).matrix();
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/log_softmax.hpp
+++ b/stan/math/rev/fun/log_softmax.hpp
@@ -33,7 +33,7 @@ inline auto log_softmax(T&& x) {
     x_arena.adj().array()
         += res_adj.array() - res_adj.sum() * res.val().array().exp();
   });
-  return return_t(res);
+  return res;
 }
 
 /**

--- a/stan/math/rev/fun/log_softmax.hpp
+++ b/stan/math/rev/fun/log_softmax.hpp
@@ -60,7 +60,7 @@ inline auto log_softmax(const T& x) {
 }
 
 template <typename T, require_eigen_st<is_var, T>* = nullptr,
-          require_not_t<is_eigen_row_vector<std::decay_t<T>>>* = nullptr>
+          require_eigen_col_vector_t<T>* = nullptr>
 inline auto log_softmax(const T& x) {
   const int a_size = x.size();
 
@@ -103,18 +103,62 @@ inline auto log_softmax(const T& x) {
  * @return softmax of the input
  * @throw std::domain_error if the input size is 0
  */
-template <typename T, require_var_matrix_t<T>* = nullptr>
+template <typename T, require_var_matrix_t<T>* = nullptr,
+          require_t<bool_constant<T::RowsAtCompileTime == 1
+                                  || T::ColsAtCompileTime == 1>>* = nullptr>
 inline auto log_softmax(const T& x) {
   check_nonzero_size("log_softmax", "x", x);
-
-  const auto& theta = (x.val().array() - x.val().maxCoeff()).eval();
-
   return make_callback_var(
-      (theta.array() - log(theta.exp().sum())).matrix(),
+      log_softmax(x.val()).eval(),
       [x](const auto& res) mutable {
+        // grad: g - sum(g) * softmax(x), where softmax(x) = exp(log_softmax(x))
         x.adj().noalias()
             += res.adj() - (res.adj().sum() * res.val().array().exp()).matrix();
       });
+}
+
+/**
+ * Return the log softmax of the rows of the specified matrix.
+ * Applied independently to each row.
+ *
+ * @tparam T type of input (var_value<Matrix>)
+ * @param x input matrix
+ * @return log-softmax applied row-wise
+ */
+template <typename T, require_var_matrix_t<T>* = nullptr,
+          require_t<bool_constant<T::RowsAtCompileTime != 1
+                                  && T::ColsAtCompileTime != 1>>* = nullptr>
+inline auto log_softmax(const T& x) {
+  check_nonzero_size("log_softmax", "x", x);
+  return make_callback_var(
+      Eigen::MatrixXd(log_softmax(x.val())),
+      [x](const auto& res) mutable {
+        // grad per row: g - softmax(x) * sum(g),  softmax(x) = exp(log_softmax(x))
+        const auto row_sums = res.adj().rowwise().sum().eval();
+        x.adj().noalias()
+            += res.adj()
+               - (res.val().array().exp().colwise() * row_sums.array())
+                     .matrix();
+      });
+}
+
+/**
+ * Return the log softmax of the rows of the specified Eigen matrix
+ * whose entries are vars. Applied independently to each row.
+ *
+ * @tparam T type of input (Eigen matrix with var scalar)
+ * @param x input matrix
+ * @return log-softmax applied row-wise
+ */
+template <typename T, require_eigen_st<is_var, T>* = nullptr,
+          require_not_t<is_eigen_vector<std::decay_t<T>>>* = nullptr>
+inline auto log_softmax(const T& x) {
+  check_nonzero_size("log_softmax", "x", x);
+  plain_type_t<T> result(x.rows(), x.cols());
+  for (int i = 0; i < x.rows(); ++i) {
+    result.row(i) = log_softmax(x.row(i));
+  }
+  return result;
 }
 
 /**

--- a/stan/math/rev/fun/log_softmax.hpp
+++ b/stan/math/rev/fun/log_softmax.hpp
@@ -3,176 +3,51 @@
 
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/rev/core.hpp>
-#include <stan/math/rev/core/typedefs.hpp>
-#include <stan/math/rev/fun/softmax.hpp>
+#include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
-#include <stan/math/prim/fun/typedefs.hpp>
 #include <stan/math/prim/fun/log_softmax.hpp>
-#include <cmath>
-#include <vector>
+#include <stan/math/prim/functor/apply_vector_unary.hpp>
 
 namespace stan {
 namespace math {
 
-namespace internal {
-
-class log_softmax_elt_vari : public vari {
- private:
-  vari** alpha_;
-  const double* softmax_alpha_;
-  const int size_;  // array sizes
-  const int idx_;   // in in softmax output
-
- public:
-  log_softmax_elt_vari(double val, vari** alpha, const double* softmax_alpha,
-                       int size, int idx)
-      : vari(val),
-        alpha_(alpha),
-        softmax_alpha_(softmax_alpha),
-        size_(size),
-        idx_(idx) {}
-  void chain() {
-    for (int m = 0; m < size_; ++m) {
-      if (m == idx_) {
-        alpha_[m]->adj_ += adj_ * (1 - softmax_alpha_[m]);
-      } else {
-        alpha_[m]->adj_ -= adj_ * softmax_alpha_[m];
-      }
-    }
-  }
-};
-}  // namespace internal
-
 /**
- * Return the log softmax of the specified vector
+ * Return the log softmax of the specified vector or row vector.
  *
- * @tparam T type of input
+ * @tparam T a `var_value` or Eigen vector/row_vector with `var` scalar
  * @param x input
- * @return softmax of the input
+ * @return log softmax of the input
  * @throw std::domain_error if the input size is 0
  */
-template <typename T, require_eigen_row_vector_t<T>* = nullptr,
-          require_eigen_st<is_var, T>* = nullptr>
-inline auto log_softmax(const T& x) {
-  return log_softmax(x.transpose()).transpose().eval();
-}
-
-template <typename T, require_eigen_st<is_var, T>* = nullptr,
-          require_eigen_col_vector_t<T>* = nullptr>
-inline auto log_softmax(const T& x) {
-  const int a_size = x.size();
-
+template <typename T, require_rev_matrix_t<T>* = nullptr>
+inline auto log_softmax(T&& x) {
   check_nonzero_size("log_softmax", "x", x);
-
-  const auto& x_ref = to_ref(x);
-
-  vari** x_vi_array
-      = ChainableStack::instance_->memalloc_.alloc_array<vari*>(a_size);
-  Eigen::Map<vector_vi>(x_vi_array, a_size) = x_ref.vi();
-
-  vector_d x_d = x_ref.val();
-
-  // fold logic of math::softmax() and math::log_softmax()
-  // to save computations
-
-  vector_d diff = (x_d.array() - x_d.maxCoeff());
-  vector_d softmax_x_d = diff.array().exp();
-  double sum = softmax_x_d.sum();
-  vector_d log_softmax_x_d = diff.array() - std::log(sum);
-
-  // end fold
-  double* softmax_x_d_array
-      = ChainableStack::instance_->memalloc_.alloc_array<double>(a_size);
-  Eigen::Map<vector_d>(softmax_x_d_array, a_size) = softmax_x_d.array() / sum;
-
-  plain_type_t<T> log_softmax_x(a_size);
-  for (int k = 0; k < a_size; ++k) {
-    log_softmax_x(k) = var(new internal::log_softmax_elt_vari(
-        log_softmax_x_d[k], x_vi_array, softmax_x_d_array, a_size, k));
-  }
-  return log_softmax_x;
+  auto x_arena = to_arena(std::forward<T>(x));
+  using return_t
+      = return_var_matrix_t<plain_type_t<decltype(x_arena.val())>, T>;
+  arena_t<return_t> res = log_softmax(x_arena.val());
+  reverse_pass_callback([x_arena, res]() mutable {
+    const auto s = res.val().array().exp().eval();
+    const auto& res_adj = to_ref(res.adj());
+    x_arena.adj().array() += res_adj.array() - res_adj.sum() * s;
+  });
+  return return_t(res);
 }
 
 /**
- * Return the log softmax of the specified vector
+ * Return the log softmax of each vector in an array.
  *
- * @tparam T type of input
- * @param x input
- * @return softmax of the input
- * @throw std::domain_error if the input size is 0
- */
-template <typename T, require_var_matrix_t<T>* = nullptr,
-          require_t<bool_constant<T::RowsAtCompileTime == 1
-                                  || T::ColsAtCompileTime == 1>>* = nullptr>
-inline auto log_softmax(const T& x) {
-  check_nonzero_size("log_softmax", "x", x);
-  return make_callback_var(
-      log_softmax(x.val()).eval(), [x](const auto& res) mutable {
-        // grad: g - sum(g) * softmax(x), where softmax(x) = exp(log_softmax(x))
-        x.adj().noalias()
-            += res.adj() - (res.adj().sum() * res.val().array().exp()).matrix();
-      });
-}
-
-/**
- * Return the log softmax of the rows of the specified matrix.
- * Applied independently to each row.
- *
- * @tparam T type of input (var_value<Matrix>)
- * @param x input matrix
- * @return log-softmax applied row-wise
- */
-template <typename T, require_var_matrix_t<T>* = nullptr,
-          require_t<bool_constant<T::RowsAtCompileTime != 1
-                                  && T::ColsAtCompileTime != 1>>* = nullptr>
-inline auto log_softmax(const T& x) {
-  check_nonzero_size("log_softmax", "x", x);
-  return make_callback_var(
-      Eigen::MatrixXd(log_softmax(x.val())), [x](const auto& res) mutable {
-        // grad per row: g - softmax(x) * sum(g),  softmax(x) =
-        // exp(log_softmax(x))
-        const auto row_sums = res.adj().rowwise().sum().eval();
-        x.adj().noalias()
-            += res.adj()
-               - (res.val().array().exp().colwise() * row_sums.array())
-                     .matrix();
-      });
-}
-
-/**
- * Return the log softmax of the rows of the specified Eigen matrix
- * whose entries are vars. Applied independently to each row.
- *
- * @tparam T type of input (Eigen matrix with var scalar)
- * @param x input matrix
- * @return log-softmax applied row-wise
- */
-template <typename T, require_eigen_st<is_var, T>* = nullptr,
-          require_not_t<is_eigen_vector<std::decay_t<T>>>* = nullptr>
-inline auto log_softmax(const T& x) {
-  check_nonzero_size("log_softmax", "x", x);
-  plain_type_t<T> result(x.rows(), x.cols());
-  for (int i = 0; i < x.rows(); ++i) {
-    result.row(i) = log_softmax(x.row(i));
-  }
-  return result;
-}
-
-/**
- * Return the log softmax of the specified `std::vector` or
- * `std::vector` of containers.
- *
- * @tparam T type of input
- * @param x input
- * @return softmax of the input
- * @throw std::domain_error if the input size is 0
+ * @tparam T `std::vector` whose scalar type is `var`
+ * @param x array of vectors to transform
+ * @return array of log softmax results
+ * @throw std::domain_error if any element size is 0
  */
 template <typename T, require_std_vector_st<is_var, T>* = nullptr>
 inline auto log_softmax(T&& x) {
-  return apply_vector_unary<T>::apply(std::forward<T>(x), [](auto&& alpha) {
-    return log_softmax(std::forward<decltype(alpha)>(alpha));
+  return apply_vector_unary<T>::apply(std::forward<T>(x), [](auto&& v) {
+    return log_softmax(std::forward<decltype(v)>(v));
   });
 }
 

--- a/stan/math/rev/fun/log_softmax.hpp
+++ b/stan/math/rev/fun/log_softmax.hpp
@@ -109,8 +109,7 @@ template <typename T, require_var_matrix_t<T>* = nullptr,
 inline auto log_softmax(const T& x) {
   check_nonzero_size("log_softmax", "x", x);
   return make_callback_var(
-      log_softmax(x.val()).eval(),
-      [x](const auto& res) mutable {
+      log_softmax(x.val()).eval(), [x](const auto& res) mutable {
         // grad: g - sum(g) * softmax(x), where softmax(x) = exp(log_softmax(x))
         x.adj().noalias()
             += res.adj() - (res.adj().sum() * res.val().array().exp()).matrix();
@@ -131,9 +130,9 @@ template <typename T, require_var_matrix_t<T>* = nullptr,
 inline auto log_softmax(const T& x) {
   check_nonzero_size("log_softmax", "x", x);
   return make_callback_var(
-      Eigen::MatrixXd(log_softmax(x.val())),
-      [x](const auto& res) mutable {
-        // grad per row: g - softmax(x) * sum(g),  softmax(x) = exp(log_softmax(x))
+      Eigen::MatrixXd(log_softmax(x.val())), [x](const auto& res) mutable {
+        // grad per row: g - softmax(x) * sum(g),  softmax(x) =
+        // exp(log_softmax(x))
         const auto row_sums = res.adj().rowwise().sum().eval();
         x.adj().noalias()
             += res.adj()

--- a/stan/math/rev/fun/log_softmax.hpp
+++ b/stan/math/rev/fun/log_softmax.hpp
@@ -29,9 +29,9 @@ inline auto log_softmax(T&& x) {
       = return_var_matrix_t<plain_type_t<decltype(x_arena.val())>, T>;
   arena_t<return_t> res = log_softmax(x_arena.val());
   reverse_pass_callback([x_arena, res]() mutable {
-    const auto s = res.val().array().exp().eval();
     const auto& res_adj = to_ref(res.adj());
-    x_arena.adj().array() += res_adj.array() - res_adj.sum() * s;
+    x_arena.adj().array()
+        += res_adj.array() - res_adj.sum() * res.val().array().exp();
   });
   return return_t(res);
 }

--- a/stan/math/rev/fun/log_softmax.hpp
+++ b/stan/math/rev/fun/log_softmax.hpp
@@ -53,7 +53,14 @@ class log_softmax_elt_vari : public vari {
  * @return softmax of the input
  * @throw std::domain_error if the input size is 0
  */
-template <typename T, require_eigen_st<is_var, T>* = nullptr>
+template <typename T, require_eigen_row_vector_t<T>* = nullptr,
+          require_eigen_st<is_var, T>* = nullptr>
+inline auto log_softmax(const T& x) {
+  return log_softmax(x.transpose()).transpose().eval();
+}
+
+template <typename T, require_eigen_st<is_var, T>* = nullptr,
+          require_not_t<is_eigen_row_vector<std::decay_t<T>>>* = nullptr>
 inline auto log_softmax(const T& x) {
   const int a_size = x.size();
 

--- a/stan/math/rev/fun/softmax.hpp
+++ b/stan/math/rev/fun/softmax.hpp
@@ -73,8 +73,8 @@ inline auto softmax(const Mat& m) {
   reverse_pass_callback([res_val, res, m_arena]() mutable {
     const auto& g = to_ref(res.adj());
     const auto dots = (res_val.array() * g.array()).rowwise().sum().eval();
-    m_arena.adj() += (res_val.array() * (g.array().colwise() - dots.array()))
-                         .matrix();
+    m_arena.adj()
+        += (res_val.array() * (g.array().colwise() - dots.array())).matrix();
   });
 
   return ret_type(res);

--- a/stan/math/rev/fun/softmax.hpp
+++ b/stan/math/rev/fun/softmax.hpp
@@ -23,7 +23,9 @@ namespace math {
  * @return Softmax of the input.
  * @throw std::domain_error If the input vector is size 0.
  */
-template <typename Mat, require_rev_matrix_t<Mat>* = nullptr>
+template <typename Mat, require_rev_matrix_t<Mat>* = nullptr,
+          require_t<bool_constant<Mat::RowsAtCompileTime == 1
+                                  || Mat::ColsAtCompileTime == 1>>* = nullptr>
 inline auto softmax(const Mat& alpha) {
   using mat_plain = plain_type_t<Mat>;
   using ret_type = return_var_matrix_t<Mat>;
@@ -40,6 +42,39 @@ inline auto softmax(const Mat& alpha) {
     const auto& res_adj = to_ref(res.adj());
     alpha_arena.adj()
         += -res_val * res_adj.dot(res_val) + res_val.cwiseProduct(res_adj);
+  });
+
+  return ret_type(res);
+}
+
+/**
+ * Return the softmax of the rows of the specified matrix.
+ * Softmax is applied independently to each row, producing a
+ * row-stochastic matrix.
+ *
+ * @param m Unconstrained input matrix.
+ * @return Row-stochastic matrix result.
+ */
+template <typename Mat, require_rev_matrix_t<Mat>* = nullptr,
+          require_t<bool_constant<Mat::RowsAtCompileTime != 1
+                                  && Mat::ColsAtCompileTime != 1>>* = nullptr>
+inline auto softmax(const Mat& m) {
+  using mat_plain = plain_type_t<Mat>;
+  using ret_type = return_var_matrix_t<Mat>;
+  if (m.size() == 0) {
+    return ret_type(m);
+  }
+  arena_t<mat_plain> m_arena = m;
+  using double_mat_t
+      = Eigen::Matrix<double, Mat::RowsAtCompileTime, Mat::ColsAtCompileTime>;
+  arena_t<double_mat_t> res_val = softmax(value_of(m_arena));
+  arena_t<ret_type> res = res_val;
+
+  reverse_pass_callback([res_val, res, m_arena]() mutable {
+    const auto& g = to_ref(res.adj());
+    const auto dots = (res_val.array() * g.array()).rowwise().sum().eval();
+    m_arena.adj() += (res_val.array() * (g.array().colwise() - dots.array()))
+                         .matrix();
   });
 
   return ret_type(res);

--- a/stan/math/rev/fun/softmax.hpp
+++ b/stan/math/rev/fun/softmax.hpp
@@ -23,7 +23,8 @@ namespace math {
 template <typename T, require_rev_matrix_t<T>* = nullptr>
 inline auto softmax(T&& x) {
   auto x_arena = to_arena(std::forward<T>(x));
-  using return_t = return_var_matrix_t<plain_type_t<decltype(x_arena.val())>, T>;
+  using return_t
+      = return_var_matrix_t<plain_type_t<decltype(x_arena.val())>, T>;
   if (x_arena.size() == 0) {
     return return_t(x_arena);
   }

--- a/stan/math/rev/fun/softmax.hpp
+++ b/stan/math/rev/fun/softmax.hpp
@@ -26,15 +26,13 @@ inline auto softmax(T&& x) {
   using return_t
       = return_var_matrix_t<plain_type_t<decltype(x_arena.val())>, T>;
   if (x_arena.size() == 0) {
-    return return_t(x_arena);
+    return x_arena;
   }
   arena_t<return_t> res = softmax(x_arena.val());
   reverse_pass_callback([x_arena, res]() mutable {
-    const auto& s = to_ref(res.val());
-    const auto& res_adj = to_ref(res.adj());
-    x_arena.adj().array() += s.array() * (res_adj.array() - s.dot(res_adj));
+    x_arena.adj().array() += res.val().array() * (res.adj().array() - res.val().dot(res.adj()));
   });
-  return return_t(res);
+  return res;
 }
 
 /**

--- a/stan/math/rev/fun/softmax.hpp
+++ b/stan/math/rev/fun/softmax.hpp
@@ -30,7 +30,8 @@ inline auto softmax(T&& x) {
   }
   arena_t<return_t> res = softmax(x_arena.val());
   reverse_pass_callback([x_arena, res]() mutable {
-    x_arena.adj().array() += res.val().array() * (res.adj().array() - res.val().dot(res.adj()));
+    x_arena.adj().array()
+        += res.val().array() * (res.adj().array() - res.val().dot(res.adj()));
   });
   return res;
 }

--- a/stan/math/rev/fun/softmax.hpp
+++ b/stan/math/rev/fun/softmax.hpp
@@ -31,7 +31,9 @@ inline auto softmax(const Mat& alpha) {
     return ret_type(alpha);
   }
   arena_t<mat_plain> alpha_arena = alpha;
-  arena_t<Eigen::VectorXd> res_val = softmax(value_of(alpha_arena));
+  using double_mat_t
+      = Eigen::Matrix<double, Mat::RowsAtCompileTime, Mat::ColsAtCompileTime>;
+  arena_t<double_mat_t> res_val = softmax(value_of(alpha_arena));
   arena_t<ret_type> res = res_val;
 
   reverse_pass_callback([res_val, res, alpha_arena]() mutable {

--- a/stan/math/rev/fun/softmax.hpp
+++ b/stan/math/rev/fun/softmax.hpp
@@ -3,81 +3,52 @@
 
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/rev/meta.hpp>
-#include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/rev/core/reverse_pass_callback.hpp>
 #include <stan/math/rev/core/arena_matrix.hpp>
-#include <stan/math/prim/fun/typedefs.hpp>
+#include <stan/math/rev/fun/to_arena.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/softmax.hpp>
-#include <tuple>
-#include <vector>
+#include <stan/math/prim/functor/apply_vector_unary.hpp>
 
 namespace stan {
 namespace math {
 
 /**
- * Return the softmax of the specified Eigen vector.  Softmax is
- * guaranteed to return a simplex.
+ * Return the softmax of the specified vector or row vector.
  *
- * @param alpha Unconstrained input vector.
- * @return Softmax of the input.
- * @throw std::domain_error If the input vector is size 0.
+ * @tparam T a `var_value` or Eigen vector/row_vector with `var` scalar
+ * @param x input
+ * @return softmax of the input
  */
-template <typename Mat, require_rev_matrix_t<Mat>* = nullptr,
-          require_t<bool_constant<Mat::RowsAtCompileTime == 1
-                                  || Mat::ColsAtCompileTime == 1>>* = nullptr>
-inline auto softmax(const Mat& alpha) {
-  using mat_plain = plain_type_t<Mat>;
-  using ret_type = return_var_matrix_t<Mat>;
-  if (alpha.size() == 0) {
-    return ret_type(alpha);
+template <typename T, require_rev_matrix_t<T>* = nullptr>
+inline auto softmax(T&& x) {
+  auto x_arena = to_arena(std::forward<T>(x));
+  using return_t = return_var_matrix_t<plain_type_t<decltype(x_arena.val())>, T>;
+  if (x_arena.size() == 0) {
+    return return_t(x_arena);
   }
-  arena_t<mat_plain> alpha_arena = alpha;
-  using double_mat_t
-      = Eigen::Matrix<double, Mat::RowsAtCompileTime, Mat::ColsAtCompileTime>;
-  arena_t<double_mat_t> res_val = softmax(value_of(alpha_arena));
-  arena_t<ret_type> res = res_val;
-
-  reverse_pass_callback([res_val, res, alpha_arena]() mutable {
+  auto res_val = to_arena(softmax(x_arena.val()));
+  arena_t<return_t> res = res_val;
+  reverse_pass_callback([x_arena, res]() mutable {
+    const auto& s = to_ref(res.val());
     const auto& res_adj = to_ref(res.adj());
-    alpha_arena.adj()
-        += -res_val * res_adj.dot(res_val) + res_val.cwiseProduct(res_adj);
+    x_arena.adj().array() += s.array() * (res_adj.array() - s.dot(res_adj));
   });
-
-  return ret_type(res);
+  return return_t(res);
 }
 
 /**
- * Return the softmax of the rows of the specified matrix.
- * Softmax is applied independently to each row, producing a
- * row-stochastic matrix.
+ * Return the softmax of each vector in an array.
  *
- * @param m Unconstrained input matrix.
- * @return Row-stochastic matrix result.
+ * @tparam T `std::vector` whose scalar type is `var`
+ * @param x array of vectors to transform
+ * @return array of softmax results
  */
-template <typename Mat, require_rev_matrix_t<Mat>* = nullptr,
-          require_t<bool_constant<Mat::RowsAtCompileTime != 1
-                                  && Mat::ColsAtCompileTime != 1>>* = nullptr>
-inline auto softmax(const Mat& m) {
-  using mat_plain = plain_type_t<Mat>;
-  using ret_type = return_var_matrix_t<Mat>;
-  if (m.size() == 0) {
-    return ret_type(m);
-  }
-  arena_t<mat_plain> m_arena = m;
-  using double_mat_t
-      = Eigen::Matrix<double, Mat::RowsAtCompileTime, Mat::ColsAtCompileTime>;
-  arena_t<double_mat_t> res_val = softmax(value_of(m_arena));
-  arena_t<ret_type> res = res_val;
-
-  reverse_pass_callback([res_val, res, m_arena]() mutable {
-    const auto& g = to_ref(res.adj());
-    const auto dots = (res_val.array() * g.array()).rowwise().sum().eval();
-    m_arena.adj()
-        += (res_val.array() * (g.array().colwise() - dots.array())).matrix();
+template <typename T, require_std_vector_st<is_var, T>* = nullptr>
+inline auto softmax(T&& x) {
+  return apply_vector_unary<T>::apply(std::forward<T>(x), [](auto&& v) {
+    return softmax(std::forward<decltype(v)>(v));
   });
-
-  return ret_type(res);
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/softmax.hpp
+++ b/stan/math/rev/fun/softmax.hpp
@@ -27,8 +27,7 @@ inline auto softmax(T&& x) {
   if (x_arena.size() == 0) {
     return return_t(x_arena);
   }
-  auto res_val = to_arena(softmax(x_arena.val()));
-  arena_t<return_t> res = res_val;
+  arena_t<return_t> res = softmax(x_arena.val());
   reverse_pass_callback([x_arena, res]() mutable {
     const auto& s = to_ref(res.val());
     const auto& res_adj = to_ref(res.adj());

--- a/test/unit/math/mix/fun/log_softmax_test.cpp
+++ b/test/unit/math/mix/fun/log_softmax_test.cpp
@@ -33,6 +33,17 @@ TEST(MathMixMatFun, logSoftmax) {
   stan::test::expect_ad(f, x3c);
   stan::test::expect_ad_matvar(f, x3c);
 
+  // Matrices (row-wise log_softmax)
+  Eigen::MatrixXd mx2(2, 2);
+  mx2 << -1, 1, 0, 2;
+  stan::test::expect_ad(f, mx2);
+  stan::test::expect_ad_matvar(f, mx2);
+
+  Eigen::MatrixXd mx3(2, 3);
+  mx3 << -1, 1, 10, 0.5, -1, 3;
+  stan::test::expect_ad(f, mx3);
+  stan::test::expect_ad_matvar(f, mx3);
+
   // Row Vectors
   Eigen::RowVectorXd rx0(0);  // error case
   stan::test::expect_ad(f, rx0);

--- a/test/unit/math/mix/fun/log_softmax_test.cpp
+++ b/test/unit/math/mix/fun/log_softmax_test.cpp
@@ -33,17 +33,6 @@ TEST(MathMixMatFun, logSoftmax) {
   stan::test::expect_ad(f, x3c);
   stan::test::expect_ad_matvar(f, x3c);
 
-  // Matrices (row-wise log_softmax)
-  Eigen::MatrixXd mx2(2, 2);
-  mx2 << -1, 1, 0, 2;
-  stan::test::expect_ad(f, mx2);
-  stan::test::expect_ad_matvar(f, mx2);
-
-  Eigen::MatrixXd mx3(2, 3);
-  mx3 << -1, 1, 10, 0.5, -1, 3;
-  stan::test::expect_ad(f, mx3);
-  stan::test::expect_ad_matvar(f, mx3);
-
   // Row Vectors
   Eigen::RowVectorXd rx0(0);  // error case
   stan::test::expect_ad(f, rx0);

--- a/test/unit/math/mix/fun/softmax_test.cpp
+++ b/test/unit/math/mix/fun/softmax_test.cpp
@@ -9,6 +9,7 @@ TEST(MathMixMatFun, softmax) {
   tols.hessian_hessian_ = 1e-2;
   tols.hessian_fvar_hessian_ = 1e-2;
 
+  // Column vectors
   Eigen::VectorXd a(0);
   stan::test::expect_ad(tols, f, a);
   expect_ad_matvar(f, a);
@@ -41,4 +42,29 @@ TEST(MathMixMatFun, softmax) {
   d4 << 0, 3, -1;
   stan::test::expect_ad(tols, f, d4);
   expect_ad_matvar(f, d4);
+
+  // Row vectors
+  Eigen::RowVectorXd ra(0);
+  stan::test::expect_ad(tols, f, ra);
+  expect_ad_matvar(f, ra);
+
+  Eigen::RowVectorXd rb(1);
+  rb << 0;
+  stan::test::expect_ad(tols, f, rb);
+  expect_ad_matvar(f, rb);
+
+  Eigen::RowVectorXd rc(2);
+  rc << -1, 1;
+  stan::test::expect_ad(tols, f, rc);
+  expect_ad_matvar(f, rc);
+
+  Eigen::RowVectorXd rd(3);
+  rd << -1, 1, 10;
+  stan::test::expect_ad(tols, f, rd);
+  expect_ad_matvar(f, rd);
+
+  Eigen::RowVectorXd rd2(3);
+  rd2 << 0.5, -1, 3;
+  stan::test::expect_ad(tols, f, rd2);
+  expect_ad_matvar(f, rd2);
 }

--- a/test/unit/math/mix/fun/softmax_test.cpp
+++ b/test/unit/math/mix/fun/softmax_test.cpp
@@ -43,17 +43,6 @@ TEST(MathMixMatFun, softmax) {
   stan::test::expect_ad(tols, f, d4);
   expect_ad_matvar(f, d4);
 
-  // Matrices (row-wise softmax)
-  Eigen::MatrixXd ma(2, 3);
-  ma << -1, 1, 10, 0.5, -1, 3;
-  stan::test::expect_ad(tols, f, ma);
-  expect_ad_matvar(f, ma);
-
-  Eigen::MatrixXd mb(3, 2);
-  mb << 0, 1, -1, 2, 3, -2;
-  stan::test::expect_ad(tols, f, mb);
-  expect_ad_matvar(f, mb);
-
   // Row vectors
   Eigen::RowVectorXd ra(0);
   stan::test::expect_ad(tols, f, ra);
@@ -78,4 +67,29 @@ TEST(MathMixMatFun, softmax) {
   rd2 << 0.5, -1, 3;
   stan::test::expect_ad(tols, f, rd2);
   expect_ad_matvar(f, rd2);
+
+  // Arrays of vectors (array[] vector and array[] row_vector)
+  std::vector<Eigen::VectorXd> stvx0{a, a};  // error case
+  stan::test::expect_ad(tols, f, stvx0);
+  expect_ad_matvar(f, stvx0);
+
+  std::vector<Eigen::VectorXd> stvx1{b, b};
+  stan::test::expect_ad(tols, f, stvx1);
+  expect_ad_matvar(f, stvx1);
+
+  std::vector<Eigen::VectorXd> stvx2{c, d};
+  stan::test::expect_ad(tols, f, stvx2);
+  expect_ad_matvar(f, stvx2);
+
+  std::vector<Eigen::RowVectorXd> strx0{ra, ra};  // error case
+  stan::test::expect_ad(tols, f, strx0);
+  expect_ad_matvar(f, strx0);
+
+  std::vector<Eigen::RowVectorXd> strx1{rb, rb};
+  stan::test::expect_ad(tols, f, strx1);
+  expect_ad_matvar(f, strx1);
+
+  std::vector<Eigen::RowVectorXd> strx2{rc, rd};
+  stan::test::expect_ad(tols, f, strx2);
+  expect_ad_matvar(f, strx2);
 }

--- a/test/unit/math/mix/fun/softmax_test.cpp
+++ b/test/unit/math/mix/fun/softmax_test.cpp
@@ -43,6 +43,17 @@ TEST(MathMixMatFun, softmax) {
   stan::test::expect_ad(tols, f, d4);
   expect_ad_matvar(f, d4);
 
+  // Matrices (row-wise softmax)
+  Eigen::MatrixXd ma(2, 3);
+  ma << -1, 1, 10, 0.5, -1, 3;
+  stan::test::expect_ad(tols, f, ma);
+  expect_ad_matvar(f, ma);
+
+  Eigen::MatrixXd mb(3, 2);
+  mb << 0, 1, -1, 2, 3, -2;
+  stan::test::expect_ad(tols, f, mb);
+  expect_ad_matvar(f, mb);
+
   // Row vectors
   Eigen::RowVectorXd ra(0);
   stan::test::expect_ad(tols, f, ra);

--- a/test/unit/math/prim/fun/log_softmax_test.cpp
+++ b/test/unit/math/prim/fun/log_softmax_test.cpp
@@ -83,37 +83,6 @@ TEST(MathMatrixPrimMat, log_softmax_neg_inf) {
   EXPECT_FLOAT_EQ(1.0 - lse_finite, result[1]);
   EXPECT_FLOAT_EQ(2.0 - lse_finite, result[2]);
 
-  // Row-wise on a matrix.
-  Matrix<double, Dynamic, Dynamic> m(2, 3);
-  m << neg_inf, 1.0, 2.0,  //
-      0.0, neg_inf, 0.0;
-  Matrix<double, Dynamic, Dynamic> mres = log_softmax(m);
-  EXPECT_EQ(neg_inf, mres(0, 0));
-  EXPECT_FLOAT_EQ(1.0 - lse_finite, mres(0, 1));
-  EXPECT_FLOAT_EQ(2.0 - lse_finite, mres(0, 2));
-  EXPECT_FLOAT_EQ(-std::log(2.0), mres(1, 0));
-  EXPECT_EQ(neg_inf, mres(1, 1));
-  EXPECT_FLOAT_EQ(-std::log(2.0), mres(1, 2));
-}
-
-TEST(MathMatrixPrimMat, log_softmax_matrix) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using stan::math::log_softmax;
-  using stan::math::softmax;
-
-  Matrix<double, Dynamic, Dynamic> m(2, 3);
-  m << -1.0, 1.0, 10.0, 0.5, -1.0, 3.0;
-  Matrix<double, Dynamic, Dynamic> result = log_softmax(m);
-
-  EXPECT_EQ(m.rows(), result.rows());
-  EXPECT_EQ(m.cols(), result.cols());
-  // each row matches per-row log_softmax and is consistent with log(softmax)
-  for (int i = 0; i < result.rows(); ++i) {
-    Matrix<double, 1, Dynamic> expected = log_softmax(m.row(i));
-    for (int j = 0; j < result.cols(); ++j)
-      EXPECT_FLOAT_EQ(expected(j), result(i, j));
-  }
 }
 
 TEST(MathMatrixPrimMat, log_softmax_exception) {

--- a/test/unit/math/prim/fun/log_softmax_test.cpp
+++ b/test/unit/math/prim/fun/log_softmax_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
+#include <limits>
 #include <vector>
 
 inline void test_log_softmax(
@@ -66,6 +67,35 @@ TEST(MathMatrixPrimMat, log_softmax) {
   // x3 << -1.0, 1.0, 10.0;
   // test_log_softmax(x3);
 }
+TEST(MathMatrixPrimMat, log_softmax_neg_inf) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::log_softmax;
+  constexpr double neg_inf = -std::numeric_limits<double>::infinity();
+
+  // -inf in a vector stays -inf in the output; the rest get the
+  // proper restricted log-softmax.
+  Matrix<double, Dynamic, 1> v(3);
+  v << neg_inf, 1.0, 2.0;
+  Matrix<double, Dynamic, 1> result = log_softmax(v);
+  const double lse_finite = std::log(exp(1.0) + exp(2.0));
+  EXPECT_EQ(neg_inf, result[0]);
+  EXPECT_FLOAT_EQ(1.0 - lse_finite, result[1]);
+  EXPECT_FLOAT_EQ(2.0 - lse_finite, result[2]);
+
+  // Row-wise on a matrix.
+  Matrix<double, Dynamic, Dynamic> m(2, 3);
+  m << neg_inf, 1.0, 2.0,  //
+      0.0, neg_inf, 0.0;
+  Matrix<double, Dynamic, Dynamic> mres = log_softmax(m);
+  EXPECT_EQ(neg_inf, mres(0, 0));
+  EXPECT_FLOAT_EQ(1.0 - lse_finite, mres(0, 1));
+  EXPECT_FLOAT_EQ(2.0 - lse_finite, mres(0, 2));
+  EXPECT_FLOAT_EQ(-std::log(2.0), mres(1, 0));
+  EXPECT_EQ(neg_inf, mres(1, 1));
+  EXPECT_FLOAT_EQ(-std::log(2.0), mres(1, 2));
+}
+
 TEST(MathMatrixPrimMat, log_softmax_matrix) {
   using Eigen::Dynamic;
   using Eigen::Matrix;

--- a/test/unit/math/prim/fun/log_softmax_test.cpp
+++ b/test/unit/math/prim/fun/log_softmax_test.cpp
@@ -66,6 +66,26 @@ TEST(MathMatrixPrimMat, log_softmax) {
   // x3 << -1.0, 1.0, 10.0;
   // test_log_softmax(x3);
 }
+TEST(MathMatrixPrimMat, log_softmax_matrix) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::log_softmax;
+  using stan::math::softmax;
+
+  Matrix<double, Dynamic, Dynamic> m(2, 3);
+  m << -1.0, 1.0, 10.0, 0.5, -1.0, 3.0;
+  Matrix<double, Dynamic, Dynamic> result = log_softmax(m);
+
+  EXPECT_EQ(m.rows(), result.rows());
+  EXPECT_EQ(m.cols(), result.cols());
+  // each row matches per-row log_softmax and is consistent with log(softmax)
+  for (int i = 0; i < result.rows(); ++i) {
+    Matrix<double, 1, Dynamic> expected = log_softmax(m.row(i));
+    for (int j = 0; j < result.cols(); ++j)
+      EXPECT_FLOAT_EQ(expected(j), result(i, j));
+  }
+}
+
 TEST(MathMatrixPrimMat, log_softmax_exception) {
   using stan::math::log_softmax;
   stan::math::vector_d v0;  // size == 0

--- a/test/unit/math/prim/fun/log_softmax_test.cpp
+++ b/test/unit/math/prim/fun/log_softmax_test.cpp
@@ -82,7 +82,6 @@ TEST(MathMatrixPrimMat, log_softmax_neg_inf) {
   EXPECT_EQ(neg_inf, result[0]);
   EXPECT_FLOAT_EQ(1.0 - lse_finite, result[1]);
   EXPECT_FLOAT_EQ(2.0 - lse_finite, result[2]);
-
 }
 
 TEST(MathMatrixPrimMat, log_softmax_exception) {

--- a/test/unit/math/prim/fun/softmax_test.cpp
+++ b/test/unit/math/prim/fun/softmax_test.cpp
@@ -29,6 +29,27 @@ TEST(MathMatrixPrimMat, softmax) {
   EXPECT_FLOAT_EQ(exp(10) / (exp(-1) + exp(1) + exp(10.0)), theta3[2]);
 }
 
+TEST(MathMatrixPrimMat, softmax_matrix) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::softmax;
+
+  Matrix<double, Dynamic, Dynamic> m(2, 3);
+  m << -1.0, 1.0, 10.0, 0.5, -1.0, 3.0;
+  Matrix<double, Dynamic, Dynamic> theta = softmax(m);
+
+  EXPECT_EQ(m.rows(), theta.rows());
+  EXPECT_EQ(m.cols(), theta.cols());
+  // each row sums to 1
+  for (int i = 0; i < theta.rows(); ++i) {
+    EXPECT_FLOAT_EQ(1.0, theta.row(i).sum());
+    // each row matches per-row softmax
+    Matrix<double, 1, Dynamic> expected = softmax(m.row(i));
+    for (int j = 0; j < theta.cols(); ++j)
+      EXPECT_FLOAT_EQ(expected(j), theta(i, j));
+  }
+}
+
 TEST(MathMatrixPrimMat, softmax_row_vector) {
   using Eigen::Dynamic;
   using Eigen::Matrix;

--- a/test/unit/math/prim/fun/softmax_test.cpp
+++ b/test/unit/math/prim/fun/softmax_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
+#include <limits>
 
 TEST(MathMatrixPrimMat, softmax) {
   using Eigen::Dynamic;
@@ -27,6 +28,36 @@ TEST(MathMatrixPrimMat, softmax) {
   EXPECT_FLOAT_EQ(exp(-1) / (exp(-1) + exp(1) + exp(10.0)), theta3[0]);
   EXPECT_FLOAT_EQ(exp(1) / (exp(-1) + exp(1) + exp(10.0)), theta3[1]);
   EXPECT_FLOAT_EQ(exp(10) / (exp(-1) + exp(1) + exp(10.0)), theta3[2]);
+}
+
+TEST(MathMatrixPrimMat, softmax_neg_inf) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::softmax;
+  constexpr double neg_inf = -std::numeric_limits<double>::infinity();
+
+  // -inf in a vector pins that component to exactly 0; the rest renormalize.
+  Matrix<double, Dynamic, 1> v(3);
+  v << neg_inf, 1.0, 2.0;
+  Matrix<double, Dynamic, 1> theta = softmax(v);
+  EXPECT_FLOAT_EQ(0.0, theta[0]);
+  EXPECT_FLOAT_EQ(exp(1.0) / (exp(1.0) + exp(2.0)), theta[1]);
+  EXPECT_FLOAT_EQ(exp(2.0) / (exp(1.0) + exp(2.0)), theta[2]);
+  EXPECT_FLOAT_EQ(1.0, theta.sum());
+
+  // Row-wise on a matrix: each row independently handles -inf.
+  Matrix<double, Dynamic, Dynamic> m(2, 3);
+  m << neg_inf, 1.0, 2.0,  //
+      0.0, neg_inf, 0.0;
+  Matrix<double, Dynamic, Dynamic> result = softmax(m);
+  EXPECT_FLOAT_EQ(0.0, result(0, 0));
+  EXPECT_FLOAT_EQ(exp(1.0) / (exp(1.0) + exp(2.0)), result(0, 1));
+  EXPECT_FLOAT_EQ(exp(2.0) / (exp(1.0) + exp(2.0)), result(0, 2));
+  EXPECT_FLOAT_EQ(0.5, result(1, 0));
+  EXPECT_FLOAT_EQ(0.0, result(1, 1));
+  EXPECT_FLOAT_EQ(0.5, result(1, 2));
+  EXPECT_FLOAT_EQ(1.0, result.row(0).sum());
+  EXPECT_FLOAT_EQ(1.0, result.row(1).sum());
 }
 
 TEST(MathMatrixPrimMat, softmax_matrix) {

--- a/test/unit/math/prim/fun/softmax_test.cpp
+++ b/test/unit/math/prim/fun/softmax_test.cpp
@@ -44,7 +44,6 @@ TEST(MathMatrixPrimMat, softmax_neg_inf) {
   EXPECT_FLOAT_EQ(exp(1.0) / (exp(1.0) + exp(2.0)), theta[1]);
   EXPECT_FLOAT_EQ(exp(2.0) / (exp(1.0) + exp(2.0)), theta[2]);
   EXPECT_FLOAT_EQ(1.0, theta.sum());
-
 }
 
 TEST(MathMatrixPrimMat, softmax_row_vector) {

--- a/test/unit/math/prim/fun/softmax_test.cpp
+++ b/test/unit/math/prim/fun/softmax_test.cpp
@@ -28,3 +28,30 @@ TEST(MathMatrixPrimMat, softmax) {
   EXPECT_FLOAT_EQ(exp(1) / (exp(-1) + exp(1) + exp(10.0)), theta3[1]);
   EXPECT_FLOAT_EQ(exp(10) / (exp(-1) + exp(1) + exp(10.0)), theta3[2]);
 }
+
+TEST(MathMatrixPrimMat, softmax_row_vector) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::softmax;
+
+  Matrix<double, 1, Dynamic> x(1);
+  x << 0.0;
+  Matrix<double, 1, Dynamic> theta = softmax(x);
+  EXPECT_EQ(1, theta.size());
+  EXPECT_FLOAT_EQ(1.0, theta[0]);
+
+  Matrix<double, 1, Dynamic> x2(2);
+  x2 << -1.0, 1.0;
+  Matrix<double, 1, Dynamic> theta2 = softmax(x2);
+  EXPECT_EQ(2, theta2.size());
+  EXPECT_FLOAT_EQ(exp(-1) / (exp(-1) + exp(1)), theta2[0]);
+  EXPECT_FLOAT_EQ(exp(1) / (exp(-1) + exp(1)), theta2[1]);
+
+  Matrix<double, 1, Dynamic> x3(3);
+  x3 << -1.0, 1.0, 10.0;
+  Matrix<double, 1, Dynamic> theta3 = softmax(x3);
+  EXPECT_EQ(3, theta3.size());
+  EXPECT_FLOAT_EQ(exp(-1) / (exp(-1) + exp(1) + exp(10.0)), theta3[0]);
+  EXPECT_FLOAT_EQ(exp(1) / (exp(-1) + exp(1) + exp(10.0)), theta3[1]);
+  EXPECT_FLOAT_EQ(exp(10) / (exp(-1) + exp(1) + exp(10.0)), theta3[2]);
+}

--- a/test/unit/math/prim/fun/softmax_test.cpp
+++ b/test/unit/math/prim/fun/softmax_test.cpp
@@ -45,40 +45,6 @@ TEST(MathMatrixPrimMat, softmax_neg_inf) {
   EXPECT_FLOAT_EQ(exp(2.0) / (exp(1.0) + exp(2.0)), theta[2]);
   EXPECT_FLOAT_EQ(1.0, theta.sum());
 
-  // Row-wise on a matrix: each row independently handles -inf.
-  Matrix<double, Dynamic, Dynamic> m(2, 3);
-  m << neg_inf, 1.0, 2.0,  //
-      0.0, neg_inf, 0.0;
-  Matrix<double, Dynamic, Dynamic> result = softmax(m);
-  EXPECT_FLOAT_EQ(0.0, result(0, 0));
-  EXPECT_FLOAT_EQ(exp(1.0) / (exp(1.0) + exp(2.0)), result(0, 1));
-  EXPECT_FLOAT_EQ(exp(2.0) / (exp(1.0) + exp(2.0)), result(0, 2));
-  EXPECT_FLOAT_EQ(0.5, result(1, 0));
-  EXPECT_FLOAT_EQ(0.0, result(1, 1));
-  EXPECT_FLOAT_EQ(0.5, result(1, 2));
-  EXPECT_FLOAT_EQ(1.0, result.row(0).sum());
-  EXPECT_FLOAT_EQ(1.0, result.row(1).sum());
-}
-
-TEST(MathMatrixPrimMat, softmax_matrix) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using stan::math::softmax;
-
-  Matrix<double, Dynamic, Dynamic> m(2, 3);
-  m << -1.0, 1.0, 10.0, 0.5, -1.0, 3.0;
-  Matrix<double, Dynamic, Dynamic> theta = softmax(m);
-
-  EXPECT_EQ(m.rows(), theta.rows());
-  EXPECT_EQ(m.cols(), theta.cols());
-  // each row sums to 1
-  for (int i = 0; i < theta.rows(); ++i) {
-    EXPECT_FLOAT_EQ(1.0, theta.row(i).sum());
-    // each row matches per-row softmax
-    Matrix<double, 1, Dynamic> expected = softmax(m.row(i));
-    for (int j = 0; j < theta.cols(); ++j)
-      EXPECT_FLOAT_EQ(expected(j), theta(i, j));
-  }
 }
 
 TEST(MathMatrixPrimMat, softmax_row_vector) {

--- a/test/unit/math/rev/fun/log_softmax_test.cpp
+++ b/test/unit/math/rev/fun/log_softmax_test.cpp
@@ -1,11 +1,12 @@
 #include <stan/math/rev.hpp>
+#include <test/unit/math/rev/util.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 
 // Direct exercise of the var_value vector overload in
 // stan/math/rev/fun/log_softmax.hpp for both row and column var_value vectors.
 
-TEST(AgradRevLogSoftmax, var_value_col_vector) {
+TEST_F(AgradRev, log_softmax_var_value_col_vector) {
   using stan::math::log_softmax;
   using stan::math::sum;
   using stan::math::var_value;
@@ -30,11 +31,9 @@ TEST(AgradRevLogSoftmax, var_value_col_vector) {
   EXPECT_FLOAT_EQ(1.0 - 3.0 * std::exp(-1.0) / denom, x.adj()(0));
   EXPECT_FLOAT_EQ(1.0 - 3.0 * std::exp(1.0) / denom, x.adj()(1));
   EXPECT_FLOAT_EQ(1.0 - 3.0 * std::exp(2.0) / denom, x.adj()(2));
-
-  stan::math::recover_memory();
 }
 
-TEST(AgradRevLogSoftmax, var_value_row_vector) {
+TEST_F(AgradRev, log_softmax_var_value_row_vector) {
   using stan::math::log_softmax;
   using stan::math::sum;
   using stan::math::var_value;
@@ -60,6 +59,4 @@ TEST(AgradRevLogSoftmax, var_value_row_vector) {
   EXPECT_FLOAT_EQ(1.0 - 3.0 * std::exp(-1.0) / denom, x.adj()(0));
   EXPECT_FLOAT_EQ(1.0 - 3.0 * std::exp(1.0) / denom, x.adj()(1));
   EXPECT_FLOAT_EQ(1.0 - 3.0 * std::exp(2.0) / denom, x.adj()(2));
-
-  stan::math::recover_memory();
 }

--- a/test/unit/math/rev/fun/log_softmax_test.cpp
+++ b/test/unit/math/rev/fun/log_softmax_test.cpp
@@ -1,0 +1,66 @@
+#include <stan/math/rev.hpp>
+#include <gtest/gtest.h>
+#include <cmath>
+
+// Direct exercise of the var_value vector overload in
+// stan/math/rev/fun/log_softmax.hpp for both row and column var_value vectors.
+
+TEST(AgradRevLogSoftmax, var_value_col_vector) {
+  using stan::math::log_softmax;
+  using stan::math::sum;
+  using stan::math::var_value;
+
+  Eigen::VectorXd v(3);
+  v << -1, 1, 2;
+
+  var_value<Eigen::VectorXd> x(v);
+  auto y = log_softmax(x);
+
+  EXPECT_EQ(3, y.val().rows());
+  EXPECT_EQ(1, y.val().cols());
+
+  const double lse = std::log(std::exp(-1.0) + std::exp(1.0) + std::exp(2.0));
+  EXPECT_FLOAT_EQ(-1.0 - lse, y.val()(0));
+  EXPECT_FLOAT_EQ(1.0 - lse, y.val()(1));
+  EXPECT_FLOAT_EQ(2.0 - lse, y.val()(2));
+
+  // d/dx[m] sum(y) = sum_k(delta_km - softmax[m]) = 1 - n * softmax[m]
+  sum(y).grad();
+  const double denom = std::exp(-1.0) + std::exp(1.0) + std::exp(2.0);
+  EXPECT_FLOAT_EQ(1.0 - 3.0 * std::exp(-1.0) / denom, x.adj()(0));
+  EXPECT_FLOAT_EQ(1.0 - 3.0 * std::exp(1.0) / denom, x.adj()(1));
+  EXPECT_FLOAT_EQ(1.0 - 3.0 * std::exp(2.0) / denom, x.adj()(2));
+
+  stan::math::recover_memory();
+}
+
+TEST(AgradRevLogSoftmax, var_value_row_vector) {
+  using stan::math::log_softmax;
+  using stan::math::sum;
+  using stan::math::var_value;
+
+  Eigen::RowVectorXd v(3);
+  v << -1, 1, 2;
+
+  var_value<Eigen::RowVectorXd> x(v);
+  auto y = log_softmax(x);
+
+  // Output should preserve row shape.
+  EXPECT_EQ(1, y.val().rows());
+  EXPECT_EQ(3, y.val().cols());
+
+  const double lse = std::log(std::exp(-1.0) + std::exp(1.0) + std::exp(2.0));
+  EXPECT_FLOAT_EQ(-1.0 - lse, y.val()(0));
+  EXPECT_FLOAT_EQ(1.0 - lse, y.val()(1));
+  EXPECT_FLOAT_EQ(2.0 - lse, y.val()(2));
+
+  // Same gradient formula; one softmax over the entire row vector.
+  sum(y).grad();
+  const double denom = std::exp(-1.0) + std::exp(1.0) + std::exp(2.0);
+  EXPECT_FLOAT_EQ(1.0 - 3.0 * std::exp(-1.0) / denom, x.adj()(0));
+  EXPECT_FLOAT_EQ(1.0 - 3.0 * std::exp(1.0) / denom, x.adj()(1));
+  EXPECT_FLOAT_EQ(1.0 - 3.0 * std::exp(2.0) / denom, x.adj()(2));
+
+  stan::math::recover_memory();
+}
+

--- a/test/unit/math/rev/fun/log_softmax_test.cpp
+++ b/test/unit/math/rev/fun/log_softmax_test.cpp
@@ -63,4 +63,3 @@ TEST(AgradRevLogSoftmax, var_value_row_vector) {
 
   stan::math::recover_memory();
 }
-


### PR DESCRIPTION
## Summary

This refactors the `softmax` and `log_softmax` functions in the following ways:

- both `vector` and `row_vector` are now supported instead of just `vector`
- array of either is also supported
- ~~`matrix` type is also supported and the softmax is applied row-wise. (i.e. the return value is effectively a `row_stochastic_matrix` for modelling purposes)~~
- refactored the relevant code to utilize Eigen functionalities instead of some for loops and some other bits here and there, simplifying the code and improving clarity. I am honestly not  a C++ guru, but I believe these shouldn't have any negative impact on performance. Actually, I think it should have positive impact on rev.

## Tests

- Added test for the new types
- Added a test for the edge case when some of the values is -inf

## Side Effects

None to my knowledge.

## Release notes

`softmax` and `log_softmax` now support `row_vector` and arrays of either. ~~`matrix` (applied row-wise)~~

## Checklist

- [x] Copyright holder: Me, jachymb@gmail.com
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
