### PR TITLE
Feature/issue 3311 test thread tbb exp

### DIFF
--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -108,10 +108,11 @@ template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
 inline auto exp_test(Container&& x) {
   std::size_t N = x.size();
-  // tbb::parallel_for(tbb::blocked_range<size_t>(0,N),
-  //		    typename apply_exp<Container>::apply_exp(x));
-  return tbb::parallel_for(tbb::blocked_range<size_t>(0,N),
+  tbb::parallel_for(tbb::blocked_range<size_t>(0,N),
 		    typename apply_exp<Container>::apply_exp(x));
+  // return tbb::parallel_for(tbb::blocked_range<size_t>(0,N),
+  // 		    typename apply_exp<Container>::apply_exp(x));
+  return x;
   // return apply_vector_unary<Container>::apply(
   //     std::forward<Container>(x), [](auto&& v) { return v.array().exp(); });
 }

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -77,9 +77,9 @@ class apply_exp {
     for (std::size_t i = r.begin(); i != r.end(); ++i) {
       a_out[i] = std::exp(a[i]);
     }
-    return a_out;
+    return a;
   }
-  apply_exp<Container>(Container a) : my_a(a) {}
+  apply_exp<Container>(Container&& a) : my_a(a) {}
 };
 
 /**

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -98,7 +98,7 @@ inline auto exp(Container&& x) {
       std::forward<Container>(x));
 }
 
-/**
+/**x
  * Version of `exp()` that accepts std::vectors, Eigen Matrix/Array objects
  *  or expressions, and containers of these.
  *
@@ -109,7 +109,7 @@ inline auto exp(Container&& x) {
 // experimental function
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto exp_test(Container&& x) {
+inline auto exp(Container&& x) {
   std::size_t N = x.size();
   tbb::parallel_for(tbb::blocked_range<size_t>(0,N),
 		    typename apply_exp<Container>::apply_exp(x));

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -73,7 +73,6 @@ class apply_exp {
  public:
   Container operator()(const tbb::blocked_range<std::size_t>& r) const {
     Container a = my_a;
-    //Container a_out = my_a;
     for (std::size_t i = r.begin(); i != r.end(); ++i) {
       my_a[i] = std::exp(a[i]);
     }

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -73,11 +73,11 @@ class apply_exp {
  public:
   Container operator()(const tbb::blocked_range<std::size_t>& r) const {
     Container a = my_a;
-    Container a_out = my_a;
+    //Container a_out = my_a;
     for (std::size_t i = r.begin(); i != r.end(); ++i) {
-      a_out[i] = std::exp(a[i]);
+      my_a[i] = std::exp(a[i]);
     }
-    return a_out;
+    return my_a;
   }
   apply_exp<Container>(Container a) : my_a(a) {}
 };

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -71,17 +71,8 @@ class apply_exp {
 public:
   Container operator()(const tbb::blocked_range<std::size_t>& r) const {
     Container a = my_a;
-    //    Container a_out = my_a;
     for (std::size_t i = r.begin(); i != r.end(); ++i) {
-      exp(a[i]);
-      //      a_out[i] = exp(a[i]);
       a[i] = exp(a[i]);
-      // std::cout << "exp ai\n";
-      // std::cout << exp(a[i]) << std::endl;
-      // std::cout << "a_out\n";
-      // std::cout << a_out[i] << std::endl;
-      // std::cout << "a[i]= exp(a[i])\n";
-      // std::cout << a[i] << std::endl;
     }
     return a;
   }

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -69,13 +69,24 @@ template <typename Container>
 class apply_exp {
   Container const my_a;
 public:
-  void operator()(const tbb::blocked_range<std::size_t>& r) const {
+  Container operator()(const tbb::blocked_range<std::size_t>& r) const {
     Container a = my_a;
-    for (std::size_t i = r.begin(); i != r.end(); ++i)
+    //    Container a_out = my_a;
+    for (std::size_t i = r.begin(); i != r.end(); ++i) {
       exp(a[i]);
+      //      a_out[i] = exp(a[i]);
+      a[i] = exp(a[i]);
+      // std::cout << "exp ai\n";
+      // std::cout << exp(a[i]) << std::endl;
+      // std::cout << "a_out\n";
+      // std::cout << a_out[i] << std::endl;
+      // std::cout << "a[i]= exp(a[i])\n";
+      // std::cout << a[i] << std::endl;
+    }
+    return a;
   }
   apply_exp<Container>(Container a):
-      my_a(a)
+    my_a(a)
   {}
 };
 
@@ -108,11 +119,13 @@ template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
 inline auto exp_test(Container&& x) {
   std::size_t N = x.size();
+  //Container&& ret = x;
   tbb::parallel_for(tbb::blocked_range<size_t>(0,N),
 		    typename apply_exp<Container>::apply_exp(x));
+  return x;
   // return tbb::parallel_for(tbb::blocked_range<size_t>(0,N),
   // 		    typename apply_exp<Container>::apply_exp(x));
-  return x;
+  //return ret;
   // return apply_vector_unary<Container>::apply(
   //     std::forward<Container>(x), [](auto&& v) { return v.array().exp(); });
 }

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -73,10 +73,11 @@ class apply_exp {
  public:
   Container operator()(const tbb::blocked_range<std::size_t>& r) const {
     Container a = my_a;
+    Container a_out = my_a;
     for (std::size_t i = r.begin(); i != r.end(); ++i) {
-      a[i] = exp(a[i]);
+      a_out[i] = exp(a[i]);
     }
-    return a;
+    return a_out;
   }
   apply_exp<Container>(Container a) : my_a(a) {}
 };

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -75,7 +75,7 @@ class apply_exp {
     Container a = my_a;
     Container a_out = my_a;
     for (std::size_t i = r.begin(); i != r.end(); ++i) {
-      a_out[i] = exp(a[i]);
+      a_out[i] = std::exp(a[i]);
     }
     return a_out;
   }

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -72,7 +72,7 @@ class apply_exp {
 
  public:
   Container operator()(const tbb::blocked_range<std::size_t>& r) const {
-    Container a = my_a;
+    Container& a = my_a;
     for (std::size_t i = r.begin(); i != r.end(); ++i) {
       my_a[i] = std::exp(a[i]);
     }

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -77,9 +77,9 @@ class apply_exp {
     for (std::size_t i = r.begin(); i != r.end(); ++i) {
       a_out[i] = std::exp(a[i]);
     }
-    return a;
+    return a_out;
   }
-  apply_exp<Container>(Container&& a) : my_a(a) {}
+  apply_exp<Container>(Container a) : my_a(a) {}
 };
 
 /**

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -9,6 +9,157 @@
 #include <complex>
 #include <limits>
 
+#ifdef STAN_THREADS // threaded block
+#include <stan/math/prim/core.hpp>
+#include <tbb/parallel_for.h>
+#include <tbb/blocked_range.h>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the natural (base e) exponentiation of the specified
+ * complex argument.
+ *
+ * @tparam V `Arithmetic` type
+ * @param x input
+ * @return natural exponentiation of specified number
+ */
+template <typename T, require_arithmetic_t<T>* = nullptr>
+inline auto exp(T&& x) {
+  return std::exp(x);
+}
+
+/**
+ * Return the natural (base e) complex exponentiation of the specified
+ * complex argument.
+ *
+ * @tparam V `complex<Arithmetic>` type
+ * @param x complex number
+ * @return natural exponentiation of specified complex number
+ * @see documentation for `std::complex` for boundary condition and
+ * branch cut details
+ */
+template <typename T, require_complex_bt<std::is_arithmetic, T>* = nullptr>
+inline auto exp(T&& x) {
+  return std::exp(x);
+}
+
+/**
+ * Structure to wrap `exp()` so that it can be
+ * vectorized.
+ */
+struct exp_fun {
+  /**
+   * Return the exponential of the specified scalar argument.
+   *
+   * @tparam T type of argument
+   * @param[in] x argument
+   * @return Exponential of argument.
+   */
+  template <typename T>
+  static inline auto fun(T&& x) {
+    return exp(std::forward<T>(x));
+  }  
+};
+
+  // implement a class so we can parallelize a for loop of evaluating
+  // exp
+template <typename Container>
+class apply_exp {
+  Container const my_a;
+public:
+  void operator()(const tbb::blocked_range<std::size_t>& r) const {
+    Container a = my_a;
+    for (std::size_t i = r.begin(); i != r.end(); ++i)
+      exp(a[i]);
+  }
+  apply_exp<Container>(Container a):
+      my_a(a)
+  {}
+};
+
+  
+/**
+ * Return the elementwise `exp()` of the specified argument,
+ * which may be a scalar or any Stan container of numeric scalars.
+ * The return type is the same as the argument type.
+ *
+ * @tparam Container type of container
+ * @param[in] x container
+ * @return Elementwise application of exponentiation to the argument.
+ */
+template <typename Container, require_ad_container_t<Container>* = nullptr>
+inline auto exp(Container&& x) {
+  return apply_scalar_unary<exp_fun, Container>::apply(
+      std::forward<Container>(x));
+}
+
+/**
+ * Version of `exp()` that accepts std::vectors, Eigen Matrix/Array objects
+ *  or expressions, and containers of these.
+ *
+ * @tparam Container Type of x
+ * @param x Container
+ * @return Elementwise application of exponentiation to the argument.
+ */
+// experimental function
+template <typename Container,
+          require_container_bt<std::is_arithmetic, Container>* = nullptr>
+inline auto exp_test(Container&& x) {
+  std::size_t N = x.size();
+  // tbb::parallel_for(tbb::blocked_range<size_t>(0,N),
+  //		    typename apply_exp<Container>::apply_exp(x));
+  return tbb::parallel_for(tbb::blocked_range<size_t>(0,N),
+		    typename apply_exp<Container>::apply_exp(x));
+  // return apply_vector_unary<Container>::apply(
+  //     std::forward<Container>(x), [](auto&& v) { return v.array().exp(); });
+}
+  
+namespace internal {
+/**
+ * Return the natural (base e) complex exponentiation of the specified
+ * complex argument.
+ *
+ * @tparam V value type (must be Stan autodiff type)
+ * @param z complex number
+ * @return natural exponentiation of specified complex number
+ * @see documentation for `std::complex` for boundary condition and
+ * branch cut details
+ */
+template <typename V>
+inline std::complex<V> complex_exp(const std::complex<V>& z) {
+  if (is_inf(z.real()) && z.real() > 0) {
+    if (is_nan(z.imag()) || z.imag() == 0) {
+      // (+inf, nan), (+inf, 0)
+      return z;
+    } else if (is_inf(z.imag()) && z.imag() > 0) {
+      // (+inf, +inf)
+      return {z.real(), std::numeric_limits<double>::quiet_NaN()};
+    } else if (is_inf(z.imag()) && z.imag() < 0) {
+      // (+inf, -inf)
+      return {std::numeric_limits<double>::quiet_NaN(),
+              std::numeric_limits<double>::quiet_NaN()};
+    }
+  }
+  if (is_inf(z.real()) && z.real() < 0
+      && (is_nan(z.imag()) || is_inf(z.imag()))) {
+    // (-inf, nan), (-inf, -inf), (-inf, inf)
+    return {0, 0};
+  }
+  if (is_nan(z.real()) && z.imag() == -0.0) {
+    // (nan, -0)
+    return z;
+  }
+  V exp_re = exp(z.real());
+  return {exp_re * cos(z.imag()), exp_re * sin(z.imag())};
+}
+}  // namespace internal
+}  // namespace math
+}  // namespace stan 
+
+#else  // unthreaded code
+
 namespace stan {
 namespace math {
 
@@ -128,6 +279,6 @@ inline std::complex<V> complex_exp(const std::complex<V>& z) {
 }
 }  // namespace internal
 }  // namespace math
-}  // namespace stan
-
+}  // namespace stan 
+#endif
 #endif

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -9,7 +9,7 @@
 #include <complex>
 #include <limits>
 
-#ifdef STAN_THREADS // threaded block
+#ifdef STAN_THREADS  // threaded block
 #include <stan/math/prim/core.hpp>
 #include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
@@ -61,15 +61,16 @@ struct exp_fun {
   template <typename T>
   static inline auto fun(T&& x) {
     return exp(std::forward<T>(x));
-  }  
+  }
 };
 
-  // implement a class so we can parallelize a for loop of evaluating
-  // exp
+// implement a class so we can parallelize a for loop of evaluating
+// exp
 template <typename Container>
 class apply_exp {
   Container const my_a;
-public:
+
+ public:
   Container operator()(const tbb::blocked_range<std::size_t>& r) const {
     Container a = my_a;
     for (std::size_t i = r.begin(); i != r.end(); ++i) {
@@ -77,12 +78,9 @@ public:
     }
     return a;
   }
-  apply_exp<Container>(Container a):
-    my_a(a)
-  {}
+  apply_exp<Container>(Container a) : my_a(a) {}
 };
 
-  
 /**
  * Return the elementwise `exp()` of the specified argument,
  * which may be a scalar or any Stan container of numeric scalars.
@@ -111,11 +109,11 @@ template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
 inline auto exp(Container&& x) {
   std::size_t N = x.size();
-  tbb::parallel_for(tbb::blocked_range<size_t>(0,N),
-		    typename apply_exp<Container>::apply_exp(x));
+  tbb::parallel_for(tbb::blocked_range<size_t>(0, N),
+                    typename apply_exp<Container>::apply_exp(x));
   return x;
 }
-  
+
 namespace internal {
 /**
  * Return the natural (base e) complex exponentiation of the specified
@@ -156,7 +154,7 @@ inline std::complex<V> complex_exp(const std::complex<V>& z) {
 }
 }  // namespace internal
 }  // namespace math
-}  // namespace stan 
+}  // namespace stan
 
 #else  // unthreaded code
 
@@ -279,6 +277,6 @@ inline std::complex<V> complex_exp(const std::complex<V>& z) {
 }
 }  // namespace internal
 }  // namespace math
-}  // namespace stan 
+}  // namespace stan
 #endif
 #endif

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -13,6 +13,7 @@
 #include <stan/math/prim/core.hpp>
 #include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
+#include <stan/math/prim/core/init_threadpool_tbb.hpp>
 
 namespace stan {
 namespace math {
@@ -110,15 +111,9 @@ template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
 inline auto exp_test(Container&& x) {
   std::size_t N = x.size();
-  //Container&& ret = x;
   tbb::parallel_for(tbb::blocked_range<size_t>(0,N),
 		    typename apply_exp<Container>::apply_exp(x));
   return x;
-  // return tbb::parallel_for(tbb::blocked_range<size_t>(0,N),
-  // 		    typename apply_exp<Container>::apply_exp(x));
-  //return ret;
-  // return apply_vector_unary<Container>::apply(
-  //     std::forward<Container>(x), [](auto&& v) { return v.array().exp(); });
 }
   
 namespace internal {

--- a/test/unit/math/mix/fun/exp_test.cpp
+++ b/test/unit/math/mix/fun/exp_test.cpp
@@ -1,5 +1,6 @@
 #include <test/unit/math/test_ad.hpp>
 
+#if 0
 TEST(mathMixMatFun, exp) {
   auto f = [](const auto& x) {
     using stan::math::exp;
@@ -18,3 +19,4 @@ TEST(mathMixMatFun, exp) {
   stan::test::expect_ad_vector_matvar(f, stan::math::to_vector(com_args));
   stan::test::expect_ad_vector_matvar(f, stan::math::to_vector(args));
 }
+#endif

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 
 #ifdef STAN_THREADS
-TEST(MathFunctions, expInt) {
+TEST(MathFunctions, expInt0) {
   using stan::math::exp;
   EXPECT_FLOAT_EQ(std::exp(3), exp(3));
   EXPECT_FLOAT_EQ(std::exp(3.1), exp(3.1));
@@ -19,13 +19,13 @@ TEST(MathFunctions, expVecN100) {
     vec[i] = i + 1;
   }
   std::vector<double> vec_test;
-  EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+  EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
   for (size_t i = 0; i < N; ++i) {
     EXPECT_FLOAT_EQ(std::exp(i + 1), vec_test[i]);
   }
 }
 
-TEST(MathFunctions, expVecBench) {
+TEST(MathFunctions, expVecBench0) {
   // std timing includes
   using std::chrono::high_resolution_clock;
   using std::chrono::duration_cast;
@@ -49,7 +49,7 @@ TEST(MathFunctions, expVecBench) {
     std::vector<double> vec_test;
     
     auto t1 = high_resolution_clock::now();
-    EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+    EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
     auto t2 = high_resolution_clock::now();
 
 	/* Getting number of milliseconds as an integer. */
@@ -88,7 +88,7 @@ TEST(MathFunctions, expVecBench_10000000_17) {
     std::vector<double> vec_test;
     
     auto t1 = high_resolution_clock::now();
-    EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+    EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
     auto t2 = high_resolution_clock::now();
 
 	/* Getting number of milliseconds as an integer. */
@@ -129,7 +129,7 @@ TEST(MathFunctions, expVecBench_10000000_17_all10) {
     std::vector<double> vec_test;
     
     auto t1 = high_resolution_clock::now();
-    EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+    EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
     auto t2 = high_resolution_clock::now();
 
 	/* Getting number of milliseconds as an integer. */
@@ -169,7 +169,7 @@ TEST(MathFunctions, expVecBench_N2_2_threads2_all10) {
     std::vector<double> vec_test;
     
     auto t1 = high_resolution_clock::now();
-    EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+    EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
     auto t2 = high_resolution_clock::now();
 
 	/* Getting number of milliseconds as an integer. */
@@ -209,7 +209,7 @@ TEST(MathFunctions, expVecBench_N2_2_threads4_all10) {
     std::vector<double> vec_test;
     
     auto t1 = high_resolution_clock::now();
-    EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+    EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
     auto t2 = high_resolution_clock::now();
 
 	/* Getting number of milliseconds as an integer. */
@@ -249,7 +249,7 @@ TEST(MathFunctions, expVecBench_N2_2_threads8_all10) {
     std::vector<double> vec_test;
     
     auto t1 = high_resolution_clock::now();
-    EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+    EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
     auto t2 = high_resolution_clock::now();
 
 	/* Getting number of milliseconds as an integer. */

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -1,3 +1,5 @@
+
+
 #include <stan/math.hpp>
 #include <gtest/gtest.h>
 
@@ -16,12 +18,15 @@ TEST(MathFunctions, expVec) {
   for (size_t i = 0; i < N; ++i) {
     vec[i] = i + 1;
   }
-  EXPECT_NO_THROW(stan::math::exp_test(vec));
+  std::vector<double> vec_test;
+  EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
 
   // std::vector<double> vec_test;
   // vec_test = stan::math::exp_test(vec);
   // for (size_t i = 0; i < N; ++i) {
-  //   EXPECT_FLOAT_EQ(std::exp(i + 1), vec_test[i]);
+  //   std::cout << vec_test[i] << "\n";
+  //   std::cout << std::exp(i + 1) << "\n";
+  //   //EXPECT_FLOAT_EQ(std::exp(i + 1), vec_test[i]);
   // }
 }
 

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -11,7 +11,7 @@ TEST(MathFunctions, expInt) {
   EXPECT_FLOAT_EQ(std::exp(3.0), exp(3.0));
 }
 
-TEST(MathFunctions, expVec) {
+TEST(MathFunctions, expVecN100) {
   using stan::math::exp;
   size_t N = 100;
   std::vector<double> vec(N);
@@ -20,14 +20,49 @@ TEST(MathFunctions, expVec) {
   }
   std::vector<double> vec_test;
   EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+  for (size_t i = 0; i < N; ++i) {
+    EXPECT_FLOAT_EQ(std::exp(i + 1), vec_test[i]);
+  }
+}
 
-  // std::vector<double> vec_test;
-  // vec_test = stan::math::exp_test(vec);
-  // for (size_t i = 0; i < N; ++i) {
-  //   std::cout << vec_test[i] << "\n";
-  //   std::cout << std::exp(i + 1) << "\n";
-  //   //EXPECT_FLOAT_EQ(std::exp(i + 1), vec_test[i]);
-  // }
+TEST(MathFunctions, expVecBench) {
+  // std timing includes
+  using std::chrono::high_resolution_clock;
+  using std::chrono::duration_cast;
+  using std::chrono::duration;
+  using std::chrono::milliseconds;
+
+  // stan math includes
+  using stan::math::exp;
+  using stan::math::init_threadpool_tbb;
+  size_t N = 10000; // we're computing exp 10000 times but  scaling number of threads
+  // scaling Nthreads by squares N, N^2, N^3
+  std::cout << "N,nThreads,msInt,msDouble\n";
+  for (int i = 1; i < 10; ++i) { 
+    size_t Nthreads = 2;
+    Nthreads  = std::pow(Nthreads, i);
+    stan::math::init_threadpool_tbb(Nthreads);
+    std::vector<double> vec(N);
+    for (size_t i = 0; i < N; ++i) {
+      vec[i] = i + 1;
+    }
+    std::vector<double> vec_test;
+    
+    auto t1 = high_resolution_clock::now();
+    EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+    auto t2 = high_resolution_clock::now();
+
+	/* Getting number of milliseconds as an integer. */
+	auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+	/* Getting number of milliseconds as a double. */
+	duration<double, std::milli> ms_double = t2 - t1;
+
+	std::cout << N << ",";
+	std::cout << Nthreads << ",";
+	std::cout << ms_int.count() << "ms,";
+	std::cout << ms_double.count() << "ms\n";
+  }
 }
 
 #else

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -104,6 +104,47 @@ TEST(MathFunctions, expVecBench_10000000_17) {
   }
 }
 
+TEST(MathFunctions, expVecBench_10000000_17_all10) {
+  // std timing includes
+  using std::chrono::high_resolution_clock;
+  using std::chrono::duration_cast;
+  using std::chrono::duration;
+  using std::chrono::milliseconds;
+
+  // stan math includes
+  using stan::math::exp;
+  using stan::math::init_threadpool_tbb;
+  size_t N = 10000000; // we're computing exp 10000 times but  scaling number of threads
+  // scaling Nthreads by squares N, N^2, N^3
+  std::cout << "all 10\n";
+  std::cout << "N,nThreads,msInt,msDouble\n";
+  for (int i = 1; i < 17; ++i) { 
+    size_t Nthreads = 2;
+    Nthreads  = std::pow(Nthreads, i);
+    stan::math::init_threadpool_tbb(Nthreads);
+    std::vector<double> vec(N);
+    for (size_t i = 0; i < N; ++i) {
+      vec[i] = 10;
+    }
+    std::vector<double> vec_test;
+    
+    auto t1 = high_resolution_clock::now();
+    EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+    auto t2 = high_resolution_clock::now();
+
+	/* Getting number of milliseconds as an integer. */
+	auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+	/* Getting number of milliseconds as a double. */
+	duration<double, std::milli> ms_double = t2 - t1;
+
+	std::cout << N << ",";
+	std::cout << Nthreads << ",";
+	std::cout << ms_int.count() << "ms,";
+	std::cout << ms_double.count() << "ms\n";
+  }
+}
+
 
 #else
 

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -148,7 +148,147 @@ TEST(MathFunctions, expVecBench_10000000_17_all10) {
 
 #else
 
+TEST(MathFunctions, expVecBench_10000000) {
+  std::cout << "NO THREADING\n";
+  // std timing includes
+  using std::chrono::high_resolution_clock;
+  using std::chrono::duration_cast;
+  using std::chrono::duration;
+  using std::chrono::milliseconds;
+
+  // stan math includes
+  using stan::math::exp;
+  size_t N = 10000000; // we're computing exp 10000 times but  scaling number of threads
+  // scaling Nthreads by squares N, N^2, N^3
+  std::cout << "N,noThreads,msInt,msDouble\n";
+  std::vector<double> vec(N);
+  for (size_t i = 0; i < N; ++i) {
+    vec[i] = i + 1;
+  }
+  std::vector<double> vec_test;
+  
+  auto t1 = high_resolution_clock::now();
+  EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
+  auto t2 = high_resolution_clock::now();
+
+  /* Getting number of milliseconds as an integer. */
+  auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+  /* Getting number of milliseconds as a double. */
+  duration<double, std::milli> ms_double = t2 - t1;
+  
+  std::cout << N << ",";
+  std::cout << "NA" << ",";
+  std::cout << ms_int.count() << "ms,";
+  std::cout << ms_double.count() << "ms\n";
+}
+
 TEST(MathFunctions, expVecBench) {
+  std::cout << "NO THREADING 10000 Nincr\n";
+  // std timing includes
+  using std::chrono::high_resolution_clock;
+  using std::chrono::duration_cast;
+  using std::chrono::duration;
+  using std::chrono::milliseconds;
+
+  // stan math includes
+  using stan::math::exp;
+  size_t N = 10000; // we're computing exp 10000 times but  scaling number of threads
+  // scaling Nthreads by squares N, N^2, N^3
+  std::cout << "N,noThreads,msInt,msDouble\n";
+  std::vector<double> vec(N);
+  for (size_t i = 0; i < N; ++i) {
+    vec[i] = i + 1;
+  }
+  std::vector<double> vec_test;
+  
+  auto t1 = high_resolution_clock::now();
+  EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
+  auto t2 = high_resolution_clock::now();
+
+  /* Getting number of milliseconds as an integer. */
+  auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+  /* Getting number of milliseconds as a double. */
+  duration<double, std::milli> ms_double = t2 - t1;
+  
+  std::cout << N << ",";
+  std::cout << "NA" << ",";
+  std::cout << ms_int.count() << "ms,";
+  std::cout << ms_double.count() << "ms\n";
+}
+
+TEST(MathFunctions, expVecBench_10000000_10only) {
+  std::cout << "NO THREADING 10000000 10 ONLY\n";
+  // std timing includes
+  using std::chrono::high_resolution_clock;
+  using std::chrono::duration_cast;
+  using std::chrono::duration;
+  using std::chrono::milliseconds;
+
+  // stan math includes
+  using stan::math::exp;
+  size_t N = 10000000; // we're computing exp 10000 times but  scaling number of threads
+  // scaling Nthreads by squares N, N^2, N^3
+  std::cout << "N,noThreads,msInt,msDouble\n";
+  std::vector<double> vec(N);
+  for (size_t i = 0; i < N; ++i) {
+    vec[i] = 10;
+  }
+  std::vector<double> vec_test;
+  
+  auto t1 = high_resolution_clock::now();
+  EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
+  auto t2 = high_resolution_clock::now();
+
+  /* Getting number of milliseconds as an integer. */
+  auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+  /* Getting number of milliseconds as a double. */
+  duration<double, std::milli> ms_double = t2 - t1;
+  
+  std::cout << N << ",";
+  std::cout << "NA" << ",";
+  std::cout << ms_int.count() << "ms,";
+  std::cout << ms_double.count() << "ms\n";
+}
+
+TEST(MathFunctions, expVecBench_10000_10only) {
+  std::cout << "NO THREADING, 10000 10 only\n";
+  // std timing includes
+  using std::chrono::high_resolution_clock;
+  using std::chrono::duration_cast;
+  using std::chrono::duration;
+  using std::chrono::milliseconds;
+
+  // stan math includes
+  using stan::math::exp;
+  size_t N = 10000; // we're computing exp 10000 times but  scaling number of threads
+  // scaling Nthreads by squares N, N^2, N^3
+  std::cout << "N,noThreads,msInt,msDouble\n";
+  std::vector<double> vec(N);
+  for (size_t i = 0; i < N; ++i) {
+    vec[i] = 10;
+  }
+  std::vector<double> vec_test;
+  
+  auto t1 = high_resolution_clock::now();
+  EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
+  auto t2 = high_resolution_clock::now();
+
+  /* Getting number of milliseconds as an integer. */
+  auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+  /* Getting number of milliseconds as a double. */
+  duration<double, std::milli> ms_double = t2 - t1;
+  
+  std::cout << N << ",";
+  std::cout << "NA" << ",";
+  std::cout << ms_int.count() << "ms,";
+  std::cout << ms_double.count() << "ms\n";
+}
+
+TEST(MathFunctions, expVecBench_10000_Nincr) {
   std::cout << "NO THREADING\n";
   // std timing includes
   using std::chrono::high_resolution_clock;
@@ -182,6 +322,7 @@ TEST(MathFunctions, expVecBench) {
   std::cout << ms_int.count() << "ms,";
   std::cout << ms_double.count() << "ms\n";
 }
+
 
 TEST(MathFunctions, expInt) {
   using stan::math::exp;

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -10,6 +10,14 @@ TEST(MathFunctions, expInt0) {
   EXPECT_FLOAT_EQ(std::exp(3.1), exp(3.1));
   EXPECT_FLOAT_EQ(std::exp(3.0), exp(3.0));
 }
+TEST(MathFuncions, investigateDrift) {
+  using stan::math::exp;
+  for (size_t i = 0; i < 100; ++i) {
+    EXPECT_FLOAT_EQ(std::exp(i), exp(i));
+    std::cout << "std::exp: " << std::exp(i) << std::endl;
+    std::cout << "stan::math::exp(i): " << stan::math::exp(i) << std::endl;
+  }
+}
 
 TEST(MathFunctions, expVecN100) {
   using stan::math::exp;
@@ -305,6 +313,15 @@ TEST(MathFunctions, expVecBench_10000000) {
             << ",";
   std::cout << ms_int.count() << "ms,";
   std::cout << ms_double.count() << "ms\n";
+}
+
+TEST(MathFuncions, investigateDrift) {
+  using stan::math::exp;
+  for (size_t i = 0; i < 100; ++i) {
+    EXPECT_FLOAT_EQ(std::exp(i), exp(i));
+    std::cout << "std::exp: " << std::exp(i) << std::endl;
+    std::cout << "stan::math::exp(i): " << stan::math::exp(i) << std::endl;
+  }
 }
 
 TEST(MathFunctions, expVecBench) {

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -421,26 +421,28 @@ TEST(MathFunctions, expVecBench_N2_noThreads_exp10) {
   size_t N = 2; // we're computing exp 10000 times but  scaling number of threads
   // scaling Nthreads by squares N, N^2, N^3
   std::cout << "N,noThreads,msInt,msDouble\n";
-  std::vector<double> vec(N);
   for (size_t i = 0; i < 30; ++i) {
-    vec[i] = 10;
-  }
-  std::vector<double> vec_test;
-  N = std::pow(2, i);
-  auto t1 = high_resolution_clock::now();
-  EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
-  auto t2 = high_resolution_clock::now();
+    std::vector<double> vec_test;
+    N = std::pow(2, i);
+    std::vector<double> vec(N);
+    for (size_t i = 0; i < N; ++i) {
+      vec[i] = 10;
+    }
+    auto t1 = high_resolution_clock::now();
+    EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
+    auto t2 = high_resolution_clock::now();
 
-  /* Getting number of milliseconds as an integer. */
-  auto ms_int = duration_cast<milliseconds>(t2 - t1);
+    /* Getting number of milliseconds as an integer. */
+    auto ms_int = duration_cast<milliseconds>(t2 - t1);
 
-  /* Getting number of milliseconds as a double. */
-  duration<double, std::milli> ms_double = t2 - t1;
+    /* Getting number of milliseconds as a double. */
+    duration<double, std::milli> ms_double = t2 - t1;
   
-  std::cout << N << ",";
-  std::cout << "NA" << ",";
-  std::cout << ms_int.count() << "ms,";
-  std::cout << ms_double.count() << "ms\n";
+    std::cout << N << ",";
+    std::cout << "NA" << ",";
+    std::cout << ms_int.count() << "ms,";
+    std::cout << ms_double.count() << "ms\n";
+  }
 }
 
 TEST(MathFunctions, expVecBench_10000_Nincr) {

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -64,6 +64,46 @@ TEST(MathFunctions, expVecBench) {
 	std::cout << ms_double.count() << "ms\n";
   }
 }
+TEST(MathFunctions, expVecBench_10000000_17) {
+  // std timing includes
+  using std::chrono::high_resolution_clock;
+  using std::chrono::duration_cast;
+  using std::chrono::duration;
+  using std::chrono::milliseconds;
+
+  // stan math includes
+  using stan::math::exp;
+  using stan::math::init_threadpool_tbb;
+  size_t N = 10000000; // we're computing exp 10000 times but  scaling number of threads
+  // scaling Nthreads by squares N, N^2, N^3
+  std::cout << "N,nThreads,msInt,msDouble\n";
+  for (int i = 1; i < 17; ++i) { 
+    size_t Nthreads = 2;
+    Nthreads  = std::pow(Nthreads, i);
+    stan::math::init_threadpool_tbb(Nthreads);
+    std::vector<double> vec(N);
+    for (size_t i = 0; i < N; ++i) {
+      vec[i] = i + 1;
+    }
+    std::vector<double> vec_test;
+    
+    auto t1 = high_resolution_clock::now();
+    EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+    auto t2 = high_resolution_clock::now();
+
+	/* Getting number of milliseconds as an integer. */
+	auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+	/* Getting number of milliseconds as a double. */
+	duration<double, std::milli> ms_double = t2 - t1;
+
+	std::cout << N << ",";
+	std::cout << Nthreads << ",";
+	std::cout << ms_int.count() << "ms,";
+	std::cout << ms_double.count() << "ms\n";
+  }
+}
+
 
 #else
 

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -10,7 +10,7 @@ TEST(MathFunctions, expInt0) {
   EXPECT_FLOAT_EQ(std::exp(3.1), exp(3.1));
   EXPECT_FLOAT_EQ(std::exp(3.0), exp(3.0));
 }
-TEST(MathFuncions, investigateDrift) {
+TEST(MathFuncions, investigateDrift0) {
   using stan::math::exp;
   for (size_t i = 0; i < 100; ++i) {
     EXPECT_FLOAT_EQ(std::exp(i), exp(i));
@@ -315,7 +315,7 @@ TEST(MathFunctions, expVecBench_10000000) {
   std::cout << ms_double.count() << "ms\n";
 }
 
-TEST(MathFuncions, investigateDrift) {
+TEST(MathFuncions, investigateDrift1) {
   using stan::math::exp;
   for (size_t i = 0; i < 100; ++i) {
     EXPECT_FLOAT_EQ(std::exp(i), exp(i));

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -145,6 +145,126 @@ TEST(MathFunctions, expVecBench_10000000_17_all10) {
   }
 }
 
+TEST(MathFunctions, expVecBench_N2_2_threads2_all10) {
+  // std timing includes
+  using std::chrono::high_resolution_clock;
+  using std::chrono::duration_cast;
+  using std::chrono::duration;
+  using std::chrono::milliseconds;
+
+  // stan math includes
+  using stan::math::exp;
+  using stan::math::init_threadpool_tbb;
+  std::cout << "all 10\n";
+  std::cout << "N,nThreads,msInt,msDouble\n";
+  for (int i = 1; i < 30; ++i) { 
+    size_t Nthreads = 2;
+    //    Nthreads  = std::pow(Nthreads, i);
+    size_t N  = std::pow(2, i);
+    stan::math::init_threadpool_tbb(Nthreads);
+    std::vector<double> vec(N);
+    for (size_t i = 0; i < N; ++i) {
+      vec[i] = 10;
+    }
+    std::vector<double> vec_test;
+    
+    auto t1 = high_resolution_clock::now();
+    EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+    auto t2 = high_resolution_clock::now();
+
+	/* Getting number of milliseconds as an integer. */
+	auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+	/* Getting number of milliseconds as a double. */
+	duration<double, std::milli> ms_double = t2 - t1;
+
+	std::cout << N << ",";
+	std::cout << Nthreads << ",";
+	std::cout << ms_int.count() << "ms,";
+	std::cout << ms_double.count() << "ms\n";
+  }
+}
+
+TEST(MathFunctions, expVecBench_N2_2_threads4_all10) {
+  // std timing includes
+  using std::chrono::high_resolution_clock;
+  using std::chrono::duration_cast;
+  using std::chrono::duration;
+  using std::chrono::milliseconds;
+
+  // stan math includes
+  using stan::math::exp;
+  using stan::math::init_threadpool_tbb;
+  std::cout << "all 10\n";
+  std::cout << "N,nThreads,msInt,msDouble\n";
+  for (int i = 1; i < 30; ++i) { 
+    size_t Nthreads = 4;
+    //    Nthreads  = std::pow(Nthreads, i);
+    size_t N  = std::pow(2, i);
+    stan::math::init_threadpool_tbb(Nthreads);
+    std::vector<double> vec(N);
+    for (size_t i = 0; i < N; ++i) {
+      vec[i] = 10;
+    }
+    std::vector<double> vec_test;
+    
+    auto t1 = high_resolution_clock::now();
+    EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+    auto t2 = high_resolution_clock::now();
+
+	/* Getting number of milliseconds as an integer. */
+	auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+	/* Getting number of milliseconds as a double. */
+	duration<double, std::milli> ms_double = t2 - t1;
+
+	std::cout << N << ",";
+	std::cout << Nthreads << ",";
+	std::cout << ms_int.count() << "ms,";
+	std::cout << ms_double.count() << "ms\n";
+  }
+}
+
+TEST(MathFunctions, expVecBench_N2_2_threads8_all10) {
+  // std timing includes
+  using std::chrono::high_resolution_clock;
+  using std::chrono::duration_cast;
+  using std::chrono::duration;
+  using std::chrono::milliseconds;
+
+  // stan math includes
+  using stan::math::exp;
+  using stan::math::init_threadpool_tbb;
+  std::cout << "all 10\n";
+  std::cout << "N,nThreads,msInt,msDouble\n";
+  for (int i = 1; i < 30; ++i) { 
+    size_t Nthreads = 8;
+    //    Nthreads  = std::pow(Nthreads, i);
+    size_t N  = std::pow(2, i);
+    stan::math::init_threadpool_tbb(Nthreads);
+    std::vector<double> vec(N);
+    for (size_t i = 0; i < N; ++i) {
+      vec[i] = 10;
+    }
+    std::vector<double> vec_test;
+    
+    auto t1 = high_resolution_clock::now();
+    EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
+    auto t2 = high_resolution_clock::now();
+
+	/* Getting number of milliseconds as an integer. */
+	auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+	/* Getting number of milliseconds as a double. */
+	duration<double, std::milli> ms_double = t2 - t1;
+
+	std::cout << N << ",";
+	std::cout << Nthreads << ",";
+	std::cout << ms_int.count() << "ms,";
+	std::cout << ms_double.count() << "ms\n";
+  }
+}
+
 
 #else
 
@@ -272,6 +392,41 @@ TEST(MathFunctions, expVecBench_10000_10only) {
   }
   std::vector<double> vec_test;
   
+  auto t1 = high_resolution_clock::now();
+  EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
+  auto t2 = high_resolution_clock::now();
+
+  /* Getting number of milliseconds as an integer. */
+  auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+  /* Getting number of milliseconds as a double. */
+  duration<double, std::milli> ms_double = t2 - t1;
+  
+  std::cout << N << ",";
+  std::cout << "NA" << ",";
+  std::cout << ms_int.count() << "ms,";
+  std::cout << ms_double.count() << "ms\n";
+}
+
+TEST(MathFunctions, expVecBench_N2_noThreads_exp10) {
+  std::cout << "NO THREADING scaleN, exp(10)\n";
+  // std timing includes
+  using std::chrono::high_resolution_clock;
+  using std::chrono::duration_cast;
+  using std::chrono::duration;
+  using std::chrono::milliseconds;
+
+  // stan math includes
+  using stan::math::exp;
+  size_t N = 2; // we're computing exp 10000 times but  scaling number of threads
+  // scaling Nthreads by squares N, N^2, N^3
+  std::cout << "N,noThreads,msInt,msDouble\n";
+  std::vector<double> vec(N);
+  for (size_t i = 0; i < 30; ++i) {
+    vec[i] = 10;
+  }
+  std::vector<double> vec_test;
+  N = std::pow(2, i);
   auto t1 = high_resolution_clock::now();
   EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
   auto t2 = high_resolution_clock::now();

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -1,9 +1,35 @@
 #include <stan/math.hpp>
 #include <gtest/gtest.h>
 
+#ifdef STAN_THREADS
 TEST(MathFunctions, expInt) {
   using stan::math::exp;
   EXPECT_FLOAT_EQ(std::exp(3), exp(3));
   EXPECT_FLOAT_EQ(std::exp(3.1), exp(3.1));
   EXPECT_FLOAT_EQ(std::exp(3.0), exp(3.0));
 }
+
+TEST(MathFunctions, expVec) {
+  using stan::math::exp;
+  size_t N = 100;
+  std::vector<double> vec(N);
+  for (size_t i = 0; i < N; ++i) {
+    vec[i] = i + 1;
+  }
+  EXPECT_NO_THROW(stan::math::exp_test(vec));
+
+  // std::vector<double> vec_test;
+  // vec_test = stan::math::exp_test(vec);
+  // for (size_t i = 0; i < N; ++i) {
+  //   EXPECT_FLOAT_EQ(std::exp(i + 1), vec_test[i]);
+  // }
+}
+
+#else
+TEST(MathFunctions, expInt) {
+  using stan::math::exp;
+  EXPECT_FLOAT_EQ(std::exp(3), exp(3));
+  EXPECT_FLOAT_EQ(std::exp(3.1), exp(3.1));
+  EXPECT_FLOAT_EQ(std::exp(3.0), exp(3.0));
+}
+#endif

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -27,129 +27,132 @@ TEST(MathFunctions, expVecN100) {
 
 TEST(MathFunctions, expVecBench) {
   // std timing includes
-  using std::chrono::high_resolution_clock;
-  using std::chrono::duration_cast;
   using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
   using std::chrono::milliseconds;
 
   // stan math includes
   using stan::math::exp;
   using stan::math::init_threadpool_tbb;
-  size_t N = 10000; // we're computing exp 10000 times but  scaling number of threads
+  size_t N = 10000;  // we're computing exp 10000 times but  scaling number of
+                     // threads
   // scaling Nthreads by squares N, N^2, N^3
   std::cout << "N,nThreads,msInt,msDouble\n";
-  for (int i = 1; i < 10; ++i) { 
+  for (int i = 1; i < 10; ++i) {
     size_t Nthreads = 2;
-    Nthreads  = std::pow(Nthreads, i);
+    Nthreads = std::pow(Nthreads, i);
     stan::math::init_threadpool_tbb(Nthreads);
     std::vector<double> vec(N);
     for (size_t i = 0; i < N; ++i) {
       vec[i] = i + 1;
     }
     std::vector<double> vec_test;
-    
+
     auto t1 = high_resolution_clock::now();
     EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
     auto t2 = high_resolution_clock::now();
 
-	/* Getting number of milliseconds as an integer. */
-	auto ms_int = duration_cast<milliseconds>(t2 - t1);
+    /* Getting number of milliseconds as an integer. */
+    auto ms_int = duration_cast<milliseconds>(t2 - t1);
 
-	/* Getting number of milliseconds as a double. */
-	duration<double, std::milli> ms_double = t2 - t1;
+    /* Getting number of milliseconds as a double. */
+    duration<double, std::milli> ms_double = t2 - t1;
 
-	std::cout << N << ",";
-	std::cout << Nthreads << ",";
-	std::cout << ms_int.count() << "ms,";
-	std::cout << ms_double.count() << "ms\n";
+    std::cout << N << ",";
+    std::cout << Nthreads << ",";
+    std::cout << ms_int.count() << "ms,";
+    std::cout << ms_double.count() << "ms\n";
   }
 }
 TEST(MathFunctions, expVecBench_10000000_17) {
   // std timing includes
-  using std::chrono::high_resolution_clock;
-  using std::chrono::duration_cast;
   using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
   using std::chrono::milliseconds;
 
   // stan math includes
   using stan::math::exp;
   using stan::math::init_threadpool_tbb;
-  size_t N = 10000000; // we're computing exp 10000 times but  scaling number of threads
+  size_t N = 10000000;  // we're computing exp 10000 times but  scaling number
+                        // of threads
   // scaling Nthreads by squares N, N^2, N^3
   std::cout << "N,nThreads,msInt,msDouble\n";
-  for (int i = 1; i < 17; ++i) { 
+  for (int i = 1; i < 17; ++i) {
     size_t Nthreads = 2;
-    Nthreads  = std::pow(Nthreads, i);
+    Nthreads = std::pow(Nthreads, i);
     stan::math::init_threadpool_tbb(Nthreads);
     std::vector<double> vec(N);
     for (size_t i = 0; i < N; ++i) {
       vec[i] = i + 1;
     }
     std::vector<double> vec_test;
-    
+
     auto t1 = high_resolution_clock::now();
     EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
     auto t2 = high_resolution_clock::now();
 
-	/* Getting number of milliseconds as an integer. */
-	auto ms_int = duration_cast<milliseconds>(t2 - t1);
+    /* Getting number of milliseconds as an integer. */
+    auto ms_int = duration_cast<milliseconds>(t2 - t1);
 
-	/* Getting number of milliseconds as a double. */
-	duration<double, std::milli> ms_double = t2 - t1;
+    /* Getting number of milliseconds as a double. */
+    duration<double, std::milli> ms_double = t2 - t1;
 
-	std::cout << N << ",";
-	std::cout << Nthreads << ",";
-	std::cout << ms_int.count() << "ms,";
-	std::cout << ms_double.count() << "ms\n";
+    std::cout << N << ",";
+    std::cout << Nthreads << ",";
+    std::cout << ms_int.count() << "ms,";
+    std::cout << ms_double.count() << "ms\n";
   }
 }
 
 TEST(MathFunctions, expVecBench_10000000_17_all10) {
   // std timing includes
-  using std::chrono::high_resolution_clock;
-  using std::chrono::duration_cast;
   using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
   using std::chrono::milliseconds;
 
   // stan math includes
   using stan::math::exp;
   using stan::math::init_threadpool_tbb;
-  size_t N = 10000000; // we're computing exp 10000 times but  scaling number of threads
+  size_t N = 10000000;  // we're computing exp 10000 times but  scaling number
+                        // of threads
   // scaling Nthreads by squares N, N^2, N^3
   std::cout << "all 10\n";
   std::cout << "N,nThreads,msInt,msDouble\n";
-  for (int i = 1; i < 17; ++i) { 
+  for (int i = 1; i < 17; ++i) {
     size_t Nthreads = 2;
-    Nthreads  = std::pow(Nthreads, i);
+    Nthreads = std::pow(Nthreads, i);
     stan::math::init_threadpool_tbb(Nthreads);
     std::vector<double> vec(N);
     for (size_t i = 0; i < N; ++i) {
       vec[i] = 10;
     }
     std::vector<double> vec_test;
-    
+
     auto t1 = high_resolution_clock::now();
     EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
     auto t2 = high_resolution_clock::now();
 
-	/* Getting number of milliseconds as an integer. */
-	auto ms_int = duration_cast<milliseconds>(t2 - t1);
+    /* Getting number of milliseconds as an integer. */
+    auto ms_int = duration_cast<milliseconds>(t2 - t1);
 
-	/* Getting number of milliseconds as a double. */
-	duration<double, std::milli> ms_double = t2 - t1;
+    /* Getting number of milliseconds as a double. */
+    duration<double, std::milli> ms_double = t2 - t1;
 
-	std::cout << N << ",";
-	std::cout << Nthreads << ",";
-	std::cout << ms_int.count() << "ms,";
-	std::cout << ms_double.count() << "ms\n";
+    std::cout << N << ",";
+    std::cout << Nthreads << ",";
+    std::cout << ms_int.count() << "ms,";
+    std::cout << ms_double.count() << "ms\n";
   }
 }
 
 TEST(MathFunctions, expVecBench_N2_2_threads2_all10) {
   // std timing includes
-  using std::chrono::high_resolution_clock;
-  using std::chrono::duration_cast;
   using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
   using std::chrono::milliseconds;
 
   // stan math includes
@@ -157,39 +160,39 @@ TEST(MathFunctions, expVecBench_N2_2_threads2_all10) {
   using stan::math::init_threadpool_tbb;
   std::cout << "all 10\n";
   std::cout << "N,nThreads,msInt,msDouble\n";
-  for (int i = 1; i < 30; ++i) { 
+  for (int i = 1; i < 30; ++i) {
     size_t Nthreads = 2;
     //    Nthreads  = std::pow(Nthreads, i);
-    size_t N  = std::pow(2, i);
+    size_t N = std::pow(2, i);
     stan::math::init_threadpool_tbb(Nthreads);
     std::vector<double> vec(N);
     for (size_t i = 0; i < N; ++i) {
       vec[i] = 10;
     }
     std::vector<double> vec_test;
-    
+
     auto t1 = high_resolution_clock::now();
     EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
     auto t2 = high_resolution_clock::now();
 
-	/* Getting number of milliseconds as an integer. */
-	auto ms_int = duration_cast<milliseconds>(t2 - t1);
+    /* Getting number of milliseconds as an integer. */
+    auto ms_int = duration_cast<milliseconds>(t2 - t1);
 
-	/* Getting number of milliseconds as a double. */
-	duration<double, std::milli> ms_double = t2 - t1;
+    /* Getting number of milliseconds as a double. */
+    duration<double, std::milli> ms_double = t2 - t1;
 
-	std::cout << N << ",";
-	std::cout << Nthreads << ",";
-	std::cout << ms_int.count() << "ms,";
-	std::cout << ms_double.count() << "ms\n";
+    std::cout << N << ",";
+    std::cout << Nthreads << ",";
+    std::cout << ms_int.count() << "ms,";
+    std::cout << ms_double.count() << "ms\n";
   }
 }
 
 TEST(MathFunctions, expVecBench_N2_2_threads4_all10) {
   // std timing includes
-  using std::chrono::high_resolution_clock;
-  using std::chrono::duration_cast;
   using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
   using std::chrono::milliseconds;
 
   // stan math includes
@@ -197,39 +200,39 @@ TEST(MathFunctions, expVecBench_N2_2_threads4_all10) {
   using stan::math::init_threadpool_tbb;
   std::cout << "all 10\n";
   std::cout << "N,nThreads,msInt,msDouble\n";
-  for (int i = 1; i < 30; ++i) { 
+  for (int i = 1; i < 30; ++i) {
     size_t Nthreads = 4;
     //    Nthreads  = std::pow(Nthreads, i);
-    size_t N  = std::pow(2, i);
+    size_t N = std::pow(2, i);
     stan::math::init_threadpool_tbb(Nthreads);
     std::vector<double> vec(N);
     for (size_t i = 0; i < N; ++i) {
       vec[i] = 10;
     }
     std::vector<double> vec_test;
-    
+
     auto t1 = high_resolution_clock::now();
     EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
     auto t2 = high_resolution_clock::now();
 
-	/* Getting number of milliseconds as an integer. */
-	auto ms_int = duration_cast<milliseconds>(t2 - t1);
+    /* Getting number of milliseconds as an integer. */
+    auto ms_int = duration_cast<milliseconds>(t2 - t1);
 
-	/* Getting number of milliseconds as a double. */
-	duration<double, std::milli> ms_double = t2 - t1;
+    /* Getting number of milliseconds as a double. */
+    duration<double, std::milli> ms_double = t2 - t1;
 
-	std::cout << N << ",";
-	std::cout << Nthreads << ",";
-	std::cout << ms_int.count() << "ms,";
-	std::cout << ms_double.count() << "ms\n";
+    std::cout << N << ",";
+    std::cout << Nthreads << ",";
+    std::cout << ms_int.count() << "ms,";
+    std::cout << ms_double.count() << "ms\n";
   }
 }
 
 TEST(MathFunctions, expVecBench_N2_2_threads8_all10) {
   // std timing includes
-  using std::chrono::high_resolution_clock;
-  using std::chrono::duration_cast;
   using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
   using std::chrono::milliseconds;
 
   // stan math includes
@@ -237,48 +240,48 @@ TEST(MathFunctions, expVecBench_N2_2_threads8_all10) {
   using stan::math::init_threadpool_tbb;
   std::cout << "all 10\n";
   std::cout << "N,nThreads,msInt,msDouble\n";
-  for (int i = 1; i < 30; ++i) { 
+  for (int i = 1; i < 30; ++i) {
     size_t Nthreads = 8;
     //    Nthreads  = std::pow(Nthreads, i);
-    size_t N  = std::pow(2, i);
+    size_t N = std::pow(2, i);
     stan::math::init_threadpool_tbb(Nthreads);
     std::vector<double> vec(N);
     for (size_t i = 0; i < N; ++i) {
       vec[i] = 10;
     }
     std::vector<double> vec_test;
-    
+
     auto t1 = high_resolution_clock::now();
     EXPECT_NO_THROW(vec_test = stan::math::exp_test(vec));
     auto t2 = high_resolution_clock::now();
 
-	/* Getting number of milliseconds as an integer. */
-	auto ms_int = duration_cast<milliseconds>(t2 - t1);
+    /* Getting number of milliseconds as an integer. */
+    auto ms_int = duration_cast<milliseconds>(t2 - t1);
 
-	/* Getting number of milliseconds as a double. */
-	duration<double, std::milli> ms_double = t2 - t1;
+    /* Getting number of milliseconds as a double. */
+    duration<double, std::milli> ms_double = t2 - t1;
 
-	std::cout << N << ",";
-	std::cout << Nthreads << ",";
-	std::cout << ms_int.count() << "ms,";
-	std::cout << ms_double.count() << "ms\n";
+    std::cout << N << ",";
+    std::cout << Nthreads << ",";
+    std::cout << ms_int.count() << "ms,";
+    std::cout << ms_double.count() << "ms\n";
   }
 }
-
 
 #else
 
 TEST(MathFunctions, expVecBench_10000000) {
   std::cout << "NO THREADING\n";
   // std timing includes
-  using std::chrono::high_resolution_clock;
-  using std::chrono::duration_cast;
   using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
   using std::chrono::milliseconds;
 
   // stan math includes
   using stan::math::exp;
-  size_t N = 10000000; // we're computing exp 10000 times but  scaling number of threads
+  size_t N = 10000000;  // we're computing exp 10000 times but  scaling number
+                        // of threads
   // scaling Nthreads by squares N, N^2, N^3
   std::cout << "N,noThreads,msInt,msDouble\n";
   std::vector<double> vec(N);
@@ -286,7 +289,7 @@ TEST(MathFunctions, expVecBench_10000000) {
     vec[i] = i + 1;
   }
   std::vector<double> vec_test;
-  
+
   auto t1 = high_resolution_clock::now();
   EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
   auto t2 = high_resolution_clock::now();
@@ -296,9 +299,10 @@ TEST(MathFunctions, expVecBench_10000000) {
 
   /* Getting number of milliseconds as a double. */
   duration<double, std::milli> ms_double = t2 - t1;
-  
+
   std::cout << N << ",";
-  std::cout << "NA" << ",";
+  std::cout << "NA"
+            << ",";
   std::cout << ms_int.count() << "ms,";
   std::cout << ms_double.count() << "ms\n";
 }
@@ -306,14 +310,15 @@ TEST(MathFunctions, expVecBench_10000000) {
 TEST(MathFunctions, expVecBench) {
   std::cout << "NO THREADING 10000 Nincr\n";
   // std timing includes
-  using std::chrono::high_resolution_clock;
-  using std::chrono::duration_cast;
   using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
   using std::chrono::milliseconds;
 
   // stan math includes
   using stan::math::exp;
-  size_t N = 10000; // we're computing exp 10000 times but  scaling number of threads
+  size_t N = 10000;  // we're computing exp 10000 times but  scaling number of
+                     // threads
   // scaling Nthreads by squares N, N^2, N^3
   std::cout << "N,noThreads,msInt,msDouble\n";
   std::vector<double> vec(N);
@@ -321,7 +326,7 @@ TEST(MathFunctions, expVecBench) {
     vec[i] = i + 1;
   }
   std::vector<double> vec_test;
-  
+
   auto t1 = high_resolution_clock::now();
   EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
   auto t2 = high_resolution_clock::now();
@@ -331,9 +336,10 @@ TEST(MathFunctions, expVecBench) {
 
   /* Getting number of milliseconds as a double. */
   duration<double, std::milli> ms_double = t2 - t1;
-  
+
   std::cout << N << ",";
-  std::cout << "NA" << ",";
+  std::cout << "NA"
+            << ",";
   std::cout << ms_int.count() << "ms,";
   std::cout << ms_double.count() << "ms\n";
 }
@@ -341,14 +347,15 @@ TEST(MathFunctions, expVecBench) {
 TEST(MathFunctions, expVecBench_10000000_10only) {
   std::cout << "NO THREADING 10000000 10 ONLY\n";
   // std timing includes
-  using std::chrono::high_resolution_clock;
-  using std::chrono::duration_cast;
   using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
   using std::chrono::milliseconds;
 
   // stan math includes
   using stan::math::exp;
-  size_t N = 10000000; // we're computing exp 10000 times but  scaling number of threads
+  size_t N = 10000000;  // we're computing exp 10000 times but  scaling number
+                        // of threads
   // scaling Nthreads by squares N, N^2, N^3
   std::cout << "N,noThreads,msInt,msDouble\n";
   std::vector<double> vec(N);
@@ -356,7 +363,7 @@ TEST(MathFunctions, expVecBench_10000000_10only) {
     vec[i] = 10;
   }
   std::vector<double> vec_test;
-  
+
   auto t1 = high_resolution_clock::now();
   EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
   auto t2 = high_resolution_clock::now();
@@ -366,9 +373,10 @@ TEST(MathFunctions, expVecBench_10000000_10only) {
 
   /* Getting number of milliseconds as a double. */
   duration<double, std::milli> ms_double = t2 - t1;
-  
+
   std::cout << N << ",";
-  std::cout << "NA" << ",";
+  std::cout << "NA"
+            << ",";
   std::cout << ms_int.count() << "ms,";
   std::cout << ms_double.count() << "ms\n";
 }
@@ -376,14 +384,15 @@ TEST(MathFunctions, expVecBench_10000000_10only) {
 TEST(MathFunctions, expVecBench_10000_10only) {
   std::cout << "NO THREADING, 10000 10 only\n";
   // std timing includes
-  using std::chrono::high_resolution_clock;
-  using std::chrono::duration_cast;
   using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
   using std::chrono::milliseconds;
 
   // stan math includes
   using stan::math::exp;
-  size_t N = 10000; // we're computing exp 10000 times but  scaling number of threads
+  size_t N = 10000;  // we're computing exp 10000 times but  scaling number of
+                     // threads
   // scaling Nthreads by squares N, N^2, N^3
   std::cout << "N,noThreads,msInt,msDouble\n";
   std::vector<double> vec(N);
@@ -391,7 +400,7 @@ TEST(MathFunctions, expVecBench_10000_10only) {
     vec[i] = 10;
   }
   std::vector<double> vec_test;
-  
+
   auto t1 = high_resolution_clock::now();
   EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
   auto t2 = high_resolution_clock::now();
@@ -401,9 +410,10 @@ TEST(MathFunctions, expVecBench_10000_10only) {
 
   /* Getting number of milliseconds as a double. */
   duration<double, std::milli> ms_double = t2 - t1;
-  
+
   std::cout << N << ",";
-  std::cout << "NA" << ",";
+  std::cout << "NA"
+            << ",";
   std::cout << ms_int.count() << "ms,";
   std::cout << ms_double.count() << "ms\n";
 }
@@ -411,14 +421,15 @@ TEST(MathFunctions, expVecBench_10000_10only) {
 TEST(MathFunctions, expVecBench_N2_noThreads_exp10) {
   std::cout << "NO THREADING scaleN, exp(10)\n";
   // std timing includes
-  using std::chrono::high_resolution_clock;
-  using std::chrono::duration_cast;
   using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
   using std::chrono::milliseconds;
 
   // stan math includes
   using stan::math::exp;
-  size_t N = 2; // we're computing exp 10000 times but  scaling number of threads
+  size_t N
+      = 2;  // we're computing exp 10000 times but  scaling number of threads
   // scaling Nthreads by squares N, N^2, N^3
   std::cout << "N,noThreads,msInt,msDouble\n";
   for (size_t i = 0; i < 30; ++i) {
@@ -437,9 +448,10 @@ TEST(MathFunctions, expVecBench_N2_noThreads_exp10) {
 
     /* Getting number of milliseconds as a double. */
     duration<double, std::milli> ms_double = t2 - t1;
-  
+
     std::cout << N << ",";
-    std::cout << "NA" << ",";
+    std::cout << "NA"
+              << ",";
     std::cout << ms_int.count() << "ms,";
     std::cout << ms_double.count() << "ms\n";
   }
@@ -448,14 +460,15 @@ TEST(MathFunctions, expVecBench_N2_noThreads_exp10) {
 TEST(MathFunctions, expVecBench_10000_Nincr) {
   std::cout << "NO THREADING\n";
   // std timing includes
-  using std::chrono::high_resolution_clock;
-  using std::chrono::duration_cast;
   using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
   using std::chrono::milliseconds;
 
   // stan math includes
   using stan::math::exp;
-  size_t N = 10000; // we're computing exp 10000 times but  scaling number of threads
+  size_t N = 10000;  // we're computing exp 10000 times but  scaling number of
+                     // threads
   // scaling Nthreads by squares N, N^2, N^3
   std::cout << "N,noThreads,msInt,msDouble\n";
   std::vector<double> vec(N);
@@ -463,7 +476,7 @@ TEST(MathFunctions, expVecBench_10000_Nincr) {
     vec[i] = i + 1;
   }
   std::vector<double> vec_test;
-  
+
   auto t1 = high_resolution_clock::now();
   EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
   auto t2 = high_resolution_clock::now();
@@ -473,13 +486,13 @@ TEST(MathFunctions, expVecBench_10000_Nincr) {
 
   /* Getting number of milliseconds as a double. */
   duration<double, std::milli> ms_double = t2 - t1;
-  
+
   std::cout << N << ",";
-  std::cout << "NA" << ",";
+  std::cout << "NA"
+            << ",";
   std::cout << ms_int.count() << "ms,";
   std::cout << ms_double.count() << "ms\n";
 }
-
 
 TEST(MathFunctions, expInt) {
   using stan::math::exp;

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -66,6 +66,42 @@ TEST(MathFunctions, expVecBench) {
 }
 
 #else
+
+TEST(MathFunctions, expVecBench) {
+  std::cout << "NO THREADING\n";
+  // std timing includes
+  using std::chrono::high_resolution_clock;
+  using std::chrono::duration_cast;
+  using std::chrono::duration;
+  using std::chrono::milliseconds;
+
+  // stan math includes
+  using stan::math::exp;
+  size_t N = 10000; // we're computing exp 10000 times but  scaling number of threads
+  // scaling Nthreads by squares N, N^2, N^3
+  std::cout << "N,noThreads,msInt,msDouble\n";
+  std::vector<double> vec(N);
+  for (size_t i = 0; i < N; ++i) {
+    vec[i] = i + 1;
+  }
+  std::vector<double> vec_test;
+  
+  auto t1 = high_resolution_clock::now();
+  EXPECT_NO_THROW(vec_test = stan::math::exp(vec));
+  auto t2 = high_resolution_clock::now();
+
+  /* Getting number of milliseconds as an integer. */
+  auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+  /* Getting number of milliseconds as a double. */
+  duration<double, std::milli> ms_double = t2 - t1;
+  
+  std::cout << N << ",";
+  std::cout << "NA" << ",";
+  std::cout << ms_int.count() << "ms,";
+  std::cout << ms_double.count() << "ms\n";
+}
+
 TEST(MathFunctions, expInt) {
   using stan::math::exp;
   EXPECT_FLOAT_EQ(std::exp(3), exp(3));


### PR DESCRIPTION
## Summary

I wrote a class that contains an `operator` for exp, which allows use to use `tbb` for parallelization of a for loop. It looks like at lower number of observations, the parallelization is marginal, but at higher number of observations the parallelism of the for loop, using `tbb::parallel_for`,  for example, at ~=32,000 there seems to be a speed up at 4 threads that sustains as we increase the size of the `Container`.

## Tests

I tested for numerical accuracy, which checks out. Moreover, I did the following performance tests:

1. Low number of observations with threading, no threading, and scaling the number of threads (seems to vary based on number of processes running on my computer but marginal speed-up
2. N=10mm, scaling number of threads. Does not crash, but after a certain amount of threads the speedup plateaus and there is no gain from adding additional threads.
3. Fix Scale N, fix number of threads. After a certain amount of observations (2^15) definite speed up at even 4 threads. At 2 threads, we don't start to see an advantage until N=2^30, but it kicks in with higher number of threads at lower number of observations.

## Side Effects

1. Yes. If we kick in threads too early, there's actually a slow down in computing `exp` on a vector with a lower number of observations. May be it would be good if there was a default min threads, or have them kick in only when dataset is a certain size. Moreover, this is just one function, so the result may be different when we have a composite function (Gaussian). I think this may be advantageous at lower number observations, but have not evaluated this.

2. What I've done is added a directive that runs the multithreaded code for only vector, and calls the original code (but it's copy pasted into the STAN_THREADS section) accordingly if the function is not threaded for `exp`. I'd be open to a quick re-factor if  we wanted to set it up like openCL, and have a `threads` directory under `stan\math\prim`.

## Release notes

?

## Checklist

- [x] Copyright holder: (Andre Zapico, Likely LLC, 2026)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
