### PR TITLE
remove extra std::forward in fwd/functor/reduce_sum loop

### DIFF
--- a/stan/math/fwd/functor/reduce_sum.hpp
+++ b/stan/math/fwd/functor/reduce_sum.hpp
@@ -85,7 +85,7 @@ struct reduce_sum_impl {
         }
 
         sum += ReduceFunction()(std::forward<Vec>(sub_slice), start, end, msgs,
-                                std::forward<Args>(args)...);
+                                args);
       }
       return sum;
     }

--- a/stan/math/fwd/functor/reduce_sum.hpp
+++ b/stan/math/fwd/functor/reduce_sum.hpp
@@ -73,19 +73,18 @@ struct reduce_sum_impl {
                               msgs, std::forward<Args>(args)...);
     } else {
       return_type_t<Vec, Args...> sum = 0.0;
+      std::decay_t<Vec> sub_slice;
       for (size_t i = 0; i < (vmapped.size() + grainsize - 1) / grainsize;
            ++i) {
         size_t start = i * grainsize;
         size_t end = std::min((i + 1) * grainsize, vmapped.size()) - 1;
-
-        std::decay_t<Vec> sub_slice;
+        sub_slice.clear();
         sub_slice.reserve(end - start + 1);
+
         for (size_t i = start; i <= end; ++i) {
           sub_slice.emplace_back(vmapped[i]);
         }
-
-        sum += ReduceFunction()(std::forward<Vec>(sub_slice), start, end, msgs,
-                                args);
+        sum += ReduceFunction()(sub_slice, start, end, msgs, args...);
       }
       return sum;
     }

--- a/test/unit/math/rev/functor/reduce_sum_test.cpp
+++ b/test/unit/math/rev/functor/reduce_sum_test.cpp
@@ -429,4 +429,3 @@ TEST_F(AgradRev, StanMathRev_reduce_sum_linked_args) {
 
   stan::math::recover_memory();
 }
-

--- a/test/unit/math/rev/functor/reduce_sum_test.cpp
+++ b/test/unit/math/rev/functor/reduce_sum_test.cpp
@@ -430,30 +430,3 @@ TEST_F(AgradRev, StanMathRev_reduce_sum_linked_args) {
   stan::math::recover_memory();
 }
 
-
-TEST(StanMathPrim_reduce_sum, no_threads_return_type_deduction) {
-  struct int_sum_fn {
-    int operator()(const std::vector<int>& slice, size_t, size_t,
-                   std::ostream*) const {
-      return std::accumulate(slice.begin(), slice.end(), 0);
-    }
-  };
-
-  std::vector<int> data = {1, 2, 3, 4};
-  // This must compile (even without STAN_THREADS)
-  auto result = stan::math::reduce_sum<int_sum_fn>(data, 1, nullptr);
-  EXPECT_DOUBLE_EQ(result, 10.0);  // return_type_t<vector<int>> = double
-}
-
-TEST(StanMathPrim_reduce_sum, no_threads_empty_return_type_deduction) {
-  struct int_sum_fn {
-    int operator()(const std::vector<int>& slice, size_t, size_t,
-                   std::ostream*) const {
-      return 0;
-    }
-  };
-
-  std::vector<int> empty;
-  auto result = stan::math::reduce_sum<int_sum_fn>(empty, 1, nullptr);
-  EXPECT_DOUBLE_EQ(result, 0.0);
-}

--- a/test/unit/math/rev/functor/reduce_sum_test.cpp
+++ b/test/unit/math/rev/functor/reduce_sum_test.cpp
@@ -429,3 +429,31 @@ TEST_F(AgradRev, StanMathRev_reduce_sum_linked_args) {
 
   stan::math::recover_memory();
 }
+
+
+TEST(StanMathPrim_reduce_sum, no_threads_return_type_deduction) {
+  struct int_sum_fn {
+    int operator()(const std::vector<int>& slice, size_t, size_t,
+                   std::ostream*) const {
+      return std::accumulate(slice.begin(), slice.end(), 0);
+    }
+  };
+
+  std::vector<int> data = {1, 2, 3, 4};
+  // This must compile (even without STAN_THREADS)
+  auto result = stan::math::reduce_sum<int_sum_fn>(data, 1, nullptr);
+  EXPECT_DOUBLE_EQ(result, 10.0);  // return_type_t<vector<int>> = double
+}
+
+TEST(StanMathPrim_reduce_sum, no_threads_empty_return_type_deduction) {
+  struct int_sum_fn {
+    int operator()(const std::vector<int>& slice, size_t, size_t,
+                   std::ostream*) const {
+      return 0;
+    }
+  };
+
+  std::vector<int> empty;
+  auto result = stan::math::reduce_sum<int_sum_fn>(empty, 1, nullptr);
+  EXPECT_DOUBLE_EQ(result, 0.0);
+}


### PR DESCRIPTION

## Summary

Fixes https://github.com/stan-dev/math/issues/3303 by removing extra `std::forward` in `fwd/functor/reduce_sum.hpp`

## Tests

No new tests. I think this is a pretty reasonable potential bug that is just an extra forward reference in a loop.

## Checklist

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
