### PR TITLE
Fix typo in tuple_to_laplace_options forwarding function

### DIFF
--- a/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
+++ b/stan/math/mix/functor/laplace_marginal_density_estimator.hpp
@@ -154,7 +154,7 @@ inline constexpr auto tuple_to_laplace_options(Options&& ops) {
     }
     auto defaults = laplace_options_default{};
     return laplace_options_user_supplied{
-        value_of(std::get<0>(std::forward<Ops>(ops))),
+        value_of(std::get<0>(std::forward<Options>(ops))),
         std::get<1>(ops),
         std::get<2>(ops),
         defaults.hessian_block_size,
@@ -163,7 +163,7 @@ inline constexpr auto tuple_to_laplace_options(Options&& ops) {
         (std::get<5>(ops) > 0) ? true : false,
     };
   } else {
-    return std::forward<Ops>(ops);
+    return std::forward<Options>(ops);
   }
 }
 

--- a/test/unit/math/laplace/tuple_to_laplace_options_test.cpp
+++ b/test/unit/math/laplace/tuple_to_laplace_options_test.cpp
@@ -1,0 +1,34 @@
+#include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/laplace/laplace_utility.hpp>
+
+TEST(laplace_utils, tuple_to_laplace_options) {
+  using stan::math::laplace_options_user_supplied;
+  using stan::math::internal::tuple_to_laplace_options;
+
+  auto ops = std::make_tuple(Eigen::VectorXd::Zero(3), 1e-6, 100, 1, 2, 0);
+  auto laplace_opts = tuple_to_laplace_options(ops);
+  EXPECT_EQ(laplace_opts.hessian_block_size, 1);
+  EXPECT_EQ(laplace_opts.solver, 1);
+  EXPECT_EQ(laplace_opts.tolerance, 1e-6);
+  EXPECT_EQ(laplace_opts.max_num_steps, 100);
+  EXPECT_EQ(laplace_opts.line_search.max_iterations, 2);
+  EXPECT_EQ(laplace_opts.allow_fallthrough, false);
+  EXPECT_EQ(laplace_opts.theta_0, Eigen::VectorXd::Zero(3));
+  static_assert(std::is_same_v<decltype(laplace_opts), laplace_options_user_supplied>);
+}
+
+TEST(laplace_utils, tuple_to_laplace_options_move) {
+  using stan::math::laplace_options_user_supplied;
+  using stan::math::internal::tuple_to_laplace_options;
+
+  auto ops = std::make_tuple(Eigen::VectorXd::Zero(3), 1e-6, 100, 1, 2, 1);
+  auto laplace_opts = tuple_to_laplace_options(std::move(ops));
+  EXPECT_EQ(laplace_opts.hessian_block_size, 1);
+  EXPECT_EQ(laplace_opts.solver, 1);
+  EXPECT_EQ(laplace_opts.tolerance, 1e-6);
+  EXPECT_EQ(laplace_opts.max_num_steps, 100);
+  EXPECT_EQ(laplace_opts.line_search.max_iterations, 2);
+  EXPECT_EQ(laplace_opts.allow_fallthrough, true);
+  EXPECT_EQ(laplace_opts.theta_0, Eigen::VectorXd::Zero(3));
+  static_assert(std::is_same_v<decltype(laplace_opts), laplace_options_user_supplied>);
+}

--- a/test/unit/math/laplace/tuple_to_laplace_options_test.cpp
+++ b/test/unit/math/laplace/tuple_to_laplace_options_test.cpp
@@ -14,7 +14,8 @@ TEST(laplace_utils, tuple_to_laplace_options) {
   EXPECT_EQ(laplace_opts.line_search.max_iterations, 2);
   EXPECT_EQ(laplace_opts.allow_fallthrough, false);
   EXPECT_EQ(laplace_opts.theta_0, Eigen::VectorXd::Zero(3));
-  static_assert(std::is_same_v<decltype(laplace_opts), laplace_options_user_supplied>);
+  static_assert(
+      std::is_same_v<decltype(laplace_opts), laplace_options_user_supplied>);
 }
 
 TEST(laplace_utils, tuple_to_laplace_options_move) {
@@ -30,5 +31,6 @@ TEST(laplace_utils, tuple_to_laplace_options_move) {
   EXPECT_EQ(laplace_opts.line_search.max_iterations, 2);
   EXPECT_EQ(laplace_opts.allow_fallthrough, true);
   EXPECT_EQ(laplace_opts.theta_0, Eigen::VectorXd::Zero(3));
-  static_assert(std::is_same_v<decltype(laplace_opts), laplace_options_user_supplied>);
+  static_assert(
+      std::is_same_v<decltype(laplace_opts), laplace_options_user_supplied>);
 }


### PR DESCRIPTION

## Summary

Fixes `tuple_to_laplace_options` typo so that we use `std::forward<Options>` instead of `std::forward<Opts>`

## Tests

None for one liner

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
