### PR TITLE
Use -isystem for libraries

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -118,10 +118,13 @@ endif
 ##
 O ?= 3
 
+## Replace with -I if running into system conflicts
+INC_FLAG ?= -isystem
+
 ## setup includes
-INC ?= $(INC_FIRST) -I $(if $(MATH),$(MATH),.) -I $(EIGEN) -I $(BOOST) $(INC_SUNDIALS)
-INC_SUNDIALS ?= -I $(SUNDIALS)/include -I $(SUNDIALS)/src/sundials
-INC_GTEST ?= -I $(GTEST)/include -I $(GTEST)
+INC ?= $(INC_FIRST) -I $(if $(MATH),$(MATH),.) $(INC_FLAG) $(EIGEN) $(INC_FLAG) $(BOOST) $(INC_SUNDIALS)
+INC_SUNDIALS ?= $(INC_FLAG) $(SUNDIALS)/include $(INC_FLAG) $(SUNDIALS)/src/sundials
+INC_GTEST ?= $(INC_FLAG) $(GTEST)/include $(INC_FLAG) $(GTEST)
 
 ## setup precompiler options
 CPPFLAGS_BOOST ?= -DBOOST_DISABLE_ASSERTS
@@ -254,7 +257,7 @@ ifdef STAN_OPENCL
   CPPFLAGS_OPENCL ?= -DSTAN_OPENCL -DOPENCL_DEVICE_ID=$(OPENCL_DEVICE_ID) -DOPENCL_PLATFORM_ID=$(OPENCL_PLATFORM_ID)
   CPPFLAGS_OPENCL += -DCL_HPP_TARGET_OPENCL_VERSION=120 -DCL_HPP_MINIMUM_OPENCL_VERSION=120
   CPPFLAGS_OPENCL += -DCL_HPP_ENABLE_EXCEPTIONS -Wno-ignored-attributes
-  CXXFLAGS_OPENCL ?= -I $(OPENCL)
+  CXXFLAGS_OPENCL ?= $(INC_FLAG) $(OPENCL)
 
 	ifdef INTEGRATED_OPENCL
 		CPPFLAGS_OPENCL += -DINTEGRATED_OPENCL=1
@@ -288,9 +291,9 @@ endif
 ifdef TBB_LIB
 
 ifdef TBB_INC
-CXXFLAGS_TBB ?= -I $(TBB_INC)
+CXXFLAGS_TBB ?= $(INC_FLAG) $(TBB_INC)
 else
-CXXFLAGS_TBB ?= -I $(TBB)/include
+CXXFLAGS_TBB ?= $(INC_FLAG) $(TBB)/include
 endif
 
 # MacOS ld does not support --disable-new-dtags
@@ -321,7 +324,7 @@ ifeq ($(OS),Linux)
   TBB_TARGETS ?= $(addprefix $(TBB_BIN)/lib,$(addsuffix $(LIBRARY_SUFFIX).2,$(TBB_LIBRARIES)))
 endif
 
-CXXFLAGS_TBB ?= -I $(TBB)/include
+CXXFLAGS_TBB ?= $(INC_FLAG) $(TBB)/include
 LDFLAGS_TBB ?= -Wl,-L,"$(TBB_BIN_ABSOLUTE_PATH)" $(LDFLAGS_FLTO_FLTO) $(LDFLAGS_OPTIM_TBB)
 
 # Windows LLVM/Clang does not support -rpath, but is not needed on Windows anyway

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -119,12 +119,12 @@ endif
 O ?= 3
 
 ## Replace with -I if running into system conflicts
-INC_FLAG ?= -isystem
+INC_DIR_OPT ?= -isystem
 
 ## setup includes
-INC ?= $(INC_FIRST) -I $(if $(MATH),$(MATH),.) $(INC_FLAG) $(EIGEN) $(INC_FLAG) $(BOOST) $(INC_SUNDIALS)
-INC_SUNDIALS ?= $(INC_FLAG) $(SUNDIALS)/include $(INC_FLAG) $(SUNDIALS)/src/sundials
-INC_GTEST ?= $(INC_FLAG) $(GTEST)/include $(INC_FLAG) $(GTEST)
+INC ?= $(INC_FIRST) -I $(if $(MATH),$(MATH),.) $(INC_DIR_OPT) $(EIGEN) $(INC_DIR_OPT) $(BOOST) $(INC_SUNDIALS)
+INC_SUNDIALS ?= $(INC_DIR_OPT) $(SUNDIALS)/include $(INC_DIR_OPT) $(SUNDIALS)/src/sundials
+INC_GTEST ?= $(INC_DIR_OPT) $(GTEST)/include $(INC_DIR_OPT) $(GTEST)
 
 ## setup precompiler options
 CPPFLAGS_BOOST ?= -DBOOST_DISABLE_ASSERTS
@@ -257,7 +257,7 @@ ifdef STAN_OPENCL
   CPPFLAGS_OPENCL ?= -DSTAN_OPENCL -DOPENCL_DEVICE_ID=$(OPENCL_DEVICE_ID) -DOPENCL_PLATFORM_ID=$(OPENCL_PLATFORM_ID)
   CPPFLAGS_OPENCL += -DCL_HPP_TARGET_OPENCL_VERSION=120 -DCL_HPP_MINIMUM_OPENCL_VERSION=120
   CPPFLAGS_OPENCL += -DCL_HPP_ENABLE_EXCEPTIONS -Wno-ignored-attributes
-  CXXFLAGS_OPENCL ?= $(INC_FLAG) $(OPENCL)
+  CXXFLAGS_OPENCL ?= $(INC_DIR_OPT) $(OPENCL)
 
 	ifdef INTEGRATED_OPENCL
 		CPPFLAGS_OPENCL += -DINTEGRATED_OPENCL=1
@@ -291,9 +291,9 @@ endif
 ifdef TBB_LIB
 
 ifdef TBB_INC
-CXXFLAGS_TBB ?= $(INC_FLAG) $(TBB_INC)
+CXXFLAGS_TBB ?= $(INC_DIR_OPT) $(TBB_INC)
 else
-CXXFLAGS_TBB ?= $(INC_FLAG) $(TBB)/include
+CXXFLAGS_TBB ?= $(INC_DIR_OPT) $(TBB)/include
 endif
 
 # MacOS ld does not support --disable-new-dtags
@@ -324,7 +324,7 @@ ifeq ($(OS),Linux)
   TBB_TARGETS ?= $(addprefix $(TBB_BIN)/lib,$(addsuffix $(LIBRARY_SUFFIX).2,$(TBB_LIBRARIES)))
 endif
 
-CXXFLAGS_TBB ?= $(INC_FLAG) $(TBB)/include
+CXXFLAGS_TBB ?= $(INC_DIR_OPT) $(TBB)/include
 LDFLAGS_TBB ?= -Wl,-L,"$(TBB_BIN_ABSOLUTE_PATH)" $(LDFLAGS_FLTO_FLTO) $(LDFLAGS_OPTIM_TBB)
 
 # Windows LLVM/Clang does not support -rpath, but is not needed on Windows anyway


### PR DESCRIPTION

## Summary

Would close #3332. This adds a setting called `INC_FLAG` such that a user who would prefer to get all warnings could use `INC_FLAG="-I" make ...`


## Tests

None

## Side Effects

*should* be none, but part of the reason for making this configurable is to guard against weird behavior on some compilers 

## Release notes

Stan's vendored dependencies are now included with `-isystem` by default. 

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
