### PR TITLE
Fix 3331: `make_holder(...)` with `var_value<Matrix>` output now eagerly executes

### DIFF
--- a/stan/math/prim/meta/holder.hpp
+++ b/stan/math/prim/meta/holder.hpp
@@ -479,9 +479,13 @@ inline auto make_holder_impl(F&& func, std::index_sequence<Is...>,
 template <typename F, typename... Args,
           require_not_plain_type_t<std::invoke_result_t<F, Args&&...>>*>
 inline auto make_holder(F&& func, Args&&... args) {
-  return internal::make_holder_impl(std::forward<F>(func),
-                                    std::make_index_sequence<sizeof...(Args)>(),
-                                    std::forward<Args>(args)...);
+  if constexpr (is_var_matrix_v<std::invoke_result_t<F, Args&&...>>) {
+    return std::forward<F>(func)(std::forward<Args>(args)...);
+  } else {
+    return internal::make_holder_impl(std::forward<F>(func),
+                                      std::make_index_sequence<sizeof...(Args)>(),
+                                      std::forward<Args>(args)...);
+  }
 }
 
 /**

--- a/stan/math/prim/meta/holder.hpp
+++ b/stan/math/prim/meta/holder.hpp
@@ -482,9 +482,9 @@ inline auto make_holder(F&& func, Args&&... args) {
   if constexpr (is_var_matrix_v<std::invoke_result_t<F, Args&&...>>) {
     return std::forward<F>(func)(std::forward<Args>(args)...);
   } else {
-    return internal::make_holder_impl(std::forward<F>(func),
-                                      std::make_index_sequence<sizeof...(Args)>(),
-                                      std::forward<Args>(args)...);
+    return internal::make_holder_impl(
+        std::forward<F>(func), std::make_index_sequence<sizeof...(Args)>(),
+        std::forward<Args>(args)...);
   }
 }
 

--- a/stan/math/prim/meta/is_var_matrix.hpp
+++ b/stan/math/prim/meta/is_var_matrix.hpp
@@ -19,6 +19,8 @@ struct is_var_matrix
     : bool_constant<
           math::conjunction<is_var<T>, is_eigen<value_type_t<T>>>::value> {};
 
+template <typename T>
+inline constexpr bool is_var_matrix_v = is_var_matrix<std::decay_t<T>>::value;
 /*! \ingroup require_eigens_types */
 /*! \defgroup var_matrix_types var_matrix  */
 /*! \addtogroup var_matrix_types */

--- a/test/unit/math/rev/fun/transpose_test.cpp
+++ b/test/unit/math/rev/fun/transpose_test.cpp
@@ -1,0 +1,27 @@
+#include <stan/math/rev.hpp>
+#include <test/unit/math/rev/util.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/rev/fun/util.hpp>
+
+// Reproduces a compile error: calling `transpose` on a `var_value` that holds
+// a non-plain Eigen expression (e.g. a row/block of a `var_value` matrix). The
+// resulting `var_value<Eigen::Transpose<...>>` is not a plain type, so
+// `make_holder` tries to wrap the `var_value` in an Eigen `Holder` expression,
+// which fails because `var_value` has no `StorageKind`.
+TEST_F(AgradRev, RevMatrix_transpose_var_block) {
+  using stan::math::transpose;
+  using stan::math::var_value;
+
+  Eigen::MatrixXd m(2, 3);
+  m << 1, 2, 3, 4, 5, 6;
+  var_value<Eigen::MatrixXd> m_vv(m);
+
+  // m_vv.row(0) is a var_value<Eigen::Block<Eigen::Map<...>>>
+  auto rt = transpose(m_vv.row(0));
+
+  EXPECT_EQ(3, rt.rows());
+  EXPECT_EQ(1, rt.cols());
+  EXPECT_FLOAT_EQ(1, rt.val()(0));
+  EXPECT_FLOAT_EQ(2, rt.val()(1));
+  EXPECT_FLOAT_EQ(3, rt.val()(2));
+}


### PR DESCRIPTION

## Summary

Fixes #3331 

The new test for `transpose` shows the errror, but we had incorrect type deduction in `make_holder(...);`. When the output of the function is a `var_value<View<Matrix>>` we should always eagerly evaluate. This is safe since the memory for the SoA matrix is on the stack, so any views will be safe for the forward and reverse pass. 

## Tests

Test added that shows the error

```bash
./runTests.py test/unit/math/rev/fun/transpose_test.cpp
```

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
