### PR TITLE
Enable backwards-compatibility with Eigen < 5

### DIFF
--- a/stan/math/fwd/fun/Eigen_NumTraits.hpp
+++ b/stan/math/fwd/fun/Eigen_NumTraits.hpp
@@ -218,6 +218,7 @@ struct ScalarBinaryOpTraits<std::complex<stan::math::fvar<T>>,
 
 namespace internal {
 
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
 /**
  * Partial specialization of Eigen's ternary evaluator for `.select()`
  * expressions on matrices of `fvar<T>`, restoring the lazy (Eigen 3.x)
@@ -247,6 +248,7 @@ struct ternary_evaluator<
       Arg1, Arg2, Arg3>;
   using Base::Base;
 };
+#endif
 
 }  // namespace internal
 

--- a/stan/math/prim/meta/lazy_select_evaluator.hpp
+++ b/stan/math/prim/meta/lazy_select_evaluator.hpp
@@ -71,11 +71,11 @@ struct lazy_select_evaluator
                    & static_cast<int>(Arg3Flags)
                    & (StorageOrdersAgree ? Eigen::LinearAccessBit : 0))),
     Flags = (Flags0 & ~Eigen::RowMajorBit) | (Arg1Flags & Eigen::RowMajorBit),
-    Alignment = Eigen::internal::plain_enum_min(
-        Eigen::internal::plain_enum_min(
-            Eigen::internal::evaluator<Arg1>::Alignment,
-            Eigen::internal::evaluator<Arg2>::Alignment),
-        Eigen::internal::evaluator<Arg3>::Alignment)
+    Alignment = std::min({
+      static_cast<int>(Eigen::internal::evaluator<Arg1>::Alignment),
+      static_cast<int>(Eigen::internal::evaluator<Arg2>::Alignment),
+      static_cast<int>(Eigen::internal::evaluator<Arg3>::Alignment)
+    })
   };
 
   EIGEN_DEVICE_FUNC explicit lazy_select_evaluator(const XprType& xpr)

--- a/stan/math/prim/meta/lazy_select_evaluator.hpp
+++ b/stan/math/prim/meta/lazy_select_evaluator.hpp
@@ -71,11 +71,10 @@ struct lazy_select_evaluator
                    & static_cast<int>(Arg3Flags)
                    & (StorageOrdersAgree ? Eigen::LinearAccessBit : 0))),
     Flags = (Flags0 & ~Eigen::RowMajorBit) | (Arg1Flags & Eigen::RowMajorBit),
-    Alignment = std::min({
-      static_cast<int>(Eigen::internal::evaluator<Arg1>::Alignment),
-      static_cast<int>(Eigen::internal::evaluator<Arg2>::Alignment),
-      static_cast<int>(Eigen::internal::evaluator<Arg3>::Alignment)
-    })
+    Alignment
+    = std::min({static_cast<int>(Eigen::internal::evaluator<Arg1>::Alignment),
+                static_cast<int>(Eigen::internal::evaluator<Arg2>::Alignment),
+                static_cast<int>(Eigen::internal::evaluator<Arg3>::Alignment)})
   };
 
   EIGEN_DEVICE_FUNC explicit lazy_select_evaluator(const XprType& xpr)

--- a/stan/math/rev/core/Eigen_NumTraits.hpp
+++ b/stan/math/rev/core/Eigen_NumTraits.hpp
@@ -269,6 +269,7 @@ struct ScalarBinaryOpTraits<std::complex<stan::math::var>,
 
 namespace internal {
 
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
 /**
  * Partial specialization of Eigen's ternary evaluator for `.select()`
  * expressions on matrices of `var`, restoring the lazy (Eigen 3.x)
@@ -299,6 +300,7 @@ struct ternary_evaluator<
       Arg1, Arg2, Arg3>;
   using Base::Base;
 };
+#endif
 
 /**
  * Enable linear access of inputs when using read_vi_val_adj.


### PR DESCRIPTION
## Summary

The development version of `rstan` is currently failing to build since `RcppEigen` is still a few versions behind (see [this issue](https://github.com/stan-dev/rstan/issues/1186)). The culprit is some of the new fancy ternary handling, which can be simply gated behind a preprocessor macro until `RcppEigen` updates.

## Tests

N/A - Existing tests should still pass

## Side Effects

N/A

## Release notes

Restored compatibility with Eigen < 5

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
