### PR TITLE
Force rep_matrix to always return column-major matrices

### DIFF
--- a/stan/math/prim/fun/rep_matrix.hpp
+++ b/stan/math/prim/fun/rep_matrix.hpp
@@ -47,11 +47,12 @@ inline auto rep_matrix(const T& x, int m, int n) {
  * vector.
  * @tparam Vec An Eigen vector.
  * @param x An Eigen vector. For Row vectors the values are replicated rowwise.
- * and for column vectors the values are repliacated colwise.
+ * and for column vectors the values are replicated colwise.
  * @param n Number of rows or columns.
  */
 template <typename Vec, require_eigen_vector_t<Vec>* = nullptr>
-inline auto rep_matrix(const Vec& x, int n) {
+inline Eigen::Matrix<scalar_type_t<Vec>, -1, -1> rep_matrix(const Vec& x,
+                                                            int n) {
   if constexpr (is_eigen_row_vector<Vec>::value) {
     check_nonnegative("rep_matrix", "rows", n);
     return x.replicate(n, 1);

--- a/test/unit/math/prim/fun/rep_matrix_test.cpp
+++ b/test/unit/math/prim/fun/rep_matrix_test.cpp
@@ -52,3 +52,15 @@ TEST(MathMatrixPrimMat, rep_matrix_row_vec) {
 
   EXPECT_THROW(rep_matrix(rv, -1), std::domain_error);
 }
+
+TEST(MathMatrixPrimMat, rep_matrix_both_ways) {
+  using stan::math::rep_matrix;
+
+  Eigen::Matrix<double, 1, Eigen::Dynamic> rv(3);
+  rv << 1.0, 4.0, 9.0;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> v(3);
+  v << 1.0, 4.0, 9.0;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x(3, 3);
+  x = true ? rep_matrix(v, 3) : rep_matrix(rv, 3);
+}


### PR DESCRIPTION
## Summary

Closes #3341. rep_matrix, when supplied with a row vector, could return a row-major matrix. This is assignable to a normal matrix, so it mostly was invisible, except in the case of it being in a ternary with a normal matrix; because the assignability goes both ways, the compiler doesn't know which one to select and errors.

## Tests

Added a reduced version of the repex based on the code the compiler generated for #3341

## Side Effects
None
## Release notes

Fixed an issue with rep_matrix sometimes returning a row-major matrix.

## Checklist

- [x] Copyright holder: Simons Foundation

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
