### PR TITLE
Allow select to return eigen expressions if both branches match

### DIFF
--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -8,15 +8,16 @@
 
 namespace stan {
 namespace math {
-  namespace internal {
-    template <typename T_true, typename T_false, typename = void>
-    struct is_default_ternary : std::false_type {};
+namespace internal {
+template <typename T_true, typename T_false, typename = void>
+struct is_default_ternary : std::false_type {};
 
-    template <typename T_true, typename T_false>
-    struct is_default_ternary<T_true, T_false, std::void_t<
-        decltype(true ? std::declval<T_true>() : std::declval<T_false>())
-    >> : std::true_type {};
-  }
+template <typename T_true, typename T_false>
+struct is_default_ternary<T_true, T_false,
+                          std::void_t<decltype(true ? std::declval<T_true>()
+                                                    : std::declval<T_false>())>>
+    : std::true_type {};
+}  // namespace internal
 
 /**
  * If first argument is true return the second argument,
@@ -63,10 +64,9 @@ template <
     typename T_true_plain = promote_scalar_t<T_return, plain_type_t<T_true>>,
     typename T_false_plain = promote_scalar_t<T_return, plain_type_t<T_false>>,
     require_not_t<internal::is_default_ternary<T_true, T_false>>* = nullptr,
-    require_any_t<
-      conjunction<is_container<T_true>, is_container<T_false>>,
-      conjunction<is_stan_scalar<T_true>, is_stan_scalar<T_false>>
-    >* = nullptr,
+    require_any_t<conjunction<is_container<T_true>, is_container<T_false>>,
+                  conjunction<is_stan_scalar<T_true>,
+                              is_stan_scalar<T_false>>>* = nullptr,
     require_all_same_t<T_true_plain, T_false_plain>* = nullptr>
 inline T_true_plain select(const bool c, T_true&& y_true, T_false&& y_false) {
   if constexpr (is_container_v<T_true_plain>) {

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -14,32 +14,32 @@ namespace math {
  *
  * `select(c, y1, y0) = c ? y1 : y0`.
  *
- * @tparam T_true A stan `Scalar` type
- * @tparam T_false A stan `Scalar` type
+ * @tparam ArgT Argument type, can be any type
  * @param c Boolean condition value.
  * @param y_true Value to return if condition is true.
  * @param y_false Value to return if condition is false.
  */
-template <typename T_true, typename T_false,
-          typename ReturnT = return_type_t<T_true, T_false>,
-          require_all_stan_scalar_t<T_true, T_false>* = nullptr>
-inline ReturnT select(const bool c, const T_true y_true,
-                      const T_false y_false) {
-  return c ? ReturnT(y_true) : ReturnT(y_false);
+template <typename ArgT>
+inline auto select(const bool c, ArgT&& y_true, ArgT&& y_false) {
+  if constexpr (is_container_v<ArgT>) {
+    check_matching_dims("select", "left hand side", y_true, "right hand side",
+                        y_false);
+  }
+  return c ? std::forward<ArgT>(y_true) : std::forward<ArgT>(y_false);
 }
 
 /**
  * If first argument is true return the second argument,
- * else return the third argument. Eigen expressions are
- * evaluated so that the return type is the same for both branches.
+ * else return the third argument. If the two branches have
+ * different types, but matching plain types (e.g., Eigen expressions),
+ * the return type is the plain type and the expression is evaluated.
  *
- * Both containers must have the same plain type. The scalar type
+ * Both branches must have the same plain type. The scalar type
  * of the return is determined by the return_type_t<> type trait.
  *
- * Overload for use with two containers.
- *
- * @tparam T_true A container of stan `Scalar` types
- * @tparam T_false A container of stan `Scalar` types
+ * @tparam T_true Type of first argument, can be any type
+ * @tparam T_false Type of second argument, can be any type
+ *   (with the same plain type as T_true)
  * @param c Boolean condition value.
  * @param y_true Value to return if condition is true.
  * @param y_false Value to return if condition is false.
@@ -49,41 +49,15 @@ template <
     typename T_return = return_type_t<T_true, T_false>,
     typename T_true_plain = promote_scalar_t<T_return, plain_type_t<T_true>>,
     typename T_false_plain = promote_scalar_t<T_return, plain_type_t<T_false>>,
-    require_all_container_t<T_true, T_false>* = nullptr,
     require_all_not_same_t<T_true, T_false>* = nullptr,
     require_all_same_t<T_true_plain, T_false_plain>* = nullptr>
 inline T_true_plain select(const bool c, T_true&& y_true, T_false&& y_false) {
-  check_matching_dims("select", "left hand side", y_true, "right hand side",
-                      y_false);
+  if constexpr (is_container_v<T_true_plain>) {
+    check_matching_dims("select", "left hand side", y_true, "right hand side",
+                        y_false);
+  }
   return c ? T_true_plain(std::forward<T_true>(y_true))
            : T_true_plain(std::forward<T_false>(y_false));
-}
-
-/**
- * If first argument is true return the second argument,
- * else return the third argument. Eigen expressions are
- * evaluated so that the return type is the same for both branches.
- *
- * Both containers must have the same plain type. The scalar type
- * of the return is determined by the return_type_t<> type trait.
- *
- * Overload for use with two containers.
- *
- * @tparam T_true A container of stan `Scalar` types
- * @tparam T_false A container of stan `Scalar` types
- * @param c Boolean condition value.
- * @param y_true Value to return if condition is true.
- * @param y_false Value to return if condition is false.
- */
-template <
-    typename T_true, typename T_false,
-    require_all_container_t<T_true, T_false>* = nullptr,
-    require_all_same_t<T_true, T_false>* = nullptr>
-inline auto select(const bool c, T_true&& y_true, T_false&& y_false) {
-  check_matching_dims("select", "left hand side", y_true, "right hand side",
-                      y_false);
-  return c ? std::forward<T_true>(y_true)
-           : std::forward<T_false>(y_false);
 }
 
 /**

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -50,12 +50,40 @@ template <
     typename T_true_plain = promote_scalar_t<T_return, plain_type_t<T_true>>,
     typename T_false_plain = promote_scalar_t<T_return, plain_type_t<T_false>>,
     require_all_container_t<T_true, T_false>* = nullptr,
+    require_all_not_same_t<T_true, T_false>* = nullptr,
     require_all_same_t<T_true_plain, T_false_plain>* = nullptr>
 inline T_true_plain select(const bool c, T_true&& y_true, T_false&& y_false) {
   check_matching_dims("select", "left hand side", y_true, "right hand side",
                       y_false);
   return c ? T_true_plain(std::forward<T_true>(y_true))
            : T_true_plain(std::forward<T_false>(y_false));
+}
+
+/**
+ * If first argument is true return the second argument,
+ * else return the third argument. Eigen expressions are
+ * evaluated so that the return type is the same for both branches.
+ *
+ * Both containers must have the same plain type. The scalar type
+ * of the return is determined by the return_type_t<> type trait.
+ *
+ * Overload for use with two containers.
+ *
+ * @tparam T_true A container of stan `Scalar` types
+ * @tparam T_false A container of stan `Scalar` types
+ * @param c Boolean condition value.
+ * @param y_true Value to return if condition is true.
+ * @param y_false Value to return if condition is false.
+ */
+template <
+    typename T_true, typename T_false,
+    require_all_container_t<T_true, T_false>* = nullptr,
+    require_all_same_t<T_true, T_false>* = nullptr>
+inline auto select(const bool c, T_true&& y_true, T_false&& y_false) {
+  check_matching_dims("select", "left hand side", y_true, "right hand side",
+                      y_false);
+  return c ? std::forward<T_true>(y_true)
+           : std::forward<T_false>(y_false);
 }
 
 /**

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -4,9 +4,19 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/functor/apply_scalar_binary.hpp>
+#include <stan/math/prim/meta/conjunction.hpp>
 
 namespace stan {
 namespace math {
+  namespace internal {
+    template <typename T_true, typename T_false, typename = void>
+    struct is_default_ternary : std::false_type {};
+
+    template <typename T_true, typename T_false>
+    struct is_default_ternary<T_true, T_false, std::void_t<
+        decltype(true ? std::declval<T_true>() : std::declval<T_false>())
+    >> : std::true_type {};
+  }
 
 /**
  * If first argument is true return the second argument,
@@ -22,10 +32,9 @@ namespace math {
  * @param y_false Value to return if condition is false.
  */
 template <typename T_true, typename T_false,
-          typename CommonT = std::common_type_t<T_true, T_false>,
-          require_not_t<std::is_void<CommonT>>* = nullptr>
+          require_t<internal::is_default_ternary<T_true, T_false>>* = nullptr>
 inline auto select(const bool c, T_true&& y_true, T_false&& y_false) {
-  if constexpr (is_container_v<CommonT>) {
+  if constexpr (is_container_v<T_true> || is_container_v<T_false>) {
     check_matching_dims("select", "left hand side", y_true, "right hand side",
                         y_false);
   }
@@ -53,7 +62,11 @@ template <
     typename T_return = return_type_t<T_true, T_false>,
     typename T_true_plain = promote_scalar_t<T_return, plain_type_t<T_true>>,
     typename T_false_plain = promote_scalar_t<T_return, plain_type_t<T_false>>,
-    require_t<std::is_void<std::common_type_t<T_true, T_false>>>* = nullptr,
+    require_not_t<internal::is_default_ternary<T_true, T_false>>* = nullptr,
+    require_any_t<
+      conjunction<is_container<T_true>, is_container<T_false>>,
+      conjunction<is_stan_scalar<T_true>, is_stan_scalar<T_false>>
+    >* = nullptr,
     require_all_same_t<T_true_plain, T_false_plain>* = nullptr>
 inline T_true_plain select(const bool c, T_true&& y_true, T_false&& y_false) {
   if constexpr (is_container_v<T_true_plain>) {

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -14,18 +14,22 @@ namespace math {
  *
  * `select(c, y1, y0) = c ? y1 : y0`.
  *
- * @tparam ArgT Argument type, can be any type
+ * @tparam T_true Type of first argument, can be any type
+ * @tparam T_false Type of second argument, can be any type
+ *   convertible with the first
  * @param c Boolean condition value.
  * @param y_true Value to return if condition is true.
  * @param y_false Value to return if condition is false.
  */
-template <typename ArgT>
-inline auto select(const bool c, ArgT&& y_true, ArgT&& y_false) {
-  if constexpr (is_container_v<ArgT>) {
+template <typename T_true, typename T_false,
+          typename CommonT = std::common_type_t<T_true, T_false>,
+          require_not_t<std::is_void<CommonT>>* = nullptr>
+inline auto select(const bool c, T_true&& y_true, T_false&& y_false) {
+  if constexpr (is_container_v<CommonT>) {
     check_matching_dims("select", "left hand side", y_true, "right hand side",
                         y_false);
   }
-  return c ? std::forward<ArgT>(y_true) : std::forward<ArgT>(y_false);
+  return c ? std::forward<T_true>(y_true) : std::forward<T_false>(y_false);
 }
 
 /**
@@ -49,7 +53,7 @@ template <
     typename T_return = return_type_t<T_true, T_false>,
     typename T_true_plain = promote_scalar_t<T_return, plain_type_t<T_true>>,
     typename T_false_plain = promote_scalar_t<T_return, plain_type_t<T_false>>,
-    require_all_not_same_t<T_true, T_false>* = nullptr,
+    require_t<std::is_void<std::common_type_t<T_true, T_false>>>* = nullptr,
     require_all_same_t<T_true_plain, T_false_plain>* = nullptr>
 inline T_true_plain select(const bool c, T_true&& y_true, T_false&& y_false) {
   if constexpr (is_container_v<T_true_plain>) {

--- a/test/unit/math/prim/fun/select_test.cpp
+++ b/test/unit/math/prim/fun/select_test.cpp
@@ -202,3 +202,18 @@ TEST(MathFunctions, select_array_bool) {
   EXPECT_THROW(select(val < 0, b_array_short, b_array_short),
                std::invalid_argument);
 }
+
+TEST(MathFunction, select_same_expression) {
+  using stan::math::select;
+  using VecReplT = Eigen::Replicate<Eigen::VectorXd, -1, -1>;
+  using VecTransT = Eigen::Transpose<Eigen::VectorXd>;
+
+  Eigen::VectorXd v(3);
+  v << 1.0, 4.0, 9.0;
+
+  VecReplT repl_expr = stan::math::rep_matrix(v, 3);
+  VecTransT trans_expr = stan::math::transpose(v);
+
+  VecReplT replicated_v = select(true, repl_expr, repl_expr);
+  VecTransT transp_v = select(false, trans_expr, trans_expr);
+}

--- a/test/unit/math/prim/fun/select_test.cpp
+++ b/test/unit/math/prim/fun/select_test.cpp
@@ -204,8 +204,8 @@ TEST(MathFunctions, select_array_bool) {
 }
 
 TEST(MathFunction, select_same_expression) {
-  using stan::math::select;
   using stan::math::rep_matrix;
+  using stan::math::select;
   using VecReplT = Eigen::Replicate<Eigen::VectorXd, -1, -1>;
   using VecTransT = Eigen::Transpose<Eigen::VectorXd>;
 

--- a/test/unit/math/prim/fun/select_test.cpp
+++ b/test/unit/math/prim/fun/select_test.cpp
@@ -205,13 +205,18 @@ TEST(MathFunctions, select_array_bool) {
 
 TEST(MathFunction, select_same_expression) {
   using stan::math::select;
+  using stan::math::rep_matrix;
   using VecReplT = Eigen::Replicate<Eigen::VectorXd, -1, -1>;
   using VecTransT = Eigen::Transpose<Eigen::VectorXd>;
 
   Eigen::VectorXd v(3);
   v << 1.0, 4.0, 9.0;
+  Eigen::RowVectorXd rv(3);
+  rv << 1.0, 4.0, 9.0;
 
-  VecReplT repl_expr = stan::math::rep_matrix(v, 3);
+  Eigen::MatrixXd rtn = select(true, rep_matrix(v, 3), rep_matrix(rv, 3));
+
+  VecReplT repl_expr = rep_matrix(v, 3);
   VecTransT trans_expr = stan::math::transpose(v);
 
   VecReplT replicated_v = select(true, repl_expr, repl_expr);


### PR DESCRIPTION
## Summary

Updates the `select()` function to support returning Eigen expressions as long as the same expression type is passed for both branches.

## Tests

Extra tests for expression returns have been added

## Side Effects

N/A

## Release notes

The `select()` function will now return eigen expressions without evaluation if both expression types match

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
