### PR TITLE
Rename `laplace_latent_tol_solve` to `laplace_latent_solve_tol`

### DIFF
--- a/stan/math/mix/prob/laplace_latent_solve.hpp
+++ b/stan/math/mix/prob/laplace_latent_solve.hpp
@@ -35,7 +35,7 @@ struct laplace_unused_rng {};
  */
 template <typename LLFunc, typename LLArgs, typename CovarFun,
           typename CovarArgs, typename OpsTuple>
-inline auto laplace_latent_tol_solve(LLFunc&& ll_fun, LLArgs&& ll_args,
+inline auto laplace_latent_solve_tol(LLFunc&& ll_fun, LLArgs&& ll_args,
                                      int hessian_block_size,
                                      CovarFun&& covariance_function,
                                      CovarArgs&& covar_args, OpsTuple&& ops,

--- a/test/unit/math/laplace/laplace_latent_solve_test.cpp
+++ b/test/unit/math/laplace/laplace_latent_solve_test.cpp
@@ -36,14 +36,14 @@ TEST_F(laplace_count_two_dim_diag_test, latent_solve_mean_and_cov) {
   EXPECT_NEAR(K_laplace(1, 0), Sigma_est(1, 0), tol);
 }
 
-TEST_F(laplace_count_two_dim_diag_test, latent_tol_solve_mean_and_cov) {
-  using stan::math::laplace_latent_tol_solve;
+TEST_F(laplace_count_two_dim_diag_test, latent_solve_tol_mean_and_cov) {
+  using stan::math::laplace_latent_solve_tol;
   constexpr double tolerance = 1e-12;
   constexpr int max_num_steps = 1000;
   constexpr int hessian_block_size = 1;
   constexpr int solver = 1;
   constexpr int max_steps_line_search = 0;
-  auto [mean_est, chol_est] = laplace_latent_tol_solve(
+  auto [mean_est, chol_est] = laplace_latent_solve_tol(
       poisson_log_likelihood{}, std::forward_as_tuple(y), hessian_block_size,
       stan::math::test::diagonal_kernel_functor{},
       std::forward_as_tuple(phi(0), phi(1)),


### PR DESCRIPTION
## Summary

This PR is a follow-up of #3337 and fixes a naming issue. Specifically, it changes the function name `laplace_latent_tol_solve` to `laplace_latent_solve_tol`. This change should ensure naming consistency. For completeness also the test-case name has been changed.

## Tests

I only ensured that the tests for the function run successfully but I have not implemented any new tests.

## Side Effects

I am not aware of any.

## Release notes

+ Rename `laplace_latent_tol_solve` to `laplace_latent_solve_tol`

## Checklist

- [x] Copyright holder: Aalto University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- ~[ ] the new changes are tested~
