### PR TITLE
Add map-like helpers

### DIFF
--- a/stan/math/prim/err/check_consistent_sizes.hpp
+++ b/stan/math/prim/err/check_consistent_sizes.hpp
@@ -1,8 +1,10 @@
 #ifndef STAN_MATH_PRIM_ERR_CHECK_CONSISTENT_SIZES_HPP
 #define STAN_MATH_PRIM_ERR_CHECK_CONSISTENT_SIZES_HPP
 
+#include <stan/math/prim/err/check_matching_sizes.hpp>
 #include <stan/math/prim/err/invalid_argument.hpp>
 #include <stan/math/prim/fun/size.hpp>
+#include <stan/math/prim/meta/is_container.hpp>
 #include <stan/math/prim/meta/require_generics.hpp>
 #include <algorithm>
 #include <sstream>
@@ -64,6 +66,34 @@ inline void check_consistent_sizes(const char* function, const char* name1,
                        "has size = ", msg_str.c_str());
     }();
   }
+}
+
+/**
+ * Check that the unnamed container inputs have the same size. Inputs are
+ * labeled `arg1`, `arg2`, and so on in error messages.
+ *
+ * @tparam T type of the first input
+ * @tparam Types types of the remaining inputs
+ * @param function function name (for error messages)
+ * @param x first input
+ * @param xs remaining inputs
+ * @throw `invalid_argument` if sizes are inconsistent
+ */
+template <typename T, typename... Types,
+          require_all_container_t<T, Types...>* = nullptr>
+inline void check_consistent_sizes(const char* function, T&& x, Types&&... xs) {
+  std::size_t arg_idx = 2;
+  (
+      [&](const auto& y) {
+        if (x.size() != y.size()) {
+          [&]() STAN_COLD_PATH {
+            const std::string name = "arg" + std::to_string(arg_idx);
+            check_matching_sizes(function, "arg1", x, name.c_str(), y);
+          }();
+        }
+        ++arg_idx;
+      }(xs),
+      ...);
 }
 
 }  // namespace math

--- a/stan/math/prim/err/check_matching_dims.hpp
+++ b/stan/math/prim/err/check_matching_dims.hpp
@@ -155,6 +155,35 @@ inline void check_matching_dims(const char* function, const char* name1,
   check_matching_dims(function, name1, y1, name2, y2);
 }
 
+/**
+ * Check that the unnamed Eigen inputs have the same dimensions. Inputs are
+ * labeled `arg1`, `arg2`, and so on in error messages.
+ *
+ * @tparam T type of the first input
+ * @tparam Types types of the remaining inputs
+ * @param function function name (for error messages)
+ * @param x first input
+ * @param xs remaining inputs
+ * @throw `invalid_argument` if dimensions do not match
+ */
+template <typename T, typename... Types,
+          require_all_eigen_t<T, Types...>* = nullptr>
+inline void check_matching_dims(const char* function, const T& x,
+                                const Types&... xs) {
+  std::size_t arg_idx = 2;
+  (
+      [&](const auto& y) {
+        if (x.rows() != y.rows() || x.cols() != y.cols()) {
+          [&]() STAN_COLD_PATH {
+            const std::string name = "arg" + std::to_string(arg_idx);
+            check_matching_dims(function, "arg1", x, name.c_str(), y);
+          }();
+        }
+        ++arg_idx;
+      }(xs),
+      ...);
+}
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/functor.hpp
+++ b/stan/math/prim/functor.hpp
@@ -23,6 +23,7 @@
 #include <stan/math/prim/functor/ode_ckrk.hpp>
 #include <stan/math/prim/functor/ode_rk45.hpp>
 #include <stan/math/prim/functor/ode_store_sensitivities.hpp>
+#include <stan/math/prim/functor/map.hpp>
 #include <stan/math/prim/functor/map_if.hpp>
 #include <stan/math/prim/functor/map_rect.hpp>
 #include <stan/math/prim/functor/map_rect_combine.hpp>

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -260,8 +260,8 @@ inline auto row_mapN(F&& f, Types&&... args) {
 
   auto m_refs = std::tuple{to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_rows = std::get<0>(m_refs).rows();
-  using result_row_t = plain_type_t<decltype(f(
-      (std::declval<ref_type_t<Types&&>>().row(0))...))>;
+  using result_row_t = plain_type_t<decltype(
+      f((std::declval<ref_type_t<Types&&>>().row(0))...))>;
   using T_return = scalar_type_t<result_row_t>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
 
@@ -324,8 +324,8 @@ inline auto col_mapN(F&& f, Types&&... args) {
 
   auto m_refs = std::tuple{to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_cols = std::get<0>(m_refs).cols();
-  using result_col_t = plain_type_t<decltype(f(
-      (std::declval<ref_type_t<Types&&>>().col(0))...))>;
+  using result_col_t = plain_type_t<decltype(
+      f((std::declval<ref_type_t<Types&&>>().col(0))...))>;
   using T_return = scalar_type_t<result_col_t>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
   if (n_cols == 0) {

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -4,8 +4,8 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err/check_consistent_sizes.hpp>
 #include <stan/math/prim/err/check_matching_dims.hpp>
-#include <stan/math/prim/err/check_matching_sizes.hpp>
 #include <stan/math/prim/err/check_size_match.hpp>
 #include <stan/math/prim/functor/apply.hpp>
 
@@ -22,23 +22,6 @@ namespace math {
 namespace internal {
 
 template <typename T, typename... Types>
-inline void check_all_matching_sizes(const char* function, const T& x,
-                                     const Types&... xs) {
-  std::size_t arg_idx = 2;
-  (
-      [&](const auto& y) {
-        if (x.size() != y.size()) {
-          [&]() STAN_COLD_PATH {
-            const std::string name = "x" + std::to_string(arg_idx);
-            check_matching_sizes(function, "x1", x, name.c_str(), y);
-          }();
-        }
-        ++arg_idx;
-      }(xs),
-      ...);
-}
-
-template <typename T, typename... Types>
 inline void check_all_matching_dims(const char* function, const T& x,
                                     const Types&... xs) {
   std::size_t arg_idx = 2;
@@ -53,36 +36,6 @@ inline void check_all_matching_dims(const char* function, const T& x,
         ++arg_idx;
       }(xs),
       ...);
-}
-
-template <typename T_scalar, typename T>
-inline void assign_matrix_row(
-    const char* function,
-    Eigen::Matrix<T_scalar, Eigen::Dynamic, Eigen::Dynamic>& result,
-    Eigen::Index i, T&& x) {
-  if (i == 0) {
-    result = Eigen::Matrix<T_scalar, Eigen::Dynamic, Eigen::Dynamic>(
-        result.rows(), x.cols());
-  } else {
-    check_size_match(function, "columns of result", result.cols(),
-                     "columns of returned row", x.cols());
-  }
-  result.row(i) = std::forward<T>(x);
-}
-
-template <typename T_scalar, typename T>
-inline void assign_matrix_col(
-    const char* function,
-    Eigen::Matrix<T_scalar, Eigen::Dynamic, Eigen::Dynamic>& result,
-    Eigen::Index j, T&& x) {
-  if (j == 0) {
-    result = Eigen::Matrix<T_scalar, Eigen::Dynamic, Eigen::Dynamic>(
-        x.rows(), result.cols());
-  } else {
-    check_size_match(function, "rows of result", result.rows(),
-                     "rows of returned column", x.rows());
-  }
-  result.col(j) = std::forward<T>(x);
 }
 
 }  // namespace internal
@@ -150,7 +103,7 @@ inline auto mapN(F&& f, Types&&... args) {
   static_assert(sizeof...(Types) >= 2,
                 "mapN requires at least two std::vector inputs.");
   static constexpr const char* function = "mapN";
-  internal::check_all_matching_sizes(function, args...);
+  check_consistent_sizes(function, args...);
 
   const std::size_t n = std::get<0>(std::forward_as_tuple(args...)).size();
   using T_return = std::decay_t<decltype(f((args[0])...))>;
@@ -170,7 +123,8 @@ inline auto mapN(F&& f, Types&&... args) {
  * For a matrix `m` with `n` rows, returns a matrix whose `i`-th row is
  * `f(m.row(i), args...)`. Additional arguments are shared across calls. If
  * `m` has zero rows, returns a 0x0 matrix (output column count is unknown
- * when the functor is never called).
+ * when the functor is never called). If the first returned row is empty,
+ * returns a 0x0 matrix without calling the functor on the remaining rows.
  *
  * Expensive Eigen expressions passed as `m` are evaluated once via `to_ref`
  * before the row loop, so compound expressions (e.g. `A * B`) are not
@@ -193,8 +147,8 @@ template <typename F, typename T, typename... Args,
 inline auto row_map(F&& f, T&& m, Args&&... args) {
   static constexpr const char* function = "row_map";
   decltype(auto) m_ref = to_ref(std::forward<T>(m));
-  using T_return
-      = scalar_type_t<plain_type_t<decltype(f(m_ref.row(0), args...))>>;
+  using result_row_t = plain_type_t<decltype(f(m_ref.row(0), args...))>;
+  using T_return = scalar_type_t<result_row_t>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
 
   const Eigen::Index n_rows = m_ref.rows();
@@ -202,9 +156,17 @@ inline auto row_map(F&& f, T&& m, Args&&... args) {
     return matrix_t(0, 0);
   }
 
-  matrix_t result(n_rows, 0);
-  for (Eigen::Index i = 0; i < n_rows; ++i) {
-    internal::assign_matrix_row(function, result, i, f(m_ref.row(i), args...));
+  result_row_t first_row = f(m_ref.row(0), args...);
+  if (first_row.size() == 0) {
+    return matrix_t(0, 0);
+  }
+  matrix_t result(n_rows, first_row.cols());
+  result.row(0) = first_row;
+  for (Eigen::Index i = 1; i < n_rows; ++i) {
+    result_row_t row = f(m_ref.row(i), args...);
+    check_size_match(function, "columns of result", result.cols(),
+                     "columns of returned row", row.cols());
+    result.row(i) = row;
   }
   return result;
 }
@@ -215,7 +177,8 @@ inline auto row_map(F&& f, T&& m, Args&&... args) {
  * For a matrix `m` with `k` columns, returns a matrix whose `j`-th column is
  * `f(m.col(j), args...)`. Additional arguments are shared across calls. If
  * `m` has zero columns, returns a 0x0 matrix (output row count is unknown
- * when the functor is never called).
+ * when the functor is never called). If the first returned column is empty,
+ * returns a 0x0 matrix without calling the functor on the remaining columns.
  *
  * Expensive Eigen expressions passed as `m` are evaluated once via `to_ref`
  * before the column loop, so compound expressions (e.g. `A * B`) are not
@@ -238,8 +201,8 @@ template <typename F, typename T, typename... Args,
 inline auto col_map(F&& f, T&& m, Args&&... args) {
   static constexpr const char* function = "col_map";
   decltype(auto) m_ref = to_ref(std::forward<T>(m));
-  using T_return
-      = scalar_type_t<plain_type_t<decltype(f(m_ref.col(0), args...))>>;
+  using result_col_t = plain_type_t<decltype(f(m_ref.col(0), args...))>;
+  using T_return = scalar_type_t<result_col_t>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
 
   const Eigen::Index n_cols = m_ref.cols();
@@ -247,9 +210,17 @@ inline auto col_map(F&& f, T&& m, Args&&... args) {
     return matrix_t(0, 0);
   }
 
-  matrix_t result(0, n_cols);
-  for (Eigen::Index j = 0; j < n_cols; ++j) {
-    internal::assign_matrix_col(function, result, j, f(m_ref.col(j), args...));
+  result_col_t first_col = f(m_ref.col(0), args...);
+  if (first_col.size() == 0) {
+    return matrix_t(0, 0);
+  }
+  matrix_t result(first_col.rows(), n_cols);
+  result.col(0) = first_col;
+  for (Eigen::Index j = 1; j < n_cols; ++j) {
+    result_col_t col = f(m_ref.col(j), args...);
+    check_size_match(function, "rows of result", result.rows(),
+                     "rows of returned column", col.rows());
+    result.col(j) = col;
   }
   return result;
 }
@@ -259,7 +230,8 @@ inline auto col_map(F&& f, T&& m, Args&&... args) {
  *
  * For matrices `args...` with `n` rows, returns a matrix whose `i`-th row is
  * `f(args[0].row(i), args[1].row(i), ...)`. If the inputs have zero rows,
- * returns a 0x0 matrix.
+ * returns a 0x0 matrix. If the first returned row is empty, returns a 0x0
+ * matrix without calling the functor on the remaining rows.
  *
  * Unlike `row_map`, this overload only zips matrices and does not accept
  * additional shared trailing arguments.
@@ -286,26 +258,34 @@ inline auto row_mapN(F&& f, Types&&... args) {
   static constexpr const char* function = "row_mapN";
   internal::check_all_matching_dims(function, args...);
 
-  std::tuple<ref_type_t<Types&&>...> m_refs{
-      to_ref(std::forward<Types>(args))...};
+  auto m_refs = std::tuple{to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_rows = std::get<0>(m_refs).rows();
-  using T_return = scalar_type_t<plain_type_t<decltype(
-      f((std::declval<ref_type_t<Types&&>>().row(0))...))>>;
+  using result_row_t = plain_type_t<decltype(f(
+      (std::declval<ref_type_t<Types&&>>().row(0))...))>;
+  using T_return = scalar_type_t<result_row_t>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
 
   if (n_rows == 0) {
     return matrix_t(0, 0);
   }
 
-  matrix_t result(n_rows, 0);
-  apply(
+  return apply(
       [&](auto&&... ms) {
-        for (Eigen::Index i = 0; i < n_rows; ++i) {
-          internal::assign_matrix_row(function, result, i, f((ms.row(i))...));
+        result_row_t first_row = f((ms.row(0))...);
+        if (first_row.size() == 0) {
+          return matrix_t(0, 0);
         }
+        matrix_t result(n_rows, first_row.cols());
+        result.row(0) = first_row;
+        for (Eigen::Index i = 1; i < n_rows; ++i) {
+          result_row_t row = f((ms.row(i))...);
+          check_size_match(function, "columns of result", result.cols(),
+                           "columns of returned row", row.cols());
+          result.row(i) = row;
+        }
+        return result;
       },
       m_refs);
-  return result;
 }
 
 /**
@@ -313,7 +293,8 @@ inline auto row_mapN(F&& f, Types&&... args) {
  *
  * For matrices `args...` with `k` columns, returns a matrix whose `j`-th
  * column is `f(args[0].col(j), args[1].col(j), ...)`. If the inputs have
- * zero columns, returns a 0x0 matrix.
+ * zero columns, returns a 0x0 matrix. If the first returned column is empty,
+ * returns a 0x0 matrix without calling the functor on the remaining columns.
  *
  * Unlike `col_map`, this overload only zips matrices and does not accept
  * additional shared trailing arguments.
@@ -341,26 +322,32 @@ inline auto col_mapN(F&& f, Types&&... args) {
   static constexpr const char* function = "col_mapN";
   internal::check_all_matching_dims(function, args...);
 
-  std::tuple<ref_type_t<Types&&>...> m_refs{
-      to_ref(std::forward<Types>(args))...};
+  auto m_refs = std::tuple{to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_cols = std::get<0>(m_refs).cols();
-  using T_return = scalar_type_t<plain_type_t<decltype(
-      f((std::declval<ref_type_t<Types&&>>().col(0))...))>>;
+  using result_col_t = plain_type_t<decltype(f(
+      (std::declval<ref_type_t<Types&&>>().col(0))...))>;
+  using T_return = scalar_type_t<result_col_t>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
-
   if (n_cols == 0) {
     return matrix_t(0, 0);
   }
-
-  matrix_t result(0, n_cols);
-  apply(
+  return apply(
       [&](auto&&... ms) {
-        for (Eigen::Index j = 0; j < n_cols; ++j) {
-          internal::assign_matrix_col(function, result, j, f((ms.col(j))...));
+        result_col_t first_col = f((ms.col(0))...);
+        if (first_col.size() == 0) {
+          return matrix_t(0, 0);
         }
+        matrix_t result(first_col.rows(), n_cols);
+        result.col(0) = first_col;
+        for (Eigen::Index j = 1; j < n_cols; ++j) {
+          result_col_t col = f((ms.col(j))...);
+          check_size_match(function, "rows of result", result.rows(),
+                           "rows of returned column", col.rows());
+          result.col(j) = col;
+        }
+        return result;
       },
       m_refs);
-  return result;
 }
 
 }  // namespace math

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -26,8 +26,7 @@ inline decltype(auto) with_tuple_prefix(F& f, Tuple& tup, Callback&& callback) {
   return apply(
       [&](auto&&... tuple_args) -> decltype(auto) {
         auto prefixed_f = [&](auto&&... args) -> decltype(auto) {
-          return eval(
-              f(tuple_args..., std::forward<decltype(args)>(args)...));
+          return eval(f(tuple_args..., std::forward<decltype(args)>(args)...));
         };
         return std::forward<Callback>(callback)(prefixed_f);
       },

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -286,8 +286,8 @@ inline auto row_mapN(F&& f, Types&&... args) {
   std::tuple<ref_type_t<Types&&>...> m_refs{
       to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_rows = std::get<0>(m_refs).rows();
-  using T_return = scalar_type_t<plain_type_t<decltype(f(
-      (std::declval<ref_type_t<Types&&>>().row(0))...))>>;
+  using T_return = scalar_type_t<plain_type_t<decltype(
+      f((std::declval<ref_type_t<Types&&>>().row(0))...))>>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
 
   if (n_rows == 0) {
@@ -341,8 +341,8 @@ inline auto col_mapN(F&& f, Types&&... args) {
   std::tuple<ref_type_t<Types&&>...> m_refs{
       to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_cols = std::get<0>(m_refs).cols();
-  using T_return = scalar_type_t<plain_type_t<decltype(f(
-      (std::declval<ref_type_t<Types&&>>().col(0))...))>>;
+  using T_return = scalar_type_t<plain_type_t<decltype(
+      f((std::declval<ref_type_t<Types&&>>().col(0))...))>>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
 
   if (n_cols == 0) {

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -215,8 +215,8 @@ inline auto row_mapN(F&& f, Tuple&& ms, Args&&... args) {
         return apply(
             [&f, &args..., &n_rows](auto&&... mrs) {
               using matrix_t
-                  = Eigen::Matrix<scalar_type_t<plain_type_t<decltype(f(
-                                      (mrs.row(0))..., args...))>>,
+                  = Eigen::Matrix<scalar_type_t<plain_type_t<decltype(
+                                      f((mrs.row(0))..., args...))>>,
                                   Eigen::Dynamic, Eigen::Dynamic>;
 
               if (n_rows == 0) {
@@ -280,8 +280,8 @@ inline auto col_mapN(F&& f, Tuple&& ms, Args&&... args) {
         return apply(
             [&f, &args..., &n_cols](auto&&... mrs) {
               using matrix_t
-                  = Eigen::Matrix<scalar_type_t<plain_type_t<decltype(f(
-                                      (mrs.col(0))..., args...))>>,
+                  = Eigen::Matrix<scalar_type_t<plain_type_t<decltype(
+                                      f((mrs.col(0))..., args...))>>,
                                   Eigen::Dynamic, Eigen::Dynamic>;
 
               if (n_cols == 0) {

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -1,0 +1,366 @@
+#ifndef STAN_MATH_PRIM_FUNCTOR_MAP_HPP
+#define STAN_MATH_PRIM_FUNCTOR_MAP_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err/check_matching_dims.hpp>
+#include <stan/math/prim/err/check_matching_sizes.hpp>
+#include <stan/math/prim/err/check_size_match.hpp>
+#include <stan/math/prim/functor/apply.hpp>
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+namespace internal {
+
+template <typename T, typename... Types>
+inline void check_all_matching_sizes(const char* function, const T& x,
+                                     const Types&... xs) {
+  std::size_t arg_idx = 2;
+  (
+      [&](const auto& y) {
+        if (x.size() != y.size()) {
+          [&]() STAN_COLD_PATH {
+            const std::string name = "x" + std::to_string(arg_idx);
+            check_matching_sizes(function, "x1", x, name.c_str(), y);
+          }();
+        }
+        ++arg_idx;
+      }(xs),
+      ...);
+}
+
+template <typename T, typename... Types>
+inline void check_all_matching_dims(const char* function, const T& x,
+                                    const Types&... xs) {
+  std::size_t arg_idx = 2;
+  (
+      [&](const auto& y) {
+        if (x.rows() != y.rows() || x.cols() != y.cols()) {
+          [&]() STAN_COLD_PATH {
+            const std::string name = "x" + std::to_string(arg_idx);
+            check_matching_dims(function, "x1", x, name.c_str(), y);
+          }();
+        }
+        ++arg_idx;
+      }(xs),
+      ...);
+}
+
+template <typename T_scalar, typename T>
+inline void assign_matrix_row(
+    const char* function,
+    Eigen::Matrix<T_scalar, Eigen::Dynamic, Eigen::Dynamic>& result,
+    Eigen::Index i, T&& x) {
+  if (i == 0) {
+    result.resize(result.rows(), x.cols());
+  } else {
+    check_size_match(function, "columns of result", result.cols(),
+                     "columns of returned row", x.cols());
+  }
+  result.row(i) = std::forward<T>(x);
+}
+
+template <typename T_scalar, typename T>
+inline void assign_matrix_col(
+    const char* function,
+    Eigen::Matrix<T_scalar, Eigen::Dynamic, Eigen::Dynamic>& result,
+    Eigen::Index j, T&& x) {
+  if (j == 0) {
+    result.resize(x.rows(), result.cols());
+  } else {
+    check_size_match(function, "rows of result", result.rows(),
+                     "rows of returned column", x.rows());
+  }
+  result.col(j) = std::forward<T>(x);
+}
+
+}  // namespace internal
+
+/**
+ * Apply a functor to each element of a std::vector and collect the results.
+ *
+ * For a vector `x` of length `n`, returns a std::vector whose `i`-th element
+ * is `f(x[i], args...)`. Additional arguments are shared across calls, which
+ * allows passing parameters without closures. If `x` is empty, returns an
+ * empty std::vector.
+ *
+ * The element type of the returned std::vector is deduced from the return type
+ * of `f` to allow for cases where the input and return scalar types differ
+ * (e.g., functions implicitly promoting integers).
+ *
+ * @tparam F Type of functor to apply.
+ * @tparam T Type of input std::vector.
+ * @tparam Args Types of shared arguments passed to each call.
+ * @param f functor to apply to each element.
+ * @param x std::vector input to which operation is applied.
+ * @param args shared arguments passed to each call.
+ * @return std::vector with result of applying functor to each element of `x`.
+ */
+template <typename F, typename T, typename... Args,
+          require_std_vector_t<T>* = nullptr>
+inline auto map(F&& f, T&& x, Args&&... args) {
+  using T_return = std::decay_t<decltype(f(x[0], args...))>;
+  std::vector<T_return> result;
+  result.reserve(x.size());
+
+  for (auto&& xi : x) {
+    result.push_back(f(xi, args...));
+  }
+
+  return result;
+}
+
+/**
+ * Apply a functor elementwise to N std::vector inputs of the same size.
+ *
+ * For vectors `args...` of length `n`, returns a std::vector whose `i`-th
+ * element is `f(args[0][i], args[1][i], ...)`. If the inputs are empty,
+ * returns an empty std::vector.
+ *
+ * Unlike `map`, this overload only zips containers and does not accept
+ * additional shared trailing arguments. Pass shared state through the
+ * functor (e.g. a capturing lambda) when needed.
+ *
+ * The element type of the returned std::vector is deduced from the return type
+ * of `f` to allow for cases where the input and return scalar types differ
+ * (e.g., functions implicitly promoting integers).
+ *
+ * @tparam F Type of functor to apply.
+ * @tparam Types Types of input std::vector containers.
+ * @param f functor to apply to each tuple of elements.
+ * @param args std::vector inputs to which operation is applied.
+ * @return std::vector with result of applying functor to each tuple of
+ * elements.
+ * @throw std::invalid_argument if the inputs have different sizes.
+ */
+template <typename F, typename... Types,
+          require_all_std_vector_t<Types...>* = nullptr>
+inline auto mapN(F&& f, Types&&... args) {
+  static_assert(sizeof...(Types) >= 2,
+                "mapN requires at least two std::vector inputs.");
+  static constexpr const char* function = "mapN";
+  internal::check_all_matching_sizes(function, args...);
+
+  const std::size_t n = std::get<0>(std::forward_as_tuple(args...)).size();
+  using T_return = std::decay_t<decltype(f((args[0])...))>;
+  std::vector<T_return> result;
+  result.reserve(n);
+
+  for (std::size_t i = 0; i < n; ++i) {
+    result.push_back(f((args[i])...));
+  }
+
+  return result;
+}
+
+/**
+ * Apply a functor to each row of an Eigen matrix and collect the results.
+ *
+ * For a matrix `m` with `n` rows, returns a matrix whose `i`-th row is
+ * `f(m.row(i), args...)`. Additional arguments are shared across calls. If
+ * `m` has zero rows, returns a 0x0 matrix (output column count is unknown
+ * when the functor is never called).
+ *
+ * Expensive Eigen expressions passed as `m` are evaluated once via `to_ref`
+ * before the row loop, so compound expressions (e.g. `A * B`) are not
+ * re-evaluated for every row.
+ *
+ * The functor must return a type assignable to a matrix row. All returned
+ * rows must have the same number of columns.
+ *
+ * @tparam F Type of functor to apply.
+ * @tparam T Eigen matrix type.
+ * @tparam Args Types of shared arguments passed to each call.
+ * @param f functor to apply to each row.
+ * @param m Eigen matrix input to which operation is applied.
+ * @param args shared arguments passed to each call.
+ * @return Eigen matrix with result of applying functor to each row of `m`.
+ * @throw std::invalid_argument if returned rows have inconsistent sizes.
+ */
+template <typename F, typename T, typename... Args,
+          require_eigen_matrix_dynamic_t<T>* = nullptr>
+inline auto row_map(F&& f, T&& m, Args&&... args) {
+  static constexpr const char* function = "row_map";
+  decltype(auto) m_ref = to_ref(std::forward<T>(m));
+  using T_return
+      = scalar_type_t<plain_type_t<decltype(f(m_ref.row(0), args...))>>;
+  using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
+
+  const Eigen::Index n_rows = m_ref.rows();
+  if (n_rows == 0) {
+    return matrix_t(0, 0);
+  }
+
+  matrix_t result(n_rows, 0);
+  for (Eigen::Index i = 0; i < n_rows; ++i) {
+    internal::assign_matrix_row(function, result, i, f(m_ref.row(i), args...));
+  }
+  return result;
+}
+
+/**
+ * Apply a functor to each column of an Eigen matrix and collect the results.
+ *
+ * For a matrix `m` with `k` columns, returns a matrix whose `j`-th column is
+ * `f(m.col(j), args...)`. Additional arguments are shared across calls. If
+ * `m` has zero columns, returns a 0x0 matrix (output row count is unknown
+ * when the functor is never called).
+ *
+ * Expensive Eigen expressions passed as `m` are evaluated once via `to_ref`
+ * before the column loop, so compound expressions (e.g. `A * B`) are not
+ * re-evaluated for every column.
+ *
+ * The functor must return a type assignable to a matrix column. All returned
+ * columns must have the same number of rows.
+ *
+ * @tparam F Type of functor to apply.
+ * @tparam T Eigen matrix type.
+ * @tparam Args Types of shared arguments passed to each call.
+ * @param f functor to apply to each column.
+ * @param m Eigen matrix input to which operation is applied.
+ * @param args shared arguments passed to each call.
+ * @return Eigen matrix with result of applying functor to each column of `m`.
+ * @throw std::invalid_argument if returned columns have inconsistent sizes.
+ */
+template <typename F, typename T, typename... Args,
+          require_eigen_matrix_dynamic_t<T>* = nullptr>
+inline auto col_map(F&& f, T&& m, Args&&... args) {
+  static constexpr const char* function = "col_map";
+  decltype(auto) m_ref = to_ref(std::forward<T>(m));
+  using T_return
+      = scalar_type_t<plain_type_t<decltype(f(m_ref.col(0), args...))>>;
+  using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
+
+  const Eigen::Index n_cols = m_ref.cols();
+  if (n_cols == 0) {
+    return matrix_t(0, 0);
+  }
+
+  matrix_t result(0, n_cols);
+  for (Eigen::Index j = 0; j < n_cols; ++j) {
+    internal::assign_matrix_col(function, result, j, f(m_ref.col(j), args...));
+  }
+  return result;
+}
+
+/**
+ * Apply a functor rowwise to N Eigen matrices with identical dimensions.
+ *
+ * For matrices `args...` with `n` rows, returns a matrix whose `i`-th row is
+ * `f(args[0].row(i), args[1].row(i), ...)`. If the inputs have zero rows,
+ * returns a 0x0 matrix.
+ *
+ * Unlike `row_map`, this overload only zips matrices and does not accept
+ * additional shared trailing arguments.
+ *
+ * Expensive Eigen expressions in `args...` are each evaluated once via
+ * `to_ref` before the row loop.
+ *
+ * The functor must return a type assignable to a matrix row. All returned
+ * rows must have the same number of columns.
+ *
+ * @tparam F Type of functor to apply.
+ * @tparam Types Eigen matrix types.
+ * @param f functor to apply to each tuple of rows.
+ * @param args Eigen matrix inputs to which operation is applied.
+ * @return Eigen matrix with result of applying functor to each tuple of rows.
+ * @throw std::invalid_argument if the inputs have different dimensions or
+ * returned rows have inconsistent sizes.
+ */
+template <typename F, typename... Types,
+          require_all_eigen_matrix_dynamic_t<Types...>* = nullptr>
+inline auto row_mapN(F&& f, Types&&... args) {
+  static_assert(sizeof...(Types) >= 2,
+                "row_mapN requires at least two Eigen matrix inputs.");
+  static constexpr const char* function = "row_mapN";
+  internal::check_all_matching_dims(function, args...);
+
+  std::tuple<ref_type_t<Types&&>...> m_refs{
+      to_ref(std::forward<Types>(args))...};
+  const Eigen::Index n_rows = std::get<0>(m_refs).rows();
+  using T_return = scalar_type_t<plain_type_t<decltype(f(
+      (std::declval<ref_type_t<Types&&>>().row(0))...))>>;
+  using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
+
+  if (n_rows == 0) {
+    return matrix_t(0, 0);
+  }
+
+  matrix_t result(n_rows, 0);
+  apply(
+      [&](auto&&... ms) {
+        for (Eigen::Index i = 0; i < n_rows; ++i) {
+          internal::assign_matrix_row(function, result, i, f((ms.row(i))...));
+        }
+      },
+      m_refs);
+  return result;
+}
+
+/**
+ * Apply a functor columnwise to N Eigen matrices with identical dimensions.
+ *
+ * For matrices `args...` with `k` columns, returns a matrix whose `j`-th
+ * column is `f(args[0].col(j), args[1].col(j), ...)`. If the inputs have
+ * zero columns, returns a 0x0 matrix.
+ *
+ * Unlike `col_map`, this overload only zips matrices and does not accept
+ * additional shared trailing arguments.
+ *
+ * Expensive Eigen expressions in `args...` are each evaluated once via
+ * `to_ref` before the column loop.
+ *
+ * The functor must return a type assignable to a matrix column. All returned
+ * columns must have the same number of rows.
+ *
+ * @tparam F Type of functor to apply.
+ * @tparam Types Eigen matrix types.
+ * @param f functor to apply to each tuple of columns.
+ * @param args Eigen matrix inputs to which operation is applied.
+ * @return Eigen matrix with result of applying functor to each tuple of
+ * columns.
+ * @throw std::invalid_argument if the inputs have different dimensions or
+ * returned columns have inconsistent sizes.
+ */
+template <typename F, typename... Types,
+          require_all_eigen_matrix_dynamic_t<Types...>* = nullptr>
+inline auto col_mapN(F&& f, Types&&... args) {
+  static_assert(sizeof...(Types) >= 2,
+                "col_mapN requires at least two Eigen matrix inputs.");
+  static constexpr const char* function = "col_mapN";
+  internal::check_all_matching_dims(function, args...);
+
+  std::tuple<ref_type_t<Types&&>...> m_refs{
+      to_ref(std::forward<Types>(args))...};
+  const Eigen::Index n_cols = std::get<0>(m_refs).cols();
+  using T_return = scalar_type_t<plain_type_t<decltype(f(
+      (std::declval<ref_type_t<Types&&>>().col(0))...))>>;
+  using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
+
+  if (n_cols == 0) {
+    return matrix_t(0, 0);
+  }
+
+  matrix_t result(0, n_cols);
+  apply(
+      [&](auto&&... ms) {
+        for (Eigen::Index j = 0; j < n_cols; ++j) {
+          internal::assign_matrix_col(function, result, j, f((ms.col(j))...));
+        }
+      },
+      m_refs);
+  return result;
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_FUNCTOR_MAP_HPP
 
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/eval.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err/check_consistent_sizes.hpp>
@@ -63,51 +64,26 @@ inline auto map(F&& f, T&& x, Args&&... args) {
  * @throw std::invalid_argument if the inputs have different sizes
  */
 template <typename F, typename Tuple, typename... Args,
-          require_tuple_t<Tuple>* = nullptr>
+          require_all_tuple_elements_t<is_std_vector, Tuple>* = nullptr>
 inline auto mapN(F&& f, Tuple&& xs, Args&&... args) {
-  static_assert(tuple_size_v<Tuple> >= 2,
-                "mapN requires a tuple of at least two std::vector inputs.");
   static constexpr const char* function = "mapN";
 
   return apply(
-      [&](auto&&... xs) {
-        static_assert((is_std_vector<std::decay_t<decltype(xs)>>::value && ...),
-                      "mapN tuple elements must be std::vector.");
-        check_consistent_sizes(function, xs...);
+      [&f, &args...](auto&&... xs_inner) {
+        check_consistent_sizes(function, xs_inner...);
 
-        const std::size_t n = std::get<0>(std::forward_as_tuple(xs...)).size();
-        using T_return = std::decay_t<decltype(f((xs[0])..., args...))>;
+        const std::size_t n
+            = std::get<0>(std::forward_as_tuple(xs_inner...)).size();
+        using T_return = std::decay_t<decltype(f((xs_inner[0])..., args...))>;
         std::vector<T_return> result;
         result.reserve(n);
 
         for (std::size_t i = 0; i < n; ++i) {
-          result.push_back(f((xs[i])..., args...));
+          result.push_back(f((xs_inner[i])..., args...));
         }
         return result;
       },
       std::forward<Tuple>(xs));
-}
-
-/**
- * Return a std::vector whose i-th element is `f(x1[i], x2[i], ...)`.
- * Convenience overload equivalent to
- * `mapN(f, std::forward_as_tuple(x1, x2, xs...))`.
- *
- * @tparam F type of functor
- * @tparam T1 type of first std::vector
- * @tparam T2 type of second std::vector
- * @tparam Ts types of additional std::vector inputs
- * @param[in] f functor applied to each tuple of elements
- * @param[in] x1 first std::vector
- * @param[in] x2 second std::vector
- * @param[in] xs additional std::vector inputs
- * @return std::vector of results
- * @throw std::invalid_argument if the inputs have different sizes
- */
-template <typename F, typename T1, typename T2, typename... Ts,
-          require_all_std_vector_t<T1, T2, Ts...>* = nullptr>
-inline auto mapN(F&& f, T1&& x1, T2&& x2, Ts&&... xs) {
-  return mapN(std::forward<F>(f), std::forward_as_tuple(x1, x2, xs...));
 }
 
 /**
@@ -130,26 +106,28 @@ template <typename F, typename T, typename... Args,
 inline auto row_map(F&& f, T&& m, Args&&... args) {
   static constexpr const char* function = "row_map";
   decltype(auto) m_ref = to_ref(std::forward<T>(m));
-  using result_row_t = plain_type_t<decltype(f(m_ref.row(0), args...))>;
-  using T_return = scalar_type_t<result_row_t>;
-  using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
+
+  using matrix_t = Eigen::Matrix<
+      scalar_type_t<plain_type_t<decltype(f(m_ref.row(0), args...))>>,
+      Eigen::Dynamic, Eigen::Dynamic>;
 
   const Eigen::Index n_rows = m_ref.rows();
   if (n_rows == 0) {
     return matrix_t(0, 0);
   }
 
-  result_row_t first_row = f(m_ref.row(0), args...);
-  if (first_row.size() == 0) {
+  auto row_i = eval(f(m_ref.row(0), args...));
+
+  if (row_i.size() == 0) {
     return matrix_t(0, 0);
   }
-  matrix_t result(n_rows, first_row.cols());
-  result.row(0) = first_row;
+  matrix_t result(n_rows, row_i.cols());
+  result.row(0) = row_i;
   for (Eigen::Index i = 1; i < n_rows; ++i) {
-    result_row_t row = f(m_ref.row(i), args...);
+    row_i = f(m_ref.row(i), args...);
     check_size_match(function, "columns of result", result.cols(),
-                     "columns of returned row", row.cols());
-    result.row(i) = row;
+                     "columns of returned row", row_i.cols());
+    result.row(i) = row_i;
   }
   return result;
 }
@@ -174,26 +152,28 @@ template <typename F, typename T, typename... Args,
 inline auto col_map(F&& f, T&& m, Args&&... args) {
   static constexpr const char* function = "col_map";
   decltype(auto) m_ref = to_ref(std::forward<T>(m));
-  using result_col_t = plain_type_t<decltype(f(m_ref.col(0), args...))>;
-  using T_return = scalar_type_t<result_col_t>;
-  using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
+
+  using matrix_t = Eigen::Matrix<
+      scalar_type_t<plain_type_t<decltype(f(m_ref.col(0), args...))>>,
+      Eigen::Dynamic, Eigen::Dynamic>;
 
   const Eigen::Index n_cols = m_ref.cols();
   if (n_cols == 0) {
     return matrix_t(0, 0);
   }
 
-  result_col_t first_col = f(m_ref.col(0), args...);
-  if (first_col.size() == 0) {
+  auto col_j = eval(f(m_ref.col(0), args...));
+
+  if (col_j.size() == 0) {
     return matrix_t(0, 0);
   }
-  matrix_t result(first_col.rows(), n_cols);
-  result.col(0) = first_col;
+  matrix_t result(col_j.rows(), n_cols);
+  result.col(0) = col_j;
   for (Eigen::Index j = 1; j < n_cols; ++j) {
-    result_col_t col = f(m_ref.col(j), args...);
+    col_j = f(m_ref.col(j), args...);
     check_size_match(function, "rows of result", result.rows(),
-                     "rows of returned column", col.rows());
-    result.col(j) = col;
+                     "rows of returned column", col_j.rows());
+    result.col(j) = col_j;
   }
   return result;
 }
@@ -219,13 +199,10 @@ inline auto col_map(F&& f, T&& m, Args&&... args) {
 template <typename F, typename Tuple, typename... Args,
           require_tuple_t<Tuple>* = nullptr>
 inline auto row_mapN(F&& f, Tuple&& ms, Args&&... args) {
-  static_assert(tuple_size_v<Tuple> >= 2,
-                "row_mapN requires a tuple of at least two Eigen matrix "
-                "inputs.");
   static constexpr const char* function = "row_mapN";
 
   return apply(
-      [&](auto&&... mats) {
+      [&f, &args...](auto&&... mats) {
         static_assert(
             (is_eigen_matrix_dynamic<std::decay_t<decltype(mats)>>::value
              && ...),
@@ -234,58 +211,36 @@ inline auto row_mapN(F&& f, Tuple&& ms, Args&&... args) {
 
         auto m_refs = std::tuple{to_ref(std::forward<decltype(mats)>(mats))...};
         const Eigen::Index n_rows = std::get<0>(m_refs).rows();
-        using result_row_t = plain_type_t<decltype(f(
-            (std::declval<ref_type_t<decltype(mats)>>().row(0))..., args...))>;
-        using T_return = scalar_type_t<result_row_t>;
-        using matrix_t
-            = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
-
-        if (n_rows == 0) {
-          return matrix_t(0, 0);
-        }
 
         return apply(
-            [&](auto&&... mrs) {
-              result_row_t first_row = f((mrs.row(0))..., args...);
-              if (first_row.size() == 0) {
+            [&f, &args..., &n_rows](auto&&... mrs) {
+              using matrix_t
+                  = Eigen::Matrix<scalar_type_t<plain_type_t<decltype(f(
+                                      (mrs.row(0))..., args...))>>,
+                                  Eigen::Dynamic, Eigen::Dynamic>;
+
+              if (n_rows == 0) {
                 return matrix_t(0, 0);
               }
-              matrix_t result(n_rows, first_row.cols());
-              result.row(0) = first_row;
+
+              auto row_i = eval(f((mrs.row(0))..., args...));
+
+              if (row_i.size() == 0) {
+                return matrix_t(0, 0);
+              }
+              matrix_t result(n_rows, row_i.cols());
+              result.row(0) = row_i;
               for (Eigen::Index i = 1; i < n_rows; ++i) {
-                result_row_t row = f((mrs.row(i))..., args...);
+                row_i = f((mrs.row(i))..., args...);
                 check_size_match(function, "columns of result", result.cols(),
-                                 "columns of returned row", row.cols());
-                result.row(i) = row;
+                                 "columns of returned row", row_i.cols());
+                result.row(i) = row_i;
               }
               return result;
             },
             m_refs);
       },
       std::forward<Tuple>(ms));
-}
-
-/**
- * Return a matrix whose i-th row is `f(m1.row(i), m2.row(i), ...)`.
- * Convenience overload equivalent to
- * `row_mapN(f, std::forward_as_tuple(m1, m2, ms...))`.
- *
- * @tparam F type of functor
- * @tparam T1 type of first Eigen matrix
- * @tparam T2 type of second Eigen matrix
- * @tparam Ts types of additional Eigen matrix inputs
- * @param[in] f functor applied to each tuple of rows
- * @param[in] m1 first Eigen matrix
- * @param[in] m2 second Eigen matrix
- * @param[in] ms additional Eigen matrix inputs
- * @return matrix of results
- * @throw std::invalid_argument if the inputs have different dimensions or
- * returned rows have inconsistent sizes
- */
-template <typename F, typename T1, typename T2, typename... Ts,
-          require_all_eigen_matrix_dynamic_t<T1, T2, Ts...>* = nullptr>
-inline auto row_mapN(F&& f, T1&& m1, T2&& m2, Ts&&... ms) {
-  return row_mapN(std::forward<F>(f), std::forward_as_tuple(m1, m2, ms...));
 }
 
 /**
@@ -309,13 +264,10 @@ inline auto row_mapN(F&& f, T1&& m1, T2&& m2, Ts&&... ms) {
 template <typename F, typename Tuple, typename... Args,
           require_tuple_t<Tuple>* = nullptr>
 inline auto col_mapN(F&& f, Tuple&& ms, Args&&... args) {
-  static_assert(tuple_size_v<Tuple> >= 2,
-                "col_mapN requires a tuple of at least two Eigen matrix "
-                "inputs.");
   static constexpr const char* function = "col_mapN";
 
   return apply(
-      [&](auto&&... mats) {
+      [&f, &args...](auto&&... mats) {
         static_assert(
             (is_eigen_matrix_dynamic<std::decay_t<decltype(mats)>>::value
              && ...),
@@ -324,58 +276,36 @@ inline auto col_mapN(F&& f, Tuple&& ms, Args&&... args) {
 
         auto m_refs = std::tuple{to_ref(std::forward<decltype(mats)>(mats))...};
         const Eigen::Index n_cols = std::get<0>(m_refs).cols();
-        using result_col_t = plain_type_t<decltype(f(
-            (std::declval<ref_type_t<decltype(mats)>>().col(0))..., args...))>;
-        using T_return = scalar_type_t<result_col_t>;
-        using matrix_t
-            = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
-
-        if (n_cols == 0) {
-          return matrix_t(0, 0);
-        }
 
         return apply(
-            [&](auto&&... mrs) {
-              result_col_t first_col = f((mrs.col(0))..., args...);
-              if (first_col.size() == 0) {
+            [&f, &args..., &n_cols](auto&&... mrs) {
+              using matrix_t
+                  = Eigen::Matrix<scalar_type_t<plain_type_t<decltype(f(
+                                      (mrs.col(0))..., args...))>>,
+                                  Eigen::Dynamic, Eigen::Dynamic>;
+
+              if (n_cols == 0) {
                 return matrix_t(0, 0);
               }
-              matrix_t result(first_col.rows(), n_cols);
-              result.col(0) = first_col;
+
+              auto col_j = eval(f((mrs.col(0))..., args...));
+
+              if (col_j.size() == 0) {
+                return matrix_t(0, 0);
+              }
+              matrix_t result(col_j.rows(), n_cols);
+              result.col(0) = col_j;
               for (Eigen::Index j = 1; j < n_cols; ++j) {
-                result_col_t col = f((mrs.col(j))..., args...);
+                col_j = f((mrs.col(j))..., args...);
                 check_size_match(function, "rows of result", result.rows(),
-                                 "rows of returned column", col.rows());
-                result.col(j) = col;
+                                 "rows of returned column", col_j.rows());
+                result.col(j) = col_j;
               }
               return result;
             },
             m_refs);
       },
       std::forward<Tuple>(ms));
-}
-
-/**
- * Return a matrix whose j-th column is `f(m1.col(j), m2.col(j), ...)`.
- * Convenience overload equivalent to
- * `col_mapN(f, std::forward_as_tuple(m1, m2, ms...))`.
- *
- * @tparam F type of functor
- * @tparam T1 type of first Eigen matrix
- * @tparam T2 type of second Eigen matrix
- * @tparam Ts types of additional Eigen matrix inputs
- * @param[in] f functor applied to each tuple of columns
- * @param[in] m1 first Eigen matrix
- * @param[in] m2 second Eigen matrix
- * @param[in] ms additional Eigen matrix inputs
- * @return matrix of results
- * @throw std::invalid_argument if the inputs have different dimensions or
- * returned columns have inconsistent sizes
- */
-template <typename F, typename T1, typename T2, typename... Ts,
-          require_all_eigen_matrix_dynamic_t<T1, T2, Ts...>* = nullptr>
-inline auto col_mapN(F&& f, T1&& m1, T2&& m2, Ts&&... ms) {
-  return col_mapN(std::forward<F>(f), std::forward_as_tuple(m1, m2, ms...));
 }
 
 }  // namespace math

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -276,8 +276,8 @@ inline auto row_mapN(F&& f, Types&&... args) {
 
   auto m_refs = std::tuple{to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_rows = std::get<0>(m_refs).rows();
-  using result_row_t = plain_type_t<decltype(f(
-      (std::declval<ref_type_t<Types&&>>().row(0))...))>;
+  using result_row_t = plain_type_t<decltype(
+      f((std::declval<ref_type_t<Types&&>>().row(0))...))>;
   using T_return = scalar_type_t<result_row_t>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
 
@@ -361,8 +361,8 @@ inline auto col_mapN(F&& f, Types&&... args) {
 
   auto m_refs = std::tuple{to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_cols = std::get<0>(m_refs).cols();
-  using result_col_t = plain_type_t<decltype(f(
-      (std::declval<ref_type_t<Types&&>>().col(0))...))>;
+  using result_col_t = plain_type_t<decltype(
+      f((std::declval<ref_type_t<Types&&>>().col(0))...))>;
   using T_return = scalar_type_t<result_col_t>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
   if (n_cols == 0) {

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_FUNCTOR_MAP_HPP
 
 #include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/eval.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err/check_consistent_sizes.hpp>
@@ -25,7 +26,8 @@ inline decltype(auto) with_tuple_prefix(F& f, Tuple& tup, Callback&& callback) {
   return apply(
       [&](auto&&... tuple_args) -> decltype(auto) {
         auto prefixed_f = [&](auto&&... args) -> decltype(auto) {
-          return f(tuple_args..., std::forward<decltype(args)>(args)...);
+          return eval(
+              f(tuple_args..., std::forward<decltype(args)>(args)...));
         };
         return std::forward<Callback>(callback)(prefixed_f);
       },

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -10,7 +10,6 @@
 #include <stan/math/prim/functor/apply.hpp>
 
 #include <cstddef>
-#include <string>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -18,27 +17,6 @@
 
 namespace stan {
 namespace math {
-
-namespace internal {
-
-template <typename T, typename... Types>
-inline void check_all_matching_dims(const char* function, const T& x,
-                                    const Types&... xs) {
-  std::size_t arg_idx = 2;
-  (
-      [&](const auto& y) {
-        if (x.rows() != y.rows() || x.cols() != y.cols()) {
-          [&]() STAN_COLD_PATH {
-            const std::string name = "x" + std::to_string(arg_idx);
-            check_matching_dims(function, "x1", x, name.c_str(), y);
-          }();
-        }
-        ++arg_idx;
-      }(xs),
-      ...);
-}
-
-}  // namespace internal
 
 /**
  * Apply a functor to each element of a std::vector and collect the results.
@@ -256,7 +234,7 @@ inline auto row_mapN(F&& f, Types&&... args) {
   static_assert(sizeof...(Types) >= 2,
                 "row_mapN requires at least two Eigen matrix inputs.");
   static constexpr const char* function = "row_mapN";
-  internal::check_all_matching_dims(function, args...);
+  check_matching_dims(function, args...);
 
   auto m_refs = std::tuple{to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_rows = std::get<0>(m_refs).rows();
@@ -320,7 +298,7 @@ inline auto col_mapN(F&& f, Types&&... args) {
   static_assert(sizeof...(Types) >= 2,
                 "col_mapN requires at least two Eigen matrix inputs.");
   static constexpr const char* function = "col_mapN";
-  internal::check_all_matching_dims(function, args...);
+  check_matching_dims(function, args...);
 
   auto m_refs = std::tuple{to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_cols = std::get<0>(m_refs).cols();

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -289,8 +289,8 @@ inline auto row_mapN(F&& f, Types&&... args) {
   std::tuple<ref_type_t<Types&&>...> m_refs{
       to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_rows = std::get<0>(m_refs).rows();
-  using T_return = scalar_type_t<plain_type_t<decltype(f(
-      (std::declval<ref_type_t<Types&&>>().row(0))...))>>;
+  using T_return = scalar_type_t<plain_type_t<decltype(
+      f((std::declval<ref_type_t<Types&&>>().row(0))...))>>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
 
   if (n_rows == 0) {
@@ -344,8 +344,8 @@ inline auto col_mapN(F&& f, Types&&... args) {
   std::tuple<ref_type_t<Types&&>...> m_refs{
       to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_cols = std::get<0>(m_refs).cols();
-  using T_return = scalar_type_t<plain_type_t<decltype(f(
-      (std::declval<ref_type_t<Types&&>>().col(0))...))>>;
+  using T_return = scalar_type_t<plain_type_t<decltype(
+      f((std::declval<ref_type_t<Types&&>>().col(0))...))>>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
 
   if (n_cols == 0) {

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_FUNCTOR_MAP_HPP
 
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/fun/eval.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err/check_consistent_sizes.hpp>
@@ -19,41 +18,18 @@
 namespace stan {
 namespace math {
 
-namespace internal {
-
-template <typename F, typename Tuple, typename Callback>
-inline decltype(auto) with_tuple_prefix(F& f, Tuple& tup, Callback&& callback) {
-  return apply(
-      [&](auto&&... tuple_args) -> decltype(auto) {
-        auto prefixed_f = [&](auto&&... args) -> decltype(auto) {
-          return eval(f(tuple_args..., std::forward<decltype(args)>(args)...));
-        };
-        return std::forward<Callback>(callback)(prefixed_f);
-      },
-      tup);
-}
-
-}  // namespace internal
-
 /**
- * Apply a functor to each element of a std::vector and collect the results.
+ * Return a std::vector whose i-th element is `f(x[i], args...)`.
+ * Additional arguments are shared across calls.  If `x` is empty, the result
+ * is empty.  The element type of the result is deduced from `f`.
  *
- * For a vector `x` of length `n`, returns a std::vector whose `i`-th element
- * is `f(x[i], args...)`. Additional arguments are shared across calls, which
- * allows passing parameters without closures. If `x` is empty, returns an
- * empty std::vector.
- *
- * The element type of the returned std::vector is deduced from the return type
- * of `f` to allow for cases where the input and return scalar types differ
- * (e.g., functions implicitly promoting integers).
- *
- * @tparam F Type of functor to apply.
- * @tparam T Type of input std::vector.
- * @tparam Args Types of shared arguments passed to each call.
- * @param f functor to apply to each element.
- * @param x std::vector input to which operation is applied.
- * @param args shared arguments passed to each call.
- * @return std::vector with result of applying functor to each element of `x`.
+ * @tparam F type of functor
+ * @tparam T type of input std::vector
+ * @tparam Args types of shared arguments
+ * @param[in] f functor applied to each element
+ * @param[in] x input std::vector
+ * @param[in] args shared arguments passed to each call
+ * @return std::vector of results
  */
 template <typename F, typename T, typename... Args,
           require_std_vector_t<T>* = nullptr>
@@ -70,94 +46,84 @@ inline auto map(F&& f, T&& x, Args&&... args) {
 }
 
 /**
- * Apply a functor elementwise to N std::vector inputs of the same size.
+ * Return a std::vector whose i-th element is
+ * `f(get<0>(xs)[i], get<1>(xs)[i], ..., args...)`.
+ * The tuple `xs` must contain at least two equal-sized std::vector inputs.
+ * Additional trailing arguments are shared across calls.  If the inputs are
+ * empty, the result is empty.  The element type of the result is deduced from
+ * `f`.
  *
- * For vectors `args...` of length `n`, returns a std::vector whose `i`-th
- * element is `f(args[0][i], args[1][i], ...)`. If the inputs are empty,
- * returns an empty std::vector.
- *
- * Unlike `map`, this overload only zips containers and does not accept
- * additional shared trailing arguments. Pass shared state through the
- * functor (e.g. a capturing lambda) when needed.
- *
- * The element type of the returned std::vector is deduced from the return type
- * of `f` to allow for cases where the input and return scalar types differ
- * (e.g., functions implicitly promoting integers).
- *
- * @tparam F Type of functor to apply.
- * @tparam Types Types of input std::vector containers.
- * @param f functor to apply to each tuple of elements.
- * @param args std::vector inputs to which operation is applied.
- * @return std::vector with result of applying functor to each tuple of
- * elements.
- * @throw std::invalid_argument if the inputs have different sizes.
+ * @tparam F type of functor
+ * @tparam Tuple type of tuple of std::vector inputs
+ * @tparam Args types of shared arguments
+ * @param[in] f functor applied to each tuple of elements
+ * @param[in] xs tuple of std::vector inputs
+ * @param[in] args shared arguments passed to each call
+ * @return std::vector of results
+ * @throw std::invalid_argument if the inputs have different sizes
  */
-template <typename F, typename... Types,
-          require_all_std_vector_t<Types...>* = nullptr>
-inline auto mapN(F&& f, Types&&... args) {
-  static_assert(sizeof...(Types) >= 2,
-                "mapN requires at least two std::vector inputs.");
+template <typename F, typename Tuple, typename... Args,
+          require_tuple_t<Tuple>* = nullptr>
+inline auto mapN(F&& f, Tuple&& xs, Args&&... args) {
+  static_assert(tuple_size_v<Tuple> >= 2,
+                "mapN requires a tuple of at least two std::vector inputs.");
   static constexpr const char* function = "mapN";
-  check_consistent_sizes(function, args...);
 
-  const std::size_t n = std::get<0>(std::forward_as_tuple(args...)).size();
-  using T_return = std::decay_t<decltype(f((args[0])...))>;
-  std::vector<T_return> result;
-  result.reserve(n);
+  return apply(
+      [&](auto&&... xs) {
+        static_assert((is_std_vector<std::decay_t<decltype(xs)>>::value && ...),
+                      "mapN tuple elements must be std::vector.");
+        check_consistent_sizes(function, xs...);
 
-  for (std::size_t i = 0; i < n; ++i) {
-    result.push_back(f((args[i])...));
-  }
+        const std::size_t n = std::get<0>(std::forward_as_tuple(xs...)).size();
+        using T_return = std::decay_t<decltype(f((xs[0])..., args...))>;
+        std::vector<T_return> result;
+        result.reserve(n);
 
-  return result;
+        for (std::size_t i = 0; i < n; ++i) {
+          result.push_back(f((xs[i])..., args...));
+        }
+        return result;
+      },
+      std::forward<Tuple>(xs));
 }
 
 /**
- * Apply a functor elementwise to N std::vectors with tuple arguments prepended
- * to each call.
+ * Return a std::vector whose i-th element is `f(x1[i], x2[i], ...)`.
+ * Convenience overload equivalent to
+ * `mapN(f, std::forward_as_tuple(x1, x2, xs...))`.
  *
- * @tparam F Type of functor to apply.
- * @tparam Tuple Type of tuple containing leading shared arguments.
- * @tparam Types Types of input std::vector containers.
- * @param f functor to apply to each tuple of elements.
- * @param tup leading shared arguments expanded before each tuple of elements.
- * @param args std::vector inputs to which operation is applied.
- * @return std::vector with result of applying functor to each tuple of
- * elements.
+ * @tparam F type of functor
+ * @tparam T1 type of first std::vector
+ * @tparam T2 type of second std::vector
+ * @tparam Ts types of additional std::vector inputs
+ * @param[in] f functor applied to each tuple of elements
+ * @param[in] x1 first std::vector
+ * @param[in] x2 second std::vector
+ * @param[in] xs additional std::vector inputs
+ * @return std::vector of results
+ * @throw std::invalid_argument if the inputs have different sizes
  */
-template <typename F, typename Tuple, typename... Types,
-          require_tuple_t<Tuple>* = nullptr,
-          require_all_std_vector_t<Types...>* = nullptr>
-inline auto mapN(F&& f, Tuple&& tup, Types&&... args) {
-  return internal::with_tuple_prefix(f, tup, [&](auto&& prefixed_f) {
-    return mapN(prefixed_f, std::forward<Types>(args)...);
-  });
+template <typename F, typename T1, typename T2, typename... Ts,
+          require_all_std_vector_t<T1, T2, Ts...>* = nullptr>
+inline auto mapN(F&& f, T1&& x1, T2&& x2, Ts&&... xs) {
+  return mapN(std::forward<F>(f), std::forward_as_tuple(x1, x2, xs...));
 }
 
 /**
- * Apply a functor to each row of an Eigen matrix and collect the results.
+ * Return a matrix whose i-th row is `f(m.row(i), args...)`.
+ * Additional arguments are shared across calls.  If `m` has zero rows, or if
+ * the first returned row is empty, returns a 0x0 matrix.  All returned rows
+ * must have the same number of columns.
  *
- * For a matrix `m` with `n` rows, returns a matrix whose `i`-th row is
- * `f(m.row(i), args...)`. Additional arguments are shared across calls. If
- * `m` has zero rows, returns a 0x0 matrix (output column count is unknown
- * when the functor is never called). If the first returned row is empty,
- * returns a 0x0 matrix without calling the functor on the remaining rows.
- *
- * Expensive Eigen expressions passed as `m` are evaluated once via `to_ref`
- * before the row loop, so compound expressions (e.g. `A * B`) are not
- * re-evaluated for every row.
- *
- * The functor must return a type assignable to a matrix row. All returned
- * rows must have the same number of columns.
- *
- * @tparam F Type of functor to apply.
- * @tparam T Eigen matrix type.
- * @tparam Args Types of shared arguments passed to each call.
- * @param f functor to apply to each row.
- * @param m Eigen matrix input to which operation is applied.
- * @param args shared arguments passed to each call.
- * @return Eigen matrix with result of applying functor to each row of `m`.
- * @throw std::invalid_argument if returned rows have inconsistent sizes.
+ * @tparam F type of functor
+ * @tparam T type of Eigen matrix
+ * @tparam Args types of shared arguments
+ * @param[in] f functor applied to each row
+ * @param[in] m input matrix
+ * @param[in] args shared arguments passed to each call
+ * @return matrix of results
+ * @throw std::invalid_argument if returned rows have inconsistent sizes
  */
 template <typename F, typename T, typename... Args,
           require_eigen_matrix_dynamic_t<T>* = nullptr>
@@ -189,29 +155,19 @@ inline auto row_map(F&& f, T&& m, Args&&... args) {
 }
 
 /**
- * Apply a functor to each column of an Eigen matrix and collect the results.
- *
- * For a matrix `m` with `k` columns, returns a matrix whose `j`-th column is
- * `f(m.col(j), args...)`. Additional arguments are shared across calls. If
- * `m` has zero columns, returns a 0x0 matrix (output row count is unknown
- * when the functor is never called). If the first returned column is empty,
- * returns a 0x0 matrix without calling the functor on the remaining columns.
- *
- * Expensive Eigen expressions passed as `m` are evaluated once via `to_ref`
- * before the column loop, so compound expressions (e.g. `A * B`) are not
- * re-evaluated for every column.
- *
- * The functor must return a type assignable to a matrix column. All returned
+ * Return a matrix whose j-th column is `f(m.col(j), args...)`.
+ * Additional arguments are shared across calls.  If `m` has zero columns, or
+ * if the first returned column is empty, returns a 0x0 matrix.  All returned
  * columns must have the same number of rows.
  *
- * @tparam F Type of functor to apply.
- * @tparam T Eigen matrix type.
- * @tparam Args Types of shared arguments passed to each call.
- * @param f functor to apply to each column.
- * @param m Eigen matrix input to which operation is applied.
- * @param args shared arguments passed to each call.
- * @return Eigen matrix with result of applying functor to each column of `m`.
- * @throw std::invalid_argument if returned columns have inconsistent sizes.
+ * @tparam F type of functor
+ * @tparam T type of Eigen matrix
+ * @tparam Args types of shared arguments
+ * @param[in] f functor applied to each column
+ * @param[in] m input matrix
+ * @param[in] args shared arguments passed to each call
+ * @return matrix of results
+ * @throw std::invalid_argument if returned columns have inconsistent sizes
  */
 template <typename F, typename T, typename... Args,
           require_eigen_matrix_dynamic_t<T>* = nullptr>
@@ -243,171 +199,183 @@ inline auto col_map(F&& f, T&& m, Args&&... args) {
 }
 
 /**
- * Apply a functor rowwise to N Eigen matrices with identical dimensions.
+ * Return a matrix whose i-th row is
+ * `f(get<0>(ms).row(i), get<1>(ms).row(i), ..., args...)`.
+ * The tuple `ms` must contain at least two Eigen matrices with identical
+ * dimensions.  Additional trailing arguments are shared across calls.  If the
+ * inputs have zero rows, or if the first returned row is empty, returns a 0x0
+ * matrix.  All returned rows must have the same number of columns.
  *
- * For matrices `args...` with `n` rows, returns a matrix whose `i`-th row is
- * `f(args[0].row(i), args[1].row(i), ...)`. If the inputs have zero rows,
- * returns a 0x0 matrix. If the first returned row is empty, returns a 0x0
- * matrix without calling the functor on the remaining rows.
- *
- * Unlike `row_map`, this overload only zips matrices and does not accept
- * additional shared trailing arguments.
- *
- * Expensive Eigen expressions in `args...` are each evaluated once via
- * `to_ref` before the row loop.
- *
- * The functor must return a type assignable to a matrix row. All returned
- * rows must have the same number of columns.
- *
- * @tparam F Type of functor to apply.
- * @tparam Types Eigen matrix types.
- * @param f functor to apply to each tuple of rows.
- * @param args Eigen matrix inputs to which operation is applied.
- * @return Eigen matrix with result of applying functor to each tuple of rows.
+ * @tparam F type of functor
+ * @tparam Tuple type of tuple of Eigen matrix inputs
+ * @tparam Args types of shared arguments
+ * @param[in] f functor applied to each tuple of rows
+ * @param[in] ms tuple of Eigen matrix inputs
+ * @param[in] args shared arguments passed to each call
+ * @return matrix of results
  * @throw std::invalid_argument if the inputs have different dimensions or
- * returned rows have inconsistent sizes.
+ * returned rows have inconsistent sizes
  */
-template <typename F, typename... Types,
-          require_all_eigen_matrix_dynamic_t<Types...>* = nullptr>
-inline auto row_mapN(F&& f, Types&&... args) {
-  static_assert(sizeof...(Types) >= 2,
-                "row_mapN requires at least two Eigen matrix inputs.");
+template <typename F, typename Tuple, typename... Args,
+          require_tuple_t<Tuple>* = nullptr>
+inline auto row_mapN(F&& f, Tuple&& ms, Args&&... args) {
+  static_assert(tuple_size_v<Tuple> >= 2,
+                "row_mapN requires a tuple of at least two Eigen matrix "
+                "inputs.");
   static constexpr const char* function = "row_mapN";
-  check_matching_dims(function, args...);
-
-  auto m_refs = std::tuple{to_ref(std::forward<Types>(args))...};
-  const Eigen::Index n_rows = std::get<0>(m_refs).rows();
-  using result_row_t = plain_type_t<decltype(
-      f((std::declval<ref_type_t<Types&&>>().row(0))...))>;
-  using T_return = scalar_type_t<result_row_t>;
-  using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
-
-  if (n_rows == 0) {
-    return matrix_t(0, 0);
-  }
 
   return apply(
-      [&](auto&&... ms) {
-        result_row_t first_row = f((ms.row(0))...);
-        if (first_row.size() == 0) {
+      [&](auto&&... mats) {
+        static_assert(
+            (is_eigen_matrix_dynamic<std::decay_t<decltype(mats)>>::value
+             && ...),
+            "row_mapN tuple elements must be Eigen matrices.");
+        check_matching_dims(function, mats...);
+
+        auto m_refs = std::tuple{to_ref(std::forward<decltype(mats)>(mats))...};
+        const Eigen::Index n_rows = std::get<0>(m_refs).rows();
+        using result_row_t = plain_type_t<decltype(f(
+            (std::declval<ref_type_t<decltype(mats)>>().row(0))..., args...))>;
+        using T_return = scalar_type_t<result_row_t>;
+        using matrix_t
+            = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
+
+        if (n_rows == 0) {
           return matrix_t(0, 0);
         }
-        matrix_t result(n_rows, first_row.cols());
-        result.row(0) = first_row;
-        for (Eigen::Index i = 1; i < n_rows; ++i) {
-          result_row_t row = f((ms.row(i))...);
-          check_size_match(function, "columns of result", result.cols(),
-                           "columns of returned row", row.cols());
-          result.row(i) = row;
-        }
-        return result;
+
+        return apply(
+            [&](auto&&... mrs) {
+              result_row_t first_row = f((mrs.row(0))..., args...);
+              if (first_row.size() == 0) {
+                return matrix_t(0, 0);
+              }
+              matrix_t result(n_rows, first_row.cols());
+              result.row(0) = first_row;
+              for (Eigen::Index i = 1; i < n_rows; ++i) {
+                result_row_t row = f((mrs.row(i))..., args...);
+                check_size_match(function, "columns of result", result.cols(),
+                                 "columns of returned row", row.cols());
+                result.row(i) = row;
+              }
+              return result;
+            },
+            m_refs);
       },
-      m_refs);
+      std::forward<Tuple>(ms));
 }
 
 /**
- * Apply a functor rowwise to N Eigen matrices with tuple arguments prepended
- * to each call.
+ * Return a matrix whose i-th row is `f(m1.row(i), m2.row(i), ...)`.
+ * Convenience overload equivalent to
+ * `row_mapN(f, std::forward_as_tuple(m1, m2, ms...))`.
  *
- * @tparam F Type of functor to apply.
- * @tparam Tuple Type of tuple containing leading shared arguments.
- * @tparam Types Eigen matrix types.
- * @param f functor to apply to each tuple of rows.
- * @param tup leading shared arguments expanded before each tuple of rows.
- * @param args Eigen matrix inputs to which operation is applied.
- * @return Eigen matrix with result of applying functor to each tuple of rows.
- */
-template <typename F, typename Tuple, typename... Types,
-          require_tuple_t<Tuple>* = nullptr,
-          require_all_eigen_matrix_dynamic_t<Types...>* = nullptr>
-inline auto row_mapN(F&& f, Tuple&& tup, Types&&... args) {
-  return internal::with_tuple_prefix(f, tup, [&](auto&& prefixed_f) {
-    return row_mapN(prefixed_f, std::forward<Types>(args)...);
-  });
-}
-
-/**
- * Apply a functor columnwise to N Eigen matrices with identical dimensions.
- *
- * For matrices `args...` with `k` columns, returns a matrix whose `j`-th
- * column is `f(args[0].col(j), args[1].col(j), ...)`. If the inputs have
- * zero columns, returns a 0x0 matrix. If the first returned column is empty,
- * returns a 0x0 matrix without calling the functor on the remaining columns.
- *
- * Unlike `col_map`, this overload only zips matrices and does not accept
- * additional shared trailing arguments.
- *
- * Expensive Eigen expressions in `args...` are each evaluated once via
- * `to_ref` before the column loop.
- *
- * The functor must return a type assignable to a matrix column. All returned
- * columns must have the same number of rows.
- *
- * @tparam F Type of functor to apply.
- * @tparam Types Eigen matrix types.
- * @param f functor to apply to each tuple of columns.
- * @param args Eigen matrix inputs to which operation is applied.
- * @return Eigen matrix with result of applying functor to each tuple of
- * columns.
+ * @tparam F type of functor
+ * @tparam T1 type of first Eigen matrix
+ * @tparam T2 type of second Eigen matrix
+ * @tparam Ts types of additional Eigen matrix inputs
+ * @param[in] f functor applied to each tuple of rows
+ * @param[in] m1 first Eigen matrix
+ * @param[in] m2 second Eigen matrix
+ * @param[in] ms additional Eigen matrix inputs
+ * @return matrix of results
  * @throw std::invalid_argument if the inputs have different dimensions or
- * returned columns have inconsistent sizes.
+ * returned rows have inconsistent sizes
  */
-template <typename F, typename... Types,
-          require_all_eigen_matrix_dynamic_t<Types...>* = nullptr>
-inline auto col_mapN(F&& f, Types&&... args) {
-  static_assert(sizeof...(Types) >= 2,
-                "col_mapN requires at least two Eigen matrix inputs.");
-  static constexpr const char* function = "col_mapN";
-  check_matching_dims(function, args...);
-
-  auto m_refs = std::tuple{to_ref(std::forward<Types>(args))...};
-  const Eigen::Index n_cols = std::get<0>(m_refs).cols();
-  using result_col_t = plain_type_t<decltype(
-      f((std::declval<ref_type_t<Types&&>>().col(0))...))>;
-  using T_return = scalar_type_t<result_col_t>;
-  using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
-  if (n_cols == 0) {
-    return matrix_t(0, 0);
-  }
-  return apply(
-      [&](auto&&... ms) {
-        result_col_t first_col = f((ms.col(0))...);
-        if (first_col.size() == 0) {
-          return matrix_t(0, 0);
-        }
-        matrix_t result(first_col.rows(), n_cols);
-        result.col(0) = first_col;
-        for (Eigen::Index j = 1; j < n_cols; ++j) {
-          result_col_t col = f((ms.col(j))...);
-          check_size_match(function, "rows of result", result.rows(),
-                           "rows of returned column", col.rows());
-          result.col(j) = col;
-        }
-        return result;
-      },
-      m_refs);
+template <typename F, typename T1, typename T2, typename... Ts,
+          require_all_eigen_matrix_dynamic_t<T1, T2, Ts...>* = nullptr>
+inline auto row_mapN(F&& f, T1&& m1, T2&& m2, Ts&&... ms) {
+  return row_mapN(std::forward<F>(f), std::forward_as_tuple(m1, m2, ms...));
 }
 
 /**
- * Apply a functor columnwise to N Eigen matrices with tuple arguments
- * prepended to each call.
+ * Return a matrix whose j-th column is
+ * `f(get<0>(ms).col(j), get<1>(ms).col(j), ..., args...)`.
+ * The tuple `ms` must contain at least two Eigen matrices with identical
+ * dimensions.  Additional trailing arguments are shared across calls.  If the
+ * inputs have zero columns, or if the first returned column is empty, returns
+ * a 0x0 matrix.  All returned columns must have the same number of rows.
  *
- * @tparam F Type of functor to apply.
- * @tparam Tuple Type of tuple containing leading shared arguments.
- * @tparam Types Eigen matrix types.
- * @param f functor to apply to each tuple of columns.
- * @param tup leading shared arguments expanded before each tuple of columns.
- * @param args Eigen matrix inputs to which operation is applied.
- * @return Eigen matrix with result of applying functor to each tuple of
- * columns.
+ * @tparam F type of functor
+ * @tparam Tuple type of tuple of Eigen matrix inputs
+ * @tparam Args types of shared arguments
+ * @param[in] f functor applied to each tuple of columns
+ * @param[in] ms tuple of Eigen matrix inputs
+ * @param[in] args shared arguments passed to each call
+ * @return matrix of results
+ * @throw std::invalid_argument if the inputs have different dimensions or
+ * returned columns have inconsistent sizes
  */
-template <typename F, typename Tuple, typename... Types,
-          require_tuple_t<Tuple>* = nullptr,
-          require_all_eigen_matrix_dynamic_t<Types...>* = nullptr>
-inline auto col_mapN(F&& f, Tuple&& tup, Types&&... args) {
-  return internal::with_tuple_prefix(f, tup, [&](auto&& prefixed_f) {
-    return col_mapN(prefixed_f, std::forward<Types>(args)...);
-  });
+template <typename F, typename Tuple, typename... Args,
+          require_tuple_t<Tuple>* = nullptr>
+inline auto col_mapN(F&& f, Tuple&& ms, Args&&... args) {
+  static_assert(tuple_size_v<Tuple> >= 2,
+                "col_mapN requires a tuple of at least two Eigen matrix "
+                "inputs.");
+  static constexpr const char* function = "col_mapN";
+
+  return apply(
+      [&](auto&&... mats) {
+        static_assert(
+            (is_eigen_matrix_dynamic<std::decay_t<decltype(mats)>>::value
+             && ...),
+            "col_mapN tuple elements must be Eigen matrices.");
+        check_matching_dims(function, mats...);
+
+        auto m_refs = std::tuple{to_ref(std::forward<decltype(mats)>(mats))...};
+        const Eigen::Index n_cols = std::get<0>(m_refs).cols();
+        using result_col_t = plain_type_t<decltype(f(
+            (std::declval<ref_type_t<decltype(mats)>>().col(0))..., args...))>;
+        using T_return = scalar_type_t<result_col_t>;
+        using matrix_t
+            = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
+
+        if (n_cols == 0) {
+          return matrix_t(0, 0);
+        }
+
+        return apply(
+            [&](auto&&... mrs) {
+              result_col_t first_col = f((mrs.col(0))..., args...);
+              if (first_col.size() == 0) {
+                return matrix_t(0, 0);
+              }
+              matrix_t result(first_col.rows(), n_cols);
+              result.col(0) = first_col;
+              for (Eigen::Index j = 1; j < n_cols; ++j) {
+                result_col_t col = f((mrs.col(j))..., args...);
+                check_size_match(function, "rows of result", result.rows(),
+                                 "rows of returned column", col.rows());
+                result.col(j) = col;
+              }
+              return result;
+            },
+            m_refs);
+      },
+      std::forward<Tuple>(ms));
+}
+
+/**
+ * Return a matrix whose j-th column is `f(m1.col(j), m2.col(j), ...)`.
+ * Convenience overload equivalent to
+ * `col_mapN(f, std::forward_as_tuple(m1, m2, ms...))`.
+ *
+ * @tparam F type of functor
+ * @tparam T1 type of first Eigen matrix
+ * @tparam T2 type of second Eigen matrix
+ * @tparam Ts types of additional Eigen matrix inputs
+ * @param[in] f functor applied to each tuple of columns
+ * @param[in] m1 first Eigen matrix
+ * @param[in] m2 second Eigen matrix
+ * @param[in] ms additional Eigen matrix inputs
+ * @return matrix of results
+ * @throw std::invalid_argument if the inputs have different dimensions or
+ * returned columns have inconsistent sizes
+ */
+template <typename F, typename T1, typename T2, typename... Ts,
+          require_all_eigen_matrix_dynamic_t<T1, T2, Ts...>* = nullptr>
+inline auto col_mapN(F&& f, T1&& m1, T2&& m2, Ts&&... ms) {
+  return col_mapN(std::forward<F>(f), std::forward_as_tuple(m1, m2, ms...));
 }
 
 }  // namespace math

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -60,7 +61,8 @@ inline void assign_matrix_row(
     Eigen::Matrix<T_scalar, Eigen::Dynamic, Eigen::Dynamic>& result,
     Eigen::Index i, T&& x) {
   if (i == 0) {
-    result.resize(result.rows(), x.cols());
+    result = Eigen::Matrix<T_scalar, Eigen::Dynamic, Eigen::Dynamic>(
+        result.rows(), x.cols());
   } else {
     check_size_match(function, "columns of result", result.cols(),
                      "columns of returned row", x.cols());
@@ -74,7 +76,8 @@ inline void assign_matrix_col(
     Eigen::Matrix<T_scalar, Eigen::Dynamic, Eigen::Dynamic>& result,
     Eigen::Index j, T&& x) {
   if (j == 0) {
-    result.resize(x.rows(), result.cols());
+    result = Eigen::Matrix<T_scalar, Eigen::Dynamic, Eigen::Dynamic>(
+        x.rows(), result.cols());
   } else {
     check_size_match(function, "rows of result", result.rows(),
                      "rows of returned column", x.rows());
@@ -286,8 +289,8 @@ inline auto row_mapN(F&& f, Types&&... args) {
   std::tuple<ref_type_t<Types&&>...> m_refs{
       to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_rows = std::get<0>(m_refs).rows();
-  using T_return = scalar_type_t<plain_type_t<decltype(
-      f((std::declval<ref_type_t<Types&&>>().row(0))...))>>;
+  using T_return = scalar_type_t<plain_type_t<decltype(f(
+      (std::declval<ref_type_t<Types&&>>().row(0))...))>>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
 
   if (n_rows == 0) {
@@ -341,8 +344,8 @@ inline auto col_mapN(F&& f, Types&&... args) {
   std::tuple<ref_type_t<Types&&>...> m_refs{
       to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_cols = std::get<0>(m_refs).cols();
-  using T_return = scalar_type_t<plain_type_t<decltype(
-      f((std::declval<ref_type_t<Types&&>>().col(0))...))>>;
+  using T_return = scalar_type_t<plain_type_t<decltype(f(
+      (std::declval<ref_type_t<Types&&>>().col(0))...))>>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
 
   if (n_cols == 0) {

--- a/stan/math/prim/functor/map.hpp
+++ b/stan/math/prim/functor/map.hpp
@@ -18,6 +18,22 @@
 namespace stan {
 namespace math {
 
+namespace internal {
+
+template <typename F, typename Tuple, typename Callback>
+inline decltype(auto) with_tuple_prefix(F& f, Tuple& tup, Callback&& callback) {
+  return apply(
+      [&](auto&&... tuple_args) -> decltype(auto) {
+        auto prefixed_f = [&](auto&&... args) -> decltype(auto) {
+          return f(tuple_args..., std::forward<decltype(args)>(args)...);
+        };
+        return std::forward<Callback>(callback)(prefixed_f);
+      },
+      tup);
+}
+
+}  // namespace internal
+
 /**
  * Apply a functor to each element of a std::vector and collect the results.
  *
@@ -93,6 +109,28 @@ inline auto mapN(F&& f, Types&&... args) {
   }
 
   return result;
+}
+
+/**
+ * Apply a functor elementwise to N std::vectors with tuple arguments prepended
+ * to each call.
+ *
+ * @tparam F Type of functor to apply.
+ * @tparam Tuple Type of tuple containing leading shared arguments.
+ * @tparam Types Types of input std::vector containers.
+ * @param f functor to apply to each tuple of elements.
+ * @param tup leading shared arguments expanded before each tuple of elements.
+ * @param args std::vector inputs to which operation is applied.
+ * @return std::vector with result of applying functor to each tuple of
+ * elements.
+ */
+template <typename F, typename Tuple, typename... Types,
+          require_tuple_t<Tuple>* = nullptr,
+          require_all_std_vector_t<Types...>* = nullptr>
+inline auto mapN(F&& f, Tuple&& tup, Types&&... args) {
+  return internal::with_tuple_prefix(f, tup, [&](auto&& prefixed_f) {
+    return mapN(prefixed_f, std::forward<Types>(args)...);
+  });
 }
 
 /**
@@ -238,8 +276,8 @@ inline auto row_mapN(F&& f, Types&&... args) {
 
   auto m_refs = std::tuple{to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_rows = std::get<0>(m_refs).rows();
-  using result_row_t = plain_type_t<decltype(
-      f((std::declval<ref_type_t<Types&&>>().row(0))...))>;
+  using result_row_t = plain_type_t<decltype(f(
+      (std::declval<ref_type_t<Types&&>>().row(0))...))>;
   using T_return = scalar_type_t<result_row_t>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
 
@@ -264,6 +302,27 @@ inline auto row_mapN(F&& f, Types&&... args) {
         return result;
       },
       m_refs);
+}
+
+/**
+ * Apply a functor rowwise to N Eigen matrices with tuple arguments prepended
+ * to each call.
+ *
+ * @tparam F Type of functor to apply.
+ * @tparam Tuple Type of tuple containing leading shared arguments.
+ * @tparam Types Eigen matrix types.
+ * @param f functor to apply to each tuple of rows.
+ * @param tup leading shared arguments expanded before each tuple of rows.
+ * @param args Eigen matrix inputs to which operation is applied.
+ * @return Eigen matrix with result of applying functor to each tuple of rows.
+ */
+template <typename F, typename Tuple, typename... Types,
+          require_tuple_t<Tuple>* = nullptr,
+          require_all_eigen_matrix_dynamic_t<Types...>* = nullptr>
+inline auto row_mapN(F&& f, Tuple&& tup, Types&&... args) {
+  return internal::with_tuple_prefix(f, tup, [&](auto&& prefixed_f) {
+    return row_mapN(prefixed_f, std::forward<Types>(args)...);
+  });
 }
 
 /**
@@ -302,8 +361,8 @@ inline auto col_mapN(F&& f, Types&&... args) {
 
   auto m_refs = std::tuple{to_ref(std::forward<Types>(args))...};
   const Eigen::Index n_cols = std::get<0>(m_refs).cols();
-  using result_col_t = plain_type_t<decltype(
-      f((std::declval<ref_type_t<Types&&>>().col(0))...))>;
+  using result_col_t = plain_type_t<decltype(f(
+      (std::declval<ref_type_t<Types&&>>().col(0))...))>;
   using T_return = scalar_type_t<result_col_t>;
   using matrix_t = Eigen::Matrix<T_return, Eigen::Dynamic, Eigen::Dynamic>;
   if (n_cols == 0) {
@@ -326,6 +385,28 @@ inline auto col_mapN(F&& f, Types&&... args) {
         return result;
       },
       m_refs);
+}
+
+/**
+ * Apply a functor columnwise to N Eigen matrices with tuple arguments
+ * prepended to each call.
+ *
+ * @tparam F Type of functor to apply.
+ * @tparam Tuple Type of tuple containing leading shared arguments.
+ * @tparam Types Eigen matrix types.
+ * @param f functor to apply to each tuple of columns.
+ * @param tup leading shared arguments expanded before each tuple of columns.
+ * @param args Eigen matrix inputs to which operation is applied.
+ * @return Eigen matrix with result of applying functor to each tuple of
+ * columns.
+ */
+template <typename F, typename Tuple, typename... Types,
+          require_tuple_t<Tuple>* = nullptr,
+          require_all_eigen_matrix_dynamic_t<Types...>* = nullptr>
+inline auto col_mapN(F&& f, Tuple&& tup, Types&&... args) {
+  return internal::with_tuple_prefix(f, tup, [&](auto&& prefixed_f) {
+    return col_mapN(prefixed_f, std::forward<Types>(args)...);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/meta/is_tuple.hpp
+++ b/stan/math/prim/meta/is_tuple.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <stan/math/prim/meta/require_helpers.hpp>
+#include <stan/math/prim/meta/conjunction.hpp>
 #include <tuple>
 #include <type_traits>
 
@@ -15,6 +16,13 @@ struct is_tuple_impl : std::false_type {};
 
 template <typename... Types>
 struct is_tuple_impl<std::tuple<Types...>> : std::true_type {};
+
+template <template <class...> class TypeCheck, typename T>
+struct all_tuple_elements : std::false_type {};
+
+template <template <class...> class TypeCheck, typename... Types>
+struct all_tuple_elements<TypeCheck, std::tuple<Types...>>
+    : math::conjunction<TypeCheck<std::decay_t<Types>>...> {};
 }  // namespace internal
 
 template <typename T>
@@ -31,6 +39,13 @@ constexpr bool is_tuple_v = is_tuple<T>::value;
 /*! @tparam T the type to check */
 template <typename T>
 using require_tuple_t = require_t<is_tuple<std::decay_t<T>>>;
+
+/*! \brief Require all elements of a tuple satisfy `TypeCheck` */
+/*! @tparam TypeCheck the type trait applied to each tuple element */
+/*! @tparam T the tuple type to check */
+template <template <class...> class TypeCheck, typename T>
+using require_all_tuple_elements_t
+    = require_t<internal::all_tuple_elements<TypeCheck, std::decay_t<T>>>;
 
 /*! \brief Require type does not satisfy @ref is_tuple */
 /*! @tparam T the type to check */

--- a/test/unit/math/prim/err/check_consistent_sizes_test.cpp
+++ b/test/unit/math/prim/err/check_consistent_sizes_test.cpp
@@ -1,0 +1,32 @@
+#include <stan/math/prim/err/check_consistent_sizes.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <vector>
+
+TEST(ErrorHandling, checkConsistentSizesUnnamedArguments) {
+  using stan::math::check_consistent_sizes;
+
+  std::vector<double> x1(3);
+  std::vector<int> x2(3);
+  std::vector<double> x3(2);
+
+  EXPECT_NO_THROW(check_consistent_sizes("check_consistent_sizes", x1, x2));
+  EXPECT_THROW_MSG_WITH_COUNT(
+      check_consistent_sizes("check_consistent_sizes", x1, x2, x3),
+      std::invalid_argument, "arg1", 1);
+  EXPECT_THROW_MSG_WITH_COUNT(
+      check_consistent_sizes("check_consistent_sizes", x1, x2, x3),
+      std::invalid_argument, "arg3", 1);
+  EXPECT_NO_THROW(check_consistent_sizes("check_consistent_sizes", x1));
+}
+
+TEST(ErrorHandling, checkConsistentSizesNamedArgumentsStillResolve) {
+  using stan::math::check_consistent_sizes;
+
+  std::vector<double> x1(3);
+  std::vector<double> x2(2);
+
+  EXPECT_THROW_MSG(
+      check_consistent_sizes("check_consistent_sizes", "x1", x1, "x2", x2),
+      std::invalid_argument, "x2");
+}

--- a/test/unit/math/prim/err/check_matching_dims_test.cpp
+++ b/test/unit/math/prim/err/check_matching_dims_test.cpp
@@ -27,6 +27,23 @@ TEST(ErrorHandlingMatrix, checkMatchingDimsMatrix) {
       std::invalid_argument);
 }
 
+TEST(ErrorHandlingMatrix, checkMatchingDimsUnnamedArguments) {
+  using stan::math::check_matching_dims;
+
+  Eigen::MatrixXd x1(2, 3);
+  Eigen::MatrixXd x2(2, 3);
+  Eigen::MatrixXd x3(3, 2);
+
+  EXPECT_NO_THROW(check_matching_dims("checkMatchingDims", x1));
+  EXPECT_NO_THROW(check_matching_dims("checkMatchingDims", x1, x2));
+  EXPECT_THROW_MSG_WITH_COUNT(
+      check_matching_dims("checkMatchingDims", x1, x2, x3),
+      std::invalid_argument, "arg1", 1);
+  EXPECT_THROW_MSG_WITH_COUNT(
+      check_matching_dims("checkMatchingDims", x1, x2, x3),
+      std::invalid_argument, "arg3", 1);
+}
+
 TEST(ErrorHandlingMatrix, checkMatchingDimsArray) {
   std::vector<double> y(3);
   std::vector<double> x(3);

--- a/test/unit/math/prim/functor/map_test.cpp
+++ b/test/unit/math/prim/functor/map_test.cpp
@@ -1,0 +1,389 @@
+#include <stan/math/prim.hpp>
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+TEST(MathFunctor, map_square) {
+  std::vector<double> x{1.0, 2.0, 3.0};
+  auto y = stan::math::map([](double v) { return v * v; }, x);
+  ASSERT_EQ(y.size(), 3u);
+  EXPECT_FLOAT_EQ(y[0], 1.0);
+  EXPECT_FLOAT_EQ(y[1], 4.0);
+  EXPECT_FLOAT_EQ(y[2], 9.0);
+}
+
+TEST(MathFunctor, map_type_change) {
+  std::vector<int> x{1, 2, 3};
+  auto y = stan::math::map([](int v) { return v + 0.5; }, x);
+  EXPECT_FLOAT_EQ(y[0], 1.5);
+  EXPECT_FLOAT_EQ(y[1], 2.5);
+  EXPECT_FLOAT_EQ(y[2], 3.5);
+}
+
+TEST(MathFunctor, map_empty) {
+  std::vector<double> x;
+  auto y = stan::math::map([](double v) { return v; }, x);
+  EXPECT_EQ(y.size(), 0u);
+}
+
+TEST(MathFunctor, map_const_vector) {
+  const std::vector<double> x{1.0, 2.0, 3.0};
+  auto y = stan::math::map([](double v) { return 2.0 * v; }, x);
+  ASSERT_EQ(y.size(), 3u);
+  EXPECT_FLOAT_EQ(y[0], 2.0);
+  EXPECT_FLOAT_EQ(y[1], 4.0);
+  EXPECT_FLOAT_EQ(y[2], 6.0);
+}
+
+TEST(MathFunctor, map_variadic_args) {
+  std::vector<double> x{1.0, 2.0, 3.0};
+  double offset = 10.0;
+  double scale = 2.0;
+  auto y = stan::math::map(
+      [](double v, double mu, double sigma) { return mu + sigma * v; }, x,
+      offset, scale);
+  ASSERT_EQ(y.size(), 3u);
+  EXPECT_FLOAT_EQ(y[0], 12.0);
+  EXPECT_FLOAT_EQ(y[1], 14.0);
+  EXPECT_FLOAT_EQ(y[2], 16.0);
+}
+
+TEST(MathFunctor, map_shared_arg_reused) {
+  std::vector<double> x{1.0, 2.0, 3.0};
+  auto offset = std::make_unique<double>(10.0);
+  auto y = stan::math::map(
+      [](double v, const std::unique_ptr<double>& mu) { return v + *mu; }, x,
+      std::move(offset));
+  ASSERT_EQ(y.size(), 3u);
+  EXPECT_FLOAT_EQ(y[0], 11.0);
+  EXPECT_FLOAT_EQ(y[1], 12.0);
+  EXPECT_FLOAT_EQ(y[2], 13.0);
+}
+
+TEST(MathFunctor, mapN_add) {
+  std::vector<double> a{1.0, 2.0};
+  std::vector<double> b{10.0, 20.0};
+  auto y = stan::math::mapN([](double u, double v) { return u + v; }, a, b);
+  ASSERT_EQ(y.size(), 2u);
+  EXPECT_FLOAT_EQ(y[0], 11.0);
+  EXPECT_FLOAT_EQ(y[1], 22.0);
+}
+
+TEST(MathFunctor, mapN_mixed_scalar_types) {
+  std::vector<int> a{1, 2, 3};
+  std::vector<double> b{0.5, 1.5, 2.5};
+  auto y = stan::math::mapN([](int u, double v) { return u + v; }, a, b);
+  ASSERT_EQ(y.size(), 3u);
+  EXPECT_FLOAT_EQ(y[0], 1.5);
+  EXPECT_FLOAT_EQ(y[1], 3.5);
+  EXPECT_FLOAT_EQ(y[2], 5.5);
+}
+
+TEST(MathFunctor, mapN_three_vectors) {
+  std::vector<double> a{1.0, 2.0};
+  std::vector<double> b{10.0, 20.0};
+  std::vector<double> c{100.0, 200.0};
+  auto y = stan::math::mapN(
+      [](double u, double v, double w) { return u + v + w; }, a, b, c);
+  ASSERT_EQ(y.size(), 2u);
+  EXPECT_FLOAT_EQ(y[0], 111.0);
+  EXPECT_FLOAT_EQ(y[1], 222.0);
+}
+
+TEST(MathFunctor, mapN_empty) {
+  std::vector<double> a;
+  std::vector<double> b;
+  auto y = stan::math::mapN([](double u, double v) { return u + v; }, a, b);
+  EXPECT_EQ(y.size(), 0u);
+}
+
+TEST(MathFunctor, mapN_size_mismatch) {
+  std::vector<double> a{1.0, 2.0};
+  std::vector<double> b{10.0};
+  EXPECT_THROW(stan::math::mapN([](double u, double v) { return u + v; }, a, b),
+               std::invalid_argument);
+}
+
+TEST(MathFunctor, row_map_standardize) {
+  Eigen::MatrixXd x(2, 3);
+  x << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+  Eigen::RowVectorXd mu(3);
+  mu << 1.0, 2.0, 3.0;
+  Eigen::RowVectorXd sigma(3);
+  sigma << 1.0, 2.0, 3.0;
+
+  auto y = stan::math::row_map(
+      [](const Eigen::RowVectorXd& row, const Eigen::RowVectorXd& m,
+         const Eigen::RowVectorXd& s) {
+        return (row.array() - m.array()) / s.array();
+      },
+      x, mu, sigma);
+
+  Eigen::MatrixXd expected(2, 3);
+  expected << 0.0, 0.0, 0.0, 3.0, 1.5, 1.0;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
+TEST(MathFunctor, row_map_empty) {
+  Eigen::MatrixXd x(0, 3);
+  auto y = stan::math::row_map(
+      [](const Eigen::RowVectorXd& row) { return row; }, x);
+  EXPECT_EQ(y.rows(), 0);
+  EXPECT_EQ(y.cols(), 0);
+}
+
+TEST(MathFunctor, row_map_inconsistent_row_size) {
+  Eigen::MatrixXd x(2, 2);
+  x << 1.0, 2.0, 3.0, 4.0;
+  int call = 0;
+  EXPECT_THROW(stan::math::row_map(
+                   [&call](const Eigen::RowVectorXd&) {
+                     ++call;
+                     if (call == 1) {
+                       return Eigen::RowVectorXd::Ones(2);
+                     }
+                     return Eigen::RowVectorXd::Ones(3);
+                   },
+                   x),
+               std::invalid_argument);
+}
+
+TEST(MathFunctor, row_map_shared_arg_reused) {
+  Eigen::MatrixXd x(2, 2);
+  x << 1.0, 2.0, 3.0, 4.0;
+  auto offset = std::make_unique<double>(10.0);
+  auto y = stan::math::row_map(
+      [](const Eigen::RowVectorXd& row, const std::unique_ptr<double>& mu) {
+        return row.array() + *mu;
+      },
+      x, std::move(offset));
+
+  Eigen::MatrixXd expected(2, 2);
+  expected << 11.0, 12.0, 13.0, 14.0;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
+TEST(MathFunctor, col_map_sum_rows) {
+  Eigen::MatrixXd x(2, 2);
+  x << 1.0, 2.0, 3.0, 4.0;
+
+  auto y = stan::math::col_map(
+      [](const Eigen::VectorXd& col) {
+        return Eigen::VectorXd::Constant(1, col.sum());
+      },
+      x);
+
+  Eigen::MatrixXd expected(1, 2);
+  expected << 4.0, 6.0;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
+TEST(MathFunctor, col_map_empty) {
+  Eigen::MatrixXd x(3, 0);
+  auto y
+      = stan::math::col_map([](const Eigen::VectorXd& col) { return col; }, x);
+  EXPECT_EQ(y.rows(), 0);
+  EXPECT_EQ(y.cols(), 0);
+}
+
+TEST(MathFunctor, col_map_inconsistent_col_size) {
+  Eigen::MatrixXd x(2, 2);
+  x << 1.0, 2.0, 3.0, 4.0;
+  int call = 0;
+  EXPECT_THROW(stan::math::col_map(
+                   [&call](const Eigen::VectorXd&) {
+                     ++call;
+                     if (call == 1) {
+                       return Eigen::VectorXd::Ones(2);
+                     }
+                     return Eigen::VectorXd::Ones(3);
+                   },
+                   x),
+               std::invalid_argument);
+}
+
+TEST(MathFunctor, col_map_shared_arg_reused) {
+  Eigen::MatrixXd x(2, 2);
+  x << 1.0, 2.0, 3.0, 4.0;
+  auto scale = std::make_unique<double>(2.0);
+  auto y = stan::math::col_map(
+      [](const Eigen::VectorXd& col, const std::unique_ptr<double>& s) {
+        return (*s) * col;
+      },
+      x, std::move(scale));
+
+  Eigen::MatrixXd expected(2, 2);
+  expected << 2.0, 4.0, 6.0, 8.0;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
+TEST(MathFunctor, row_mapN_add) {
+  Eigen::MatrixXd a(2, 2);
+  a << 1.0, 2.0, 3.0, 4.0;
+  Eigen::MatrixXd b(2, 2);
+  b << 10.0, 20.0, 30.0, 40.0;
+
+  auto y
+      = stan::math::row_mapN([](const Eigen::RowVectorXd& u,
+                                const Eigen::RowVectorXd& v) { return u + v; },
+                             a, b);
+
+  Eigen::MatrixXd expected(2, 2);
+  expected << 11.0, 22.0, 33.0, 44.0;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
+TEST(MathFunctor, row_mapN_dim_mismatch) {
+  Eigen::MatrixXd a(2, 2);
+  a << 1.0, 2.0, 3.0, 4.0;
+  Eigen::MatrixXd b(2, 3);
+  b << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+  EXPECT_THROW(
+      stan::math::row_mapN([](const Eigen::RowVectorXd& u,
+                              const Eigen::RowVectorXd& v) { return u + v; },
+                           a, b),
+      std::invalid_argument);
+}
+
+TEST(MathFunctor, row_mapN_empty) {
+  Eigen::MatrixXd a(0, 2);
+  Eigen::MatrixXd b(0, 2);
+  auto y
+      = stan::math::row_mapN([](const Eigen::RowVectorXd& u,
+                                const Eigen::RowVectorXd& v) { return u + v; },
+                             a, b);
+  EXPECT_EQ(y.rows(), 0);
+  EXPECT_EQ(y.cols(), 0);
+}
+
+TEST(MathFunctor, row_mapN_mixed_scalar_types) {
+  Eigen::MatrixXi a(2, 2);
+  a << 1, 2, 3, 4;
+  Eigen::MatrixXd b(2, 2);
+  b << 0.5, 1.5, 2.5, 3.5;
+  auto y = stan::math::row_mapN(
+      [](const auto& u, const auto& v) {
+        return u.template cast<double>() + v;
+      },
+      a, b);
+
+  Eigen::MatrixXd expected(2, 2);
+  expected << 1.5, 3.5, 5.5, 7.5;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
+TEST(MathFunctor, row_mapN_inconsistent_row_size) {
+  Eigen::MatrixXd a(2, 2);
+  a << 1.0, 2.0, 3.0, 4.0;
+  Eigen::MatrixXd b(2, 2);
+  b << 10.0, 20.0, 30.0, 40.0;
+  int call = 0;
+  EXPECT_THROW(
+      stan::math::row_mapN(
+          [&call](const Eigen::RowVectorXd&, const Eigen::RowVectorXd&) {
+            ++call;
+            if (call == 1) {
+              return Eigen::RowVectorXd::Ones(2);
+            }
+            return Eigen::RowVectorXd::Ones(3);
+          },
+          a, b),
+      std::invalid_argument);
+}
+
+TEST(MathFunctor, col_mapN_add) {
+  Eigen::MatrixXd a(2, 2);
+  a << 1.0, 2.0, 3.0, 4.0;
+  Eigen::MatrixXd b(2, 2);
+  b << 10.0, 20.0, 30.0, 40.0;
+
+  auto y = stan::math::col_mapN(
+      [](const Eigen::VectorXd& u, const Eigen::VectorXd& v) { return u + v; },
+      a, b);
+
+  Eigen::MatrixXd expected(2, 2);
+  expected << 11.0, 22.0, 33.0, 44.0;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
+TEST(MathFunctor, col_mapN_dim_mismatch) {
+  Eigen::MatrixXd a(2, 2);
+  a << 1.0, 2.0, 3.0, 4.0;
+  Eigen::MatrixXd b(3, 2);
+  b << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+  EXPECT_THROW(
+      stan::math::col_mapN([](const Eigen::VectorXd& u,
+                              const Eigen::VectorXd& v) { return u + v; },
+                           a, b),
+      std::invalid_argument);
+}
+
+TEST(MathFunctor, col_mapN_empty) {
+  Eigen::MatrixXd a(2, 0);
+  Eigen::MatrixXd b(2, 0);
+  auto y = stan::math::col_mapN(
+      [](const Eigen::VectorXd& u, const Eigen::VectorXd& v) { return u + v; },
+      a, b);
+  EXPECT_EQ(y.rows(), 0);
+  EXPECT_EQ(y.cols(), 0);
+}
+
+TEST(MathFunctor, col_mapN_mixed_scalar_types) {
+  Eigen::MatrixXi a(2, 2);
+  a << 1, 2, 3, 4;
+  Eigen::MatrixXd b(2, 2);
+  b << 0.5, 1.5, 2.5, 3.5;
+  auto y = stan::math::col_mapN(
+      [](const auto& u, const auto& v) {
+        return u.template cast<double>() + v;
+      },
+      a, b);
+
+  Eigen::MatrixXd expected(2, 2);
+  expected << 1.5, 3.5, 5.5, 7.5;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
+TEST(MathFunctor, col_mapN_inconsistent_col_size) {
+  Eigen::MatrixXd a(2, 2);
+  a << 1.0, 2.0, 3.0, 4.0;
+  Eigen::MatrixXd b(2, 2);
+  b << 10.0, 20.0, 30.0, 40.0;
+  int call = 0;
+  EXPECT_THROW(stan::math::col_mapN(
+                   [&call](const Eigen::VectorXd&, const Eigen::VectorXd&) {
+                     ++call;
+                     if (call == 1) {
+                       return Eigen::VectorXd::Ones(2);
+                     }
+                     return Eigen::VectorXd::Ones(3);
+                   },
+                   a, b),
+               std::invalid_argument);
+}
+
+TEST(MathFunctor, row_map_block_expression) {
+  Eigen::MatrixXd x(3, 3);
+  x << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0;
+  auto y = stan::math::row_map([](const auto& row) { return 2.0 * row; },
+                               x.block(0, 0, 2, 3));
+
+  Eigen::MatrixXd expected(2, 3);
+  expected << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
+TEST(MathFunctor, col_map_block_expression) {
+  Eigen::MatrixXd x(3, 3);
+  x << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0;
+  auto y = stan::math::col_map([](const auto& col) { return 2.0 * col; },
+                               x.block(0, 0, 3, 2));
+
+  Eigen::MatrixXd expected(3, 2);
+  expected << 2.0, 4.0, 8.0, 10.0, 14.0, 16.0;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}

--- a/test/unit/math/prim/functor/map_test.cpp
+++ b/test/unit/math/prim/functor/map_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <stdexcept>
+#include <tuple>
 #include <vector>
 
 TEST(MathFunctor, map_square) {
@@ -90,6 +91,16 @@ TEST(MathFunctor, mapN_three_vectors) {
   ASSERT_EQ(y.size(), 2u);
   EXPECT_FLOAT_EQ(y[0], 111.0);
   EXPECT_FLOAT_EQ(y[1], 222.0);
+}
+
+TEST(MathFunctor, mapN_tuple_args) {
+  std::vector<double> a{1.0, 2.0};
+  std::vector<double> b{10.0, 20.0};
+  auto args = std::make_tuple(100.0);
+  auto y = stan::math::mapN(
+      [](double offset, double u, double v) { return offset + u + v; }, args, a,
+      b);
+  EXPECT_STD_VECTOR_FLOAT_EQ(y, std::vector<double>({111.0, 122.0}));
 }
 
 TEST(MathFunctor, mapN_empty) {
@@ -263,6 +274,24 @@ TEST(MathFunctor, row_mapN_add) {
   EXPECT_MATRIX_FLOAT_EQ(y, expected);
 }
 
+TEST(MathFunctor, row_mapN_tuple_args) {
+  Eigen::MatrixXd a(2, 2);
+  a << 1.0, 2.0, 3.0, 4.0;
+  Eigen::MatrixXd b(2, 2);
+  b << 10.0, 20.0, 30.0, 40.0;
+  auto args = std::make_tuple(100.0);
+  auto y = stan::math::row_mapN(
+      [](double offset, const Eigen::RowVectorXd& u,
+         const Eigen::RowVectorXd& v) {
+        return offset + u.array() + v.array();
+      },
+      args, a, b);
+
+  Eigen::MatrixXd expected(2, 2);
+  expected << 111.0, 122.0, 133.0, 144.0;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
 TEST(MathFunctor, row_mapN_dim_mismatch) {
   Eigen::MatrixXd a(2, 2);
   a << 1.0, 2.0, 3.0, 4.0;
@@ -349,6 +378,23 @@ TEST(MathFunctor, col_mapN_add) {
 
   Eigen::MatrixXd expected(2, 2);
   expected << 11.0, 22.0, 33.0, 44.0;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
+TEST(MathFunctor, col_mapN_tuple_args) {
+  Eigen::MatrixXd a(2, 2);
+  a << 1.0, 2.0, 3.0, 4.0;
+  Eigen::MatrixXd b(2, 2);
+  b << 10.0, 20.0, 30.0, 40.0;
+  auto args = std::make_tuple(100.0);
+  auto y = stan::math::col_mapN(
+      [](double offset, const Eigen::VectorXd& u, const Eigen::VectorXd& v) {
+        return offset + u.array() + v.array();
+      },
+      args, a, b);
+
+  Eigen::MatrixXd expected(2, 2);
+  expected << 111.0, 122.0, 133.0, 144.0;
   EXPECT_MATRIX_FLOAT_EQ(y, expected);
 }
 

--- a/test/unit/math/prim/functor/map_test.cpp
+++ b/test/unit/math/prim/functor/map_test.cpp
@@ -134,6 +134,20 @@ TEST(MathFunctor, row_map_empty) {
   EXPECT_EQ(y.cols(), 0);
 }
 
+TEST(MathFunctor, row_map_empty_result) {
+  Eigen::MatrixXd x = Eigen::MatrixXd::Ones(2, 2);
+  int calls = 0;
+  auto y = stan::math::row_map(
+      [&calls](const Eigen::RowVectorXd&) {
+        ++calls;
+        return Eigen::RowVectorXd(0);
+      },
+      x);
+  EXPECT_EQ(y.rows(), 0);
+  EXPECT_EQ(y.cols(), 0);
+  EXPECT_EQ(calls, 1);
+}
+
 TEST(MathFunctor, row_map_inconsistent_row_size) {
   Eigen::MatrixXd x(2, 2);
   x << 1.0, 2.0, 3.0, 4.0;
@@ -186,6 +200,20 @@ TEST(MathFunctor, col_map_empty) {
       = stan::math::col_map([](const Eigen::VectorXd& col) { return col; }, x);
   EXPECT_EQ(y.rows(), 0);
   EXPECT_EQ(y.cols(), 0);
+}
+
+TEST(MathFunctor, col_map_empty_result) {
+  Eigen::MatrixXd x = Eigen::MatrixXd::Ones(2, 2);
+  int calls = 0;
+  auto y = stan::math::col_map(
+      [&calls](const Eigen::VectorXd&) {
+        ++calls;
+        return Eigen::VectorXd(0);
+      },
+      x);
+  EXPECT_EQ(y.rows(), 0);
+  EXPECT_EQ(y.cols(), 0);
+  EXPECT_EQ(calls, 1);
 }
 
 TEST(MathFunctor, col_map_inconsistent_col_size) {
@@ -259,6 +287,21 @@ TEST(MathFunctor, row_mapN_empty) {
   EXPECT_EQ(y.cols(), 0);
 }
 
+TEST(MathFunctor, row_mapN_empty_result) {
+  Eigen::MatrixXd a = Eigen::MatrixXd::Ones(2, 2);
+  Eigen::MatrixXd b = Eigen::MatrixXd::Ones(2, 2);
+  int calls = 0;
+  auto y = stan::math::row_mapN(
+      [&calls](const Eigen::RowVectorXd&, const Eigen::RowVectorXd&) {
+        ++calls;
+        return Eigen::RowVectorXd(0);
+      },
+      a, b);
+  EXPECT_EQ(y.rows(), 0);
+  EXPECT_EQ(y.cols(), 0);
+  EXPECT_EQ(calls, 1);
+}
+
 TEST(MathFunctor, row_mapN_mixed_scalar_types) {
   Eigen::MatrixXi a(2, 2);
   a << 1, 2, 3, 4;
@@ -330,6 +373,21 @@ TEST(MathFunctor, col_mapN_empty) {
       a, b);
   EXPECT_EQ(y.rows(), 0);
   EXPECT_EQ(y.cols(), 0);
+}
+
+TEST(MathFunctor, col_mapN_empty_result) {
+  Eigen::MatrixXd a = Eigen::MatrixXd::Ones(2, 2);
+  Eigen::MatrixXd b = Eigen::MatrixXd::Ones(2, 2);
+  int calls = 0;
+  auto y = stan::math::col_mapN(
+      [&calls](const Eigen::VectorXd&, const Eigen::VectorXd&) {
+        ++calls;
+        return Eigen::VectorXd(0);
+      },
+      a, b);
+  EXPECT_EQ(y.rows(), 0);
+  EXPECT_EQ(y.cols(), 0);
+  EXPECT_EQ(calls, 1);
 }
 
 TEST(MathFunctor, col_mapN_mixed_scalar_types) {

--- a/test/unit/math/prim/functor/map_test.cpp
+++ b/test/unit/math/prim/functor/map_test.cpp
@@ -93,13 +93,15 @@ TEST(MathFunctor, mapN_three_vectors) {
   EXPECT_FLOAT_EQ(y[1], 222.0);
 }
 
-TEST(MathFunctor, mapN_tuple_args) {
+TEST(MathFunctor, mapN_shared_arg_reused) {
   std::vector<double> a{1.0, 2.0};
   std::vector<double> b{10.0, 20.0};
-  auto args = std::make_tuple(100.0);
+  auto offset = std::make_unique<double>(100.0);
   auto y = stan::math::mapN(
-      [](double offset, double u, double v) { return offset + u + v; }, args, a,
-      b);
+      [](double u, double v, const std::unique_ptr<double>& mu) {
+        return u + v + *mu;
+      },
+      std::forward_as_tuple(a, b), std::move(offset));
   EXPECT_STD_VECTOR_FLOAT_EQ(y, std::vector<double>({111.0, 122.0}));
 }
 
@@ -274,18 +276,18 @@ TEST(MathFunctor, row_mapN_add) {
   EXPECT_MATRIX_FLOAT_EQ(y, expected);
 }
 
-TEST(MathFunctor, row_mapN_tuple_args) {
+TEST(MathFunctor, row_mapN_shared_arg_reused) {
   Eigen::MatrixXd a(2, 2);
   a << 1.0, 2.0, 3.0, 4.0;
   Eigen::MatrixXd b(2, 2);
   b << 10.0, 20.0, 30.0, 40.0;
-  auto args = std::make_tuple(100.0);
+  auto offset = std::make_unique<double>(100.0);
   auto y = stan::math::row_mapN(
-      [](double offset, const Eigen::RowVectorXd& u,
-         const Eigen::RowVectorXd& v) {
-        return offset + u.array() + v.array();
+      [](const Eigen::RowVectorXd& u, const Eigen::RowVectorXd& v,
+         const std::unique_ptr<double>& mu) {
+        return *mu + u.array() + v.array();
       },
-      args, a, b);
+      std::forward_as_tuple(a, b), std::move(offset));
 
   Eigen::MatrixXd expected(2, 2);
   expected << 111.0, 122.0, 133.0, 144.0;
@@ -381,17 +383,18 @@ TEST(MathFunctor, col_mapN_add) {
   EXPECT_MATRIX_FLOAT_EQ(y, expected);
 }
 
-TEST(MathFunctor, col_mapN_tuple_args) {
+TEST(MathFunctor, col_mapN_shared_arg_reused) {
   Eigen::MatrixXd a(2, 2);
   a << 1.0, 2.0, 3.0, 4.0;
   Eigen::MatrixXd b(2, 2);
   b << 10.0, 20.0, 30.0, 40.0;
-  auto args = std::make_tuple(100.0);
+  auto offset = std::make_unique<double>(100.0);
   auto y = stan::math::col_mapN(
-      [](double offset, const Eigen::VectorXd& u, const Eigen::VectorXd& v) {
-        return offset + u.array() + v.array();
+      [](const Eigen::VectorXd& u, const Eigen::VectorXd& v,
+         const std::unique_ptr<double>& mu) {
+        return *mu + u.array() + v.array();
       },
-      args, a, b);
+      std::forward_as_tuple(a, b), std::move(offset));
 
   Eigen::MatrixXd expected(2, 2);
   expected << 111.0, 122.0, 133.0, 144.0;
@@ -489,5 +492,40 @@ TEST(MathFunctor, col_map_block_expression) {
 
   Eigen::MatrixXd expected(3, 2);
   expected << 2.0, 4.0, 8.0, 10.0, 14.0, 16.0;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
+TEST(MathFunctor, row_mapN_expression_inputs) {
+  Eigen::MatrixXd a(2, 2);
+  a << 1.0, 0.0, 0.0, 1.0;
+  Eigen::MatrixXd b(2, 2);
+  b << 1.0, 2.0, 3.0, 4.0;
+  Eigen::MatrixXd c(2, 2);
+  c << 10.0, 20.0, 30.0, 40.0;
+
+  auto y
+      = stan::math::row_mapN([](const Eigen::RowVectorXd& u,
+                                const Eigen::RowVectorXd& v) { return u + v; },
+                             a * b, c);
+
+  Eigen::MatrixXd expected(2, 2);
+  expected << 11.0, 22.0, 33.0, 44.0;
+  EXPECT_MATRIX_FLOAT_EQ(y, expected);
+}
+
+TEST(MathFunctor, col_mapN_expression_inputs) {
+  Eigen::MatrixXd a(2, 2);
+  a << 1.0, 0.0, 0.0, 1.0;
+  Eigen::MatrixXd b(2, 2);
+  b << 1.0, 2.0, 3.0, 4.0;
+  Eigen::MatrixXd c(2, 2);
+  c << 10.0, 20.0, 30.0, 40.0;
+
+  auto y = stan::math::col_mapN(
+      [](const Eigen::VectorXd& u, const Eigen::VectorXd& v) { return u + v; },
+      a * b, c);
+
+  Eigen::MatrixXd expected(2, 2);
+  expected << 11.0, 22.0, 33.0, 44.0;
   EXPECT_MATRIX_FLOAT_EQ(y, expected);
 }

--- a/test/unit/math/prim/functor/map_test.cpp
+++ b/test/unit/math/prim/functor/map_test.cpp
@@ -66,7 +66,8 @@ TEST(MathFunctor, map_shared_arg_reused) {
 TEST(MathFunctor, mapN_add) {
   std::vector<double> a{1.0, 2.0};
   std::vector<double> b{10.0, 20.0};
-  auto y = stan::math::mapN([](double u, double v) { return u + v; }, a, b);
+  auto y = stan::math::mapN([](double u, double v) { return u + v; },
+                            std::forward_as_tuple(a, b));
   ASSERT_EQ(y.size(), 2u);
   EXPECT_FLOAT_EQ(y[0], 11.0);
   EXPECT_FLOAT_EQ(y[1], 22.0);
@@ -75,7 +76,8 @@ TEST(MathFunctor, mapN_add) {
 TEST(MathFunctor, mapN_mixed_scalar_types) {
   std::vector<int> a{1, 2, 3};
   std::vector<double> b{0.5, 1.5, 2.5};
-  auto y = stan::math::mapN([](int u, double v) { return u + v; }, a, b);
+  auto y = stan::math::mapN([](int u, double v) { return u + v; },
+                            std::forward_as_tuple(a, b));
   ASSERT_EQ(y.size(), 3u);
   EXPECT_FLOAT_EQ(y[0], 1.5);
   EXPECT_FLOAT_EQ(y[1], 3.5);
@@ -86,8 +88,9 @@ TEST(MathFunctor, mapN_three_vectors) {
   std::vector<double> a{1.0, 2.0};
   std::vector<double> b{10.0, 20.0};
   std::vector<double> c{100.0, 200.0};
-  auto y = stan::math::mapN(
-      [](double u, double v, double w) { return u + v + w; }, a, b, c);
+  auto y
+      = stan::math::mapN([](double u, double v, double w) { return u + v + w; },
+                         std::forward_as_tuple(a, b, c));
   ASSERT_EQ(y.size(), 2u);
   EXPECT_FLOAT_EQ(y[0], 111.0);
   EXPECT_FLOAT_EQ(y[1], 222.0);
@@ -108,14 +111,16 @@ TEST(MathFunctor, mapN_shared_arg_reused) {
 TEST(MathFunctor, mapN_empty) {
   std::vector<double> a;
   std::vector<double> b;
-  auto y = stan::math::mapN([](double u, double v) { return u + v; }, a, b);
+  auto y = stan::math::mapN([](double u, double v) { return u + v; },
+                            std::forward_as_tuple(a, b));
   EXPECT_EQ(y.size(), 0u);
 }
 
 TEST(MathFunctor, mapN_size_mismatch) {
   std::vector<double> a{1.0, 2.0};
   std::vector<double> b{10.0};
-  EXPECT_THROW(stan::math::mapN([](double u, double v) { return u + v; }, a, b),
+  EXPECT_THROW(stan::math::mapN([](double u, double v) { return u + v; },
+                                std::forward_as_tuple(a, b)),
                std::invalid_argument);
 }
 
@@ -269,7 +274,7 @@ TEST(MathFunctor, row_mapN_add) {
   auto y
       = stan::math::row_mapN([](const Eigen::RowVectorXd& u,
                                 const Eigen::RowVectorXd& v) { return u + v; },
-                             a, b);
+                             std::forward_as_tuple(a, b));
 
   Eigen::MatrixXd expected(2, 2);
   expected << 11.0, 22.0, 33.0, 44.0;
@@ -303,7 +308,7 @@ TEST(MathFunctor, row_mapN_dim_mismatch) {
   EXPECT_THROW(
       stan::math::row_mapN([](const Eigen::RowVectorXd& u,
                               const Eigen::RowVectorXd& v) { return u + v; },
-                           a, b),
+                           std::forward_as_tuple(a, b)),
       std::invalid_argument);
 }
 
@@ -313,7 +318,7 @@ TEST(MathFunctor, row_mapN_empty) {
   auto y
       = stan::math::row_mapN([](const Eigen::RowVectorXd& u,
                                 const Eigen::RowVectorXd& v) { return u + v; },
-                             a, b);
+                             std::forward_as_tuple(a, b));
   EXPECT_EQ(y.rows(), 0);
   EXPECT_EQ(y.cols(), 0);
 }
@@ -327,7 +332,7 @@ TEST(MathFunctor, row_mapN_empty_result) {
         ++calls;
         return Eigen::RowVectorXd(0);
       },
-      a, b);
+      std::forward_as_tuple(a, b));
   EXPECT_EQ(y.rows(), 0);
   EXPECT_EQ(y.cols(), 0);
   EXPECT_EQ(calls, 1);
@@ -342,7 +347,7 @@ TEST(MathFunctor, row_mapN_mixed_scalar_types) {
       [](const auto& u, const auto& v) {
         return u.template cast<double>() + v;
       },
-      a, b);
+      std::forward_as_tuple(a, b));
 
   Eigen::MatrixXd expected(2, 2);
   expected << 1.5, 3.5, 5.5, 7.5;
@@ -364,7 +369,7 @@ TEST(MathFunctor, row_mapN_inconsistent_row_size) {
             }
             return Eigen::RowVectorXd::Ones(3);
           },
-          a, b),
+          std::forward_as_tuple(a, b)),
       std::invalid_argument);
 }
 
@@ -376,7 +381,7 @@ TEST(MathFunctor, col_mapN_add) {
 
   auto y = stan::math::col_mapN(
       [](const Eigen::VectorXd& u, const Eigen::VectorXd& v) { return u + v; },
-      a, b);
+      std::forward_as_tuple(a, b));
 
   Eigen::MatrixXd expected(2, 2);
   expected << 11.0, 22.0, 33.0, 44.0;
@@ -410,7 +415,7 @@ TEST(MathFunctor, col_mapN_dim_mismatch) {
   EXPECT_THROW(
       stan::math::col_mapN([](const Eigen::VectorXd& u,
                               const Eigen::VectorXd& v) { return u + v; },
-                           a, b),
+                           std::forward_as_tuple(a, b)),
       std::invalid_argument);
 }
 
@@ -419,7 +424,7 @@ TEST(MathFunctor, col_mapN_empty) {
   Eigen::MatrixXd b(2, 0);
   auto y = stan::math::col_mapN(
       [](const Eigen::VectorXd& u, const Eigen::VectorXd& v) { return u + v; },
-      a, b);
+      std::forward_as_tuple(a, b));
   EXPECT_EQ(y.rows(), 0);
   EXPECT_EQ(y.cols(), 0);
 }
@@ -433,7 +438,7 @@ TEST(MathFunctor, col_mapN_empty_result) {
         ++calls;
         return Eigen::VectorXd(0);
       },
-      a, b);
+      std::forward_as_tuple(a, b));
   EXPECT_EQ(y.rows(), 0);
   EXPECT_EQ(y.cols(), 0);
   EXPECT_EQ(calls, 1);
@@ -448,7 +453,7 @@ TEST(MathFunctor, col_mapN_mixed_scalar_types) {
       [](const auto& u, const auto& v) {
         return u.template cast<double>() + v;
       },
-      a, b);
+      std::forward_as_tuple(a, b));
 
   Eigen::MatrixXd expected(2, 2);
   expected << 1.5, 3.5, 5.5, 7.5;
@@ -469,7 +474,7 @@ TEST(MathFunctor, col_mapN_inconsistent_col_size) {
                      }
                      return Eigen::VectorXd::Ones(3);
                    },
-                   a, b),
+                   std::forward_as_tuple(a, b)),
                std::invalid_argument);
 }
 
@@ -506,7 +511,7 @@ TEST(MathFunctor, row_mapN_expression_inputs) {
   auto y
       = stan::math::row_mapN([](const Eigen::RowVectorXd& u,
                                 const Eigen::RowVectorXd& v) { return u + v; },
-                             a * b, c);
+                             std::forward_as_tuple(a * b, c));
 
   Eigen::MatrixXd expected(2, 2);
   expected << 11.0, 22.0, 33.0, 44.0;
@@ -523,7 +528,7 @@ TEST(MathFunctor, col_mapN_expression_inputs) {
 
   auto y = stan::math::col_mapN(
       [](const Eigen::VectorXd& u, const Eigen::VectorXd& v) { return u + v; },
-      a * b, c);
+      std::forward_as_tuple(a * b, c));
 
   Eigen::MatrixXd expected(2, 2);
   expected << 11.0, 22.0, 33.0, 44.0;

--- a/test/unit/math/prim/meta/is_tuple_test.cpp
+++ b/test/unit/math/prim/meta/is_tuple_test.cpp
@@ -10,3 +10,19 @@ TEST(MathMetaPrim, is_tuple) {
   EXPECT_FALSE((stan::math::is_tuple<double>::value));
   EXPECT_FALSE((stan::math::is_tuple<std::vector<double>>::value));
 }
+
+TEST(MathMetaPrim, all_tuple_elements) {
+  using stan::is_std_vector;
+  using stan::math::internal::all_tuple_elements;
+  EXPECT_TRUE((all_tuple_elements<
+               is_std_vector,
+               std::tuple<std::vector<int>, std::vector<double>>>::value));
+  EXPECT_FALSE(
+      (all_tuple_elements<is_std_vector,
+                          std::tuple<std::vector<int>, double>>::value));
+  EXPECT_TRUE((all_tuple_elements<
+               is_std_vector,
+               std::tuple<std::vector<double>&, std::vector<double>&>>::value));
+  EXPECT_FALSE((all_tuple_elements<is_std_vector, std::vector<double>>::value));
+  EXPECT_FALSE((all_tuple_elements<is_std_vector, double>::value));
+}


### PR DESCRIPTION
## Summary

Fixes #3339 

This PR adds elementwise and row-/columnwise map helpers for `std::vector` and Eigen matrices: `map`, `mapN`, `row_map`, `col_map`, `row_mapN`, and `col_mapN`.

**Implementation details:**

+ Added stan/math/prim/functor/map.hpp
   + `map(f, x, args...)`: apply f to each element of a std::vector, with optional shared args
   + `mapN(f, xs, args...)`: `xs` is a tuple of ≥2 equal-sized std::vectors and applies `f(get<0>(xs)[i], get<1>(xs)[i], ..., args...)`
   + `mapN(f, x1, x2, xs...)`: convenience function; equivalent to `mapN(f, forward_as_tuple(x1, x2, xs...))` 
   + `row_map` / `col_map`: same pattern over Eigen matrix rows/columns
   + `row_mapN` / `col_mapN`: same zip pattern over ≥2 equal-dimension Eigen matrices (tuple + trailing shared args, plus  convenience function)

Shared arguments are trailing so call sites look like `mapN(f, (x1, x2), mu, sigma)` with functor signature `f(x1_i, x2_i, mu, sigma)`.

**Other details**

+ Return types deduced from f
+ Size/dimension checks via internal helpers; inconsistent output row/column sizes throw
+ Empty Eigen inputs (or empty first returned row/column) return a 0×0 matrix, since output width/height is unknown when `f` is never usefully applied
+ Included the new header from `stan/math/prim/functor.hpp`

## Tests

+ Added `test/unit/math/prim/functor/map_test.cpp`
    + Happy-path coverage for all six functions
    + Empty-input cases
    + Size/dimension mismatch throws
    + Inconsistent returned row/column size throws
    + Eigen block-expression inputs for row_map / col_map

## Side Effects

I am not aware of any.

## Release notes

+ Added `map`, `mapN`, `row_map`, `col_map`, `row_mapN`, and `col_mapN` functors for elementwise and rowwise/columnwise mapping over std::vector and Eigen matrices.

## Checklist

- [x] Copyright holder: Aalto University
    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
- [x] the basic tests are passing
    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)
- [x] the code is written in idiomatic C++ and changes are documented in the doxygen
- [x] the new changes are tested
- [ ] (optional) open an Issue regarding SoA specialization for implemented functions (see https://github.com/stan-dev/math/pull/3346#discussion_r3622934764)
- [ ] open a follow-up PR in which `map` should support besides std::vectors also eigen [row]vectors and eigen matrices (see https://github.com/stan-dev/math/pull/3346#issuecomment-5063098861)
- [x] AI-Disclosure: I used AI-assistance to draft the PR (Cursor)