### PR TITLE
Don't error on size-zero inputs to LKJ lpdf

### DIFF
--- a/stan/math/prim/err/check_cholesky_factor.hpp
+++ b/stan/math/prim/err/check_cholesky_factor.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/value_of_rec.hpp>
 #include <stan/math/prim/err/check_positive.hpp>
+#include <stan/math/prim/err/check_nonnegative.hpp>
 #include <stan/math/prim/err/check_less_or_equal.hpp>
 #include <stan/math/prim/err/check_lower_triangular.hpp>
 #include <stan/math/prim/err/make_iter_name.hpp>
@@ -34,7 +35,7 @@ inline void check_cholesky_factor(const char* function, const char* name,
                                   const Mat& y) {
   check_less_or_equal(function, "columns and rows of Cholesky factor", y.cols(),
                       y.rows());
-  check_positive(function, "columns of Cholesky factor", y.cols());
+  check_nonnegative(function, "columns of Cholesky factor", y.cols());
   auto&& y_ref = to_ref(value_of_rec(y));
   check_lower_triangular(function, name, y_ref);
   check_positive(function, name, y_ref.diagonal());

--- a/test/unit/math/prim/prob/lkj_corr_test.cpp
+++ b/test/unit/math/prim/prob/lkj_corr_test.cpp
@@ -3,6 +3,19 @@
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/math/distributions.hpp>
 
+TEST(ProbDistributionsLkjCorr, testZero) {
+  boost::random::mt19937 rng;
+  unsigned int K = 0;
+  Eigen::MatrixXd Sigma(K, K);
+  Sigma.setZero();
+  Sigma.diagonal().setOnes();
+  double eta = stan::math::uniform_rng(0, 2, rng);
+  double f = stan::math::do_lkj_constant(eta, K);
+  EXPECT_FLOAT_EQ(0, stan::math::lkj_corr_cholesky_lpdf(Sigma, eta));
+  eta = 1.0;
+  EXPECT_FLOAT_EQ(0, stan::math::lkj_corr_cholesky_lpdf(Sigma, eta));
+}
+
 TEST(ProbDistributionsLkjCorr, testIdentity) {
   boost::random::mt19937 rng;
   unsigned int K = 4;


### PR DESCRIPTION
## Summary

The validation check order for inputs to `lkj_corr_cholesky_lpdf` changed since Stan 2.32, so that cholesky factors of size zero now error and reject instead of just returning 0. This breaks downstream applications which conditionally set the size to zero to remove it from the likelihood ( the `rmdcev` R package relies on this).

This PR updates the `check_cholesky_factor` to allow size-zero inputs

## Tests

Additional test added for size-zero handling

## Side Effects

N/A

## Release notes

`lkj_corr_cholesky_lpdf` returns `0` instead of error with size-zero inputs

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
