### PR TITLE
Add const coeffRef definitions for the Holder class

### DIFF
--- a/stan/math/prim/meta/holder.hpp
+++ b/stan/math/prim/meta/holder.hpp
@@ -169,6 +169,13 @@ class Holder
   auto* data() { return m_arg.data(); }
   const auto* data() const { return m_arg.data(); }
 
+  const auto& coeffRef(Eigen::Index row, Eigen::Index col) const {
+    return m_arg.coeffRef(row, col);
+  }
+  const auto& coeffRef(Eigen::Index index) const {
+    return m_arg.coeffRef(index);
+  }
+
   /**
    * Assignment operator assigns expressions.
    * @param other expression to assign  to this


### PR DESCRIPTION
## Summary

This PR resolves the [indexing & transposition compilation errors](https://github.com/stan-dev/stan/issues/3396) by adding `const coeffRef` definitions for the `Holder<>` class (these just delegate to the `coeffRef` implementation of the underlying type).

I've verified that all works by compiling the linked test model with this branch

## Tests

N/A

## Side Effects

N/A

## Release notes

Add `const coeffRef()` definitions for the `Holder` class to resolve downstream compilation errors

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
