### PR TITLE
Fix missing include in finite_diff_hessian_auto

### DIFF
--- a/stan/math/rev/functor/finite_diff_hessian_auto.hpp
+++ b/stan/math/rev/functor/finite_diff_hessian_auto.hpp
@@ -3,9 +3,9 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core.hpp>
+#include <stan/math/rev/functor/gradient.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/finite_diff_stepsize.hpp>
-#include <stdexcept>
 
 namespace stan {
 namespace math {


### PR DESCRIPTION
## Summary

Small PR to fix `finite_diff_hessian_auto` depending on `gradient` without `#include`-ing it, caused a compilation failure for me downstream

## Tests

N/A existing tests should still pass

## Side Effects

N/A

## Release notes

Fixed missing `#include` for `finite_diff_hessian_auto`

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
