### PR TITLE
Guard reverse-mode eigenvector adjoints against numerically degenerate eigenvalue clusters (minimal-norm gauge)

### DIFF
--- a/stan/math/rev/fun/eigendecompose_sym.hpp
+++ b/stan/math/rev/fun/eigendecompose_sym.hpp
@@ -10,6 +10,14 @@
 #include <stan/math/prim/fun/typedefs.hpp>
 #include <stan/math/prim/fun/eigendecompose_sym.hpp>
 
+#include <limits>
+
+// W-40: relative eigenvalue gap below kappa * max(1, |w|_inf) * eps marks a
+// numerically degenerate eigenvalue cluster for the reverse-mode adjoint.
+#ifndef STAN_MATH_EIGEN_GAP_KAPPA
+#define STAN_MATH_EIGEN_GAP_KAPPA 1e3
+#endif
+
 namespace stan {
 namespace math {
 
@@ -45,15 +53,43 @@ inline auto eigendecompose_sym(const T& m) {
                      * eigenvecs.val().transpose();
     // eigenvector reverse calculation
     const auto p = arena_m.val().cols();
+    // W-40 cluster-aware adjoint: see rev/fun/eigenvectors_sym.hpp. Pairs
+    // with an eigenvalue gap below STAN_MATH_EIGEN_GAP_KAPPA *
+    // max(1, |w|_inf) * eps form a numerically degenerate cluster; their
+    // 1/(w_j - w_i) coupling is replaced by zero (minimal-norm gauge).
+    // Well-separated spectra take the original path VERBATIM below.
+    const double eigengap_tau
+        = STAN_MATH_EIGEN_GAP_KAPPA
+          * std::max(1.0, eigenvals.val().cwiseAbs().maxCoeff())
+          * std::numeric_limits<double>::epsilon();
+    const bool has_degenerate_gap
+        = p > 1
+          && (eigenvals.val().tail(p - 1) - eigenvals.val().head(p - 1))
+                     .minCoeff()
+                 < eigengap_tau;
+    Eigen::MatrixXd vector_adj;
+    if (unlikely(has_degenerate_gap)) {
+      Eigen::MatrixXd gaps
+          = eigenvals.val().rowwise().replicate(p).transpose()
+            - eigenvals.val().rowwise().replicate(p);
+      Eigen::MatrixXd f = (gaps.array().abs() >= eigengap_tau)
+                              .select(gaps.array().inverse(),
+                                      Eigen::MatrixXd::Zero(p, p));
+      vector_adj = eigenvecs.val()
+                   * f.cwiseProduct(
+                       eigenvecs.val().transpose() * eigenvecs.adj_op())
+                   * eigenvecs.val().transpose();
+    } else {
     Eigen::MatrixXd f = (1
                          / (eigenvals.val().rowwise().replicate(p).transpose()
                             - eigenvals.val().rowwise().replicate(p))
                                .array());
     f.diagonal().setZero();
-    auto vector_adj
-        = eigenvecs.val()
-          * f.cwiseProduct(eigenvecs.val().transpose() * eigenvecs.adj_op())
-          * eigenvecs.val().transpose();
+    vector_adj = eigenvecs.val()
+                 * f.cwiseProduct(
+                     eigenvecs.val().transpose() * eigenvecs.adj_op())
+                 * eigenvecs.val().transpose();
+    }
 
     arena_m.adj() += value_adj + vector_adj;
   });

--- a/stan/math/rev/fun/eigenvectors_sym.hpp
+++ b/stan/math/rev/fun/eigenvectors_sym.hpp
@@ -12,6 +12,14 @@
 #include <stan/math/prim/fun/value_of_rec.hpp>
 #include <stan/math/prim/fun/eigenvectors_sym.hpp>
 
+#include <limits>
+
+// W-40: relative eigenvalue gap below kappa * max(1, |w|_inf) * eps marks a
+// numerically degenerate eigenvalue cluster for the reverse-mode adjoint.
+#ifndef STAN_MATH_EIGEN_GAP_KAPPA
+#define STAN_MATH_EIGEN_GAP_KAPPA 1e3
+#endif
+
 namespace stan {
 namespace math {
 
@@ -37,6 +45,34 @@ inline auto eigenvectors_sym(const T& m) {
 
   reverse_pass_callback([arena_m, eigenvals, eigenvecs]() mutable {
     const auto p = arena_m.val().cols();
+    // Eigenvalue pairs with a gap below STAN_MATH_EIGEN_GAP_KAPPA *
+    // max(1, |w|_inf) * eps are treated as one numerically degenerate
+    // cluster: the individual eigenvectors are not identifiable at machine
+    // resolution (any orthogonal basis of the cluster subspace is a valid
+    // answer), and the standard adjoint's 1/(w_j - w_i) coupling amplifies
+    // rounding-level differences to O(1/eps). For such pairs the coupling
+    // is replaced by its minimal-norm (zero) value -- the cluster-gauge
+    // choice; cross-cluster pairs keep the standard formula. Well-separated
+    // spectra (min adjacent gap >= threshold) take the original code path
+    // below VERBATIM, so results there are bit-identical to the unguarded
+    // implementation.
+    const double eigengap_tau = STAN_MATH_EIGEN_GAP_KAPPA
+                                * std::max(1.0, eigenvals.cwiseAbs().maxCoeff())
+                                * std::numeric_limits<double>::epsilon();
+    const bool has_degenerate_gap
+        = p > 1 && (eigenvals.tail(p - 1) - eigenvals.head(p - 1)).minCoeff()
+                       < eigengap_tau;
+    if (unlikely(has_degenerate_gap)) {
+      Eigen::MatrixXd gaps = eigenvals.rowwise().replicate(p).transpose()
+                             - eigenvals.rowwise().replicate(p);
+      Eigen::MatrixXd f = (gaps.array().abs() >= eigengap_tau)
+                              .select(gaps.array().inverse(),
+                                      Eigen::MatrixXd::Zero(p, p));
+      arena_m.adj()
+          += eigenvecs.val()
+             * f.cwiseProduct(eigenvecs.val().transpose() * eigenvecs.adj_op())
+             * eigenvecs.val().transpose();
+    } else {
     Eigen::MatrixXd f = (1
                          / (eigenvals.rowwise().replicate(p).transpose()
                             - eigenvals.rowwise().replicate(p))
@@ -46,6 +82,7 @@ inline auto eigenvectors_sym(const T& m) {
         += eigenvecs.val()
            * f.cwiseProduct(eigenvecs.val().transpose() * eigenvecs.adj_op())
            * eigenvecs.val().transpose();
+    }
   });
 
   return return_t(eigenvecs);

--- a/test/unit/math/rev/fun/eigen_cluster_adjoint_test.cpp
+++ b/test/unit/math/rev/fun/eigen_cluster_adjoint_test.cpp
@@ -1,0 +1,351 @@
+#include <stan/math/rev.hpp>
+#include <test/unit/math/rev/util.hpp>
+#include <stan/math/prim.hpp>
+#include <stan/math/rev/fun/eigenvectors_sym.hpp>
+#include <stan/math/rev/fun/eigenvalues_sym.hpp>
+#include <stan/math/rev/fun/eigendecompose_sym.hpp>
+#include <stan/math/rev/fun/sum.hpp>
+#include <stan/math/rev/fun/log.hpp>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+// Reverse-mode eigenvector adjoints on numerically degenerate spectra.
+//
+// The adjoint of eigenvectors_sym / eigendecompose_sym pairs the
+// antisymmetric F_ij = 1/(w_j - w_i) with V^T (dV).  When eigenvalues
+// coincide to machine resolution the individual eigenvectors are not
+// identifiable (any orthonormal basis of the cluster subspace is a valid
+// answer): with exact repeats F divides by zero and the gradient is NaN;
+// with rounding-level gaps the 1/(w_j - w_i) coupling amplifies rounding
+// noise to O(1/eps).  The cluster-gauged adjoint zeroes the coupling of
+// pairs whose gap falls below kappa * max(1, |w|_inf) * eps (the classical
+// minimal-norm gauge for the undetermined within-cluster rotation).
+//
+// These tests pin:
+//  1. exact repeats: finite gradients where the unguarded adjoint is NaN,
+//     and Richardson-FD consistency of order 1e-8 for cluster-INVARIANT
+//     composites (spectral functions of A whose value does not depend on
+//     the basis chosen inside a cluster);
+//  2. a rounding-degenerate jitter-floor kernel: finite gradients and
+//     agreement between the two-call idiom (eigenvectors_sym +
+//     eigenvalues_sym) and eigendecompose_sym;
+//  3. well-separated spectra: the guarded path reproduces the textbook
+//     adjoint to machine precision (the guard must not fire there).
+
+namespace {
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+using stan::math::matrix_v;
+using stan::math::var;
+
+// Integer-only xorshift so generated matrices are identical on every
+// platform (double rounding of integer arithmetic is exact).
+unsigned long long lcg_state = 88172645463325252ULL;
+double lcgu() {  // uniform-ish in (-1, 1)
+  lcg_state ^= lcg_state << 13;
+  lcg_state ^= lcg_state >> 7;
+  lcg_state ^= lcg_state << 17;
+  return static_cast<int>(lcg_state >> 33) / 1073741824.0 - 1.0;
+}
+
+// phi(A) = u' V diag(1/w) V' u + sum(log w) = u' A^{-1} u + logdet(A):
+// a spectral functional whose VALUE is invariant under the choice of
+// basis inside a degenerate cluster, so its derivative exists and is
+// smooth even at exact repeats -- the right thing to FD-check against.
+template <typename Mat>
+auto phi_inv_two_call(const Mat& A, const VectorXd& u) {
+  using scalar_t = typename Mat::Scalar;
+  Eigen::Matrix<scalar_t, -1, -1> V = stan::math::eigenvectors_sym(A);
+  Eigen::Matrix<scalar_t, -1, 1> w = stan::math::eigenvalues_sym(A);
+  Eigen::Matrix<scalar_t, -1, 1> Vu = V.transpose() * u.cast<scalar_t>();
+  Eigen::Matrix<scalar_t, -1, 1> Vu_over_w
+      = stan::math::elt_divide(Vu, w);
+  return stan::math::sum(Vu_over_w.cwiseProduct(Vu))
+         + stan::math::sum(stan::math::log(w));
+}
+
+// Same composite computed through the combined primitive.
+template <typename Mat>
+auto phi_inv_combined(const Mat& A, const VectorXd& u) {
+  using scalar_t = typename Mat::Scalar;
+  auto ed = stan::math::eigendecompose_sym(A);
+  Eigen::Matrix<scalar_t, -1, -1> V = std::get<0>(ed);
+  Eigen::Matrix<scalar_t, -1, 1> w = std::get<1>(ed);
+  Eigen::Matrix<scalar_t, -1, 1> Vu = V.transpose() * u.cast<scalar_t>();
+  Eigen::Matrix<scalar_t, -1, 1> Vu_over_w
+      = stan::math::elt_divide(Vu, w);
+  return stan::math::sum(Vu_over_w.cwiseProduct(Vu))
+         + stan::math::sum(stan::math::log(w));
+}
+
+// AD gradient of a scalar functional w.r.t. a full symmetric matrix.
+// The operand adjoint is NOT symmetric in general (the coupling term
+// pairs an antisymmetric factor with a generic downstream adjoint), so
+// the layout must be respected: entry (i, j) is g(i, j).
+template <typename Phi>
+MatrixXd ad_grad(const MatrixXd& A0, const Phi& phi) {
+  std::vector<var> av(A0.data(), A0.data() + A0.size());
+  matrix_v Am = Eigen::Map<const matrix_v>(av.data(), A0.rows(), A0.cols());
+  var f = phi(Am);
+  f.grad();
+  VectorXd g(A0.size());
+  for (int i = 0; i < A0.size(); ++i) {
+    g[i] = av[i].adj();
+  }
+  stan::math::recover_memory();
+  return Eigen::Map<const MatrixXd>(g.data(), A0.rows(), A0.cols());
+}
+
+// Richardson-extrapolated central finite difference of phi(A) along the
+// symmetric direction E_ij + E_ji.
+template <typename Phi>
+double fd_richardson(const MatrixXd& A, const Phi& phi, int i, int j) {
+  auto eval = [&](double h) {
+    MatrixXd P = A, Q = A;
+    P(i, j) += h;
+    if (i != j) {
+      P(j, i) += h;
+    }
+    Q(i, j) -= h;
+    if (i != j) {
+      Q(j, i) -= h;
+    }
+    return (phi(P) - phi(Q)) / (2 * h);
+  };
+  double d1 = eval(1e-4);
+  double d2 = eval(5e-5);
+  return (4 * d2 - d1) / 3;
+}
+
+// AD directional derivative d phi / d eps along the same direction.
+double ad_direction(const MatrixXd& g, int n, int i, int j) {
+  double ad = g(i, j);
+  if (i != j) {
+    ad += g(j, i);
+  }
+  return ad;
+}
+
+}  // namespace
+
+TEST_F(AgradRev, eigenvectors_sym_exact_repeated_eigenvalue) {
+  // Exactly 4-fold repeated eigenvalue mu = 1 followed by well-separated
+  // ones: the unguarded adjoint divides by exact zeros (NaN); the
+  // cluster-gauged adjoint is finite and equals the derivative of the
+  // (well-defined) cluster-invariant composite.
+  const int n = 12, k = 4;
+  MatrixXd A = MatrixXd::Zero(n, n);
+  for (int i = 0; i < k; ++i) {
+    A(i, i) = 1.0;  // exactly equal, k-fold
+  }
+  for (int i = k; i < n; ++i) {
+    A(i, i) = 1.0 + 2.0 * i;
+  }
+  VectorXd u(n);
+  for (int i = 0; i < n; ++i) {
+    u[i] = lcgu();
+  }
+
+  MatrixXd g = ad_grad(A, [&](const matrix_v& Am) {
+    return phi_inv_two_call(Am, u);
+  });
+  for (int i = 0; i < n * n; ++i) {
+    EXPECT_TRUE(std::isfinite(g.data()[i])) << "component " << i;
+  }
+
+  // FD consistency on cluster-diagonal, well-separated-diagonal and
+  // cross-cluster directions: for these the cluster-gauged adjoint IS
+  // the derivative of the (well-defined) composite.  (Symmetric
+  // directions with both indices inside the cluster are the deliberate
+  // exception: there the gauge drops the within-cluster mixing term by
+  // construction, so they are covered by the finiteness check above.)
+  auto phi_d = [&](const MatrixXd& Am) { return phi_inv_two_call(Am, u); };
+  for (auto [i, j] : std::vector<std::pair<int, int>>{
+           {0, 0}, {1, 1}, {5, 5}, {0, 7}}) {
+    double fd = fd_richardson(A, phi_d, i, j);
+    double ad = ad_direction(g, n, i, j);
+    double rel = std::abs(fd - ad) / std::max(1.0, std::abs(ad));
+    EXPECT_LT(rel, 1e-8) << "direction (" << i << "," << j << ")";
+  }
+
+  // The combined primitive returns the same gradient (it must: both
+  // decompose the same matrix with the same solver).
+  MatrixXd g_comb = ad_grad(A, [&](const matrix_v& Am) {
+    return phi_inv_combined(Am, u);
+  });
+  for (int i = 0; i < n * n; ++i) {
+    EXPECT_DOUBLE_EQ(g.data()[i], g_comb.data()[i]) << "component " << i;
+  }
+}
+
+TEST_F(AgradRev, eigenvectors_sym_total_degeneracy_zero_matrix) {
+  // The zero matrix has an n-fold repeated eigenvalue 0: every pair is
+  // degenerate.  Any downstream functional gets a finite gradient.
+  const int n = 8;
+  MatrixXd A = MatrixXd::Zero(n, n);
+  MatrixXd W(n, n);
+  VectorXd c(n);
+  for (int j = 0; j < n; ++j) {
+    for (int i = 0; i < n; ++i) {
+      W(i, j) = lcgu();
+    }
+  }
+  for (int i = 0; i < n; ++i) {
+    c[i] = lcgu();
+  }
+
+  auto phi = [&](const auto& Am) {
+    auto V = stan::math::eigenvectors_sym(Am);
+    auto w = stan::math::eigenvalues_sym(Am);
+    using scalar_t = typename std::decay_t<decltype(V)>::Scalar;
+    return stan::math::sum(
+               W.cast<scalar_t>().cwiseProduct(V).eval())
+           + stan::math::sum(c.cast<scalar_t>().cwiseProduct(w).eval());
+  };
+  MatrixXd g = ad_grad(A, phi);
+  for (int i = 0; i < n * n; ++i) {
+    EXPECT_TRUE(std::isfinite(g.data()[i])) << "two-call component " << i;
+  }
+
+  auto phi_ed = [&](const auto& Am) {
+    auto ed = stan::math::eigendecompose_sym(Am);
+    auto V = std::get<0>(ed);
+    auto w = std::get<1>(ed);
+    using scalar_t = typename std::decay_t<decltype(V)>::Scalar;
+    return stan::math::sum(
+               W.cast<scalar_t>().cwiseProduct(V).eval())
+           + stan::math::sum(c.cast<scalar_t>().cwiseProduct(w).eval());
+  };
+  MatrixXd g_ed = ad_grad(A, phi_ed);
+  for (int i = 0; i < n * n; ++i) {
+    EXPECT_TRUE(std::isfinite(g_ed.data()[i])) << "combined component " << i;
+  }
+}
+
+TEST_F(AgradRev, eigenvectors_sym_jitter_floor_kernel) {
+  // exp-quad kernel + 1e-5 jitter on a 30-point grid: the bottom ~10
+  // eigenvalues are pinned at the jitter floor with rounding-level
+  // internal gaps (the GP-regression posterior-covariance regime; the
+  // guard fires on the masked pairs).  The gradient must be finite, and
+  // the two-call idiom must agree with eigendecompose_sym.
+  const int n = 30;
+  VectorXd x = VectorXd::LinSpaced(n, 0.0, 1.0);
+  MatrixXd A(n, n);
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < n; ++j) {
+      A(i, j) = std::exp(-std::pow(x[i] - x[j], 2.0) / 0.05);
+    }
+    A(i, i) += 1e-5;
+  }
+  VectorXd u(n);
+  for (int i = 0; i < n; ++i) {
+    u[i] = lcgu();
+  }
+
+  MatrixXd g = ad_grad(A, [&](const matrix_v& Am) {
+    return phi_inv_two_call(Am, u);
+  });
+  for (int i = 0; i < n * n; ++i) {
+    EXPECT_TRUE(std::isfinite(g.data()[i])) << "component " << i;
+  }
+
+  MatrixXd g_comb = ad_grad(A, [&](const matrix_v& Am) {
+    return phi_inv_combined(Am, u);
+  });
+  for (int i = 0; i < n * n; ++i) {
+    EXPECT_DOUBLE_EQ(g.data()[i], g_comb.data()[i]) << "component " << i;
+  }
+}
+
+TEST_F(AgradRev, eigenvectors_sym_well_separated_matches_textbook_adjoint) {
+  // Well-separated spectra (min adjacent gap >= 1e-6 * scale, enforced)
+  // must take the unguarded code path: the operand adjoint is the
+  // textbook formula V (F ∘ (V' G_V)) V' (+ V diag(g_w) V' for the
+  // combined primitive) with F_ij = 1/(w_j - w_i), to rounding.
+  const int n = 12, n_mats = 10;
+  int tested = 0;
+  for (int m = 0; m < n_mats; ++m) {
+    MatrixXd A(n, n);
+    for (int j = 0; j < n; ++j) {
+      for (int i = 0; i < n; ++i) {
+        A(i, j) = lcgu();
+      }
+    }
+    A = ((A + A.transpose()) * 0.5).eval();
+    for (int i = 0; i < n; ++i) {
+      A(i, i) += 40.0;  // keep eigenvalue gaps O(1)
+    }
+    Eigen::SelfAdjointEigenSolver<MatrixXd> es(A);
+    VectorXd w = es.eigenvalues();
+    MatrixXd V = es.eigenvectors();
+    double scale = std::max(1.0, w.cwiseAbs().maxCoeff());
+    double mingap = (w.tail(n - 1) - w.head(n - 1)).minCoeff();
+    if (mingap < 1e-6 * scale) {
+      continue;
+    }
+    ++tested;
+    MatrixXd W(n, n);
+    VectorXd c(n);
+    for (int j = 0; j < n; ++j) {
+      for (int i = 0; i < n; ++i) {
+        W(i, j) = lcgu();
+      }
+    }
+    for (int i = 0; i < n; ++i) {
+      c[i] = lcgu();
+    }
+
+    // Reference adjoint: the textbook formula V (F o (V' G_V)) V'
+    // + V diag(g_w) V' with F_ij = 1/(w_j - w_i), evaluated in double.
+    // Both functionals below use BOTH outputs, so both arms must
+    // reproduce the full adjoint (to rounding; the guard must not fire,
+    // and a masked pair would show up as an O(1) difference).
+    Eigen::MatrixXd f
+        = (1
+           / (w.rowwise().replicate(n).transpose()
+              - w.rowwise().replicate(n))
+                 .array());
+    f.diagonal().setZero();
+    MatrixXd expected_full_adj
+        = V * f.cwiseProduct(V.transpose() * W) * V.transpose()
+          + V * c.asDiagonal() * V.transpose();
+
+    auto phi = [&](const auto& Am) {
+      auto Vv = stan::math::eigenvectors_sym(Am);
+      auto wv = stan::math::eigenvalues_sym(Am);
+      using scalar_t = typename std::decay_t<decltype(Vv)>::Scalar;
+      return stan::math::sum(
+                 W.cast<scalar_t>().cwiseProduct(Vv).eval())
+             + stan::math::sum(c.cast<scalar_t>().cwiseProduct(wv).eval());
+    };
+    MatrixXd g = ad_grad(A, phi);
+    for (int i = 0; i < n; ++i) {
+      for (int j = 0; j < n; ++j) {
+        EXPECT_NEAR(g(i, j), expected_full_adj(i, j), 1e-12)
+            << "matrix " << m << " entry (" << i << "," << j << ")";
+      }
+    }
+
+    auto phi_ed = [&](const auto& Am) {
+      auto ed = stan::math::eigendecompose_sym(Am);
+      auto Vv = std::get<0>(ed);
+      auto wv = std::get<1>(ed);
+      using scalar_t = typename std::decay_t<decltype(Vv)>::Scalar;
+      return stan::math::sum(
+                 W.cast<scalar_t>().cwiseProduct(Vv).eval())
+             + stan::math::sum(c.cast<scalar_t>().cwiseProduct(wv).eval());
+    };
+    MatrixXd g_ed = ad_grad(A, phi_ed);
+    for (int i = 0; i < n; ++i) {
+      for (int j = 0; j < n; ++j) {
+        EXPECT_NEAR(g_ed(i, j), expected_full_adj(i, j), 1e-12)
+            << "matrix " << m << " entry (" << i << "," << j << ")";
+      }
+    }
+  }
+  EXPECT_GT(tested, 0) << "no well-separated matrix generated";
+}

--- a/test/unit/math/rev/fun/eigen_cluster_adjoint_test.cpp
+++ b/test/unit/math/rev/fun/eigen_cluster_adjoint_test.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <cstdint>
 #include <utility>
 #include <vector>
 
@@ -44,7 +45,7 @@ using stan::math::var;
 
 // Integer-only xorshift so generated matrices are identical on every
 // platform (double rounding of integer arithmetic is exact).
-unsigned long long lcg_state = 88172645463325252ULL;
+std::uint64_t lcg_state = 88172645463325252ULL;
 double lcgu() {  // uniform-ish in (-1, 1)
   lcg_state ^= lcg_state << 13;
   lcg_state ^= lcg_state >> 7;


### PR DESCRIPTION
For a real symmetric eigendecomposition `A = V diag(w) Vᵀ` with distinct eigenvalues, the reverse-mode operand adjoint is (Giles 2008)

```
Ā = V (F ∘ (Vᵀ Ḡ_V)) Vᵀ  +  V diag(ḡ_w) Vᵀ,   F_ij = 1/(w_j − w_i)
```

stan-math splits this across three primitives: `eigenvectors_sym` (first term), `eigenvalues_sym` (second), `eigendecompose_sym` (both). The `1/(w_j − w_i)` factor is computed with no guard, and it is only a derivative when the eigenvalues are separated. Two failure modes 

1. Exact repeats -> NaN. `F` contains `1/0 = ±inf`, and `inf · 0` becomes NaN wherever the symmetric part of `VᵀḠ_V` vanishes.
2. Rounding-degenerate clusters -> silently wrong gradients in every build. When the gap δ falls to rounding level (1e-16…1e-13), the within-cluster eigenvectors carry condition ~1/δ ≈ 1e16: any permitted floating-point reordering (e.g. compiling with `-mavx`, which changes GEMM accumulation order by ~1e-15) selects a different but equally valid eigenbasis, and the gap factor amplifies that basis difference to O(1)–O(1e3) relative gradient changes with sign flips.

The bounded within-cluster limit involves `(G'_ij − G'_ji)/δ`, which is O(δ) mathematically but computed with absolute error ~ε‖Ḡ_V‖ by the tape — SNR ≪ 1 at rounding degeneracy. A library-level choice is required (the classical repeated-eigenvalue situation: Fox–Kapoor, Nelson, Friswell).

## Fix

Within a cluster the eigenbasis is undetermined up to an orthogonal rotation. The derivative of a smooth functional of `A` does not depend on that rotation. Zero the coupling terms whose gap is below identifiability resolution, keep the standard formula everywhere else:

```
F̃_ij = 1/(w_j − w_i)   if |w_i − w_j| ≥ τ
     = 0                otherwise
τ = κ · max(1, ‖w‖_∞) · ε_machine,   κ = 1e3 (STAN_MATH_EIGEN_GAP_KAPPA, overridable)
```

The choice for the κ default is kinda out there still. 1e3 conservative vs 1e4–1e5 for cross-build gradient reproducibility.

## Eval

`kronecker_gp`-class model, gcc 16.2.1, Zen 3, cmdstan 2.39 / bridgestan 2.9 (Eigen 3.4.0); (develop) rows are unit tests at 46a3133, Eigen 5.0.1.

Cross-ISA gradient divergence (20 random N(0,1) points, same source compiled default vs `-mavx`; grel = |Δg|/max(1,|g|)):

| arm | max grel | sign flips | components > 1e-6 |
|---|---|---|---|
| stock | 1.156 | yes | 55–221 / 438 |
| patched, κ = 1e3 | 6.96e-5 | 0 | 26 / 438 |
| patched, κ = 1e4 | 1.58e-5 | 0 | 19 / 438 |
| patched, κ = 1e5 | 3.1e-8 | 0 | 7 / 438 |

AD vs Richardson finite differences (failing points, h = 1e-4 / 5e-5; stock → patched κ=1e3): pt1 var1 2.76e-1 → 8.5e-7; pt1 bw1 1.26e-1 → 8.7e-7; pt7 var1 2.29e-1 → 1.4e-6; pt14 var1 5.17e-1 → 9.2e-7. Control component sigma1 (not routed through the eigenvector adjoint): 2.4e-11 both arms. Exact degeneracy: 435/438 NaN → 0. Well-separated spectra: 200 random symmetric 30×30, gradient dumps byte-identical 200/200.

Sampler-level (kronecker_gp, 3 reps × 4 chains, 1000+1000, fixed deterministic inits, only the .so differs):

| arm | bulk-ESS-min median (healthy reps) | R-hat max (healthy reps) |
|---|---|---|
| stock | 48.1 (29.1 / 67.2) | 1.13 |
| patched (κ = 1e3) | 367.7 (411.4 / 324.0) | 1.02 |


  ## Checklist

- [x] Copyright holder: Maximilian Scholz
    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested