### PR TITLE
square() for arithmetic types: multiply instead of calling std::pow(x, 2)

### DIFF
--- a/stan/math/prim/fun/square.hpp
+++ b/stan/math/prim/fun/square.hpp
@@ -25,7 +25,12 @@ namespace math {
  */
 template <typename T, require_arithmetic_t<T>* = nullptr>
 inline double square(const T x) {
-  return std::pow(x, 2);
+  // widen to double first, then multiply: identical to the previous
+  // std::pow(x, 2) (a correctly-rounded square equals the rounded
+  // product), including the promoted-to-double semantics for integral
+  // arguments (where x * x could overflow), without the libm call.
+  const double x_d = x;
+  return x_d * x_d;
 }
 
 /**

--- a/stan/math/rev/fun/squared_distance.hpp
+++ b/stan/math/rev/fun/squared_distance.hpp
@@ -21,11 +21,11 @@ namespace math {
 inline var squared_distance(const var& a, const var& b) {
   check_finite("squared_distance", "a", a);
   check_finite("squared_distance", "b", b);
-  return make_callback_vari(std::pow(a.val() - b.val(), 2),
-                            [a, b](const auto& vi) mutable {
-                              const double diff = 2.0 * (a.val() - b.val());
-                              a.adj() += vi.adj_ * diff;
-                              b.adj() -= vi.adj_ * diff;
+  const double diff = a.val() - b.val();
+  return make_callback_vari(diff * diff, [a, b, diff](const auto& vi) mutable {
+                              const double adj_diff = 2.0 * diff;
+                              a.adj() += vi.adj_ * adj_diff;
+                              b.adj() -= vi.adj_ * adj_diff;
                             });
 }
 
@@ -35,9 +35,9 @@ inline var squared_distance(const var& a, const var& b) {
 inline var squared_distance(const var& a, double b) {
   check_finite("squared_distance", "a", a);
   check_finite("squared_distance", "b", b);
-  return make_callback_vari(std::pow(a.val() - b, 2),
-                            [a, b](const auto& vi) mutable {
-                              a.adj() += vi.adj_ * 2.0 * (a.val() - b);
+  const double diff = a.val() - b;
+  return make_callback_vari(diff * diff, [a, b, diff](const auto& vi) mutable {
+                              a.adj() += vi.adj_ * 2.0 * diff;
                             });
 }
 


### PR DESCRIPTION
With default toolchain settings (gcc/clang default to `-fmath-errno`), `std::pow` must set `errno` on domain/range/overflow errors, so the optimizer cannot rewrite it to a multiply in general. glibc's `pow` is a branchy multi-path implementation (~105 instructions per call measured: 3,473,268 Ir over 33,078 calls) where `x * x` is one instruction.

On the measured GP regression model, `square()` accounts for 57 `pow` calls per gradient and 8.9% of gradient instructions (callgrind): 32,889 of 33,078 executed `pow` calls come from `gp_exp_quad_cov` (55 kernel pairs for N = 11, plus `square(sigma)` and `square(l)`).

Widen to `double` first, then multiply. The template is enabled for all arithmetic `T`; a naive `x * x` would compute an int product for integral `x` (overflow for |x| > 46,341 where the promoted path does not) and round twice for `float` `x`. Widening first reproduces the previous promote-then-round semantics exactly, minus the libm call

## Eval

GP regression model (`gp_exp_quad_cov`, n = 11 → 55 kernel pairs), matched binaries, identical inputs, gcc 16.2.1, glibc, Zen 3. Medians of 3 interleaved reps; callgrind on a fixed seeded run (warmup 50 / samples 50, 577 gradient calls in both arms):

| metric | stock | patched | delta |
|---|---|---|---|
| Ir / gradient (callgrind, deterministic) | 66,950 | 60,864 | −9.1% |
| pow instructions in run | 3,473,268 | 19,923 | −99.4% (residual is sampler-side Adam) |
| µs / logp_grad call (warmup stanza) | 6.681 | 5.820 | −12.9% |
| µs / logp_grad call (sampling stanza) | 6.655 | 5.640 | −15.2% |

  ## Checklist

- [x] Copyright holder: Maximilian Scholz
    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
