### PR TITLE
Fix missing signs factor in bernoulli_logit_lpmf partials above the cutoff

### DIFF
--- a/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
@@ -82,7 +82,7 @@ inline return_type_t<T_prob> bernoulli_logit_lpmf(const T_n& n,
     edge<0>(ops_partials).partials_
         = (ntheta > cutoff)
               .select(
-                  -exp_m_ntheta,
+                  promote_scalar<T_partials_return>(signs * exp_m_ntheta),
                   (ntheta >= -cutoff)
                       .select(promote_scalar<T_partials_return>(
                                   signs * exp_m_ntheta / (exp_m_ntheta + 1)),

--- a/test/unit/math/prim/prob/bernoulli_logit_test.cpp
+++ b/test/unit/math/prim/prob/bernoulli_logit_test.cpp
@@ -1,10 +1,12 @@
 #include <stan/math/prim.hpp>
+#include <stan/math/rev.hpp>
 #include <test/unit/math/prim/prob/vector_rng_test_helper.hpp>
 #include <test/unit/math/prim/prob/VectorIntRNGTestRig.hpp>
 #include <test/unit/math/prim/prob/util.hpp>
 #include <boost/math/distributions.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <gtest/gtest.h>
+#include <cmath>
 #include <limits>
 #include <vector>
 
@@ -80,5 +82,39 @@ TEST(ProbDistributionsBernoulliLogit, cutoff) {
           << ", value at cutoff - 1e-14: " << before_cutoff
           << ", value at cutoff + 1e-14: " << after_cutoff;
     }
+  }
+}
+
+TEST(ProbDistributionsBernoulliLogit, cutoff_partials_sign) {
+  // For ntheta > cutoff the value is -exp(-ntheta), so the derivative with
+  // respect to theta is signs * exp(-ntheta): positive for y = 1, negative
+  // for y = 0. Regression test: the (ntheta > cutoff) partials branch used
+  // to return -exp_m_ntheta without the signs factor, which has the wrong
+  // sign whenever y = 1 and theta > cutoff (and, symmetrically, for y = 0
+  // with theta < -cutoff).
+  using stan::math::var;
+  const double cutoff = 20;
+  const double h = 1e-3;  // keeps both FD points inside the same branch
+  for (int n = 0; n <= 1; ++n) {
+    const double theta = (n == 1 ? 1.0 : -1.0) * (cutoff + 5);
+    const double signs = 2 * n - 1;
+    const double expected = signs * std::exp(-signs * theta);
+
+    // finite-difference reference from the double implementation
+    const double fd = (stan::math::bernoulli_logit_lpmf(n, theta + h)
+                       - stan::math::bernoulli_logit_lpmf(n, theta - h))
+                      / (2 * h);
+    EXPECT_NEAR(expected, fd, 1e-6 * std::fabs(fd))
+        << "analytic derivative disagrees with finite differences for n = " << n;
+
+    // autodiff gradient
+    var theta_v = theta;
+    var lp = stan::math::bernoulli_logit_lpmf(n, theta_v);
+    lp.grad();
+    EXPECT_NEAR(theta_v.adj(), expected, 1e-9 * std::fabs(expected))
+        << "gradient has the wrong sign or magnitude for n = " << n
+        << ", theta = " << theta << ", adj = " << theta_v.adj()
+        << ", expected = " << expected;
+    stan::math::recover_memory();
   }
 }

--- a/test/unit/math/prim/prob/bernoulli_logit_test.cpp
+++ b/test/unit/math/prim/prob/bernoulli_logit_test.cpp
@@ -105,7 +105,8 @@ TEST(ProbDistributionsBernoulliLogit, cutoff_partials_sign) {
                        - stan::math::bernoulli_logit_lpmf(n, theta - h))
                       / (2 * h);
     EXPECT_NEAR(expected, fd, 1e-6 * std::fabs(fd))
-        << "analytic derivative disagrees with finite differences for n = " << n;
+        << "analytic derivative disagrees with finite differences for n = "
+        << n;
 
     // autodiff gradient
     var theta_v = theta;


### PR DESCRIPTION
`bernoulli_logit_lpmf` computes, per observation, with `signs = 2n − 1` and `ntheta = signs * theta`:

```cpp
exp_m_ntheta = exp(-ntheta);
logp = (ntheta > cutoff)
           .select(-exp_m_ntheta,
                   (ntheta < -cutoff).select(ntheta, -log1p(exp_m_ntheta)));

edge<0>(ops_partials).partials_
    = (ntheta > cutoff)
          .select(
              -exp_m_ntheta,   // <-- bug
              (ntheta >= -cutoff)
                  .select(signs * exp_m_ntheta / (exp_m_ntheta + 1),
                          signs));
```

For `ntheta > cutoff` the value is `−exp(−ntheta)`, so `d(value)/d(ntheta) = +exp_m_ntheta`, and the chain rule through `ntheta = signs · theta` (signs constant in theta) gives `∂lp/∂theta = signs · exp_m_ntheta`. The upper partials branch returns `−exp_m_ntheta` — the derivative of the value without the chain-rule factor. It is correct only when `signs = −1` (`n = 0`). For `n = 1` with `theta > 20` (and, symmetrically, `n = 0` with `theta < −20`) the gradient of every such element has the wrong sign.

## Eval

- Added regression test `cutoff_partials_sign` (`test/unit/math/prim/prob/bernoulli_logit_test.cpp`): for both `n = 1, theta = +25` and `n = 0, theta = −25` (both put ntheta above the cutoff) it checks the autodiff gradient against (a) the analytic `signs * exp(−ntheta)` and (b) central finite differences of the double implementation, h = 1e-3 (small enough that both FD points stay inside the same branch, large enough that the ~1e-11-magnitude values subtract cleanly).
- The test fails on unpatched code (the autodiff gradient comes back sign-flipped, off by exactly `2·exp(−ntheta)`) and passes with the fix. Full test binary 6/6; the file's existing value-space cutoff test is unaffected — the bug is in partials only.

## Checklist

- [x] Copyright holder: Maximilian Scholz
    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested