### PR TITLE
Efficiency: use multiplication over std::pow for squaring (#3373)

### DIFF
--- a/stan/math/prim/fun/square.hpp
+++ b/stan/math/prim/fun/square.hpp
@@ -25,7 +25,8 @@ namespace math {
  */
 template <typename T, require_arithmetic_t<T>* = nullptr>
 inline double square(const T x) {
-  return std::pow(x, 2);
+  double x_dbl = x;
+  return x_dbl * x_dbl;
 }
 
 /**

--- a/stan/math/rev/fun/squared_distance.hpp
+++ b/stan/math/rev/fun/squared_distance.hpp
@@ -21,7 +21,7 @@ namespace math {
 inline var squared_distance(const var& a, const var& b) {
   check_finite("squared_distance", "a", a);
   check_finite("squared_distance", "b", b);
-  return make_callback_vari(std::pow(a.val() - b.val(), 2),
+  return make_callback_vari((a.val() - b.val()) * (a.val() - b.val()),
                             [a, b](const auto& vi) mutable {
                               const double diff = 2.0 * (a.val() - b.val());
                               a.adj() += vi.adj_ * diff;
@@ -35,7 +35,7 @@ inline var squared_distance(const var& a, const var& b) {
 inline var squared_distance(const var& a, double b) {
   check_finite("squared_distance", "a", a);
   check_finite("squared_distance", "b", b);
-  return make_callback_vari(std::pow(a.val() - b, 2),
+  return make_callback_vari((a.val() - b) * (a.val() - b),
                             [a, b](const auto& vi) mutable {
                               a.adj() += vi.adj_ * 2.0 * (a.val() - b);
                             });

--- a/stan/math/rev/fun/squared_distance.hpp
+++ b/stan/math/rev/fun/squared_distance.hpp
@@ -21,7 +21,8 @@ namespace math {
 inline var squared_distance(const var& a, const var& b) {
   check_finite("squared_distance", "a", a);
   check_finite("squared_distance", "b", b);
-  return make_callback_vari((a.val() - b.val()) * (a.val() - b.val()),
+  double difference = a.val() - b.val();
+  return make_callback_vari(difference * difference,
                             [a, b](const auto& vi) mutable {
                               const double diff = 2.0 * (a.val() - b.val());
                               a.adj() += vi.adj_ * diff;
@@ -35,7 +36,8 @@ inline var squared_distance(const var& a, const var& b) {
 inline var squared_distance(const var& a, double b) {
   check_finite("squared_distance", "a", a);
   check_finite("squared_distance", "b", b);
-  return make_callback_vari((a.val() - b) * (a.val() - b),
+  double difference = a.val() - b;
+  return make_callback_vari(difference * difference,
                             [a, b](const auto& vi) mutable {
                               a.adj() += vi.adj_ * 2.0 * (a.val() - b);
                             });


### PR DESCRIPTION
Replaced std::pow(x, 2) with x * x after casting to double, preserving the prior rounding and overflow behavior. (Verified via grep that there are no other instances in the source code). Fixes #3373.