### PR TITLE
Replace boost/optional and boost/lexical_cast

### DIFF
--- a/stan/math/prim/core/init_threadpool_tbb.hpp
+++ b/stan/math/prim/core/init_threadpool_tbb.hpp
@@ -3,8 +3,6 @@
 
 #include <stan/math/prim/err/invalid_argument.hpp>
 
-#include <boost/lexical_cast.hpp>
-
 #ifndef TBB_INTERFACE_NEW
 #include <tbb/tbb_stddef.h>
 
@@ -20,7 +18,9 @@
 #include <tbb/task_scheduler_init.h>
 #endif
 
+#include <charconv>
 #include <cstdlib>
+#include <string_view>
 #include <thread>
 
 namespace stan {
@@ -44,32 +44,28 @@ namespace internal {
  * is invalid
  */
 inline int get_num_threads() {
-  int num_threads = 1;
 #ifdef STAN_THREADS
   const char* env_stan_num_threads = std::getenv("STAN_NUM_THREADS");
-  if (env_stan_num_threads != nullptr) {
-    try {
-      const int env_num_threads
-          = boost::lexical_cast<int>(env_stan_num_threads);
-      if (env_num_threads > 0) {
-        num_threads = env_num_threads;
-      } else if (env_num_threads == -1) {
-        num_threads = std::thread::hardware_concurrency();
-      } else {
-        invalid_argument("get_num_threads(int)", "STAN_NUM_THREADS",
-                         env_stan_num_threads,
-                         "The STAN_NUM_THREADS environment variable is '",
-                         "' but it must be positive or -1");
-      }
-    } catch (const boost::bad_lexical_cast&) {
-      invalid_argument("get_num_threads(int)", "STAN_NUM_THREADS",
-                       env_stan_num_threads,
-                       "The STAN_NUM_THREADS environment variable is '",
-                       "' but it must be a positive number or -1");
-    }
+  if (env_stan_num_threads == nullptr) {
+    return 1;
   }
+
+  const std::string_view value(env_stan_num_threads);
+  int num_threads{};
+  const auto [end, error]
+      = std::from_chars(value.begin(), value.end(), num_threads);
+  if (error != std::errc{} || end != value.end()
+      || (num_threads < 1 && num_threads != -1)) {
+    invalid_argument("get_num_threads(int)", "STAN_NUM_THREADS",
+                     env_stan_num_threads,
+                     "The STAN_NUM_THREADS environment variable is '",
+                     "' but it must be a positive number or -1");
+  }
+
+  return num_threads == -1 ? std::thread::hardware_concurrency() : num_threads;
+#else
+  return 1;
 #endif
-  return num_threads;
 }
 
 }  // namespace internal

--- a/stan/math/prim/core/init_threadpool_tbb.hpp
+++ b/stan/math/prim/core/init_threadpool_tbb.hpp
@@ -51,10 +51,10 @@ inline int get_num_threads() {
   }
 
   const std::string_view value(env_stan_num_threads);
-  int num_threads{};
+  int num_threads;
   const auto [end, error]
       = std::from_chars(value.begin(), value.end(), num_threads);
-  if (error != std::errc{} || end != value.end()
+  if (error != std::errc() || end != value.end()
       || (num_threads < 1 && num_threads != -1)) {
     invalid_argument("get_num_threads(int)", "STAN_NUM_THREADS",
                      env_stan_num_threads,

--- a/stan/math/prim/fun/grad_2F1.hpp
+++ b/stan/math/prim/fun/grad_2F1.hpp
@@ -13,7 +13,6 @@
 #include <stan/math/prim/fun/sign.hpp>
 #include <stan/math/prim/fun/hypergeometric_2F1.hpp>
 #include <cmath>
-#include <boost/optional.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/fun/hypergeometric_2F1.hpp
+++ b/stan/math/prim/fun/hypergeometric_2F1.hpp
@@ -17,7 +17,7 @@
 #include <stan/math/prim/fun/sqrt.hpp>
 #include <stan/math/prim/fun/square.hpp>
 #include <stan/math/prim/fun/hypergeometric_pFq.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace stan {
 namespace math {
@@ -29,7 +29,7 @@ namespace internal {
  * more background (and other possible special-cases), see:
  * https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F1/03/
  *
- * The return value is wrapped in a boost::optional<> type so that a void
+ * The return value is wrapped in a std::optional<> type so that a void
  * return is possible if no special-case rules are applicable
  *
  * @tparam Ta1 Type of scalar first 'a' argument
@@ -43,7 +43,7 @@ namespace internal {
  * @return Gauss hypergeometric function
  */
 template <typename Ta1, typename Ta2, typename Tb, typename Tz,
-          typename RtnT = boost::optional<return_type_t<Ta1, Ta2, Tb, Tz>>,
+          typename RtnT = std::optional<return_type_t<Ta1, Ta2, Tb, Tz>>,
           require_all_arithmetic_t<Ta1, Ta2, Tb, Tz>* = nullptr>
 inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
                                     const Tz& z) {
@@ -149,7 +149,7 @@ inline RtnT hyper_2F1_special_cases(const Ta1& a1, const Ta2& a2, const Tb& b,
  */
 template <typename Ta1, typename Ta2, typename Tb, typename Tz,
           typename ScalarT = return_type_t<Ta1, Ta2, Tb, Tz>,
-          typename OptT = boost::optional<ScalarT>,
+          typename OptT = std::optional<ScalarT>,
           require_all_arithmetic_t<Ta1, Ta2, Tb, Tz>* = nullptr>
 inline return_type_t<Ta1, Ta2, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
                                                           const Ta2& a2,
@@ -168,15 +168,15 @@ inline return_type_t<Ta1, Ta2, Tb, Tz> hypergeometric_2F1(const Ta1& a1,
   // Check whether value can be calculated by any special-case rules
   // before estimating infinite sum
   OptT special_case_a1a2 = internal::hyper_2F1_special_cases(a1, a2, b, z);
-  if (special_case_a1a2.is_initialized()) {
-    return special_case_a1a2.get();
+  if (special_case_a1a2.has_value()) {
+    return special_case_a1a2.value();
   }
 
   // Check whether any special case rules apply with 'a' arguments reversed
   // as 2F1(a1, a2, b, z) = 2F1(a2, a1, b, z)
   OptT special_case_a2a1 = internal::hyper_2F1_special_cases(a2, a1, b, z);
-  if (special_case_a2a1.is_initialized()) {
-    return special_case_a2a1.get();
+  if (special_case_a2a1.has_value()) {
+    return special_case_a2a1.value();
   }
 
   Eigen::Matrix<double, 2, 1> a_args(2);

--- a/test/unit/math/prim/core/get_num_threads_test.cpp
+++ b/test/unit/math/prim/core/get_num_threads_test.cpp
@@ -27,11 +27,11 @@ TEST(get_num_threads, incorrect_values) {
 
   set_n_threads("-2");
   EXPECT_THROW_MSG(stan::math::internal::get_num_threads(),
-                   std::invalid_argument, "must be positive or -1");
+                   std::invalid_argument, "positive number or -1");
 
   set_n_threads("0");
   EXPECT_THROW_MSG(stan::math::internal::get_num_threads(),
-                   std::invalid_argument, "must be positive or -1");
+                   std::invalid_argument, "positive number or -1");
 }
 #else
 TEST(get_num_threads, correct_values_no_stan_threads) {


### PR DESCRIPTION
## Summary

The replacement for #3356, removing only the `lexical_cast` and `optional` dependencies

## Tests

N/A - current tests should still pass

## Side Effects

N/A

## Release notes

Removed dependency on `boost/optional` and `boost/lexical_cast`

## Checklist

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
