### PR TITLE
Add missing checks on unconstraining functions

### DIFF
--- a/stan/math/prim/constraint/cholesky_corr_free.hpp
+++ b/stan/math/prim/constraint/cholesky_corr_free.hpp
@@ -16,10 +16,9 @@ inline auto cholesky_corr_free(const T& x) {
   using Eigen::Matrix;
   using std::sqrt;
 
-  check_square("cholesky_corr_free", "x", x);
-  // should validate lower-triangular, unit lengths
-
   const auto& x_ref = to_ref(x);
+  check_cholesky_factor_corr("cholesky_corr_free", "x", x_ref);
+
   int K = (x.rows() * (x.rows() - 1)) / 2;
   Matrix<value_type_t<T>, Dynamic, 1> z(K);
   int k = 0;

--- a/stan/math/prim/constraint/cov_matrix_free.hpp
+++ b/stan/math/prim/constraint/cov_matrix_free.hpp
@@ -38,8 +38,7 @@ template <typename T, require_eigen_t<T>* = nullptr>
 inline Eigen::Matrix<value_type_t<T>, Eigen::Dynamic, 1> cov_matrix_free(
     const T& y) {
   const auto& y_ref = to_ref(y);
-  check_square("cov_matrix_free", "y", y_ref);
-  check_nonzero_size("cov_matrix_free", "y", y_ref);
+  check_cov_matrix("cov_matrix_free", "y", y_ref);
 
   using std::log;
   int K = y_ref.rows();

--- a/test/sig_utils.py
+++ b/test/sig_utils.py
@@ -79,6 +79,7 @@ special_arg_values = {
     "corr_matrix_constrain": [None, 2],
     "corr_matrix_free": [1],
     "cov_matrix_constrain": [None, 1],
+    "cholesky_corr_free": [1.0],
     "cholesky_decompose": [pos_definite, None],
     "cholesky_corr_constrain": [None, 2],
     "cholesky_factor_constrain": [None, 1, 1],

--- a/test/unit/math/prim/constraint/cholesky_corr_transform_test.cpp
+++ b/test/unit/math/prim/constraint/cholesky_corr_transform_test.cpp
@@ -6,8 +6,9 @@ TEST(ProbTransform, CholeskyCorrelation4) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   Matrix<double, Dynamic, Dynamic> L(4, 4);
-  L << 1, 0, 0, 0, -0.2, 0.9797959, 0, 0, 0.5, -0.3, 0.8124038, 0, 0.7, -0.2,
-      0.6, 0.3316625;
+  L << 1., 0., 0., 0., 0.137406408, 0.990514755, 0., 0., 0.182409918,
+      0.217317336, 0.958905521, 0., -0.13727584, 0.443593876, 0.837969972,
+      0.286681258;
 
   Matrix<double, Dynamic, 1> y = stan::math::cholesky_corr_free(L);
 
@@ -103,7 +104,8 @@ TEST(ProbTransform, CholeskyCorrelationRoundTrips) {
   test_cholesky_correlation_values(L2);
 
   Matrix<double, Dynamic, Dynamic> L4(4, 4);
-  L4 << 1, 0, 0, 0, -0.2, 0.9797959, 0, 0, 0.5, -0.3, 0.8124038, 0, 0.7, -0.2,
-      0.6, 0.3316625;
+  L4 << 1., 0., 0., 0., 0.14489293, 0.98944734, 0., 0., -0.050876204,
+      -0.884785168, 0.463213577, 0., -0.412684102, -0.49899983, -0.67896005,
+      0.345983023;
   test_cholesky_correlation_values(L4);
 }


### PR DESCRIPTION
## Summary

Unlike e.g. [`cholesky_factor_free`](https://github.com/stan-dev/math/blob/0ac2be29661e8daf22fe67c3e9939998d94f4d0f/stan/math/prim/constraint/cholesky_factor_free.hpp#L31), `cholesky_factor_corr_free` wasn't checking its inputs. This means that an incorrectly specified user initialization would be silently accepted and unconstrained/reconstrained back to a somewhat arbitrary point, rather than the error every other type provides. 

Closes #3380, #3379 

## Tests



## Side Effects



## Release notes

Add missing checks to a few unconstraining functions used by initialization. 

## Checklist

- [x] Copyright holder: Simons Foundation
    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
