### PR TITLE
Fix use-after-move cases

### DIFF
--- a/stan/math/rev/fun/cholesky_decompose.hpp
+++ b/stan/math/rev/fun/cholesky_decompose.hpp
@@ -137,7 +137,7 @@ inline auto cholesky_decompose(EigMat&& A) {
   arena_t<EigMat> arena_A = std::forward<decltype(A_ref)>(A_ref);
   arena_t<promote_scalar_t<double, EigMat>> L_A(arena_A.val().eval());
 
-  check_symmetric("cholesky_decompose", "A", A);
+  check_symmetric("cholesky_decompose", "A", L_A);
   Eigen::LLT<Eigen::Ref<Eigen::MatrixXd>, Eigen::Lower> L_factor(L_A);
   check_pos_definite("cholesky_decompose", "m", L_factor);
 

--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -35,11 +35,11 @@ inline Eigen::Matrix<return_type_t<Mat1, Mat2>, 1,
                      std::decay_t<Mat1>::ColsAtCompileTime>
 columns_dot_product(Mat1&& v1, Mat2&& v2) {
   check_matching_dims("check_matching_dims", "v1", v1, "v2", v2);
-  Eigen::Matrix<var, 1, std::decay_t<Mat1>::ColsAtCompileTime> ret(1,
-                                                                   v1.cols());
+  const size_t v1_cols = v1.cols();
+  Eigen::Matrix<var, 1, std::decay_t<Mat1>::ColsAtCompileTime> ret(1, v1_cols);
   decltype(auto) v1_ref = to_ref(std::forward<Mat1>(v1));
   decltype(auto) v2_ref = to_ref(std::forward<Mat2>(v2));
-  for (size_type j = 0; j < v1.cols(); ++j) {
+  for (size_type j = 0; j < v1_cols; ++j) {
     ret.coeffRef(j) = dot_product(v1_ref.col(j), v2_ref.col(j));
   }
   return ret;


### PR DESCRIPTION
## Summary

There were two cases in the Math library which used a matrix input after `std::forward`-ing it into a `ref` or an `arena` type. This wasn't an issue unless rvalues were passed as inputs, at which point the `ref`/`arena` would move-construct and leave an empty matrix:

```cpp
#include <stan/math.hpp>
#include <iostream>

int main() {
  Eigen::MatrixXd x(1, 1);
  x << 2.0;
  Eigen::Matrix<stan::math::var, -1, -1> y(1, 1);
  y << 0.5;
  auto r = stan::math::columns_dot_product(std::move(x), y); //segfaults
  std::cout << r(0).val() << std::endl; 
  return 0;
}
```

I (and claude) could only find this in the `rev` overloads for `cholesky_decompose` and `columns_dot_product`, but not sure if there's a good way to add a more universal test for this.

## Tests
N/A - tests should still pass

## Side Effects

N/A

## Release notes

Fix use-after-move in `cholesky_decompose` and `columns_dot_product`

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
