### PR TITLE
fix integrate_1d_gauss_kronrod gradient speed

### DIFF
--- a/stan/math/rev/functor/integrate_1d_adjoint.hpp
+++ b/stan/math/rev/functor/integrate_1d_adjoint.hpp
@@ -38,6 +38,12 @@ namespace internal {
  * zero. Any other NaN propagates into the component integral and is reported as
  * a `domain_error` naming the (flattened) parameter index.
  *
+ * `shift_gradient_integrand`: when true (and the value integral `I` is finite
+ * and non-zero) each component adjoint is computed as
+ * `integrator(d f / d arg + f) - I` instead of `integrator(d f / d arg)`,
+ * which can make the computation better behaving.
+ *
+ * @tparam shift_gradient_integrand see above
  * @tparam F Type of f
  * @tparam T_a type of first limit
  * @tparam T_b type of second limit
@@ -52,8 +58,8 @@ namespace internal {
  * @param args additional arguments to pass to f
  * @return numeric integral of function f
  */
-template <typename F, typename T_a, typename T_b, typename Integrator,
-          typename... Args>
+template <bool shift_gradient_integrand = false, typename F, typename T_a,
+          typename T_b, typename Integrator, typename... Args>
 inline return_type_t<T_a, T_b, Args...> integrate_1d_adjoint(
     const char* function, const F& f, const T_a& a, const T_b& b,
     Integrator&& integrator, std::ostream* msgs, const Args&... args) {
@@ -94,13 +100,15 @@ inline return_type_t<T_a, T_b, Args...> integrate_1d_adjoint(
 
   // Argument adjoints.
   if constexpr (is_any_var_scalar_v<Args...>) {
+    const bool shift = shift_gradient_integrand && integral != 0.0
+                       && !is_inf(integral) && !is_nan(integral);
     auto args_adj = make_zeroed_arena(std::forward_as_tuple(args...));
     {
       nested_rev_autodiff argument_nest;
       auto args_copy = deep_copy_vargs<var>(std::forward_as_tuple(args...));
       auto args_copy_filter = filter_var_scalar_types(args_copy);
       auto integrate_grad = [&](auto&& target) -> double {
-        return integrator([&](const auto& x, const auto& xc) {
+        const double result = integrator([&](const auto& x, const auto& xc) {
           argument_nest.set_zero_all_adjoints();
           nested_rev_autodiff gradient_nest;
           var fx = stan::math::apply(
@@ -113,8 +121,9 @@ inline return_type_t<T_a, T_b, Args...> integrate_1d_adjoint(
           if (is_nan(gradient) && fx.val() == 0) {
             gradient = 0.0;
           }
-          return gradient;
+          return shift ? gradient + fx.val() : gradient;
         });
+        return shift ? result - integral : result;
       };
       std::size_t param_index = 0;
       auto assign_grad = [&](auto&& adj, auto&& target) {

--- a/stan/math/rev/functor/integrate_1d_adjoint.hpp
+++ b/stan/math/rev/functor/integrate_1d_adjoint.hpp
@@ -40,7 +40,7 @@ namespace internal {
  *
  * `shift_gradient_integrand`: when true (and the value integral `I` is finite
  * and non-zero) each component adjoint is computed as
- * `integrator(d f / d arg + f) - I` instead of `integrator(d f / d arg)`,
+ * `integrator(d f / d arg + c f) - c I` instead of `integrator(d f / d arg)`,
  * which can make the computation better behaving.
  *
  * @tparam shift_gradient_integrand see above
@@ -102,6 +102,9 @@ inline return_type_t<T_a, T_b, Args...> integrate_1d_adjoint(
   if constexpr (is_any_var_scalar_v<Args...>) {
     const bool shift = shift_gradient_integrand && integral != 0.0
                        && !is_inf(integral) && !is_nan(integral);
+    // Shift constant. The inverse golden ratio is unlikely to be a
+    // saturated gradient.
+    constexpr double shift_c = 0.6180339887498949;
     auto args_adj = make_zeroed_arena(std::forward_as_tuple(args...));
     {
       nested_rev_autodiff argument_nest;
@@ -121,9 +124,9 @@ inline return_type_t<T_a, T_b, Args...> integrate_1d_adjoint(
           if (is_nan(gradient) && fx.val() == 0) {
             gradient = 0.0;
           }
-          return shift ? gradient + fx.val() : gradient;
+          return shift ? gradient + shift_c * fx.val() : gradient;
         });
-        return shift ? result - integral : result;
+        return shift ? result - shift_c * integral : result;
       };
       std::size_t param_index = 0;
       auto assign_grad = [&](auto&& adj, auto&& target) {

--- a/stan/math/rev/functor/integrate_1d_gauss_kronrod.hpp
+++ b/stan/math/rev/functor/integrate_1d_gauss_kronrod.hpp
@@ -45,7 +45,8 @@ inline return_type_t<T_a, T_b, Args...> integrate_1d_gauss_kronrod_tol(
   check_less_or_equal(function, "lower limit", a, b);
   check_nonnegative(function, "max_depth", max_depth);
   check_nonnegative(function, "absolute_tolerance", absolute_tolerance);
-  return internal::integrate_1d_adjoint(
+  // `true`: gradient integrands are shifted by f
+  return internal::integrate_1d_adjoint<true>(
       function, f, a, b,
       [&](auto &&integrand) {
         return integrate_gk(std::forward<decltype(integrand)>(integrand),

--- a/test/unit/math/rev/functor/integrate_1d_gauss_kronrod_test.cpp
+++ b/test/unit/math/rev/functor/integrate_1d_gauss_kronrod_test.cpp
@@ -489,7 +489,7 @@ TEST_F(AgradRev, StanMath_integrate_1d_gk_rev_TestUniform) {
 // guard paths: an integral that is exactly zero (shift disabled) and
 // a negative integral (shift active with I < 0).
 
-long n_evals = 0;
+std::int64_t n_evals = 0;
 
 // d f / d theta is analytically zero (cos^2 + sin^2 = 1) but autodiff
 // evaluates it as round-off noise of order 1e-16 * x * f.

--- a/test/unit/math/rev/functor/integrate_1d_gauss_kronrod_test.cpp
+++ b/test/unit/math/rev/functor/integrate_1d_gauss_kronrod_test.cpp
@@ -481,4 +481,95 @@ TEST_F(AgradRev, StanMath_integrate_1d_gk_rev_TestUniform) {
   EXPECT_FLOAT_EQ(1, 1 + g[1]);
 }
 
-}  // namespace integrate_1d_gk_test
+// ── gradient-integrand shift (integrate_1d_adjoint<true>) ────────────
+//
+// The wrapper integrates (d f / d theta_i + f) and subtracts the
+// value integral.  These tests pin (a) the evaluation count on such a
+// component, which the accuracy tests above cannot see, and (b) the
+// guard paths: an integral that is exactly zero (shift disabled) and
+// a negative integral (shift active with I < 0).
+
+long n_evals = 0;
+
+// d f / d theta is analytically zero (cos^2 + sin^2 = 1) but autodiff
+// evaluates it as round-off noise of order 1e-16 * x * f.
+struct f_noisy_gradient_counted {
+  template <typename T1, typename T2, typename T3>
+  inline stan::return_type_t<T1, T2, T3> operator()(
+      const T1 &x, const T2 &xc, std::ostream *msgs,
+      const std::vector<T3> &theta, const std::vector<double> &x_r,
+      const std::vector<int> &x_i) const {
+    ++n_evals;
+    auto tx = theta[0] * x;
+    return exp(-x * x) * (cos(tx) * cos(tx) + sin(tx) * sin(tx));
+  }
+};
+
+TEST_F(AgradRev, StanMath_integrate_1d_gk_rev_GradientShift_noisy_gradient) {
+  using stan::math::var;
+  const double I_ref = std::sqrt(stan::math::pi()) * std::erf(1.0);
+  std::vector<var> theta = {2.5};
+  n_evals = 0;
+  var I = stan::math::integrate_1d_gauss_kronrod_tol(
+      f_noisy_gradient_counted{}, -1.0, 1.0, 1e-6, 0.0, 15, msgs, theta,
+      std::vector<double>{}, std::vector<int>{});
+  std::vector<double> g;
+  I.grad(theta, g);
+  EXPECT_NEAR(I_ref, I.val(), 1e-6);
+  EXPECT_NEAR(0.0, g[0], 1e-6);
+  // Value + one gradient component.  Without the shift the gradient
+  // integral hits max_depth (2^15 * 21 ≈ 6.9e5 evaluations).
+  EXPECT_LT(n_evals, 5000L);
+}
+
+struct f_odd {
+  template <typename T1, typename T2, typename T3>
+  inline stan::return_type_t<T1, T2, T3> operator()(
+      const T1 &x, const T2 &xc, std::ostream *msgs,
+      const std::vector<T3> &theta, const std::vector<double> &x_r,
+      const std::vector<int> &x_i) const {
+    return theta[0] * x * exp(-x * x);   // odd: integral over [-1, 1] is 0
+  }
+};
+
+struct f_negative {
+  template <typename T1, typename T2, typename T3>
+  inline stan::return_type_t<T1, T2, T3> operator()(
+      const T1 &x, const T2 &xc, std::ostream *msgs,
+      const std::vector<T3> &theta, const std::vector<double> &x_r,
+      const std::vector<int> &x_i) const {
+    return -theta[0] * exp(-x * x);      // negative everywhere, I < 0
+  }
+};
+
+TEST_F(AgradRev, StanMath_integrate_1d_gk_rev_GradientShift_guards) {
+  using stan::math::var;
+  // (a) exactly-zero integral: the shift is disabled and the gradient is
+  //     the (zero) integral of x exp(-x^2).
+  {
+    std::vector<var> theta = {2.5};
+    var I;
+    EXPECT_NO_THROW(I = stan::math::integrate_1d_gauss_kronrod_tol(
+                        f_odd{}, -1.0, 1.0, 1e-6, 0.0, 15, msgs, theta,
+                        std::vector<double>{}, std::vector<int>{}));
+    std::vector<double> g;
+    I.grad(theta, g);
+    EXPECT_NEAR(0.0, I.val(), 1e-8);
+    EXPECT_NEAR(0.0, g[0], 1e-8);
+  }
+  // (b) negative integral: shift active with I < 0; d I / d theta = I / theta.
+  {
+    const double th = 2.5;
+    const double I_ref = -th * std::sqrt(stan::math::pi()) * std::erf(1.0);
+    std::vector<var> theta = {th};
+    var I = stan::math::integrate_1d_gauss_kronrod_tol(
+        f_negative{}, -1.0, 1.0, 1e-8, 0.0, 15, msgs, theta,
+        std::vector<double>{}, std::vector<int>{});
+    std::vector<double> g;
+    I.grad(theta, g);
+    EXPECT_NEAR(I_ref, I.val(), 1e-7);
+    EXPECT_NEAR(I_ref / th, g[0], 1e-7);
+  }
+}
+
+}

--- a/test/unit/math/rev/functor/integrate_1d_gauss_kronrod_test.cpp
+++ b/test/unit/math/rev/functor/integrate_1d_gauss_kronrod_test.cpp
@@ -528,7 +528,7 @@ struct f_odd {
       const T1 &x, const T2 &xc, std::ostream *msgs,
       const std::vector<T3> &theta, const std::vector<double> &x_r,
       const std::vector<int> &x_i) const {
-    return theta[0] * x * exp(-x * x);   // odd: integral over [-1, 1] is 0
+    return theta[0] * x * exp(-x * x);  // odd: integral over [-1, 1] is 0
   }
 };
 
@@ -538,7 +538,7 @@ struct f_negative {
       const T1 &x, const T2 &xc, std::ostream *msgs,
       const std::vector<T3> &theta, const std::vector<double> &x_r,
       const std::vector<int> &x_i) const {
-    return -theta[0] * exp(-x * x);      // negative everywhere, I < 0
+    return -theta[0] * exp(-x * x);  // negative everywhere, I < 0
   }
 };
 
@@ -572,4 +572,4 @@ TEST_F(AgradRev, StanMath_integrate_1d_gk_rev_GradientShift_guards) {
   }
 }
 
-}
+}  // namespace integrate_1d_gk_test


### PR DESCRIPTION
Making this PR has been assisted by Claude. I have checked and edited all new code, comments, and PR text

## Summary

The gradient computation for integrate_1d_gauss_kronrod calls the Boost adaptive Gauss Kronrod again, but Boost computes each parameter's gradient integral with the same Boost adaptive Gauss–Kronrod call. Boost's bisection criterion is relative to the leaf estimate, so a gradient component that is tiny relative to `f` and dominated by round-off (e.g. the score of a saturated observation deep in a likelihood tail) never converges and bisects to `max_depth` (2¹⁵ × 21 evaluations) on every call, although its contribution to `∂ log I` is negligible. This can be fixed by shifting the integral integrand as
g_i(x) = ∂f/∂θ_i (x) + c f(x)
and returning `∫ g_i − c I`, where `I` is the value integral already computed and c != 0 is a constant 
such that `∂f/∂θ_i ≈ −c·f` does not occur for common integrands; `c = 1` is a bad choice because log-density gradients of logit-type likelihoods saturate at ±1 in the tails, which turns the shifted integrand back into noise. The inverse golden ratio is far from every integer and is not a structural constant of any link.

As this is needed only for `integrate_1d_gauss_kronrod`, `integrate_1d_adjoint` gets an option whether the shift is used. The plain `integrate_1d` and `integrate_1d_double_exponential` are unchanged: their L1-relative termination handles ordinary gradient integrands, and enabling the shift there costs 7–32 % more gradient evaluations on 10 of 35 suite integrands with no gain.

## Tests

**Measured with the fix** (same model, same point):

| | gradient | vs `integrate_1d` | max \|Δ grad\| vs `integrate_1d` |
|---|---:|---:|---:|
| GK, unpatched | 7582 ms | 134× | 2.9e-11 |
| GK, patched | 156 ms | 2.75× | 2.9e-11 |

49× faster gradients, results unchanged to 1e-11 (patched vs unpatched
GK: 1.0e-11).  Per subject the counter shows 668 850 → 2 478 gradient
evaluations.  The residual 2.75× is GK's per-integral cost on this
integrand (value-only GQ is 2.1× DE), not a gradient effect.

## Effect on every integrand in the existing GK reverse-mode test suite

Integrand evaluations (value alone; all gradient components together)
and wall for value + gradients (mean of 200, `-O3`), unpatched →
patched.  Same arguments and tolerances as the tests.  `#var` = number
of `var` inputs (parameters + var endpoints).

| integrand (test) | #var | value | gradients unpatched → patched | wall µs |
|---|---:|---:|---:|---:|
| `f1` `exp(x)+θ`, [0.2, 0.7] | 1 | 21 | 21 → 21 | 1.3 → 1.2 |
| `f2` `exp(θ cos 2πx)+θ`, var endpoints | 3 | 21 | 23 → 23 | 2.9 → 2.9 |
| `f3` `exp(x)+θ₀^2.5+2θ₁³+2θ₂`, var endpoints | 5 | 21 | 65 → 65 | 11 → 7.6 |
| `f3`, params only | 3 | 21 | 63 → 63 | 11 → 5.7 |
| `f10` `1/(1+x⁴/1.7)`, (−∞, ∞), no params | 0 | 147 | 0 → 0 | 6.3 → 2.7 |
| `f11` beta(5, 3), [0, 1] | 2 | 21 | 294 → 336 | 29 → 33 |
| `f11` beta(3, 5), [0, 1] | 2 | 21 | 294 → 336 | 20 → 23 |
| `f12` N(5.7, 1), (−∞, ∞) | 2 | 357 | 672 → 672 | 44 → 42 |
| `f13` `x+θ₀+θ₁`, endpoints = params | 4 | 21 | 44 → 44 | 1.2 → 1.2 |
| Cauchy pdf, (−∞, ∞) | 2 | 231 | 546 → 462 | 38 → 33 |
| Exponential pdf, [0, ∞) | 1 | 105 | 231 → 147 | 11 → 7.6 |
| Normal pdf, (−∞, ∞) | 2 | 441 | 1008 → 924 | 57 → 53 |
| Student-t pdf, (−∞, ∞) | 3 | 651 | 3129 → 2205 | 323 → 241 |
| Uniform pdf, endpoints = params | 4 | 21 | 44 → 44 | 2.5 → 2.3 |
| noisy gradient (new test), [−1, 1] | 1 | 21 | **throws** → 21 | — → 2.6 |
| odd, zero integral (new test) | 1 | 21 | (n/a) → 21 | — → 0.8 |
| negative integral (new test) | 1 | 21 | (n/a) → 21 | — → 0.8 |

Unpatched, the noisy-gradient case does not merely hit `max_depth`: it
then fails Stan's post-check (`error estimate 2.4e-13 exceeds
max(rel_tol × L1, abs_tol)` with `L1 ≈ 0`) and **throws**, i.e. in a
model block every proposal is rejected.  Elsewhere the change is
neutral or a mild gain (heavy-tailed pdfs 15–35% fewer gradient
evaluations); the one regression is `f11` (beta kernel: the gradient
integrands carry a `log x` factor that is easier than `f` on its own),
+14 % gradient evaluations at unchanged wall.  All 17 pre-existing
tests pass at their tolerances.

A gradient component that is analytically zero but autodiffs to
round-off noise reproduces it without any likelihood machinery
(`cos² + sin² = 1`). Added to `test/unit/math/rev/functor/integrate_1d_gauss_kronrod_test.cpp`
as `GradientShift_noisy_gradient` (evaluation-count bound + accuracy;
fails on the unpatched code, passes on the patched) together with
`GradientShift_guards` (exactly-zero integral → shift disabled; negative
integral → shift active), and the existing 17 tests pass unchanged.

## Side Effects

1. **Cost when a gradient integrand is easier than `f`.**  `f = spike(x)
   + θ`: the gradient integrand is the constant 1 and took 21
   evaluations; shifted it re-resolves the spike, 189.  Bound: gradient
   cost ≤ (p + 1) × value cost, against 2^15 × 21 per component before.
2. **Absolute, not relative, gradient accuracy.**  The shifted gradient
   inherits the value integral's absolute error (`≲ tol × L1(f)`), so a
   component with `|∂I/∂θ| ≲ tol × L1(f)` loses relative precision.
   Measured (`f = spike + ε θ x`, spike width 0.01, `tol = 1e-6`):
   unshifted exact; shifted absolute error 3e-19 … 3e-18, i.e. relative
   6e-15 at `ε = 1e-3` down to 5e-10 at `ε = 1e-9` — round-off level in
   practice, because leaves that pass the value's test are usually far
   below `tol`.  For HMC this is the right accuracy: value and gradient
   enter the Hamiltonian at the same absolute scale.

## Release notes

integrate_1d_gauss_kronrod gradient computation was modified to have much improved worst performance timing

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

Aki Vehtari 

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
